### PR TITLE
Make arithmetic and shift operators polymorphic methods on the Type interface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -442,12 +442,6 @@ parameters:
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-
-			rawMessage: Binary operation "+" between bool|float|int|string|null and bool|float|int|string|null results in an error.
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Reflection/InitializerExprTypeResolver.php
-
-		-
 			rawMessage: Binary operation "^" between bool|float|int|string|null and bool|float|int|string|null results in an error.
 			identifier: binaryOp.invalid
 			count: 1
@@ -462,7 +456,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 6
+			count: 4
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-
@@ -860,18 +854,6 @@ parameters:
 			identifier: phpstanApi.instanceofType
 			count: 1
 			path: src/Type/Accessory/OversizedArrayType.php
-
-		-
-			rawMessage: PHPDoc tag @var with type float|int is not subtype of type int.
-			identifier: varTag.type
-			count: 4
-			path: src/Type/ArithmeticOpHelper.php
-
-		-
-			rawMessage: PHPDoc tag @var with type float|int|null is not subtype of type int|null.
-			identifier: varTag.type
-			count: 6
-			path: src/Type/ArithmeticOpHelper.php
 
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ArrayType is error-prone and deprecated. Use Type::isArray() or Type::getArrays() instead.'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -454,12 +454,6 @@ parameters:
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-
-			rawMessage: Binary operation "-" between bool|float|int|string|null and bool|float|int|string|null results in an error.
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Reflection/InitializerExprTypeResolver.php
-
-		-
 			rawMessage: Binary operation "^" between bool|float|int|string|null and bool|float|int|string|null results in an error.
 			identifier: binaryOp.invalid
 			count: 1
@@ -474,7 +468,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 14
+			count: 12
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -474,7 +474,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 18
+			count: 16
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-
@@ -499,18 +499,6 @@ parameters:
 			rawMessage: PHPDoc tag @var with type float|int is not subtype of native type int.
 			identifier: varTag.nativeType
 			count: 1
-			path: src/Reflection/InitializerExprTypeResolver.php
-
-		-
-			rawMessage: PHPDoc tag @var with type float|int is not subtype of type int.
-			identifier: varTag.type
-			count: 4
-			path: src/Reflection/InitializerExprTypeResolver.php
-
-		-
-			rawMessage: PHPDoc tag @var with type float|int|null is not subtype of type int|null.
-			identifier: varTag.type
-			count: 6
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-
@@ -884,6 +872,18 @@ parameters:
 			identifier: phpstanApi.instanceofType
 			count: 1
 			path: src/Type/Accessory/OversizedArrayType.php
+
+		-
+			rawMessage: PHPDoc tag @var with type float|int is not subtype of type int.
+			identifier: varTag.type
+			count: 4
+			path: src/Type/ArithmeticOpHelper.php
+
+		-
+			rawMessage: PHPDoc tag @var with type float|int|null is not subtype of type int|null.
+			identifier: varTag.type
+			count: 6
+			path: src/Type/ArithmeticOpHelper.php
 
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ArrayType is error-prone and deprecated. Use Type::isArray() or Type::getArrays() instead.'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -474,7 +474,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 16
+			count: 14
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -462,7 +462,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 8
+			count: 6
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -442,12 +442,6 @@ parameters:
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-
-			rawMessage: Binary operation "*" between bool|float|int|string|null and bool|float|int|string|null results in an error.
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Reflection/InitializerExprTypeResolver.php
-
-		-
 			rawMessage: Binary operation "+" between bool|float|int|string|null and bool|float|int|string|null results in an error.
 			identifier: binaryOp.invalid
 			count: 1
@@ -468,7 +462,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 12
+			count: 10
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -462,7 +462,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 10
+			count: 8
 			path: src/Reflection/InitializerExprTypeResolver.php
 
 		-

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1282,105 +1282,13 @@ final class InitializerExprTypeResolver
 
 	public function getModTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
 	{
-		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
-			return $this->getNeverType($leftType, $rightType);
-		}
-
-		$extensionSpecified = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
 			->callOperatorTypeSpecifyingExtensions(new BinaryOp\Mod($left, $right), $leftType, $rightType);
-		if ($extensionSpecified !== null) {
-			return $extensionSpecified;
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
 		}
 
-		if ($leftType->toNumber() instanceof ErrorType || $rightType->toNumber() instanceof ErrorType) {
-			return new ErrorType();
-		}
-
-		$leftTypes = $leftType->getConstantScalarTypes();
-		$rightTypes = $rightType->getConstantScalarTypes();
-		$leftTypesCount = count($leftTypes);
-		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
-			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			if (!$generalize) {
-				foreach ($leftTypes as $leftTypeInner) {
-					foreach ($rightTypes as $rightTypeInner) {
-						$leftNumberType = $leftTypeInner->toNumber();
-						$rightNumberType = $rightTypeInner->toNumber();
-
-						if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-							return new ErrorType();
-						}
-
-						if (!$leftNumberType instanceof ConstantScalarType || !$rightNumberType instanceof ConstantScalarType) {
-							throw new ShouldNotHappenException();
-						}
-
-						$rightIntegerValue = (int) $rightNumberType->getValue();
-						if ($rightIntegerValue === 0) {
-							return new ErrorType();
-						}
-
-						$resultType = $this->getTypeFromValue((int) $leftNumberType->getValue() % $rightIntegerValue);
-						$resultTypes[] = $resultType;
-					}
-				}
-				return TypeCombinator::union(...$resultTypes);
-			}
-
-			$leftType = $this->optimizeScalarType($leftType);
-			$rightType = $this->optimizeScalarType($rightType);
-		}
-
-		$integerType = $rightType->toInteger();
-		if ($integerType instanceof ConstantIntegerType && $integerType->getValue() === 1) {
-			return new ConstantIntegerType(0);
-		}
-
-		$rightScalarValues = $rightType->toNumber()->getConstantScalarValues();
-		foreach ($rightScalarValues as $scalarValue) {
-
-			if (in_array($scalarValue, [0, 0.0], true)) {
-				return new ErrorType();
-			}
-		}
-
-		$positiveInt = IntegerRangeType::fromInterval(0, null);
-		if ($rightType->isInteger()->yes()) {
-			$rangeMin = null;
-			$rangeMax = null;
-
-			if ($rightType instanceof IntegerRangeType) {
-				$rangeMax = $rightType->getMax() !== null ? $rightType->getMax() - 1 : null;
-			} elseif ($rightType instanceof ConstantIntegerType) {
-				$rangeMax = $rightType->getValue() - 1;
-			} elseif ($rightType instanceof UnionType) {
-				foreach ($rightType->getTypes() as $type) {
-					if ($type instanceof IntegerRangeType) {
-						if ($type->getMax() === null) {
-							$rangeMax = null;
-						} else {
-							$rangeMax = max($rangeMax, $type->getMax());
-						}
-					} elseif ($type instanceof ConstantIntegerType) {
-						$rangeMax = max($rangeMax, $type->getValue() - 1);
-					}
-				}
-			}
-
-			if ($positiveInt->isSuperTypeOf($leftType)->yes()) {
-				$rangeMin = 0;
-			} elseif ($rangeMax !== null) {
-				$rangeMin = $rangeMax * -1;
-			}
-
-			return IntegerRangeType::fromInterval($rangeMin, $rangeMax);
-		} elseif ($positiveInt->isSuperTypeOf($leftType)->yes()) {
-			return IntegerRangeType::fromInterval(0, null);
-		}
-
-		return new IntegerType();
+		return $leftType->modulo($rightType);
 	}
 
 	/**

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -52,7 +52,6 @@ use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
 use PHPStan\Type\Accessory\HasOffsetValueType;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArithmeticOpHelper;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
@@ -1304,196 +1303,13 @@ final class InitializerExprTypeResolver
 
 	public function getPlusTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
 	{
-		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
-			return $this->getNeverType($leftType, $rightType);
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\Plus($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
 		}
 
-		$leftTypes = $leftType->getConstantScalarTypes();
-		$rightTypes = $rightType->getConstantScalarTypes();
-		$leftTypesCount = count($leftTypes);
-		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
-			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			if (!$generalize) {
-				foreach ($leftTypes as $leftTypeInner) {
-					foreach ($rightTypes as $rightTypeInner) {
-						$leftNumberType = $leftTypeInner->toNumber();
-						$rightNumberType = $rightTypeInner->toNumber();
-
-						if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-							return new ErrorType();
-						}
-
-						if (!$leftNumberType instanceof ConstantScalarType || !$rightNumberType instanceof ConstantScalarType) {
-							throw new ShouldNotHappenException();
-						}
-
-						$resultType = $this->getTypeFromValue($leftNumberType->getValue() + $rightNumberType->getValue());
-						$resultTypes[] = $resultType;
-					}
-				}
-
-				return TypeCombinator::union(...$resultTypes);
-			}
-
-			$leftType = $this->optimizeScalarType($leftType);
-			$rightType = $this->optimizeScalarType($rightType);
-		}
-
-		$leftConstantArrays = $leftType->getConstantArrays();
-		$rightConstantArrays = $rightType->getConstantArrays();
-
-		$leftCount = count($leftConstantArrays);
-		$rightCount = count($rightConstantArrays);
-		if ($leftCount > 0 && $rightCount > 0
-			&& ($leftCount + $rightCount < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
-			$resultTypes = [];
-			foreach ($rightConstantArrays as $rightConstantArray) {
-				foreach ($leftConstantArrays as $leftConstantArray) {
-					$newArrayBuilder = ConstantArrayTypeBuilder::createFromConstantArray($rightConstantArray);
-					foreach ($leftConstantArray->getKeyTypes() as $i => $leftKeyType) {
-						$optional = $leftConstantArray->isOptionalKey($i);
-						$valueType = $leftConstantArray->getOffsetValueType($leftKeyType);
-						if (!$optional) {
-							if ($rightConstantArray->hasOffsetValueType($leftKeyType)->maybe()) {
-								$valueType = TypeCombinator::union($valueType, $rightConstantArray->getOffsetValueType($leftKeyType));
-							}
-						}
-						$newArrayBuilder->setOffsetValueType(
-							$leftKeyType,
-							$valueType,
-							$optional,
-						);
-					}
-					$resultTypes[] = $newArrayBuilder->getArray();
-				}
-			}
-			return TypeCombinator::union(...$resultTypes);
-		}
-
-		$leftIsArray = $leftType->isArray();
-		$rightIsArray = $rightType->isArray();
-		if ($leftIsArray->yes() && $rightIsArray->yes()) {
-			if ($leftType->getIterableKeyType()->equals($rightType->getIterableKeyType())) {
-				// to preserve BenevolentUnionType
-				$keyType = $leftType->getIterableKeyType();
-			} else {
-				$keyTypes = [];
-				foreach ([
-					$leftType->getIterableKeyType(),
-					$rightType->getIterableKeyType(),
-				] as $keyType) {
-					$keyTypes[] = $keyType;
-				}
-				$keyType = TypeCombinator::union(...$keyTypes);
-			}
-
-			$leftIterableValueType = $leftType->getIterableValueType();
-			$arrayType = new ArrayType(
-				$keyType,
-				TypeCombinator::union($leftIterableValueType, $rightType->getIterableValueType()),
-			);
-
-			$accessories = [];
-			if ($leftCount > 0) {
-				// Use the first constant array as a reference to list potential offsets.
-				// We only need to check the first array because we're looking for offsets that exist in ALL arrays.
-				$constantArray = $leftConstantArrays[0];
-				foreach ($constantArray->getKeyTypes() as $offsetType) {
-					if (!$leftType->hasOffsetValueType($offsetType)->yes()) {
-						continue;
-					}
-
-					$valueType = $leftType->getOffsetValueType($offsetType);
-					$accessories[] = new HasOffsetValueType($offsetType, $valueType);
-				}
-			}
-
-			if ($rightCount > 0) {
-				// Use the first constant array as a reference to list potential offsets.
-				// We only need to check the first array because we're looking for offsets that exist in ALL arrays.
-				$constantArray = $rightConstantArrays[0];
-				foreach ($constantArray->getKeyTypes() as $offsetType) {
-					if (!$rightType->hasOffsetValueType($offsetType)->yes()) {
-						continue;
-					}
-
-					$valueType = TypeCombinator::union($leftIterableValueType, $rightType->getOffsetValueType($offsetType));
-					$accessories[] = new HasOffsetValueType($offsetType, $valueType);
-				}
-			}
-
-			if ($leftType->isIterableAtLeastOnce()->yes() || $rightType->isIterableAtLeastOnce()->yes()) {
-				$accessories[] = new NonEmptyArrayType();
-			}
-			if ($leftType->isList()->yes() && $rightType->isList()->yes()) {
-				$accessories[] = new AccessoryArrayListType();
-			}
-
-			if (count($accessories) > 0) {
-				$arrayType = TypeCombinator::intersect($arrayType, ...$accessories);
-			}
-
-			return $arrayType;
-		}
-
-		if ($leftType instanceof MixedType && $rightType instanceof MixedType) {
-			if ($leftIsArray->no() && $rightIsArray->no()) {
-				return new BenevolentUnionType([
-					new FloatType(),
-					new IntegerType(),
-				]);
-			}
-			return new BenevolentUnionType([
-				new FloatType(),
-				new IntegerType(),
-				new ArrayType(new MixedType(), new MixedType()),
-			]);
-		}
-
-		if (
-			($leftIsArray->yes() && $rightIsArray->no())
-			|| ($leftIsArray->no() && $rightIsArray->yes())
-		) {
-			return new ErrorType();
-		}
-
-		if (
-			($leftIsArray->yes() && $rightIsArray->maybe())
-			|| ($leftIsArray->maybe() && $rightIsArray->yes())
-		) {
-			$resultType = new ArrayType(new MixedType(), new MixedType());
-			if ($leftType->isIterableAtLeastOnce()->yes() || $rightType->isIterableAtLeastOnce()->yes()) {
-				return TypeCombinator::intersect($resultType, new NonEmptyArrayType());
-			}
-
-			return $resultType;
-		}
-
-		if ($leftIsArray->maybe() && $rightIsArray->maybe()) {
-			$plusable = new UnionType([
-				new StringType(),
-				new FloatType(),
-				new IntegerType(),
-				new ArrayType(new MixedType(), new MixedType()),
-				new BooleanType(),
-			]);
-
-			$plusableSuperTypeOfLeft = $plusable->isSuperTypeOf($leftType)->yes();
-			$plusableSuperTypeOfRight = $plusable->isSuperTypeOf($rightType)->yes();
-			if ($plusableSuperTypeOfLeft && $plusableSuperTypeOfRight) {
-				return TypeCombinator::union($leftType, $rightType);
-			}
-			if ($plusableSuperTypeOfLeft && $rightType instanceof MixedType) {
-				return $leftType;
-			}
-			if ($plusableSuperTypeOfRight && $leftType instanceof MixedType) {
-				return $rightType;
-			}
-		}
-
-		return $this->resolveCommonMath(new BinaryOp\Plus($left, $right), $leftType, $rightType);
+		return $leftType->plus($rightType);
 	}
 
 	/**
@@ -1740,20 +1556,6 @@ final class InitializerExprTypeResolver
 		}
 
 		return new TypeResult($resultType->toBoolean(), []);
-	}
-
-	/**
-	 * @param BinaryOp\Plus|BinaryOp\Minus|BinaryOp\Mul|BinaryOp\Div|BinaryOp\ShiftLeft|BinaryOp\ShiftRight $expr
-	 */
-	private function resolveCommonMath(Expr\BinaryOp $expr, Type $leftType, Type $rightType): Type
-	{
-		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
-			->callOperatorTypeSpecifyingExtensions($expr, $leftType, $rightType);
-		if ($specifiedTypes !== null) {
-			return $specifiedTypes;
-		}
-
-		return ArithmeticOpHelper::commonMath($expr->getOperatorSigil(), $leftType, $rightType);
 	}
 
 	/**

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1795,66 +1795,18 @@ final class InitializerExprTypeResolver
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
 
+		return $this->getShiftRightTypeFromTypes($left, $right, $leftType, $rightType);
+	}
+
+	public function getShiftRightTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
+	{
 		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
 			->callOperatorTypeSpecifyingExtensions(new BinaryOp\ShiftRight($left, $right), $leftType, $rightType);
 		if ($specifiedTypes !== null) {
 			return $specifiedTypes;
 		}
 
-		return $this->getShiftRightTypeFromTypes($left, $right, $leftType, $rightType);
-	}
-
-	public function getShiftRightTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
-	{
-		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
-			return $this->getNeverType($leftType, $rightType);
-		}
-
-		$leftTypes = $leftType->getConstantScalarTypes();
-		$rightTypes = $rightType->getConstantScalarTypes();
-		$leftTypesCount = count($leftTypes);
-		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
-			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			if (!$generalize) {
-				foreach ($leftTypes as $leftTypeInner) {
-					foreach ($rightTypes as $rightTypeInner) {
-						$leftNumberType = $leftTypeInner->toNumber();
-						$rightNumberType = $rightTypeInner->toNumber();
-
-						if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-							return new ErrorType();
-						}
-
-						if (!$leftNumberType instanceof ConstantScalarType || !$rightNumberType instanceof ConstantScalarType) {
-							throw new ShouldNotHappenException();
-						}
-
-						if ($rightNumberType->getValue() < 0) {
-							return new ErrorType();
-						}
-
-						$resultType = $this->getTypeFromValue(intval($leftNumberType->getValue()) >> intval($rightNumberType->getValue()));
-						$resultTypes[] = $resultType;
-					}
-				}
-
-				return TypeCombinator::union(...$resultTypes);
-			}
-
-			$leftType = $this->optimizeScalarType($leftType);
-			$rightType = $this->optimizeScalarType($rightType);
-		}
-
-		$leftNumberType = $leftType->toNumber();
-		$rightNumberType = $rightType->toNumber();
-
-		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-			return new ErrorType();
-		}
-
-		return $this->resolveCommonMath(new Expr\BinaryOp\ShiftRight($left, $right), $leftType, $rightType);
+		return $leftType->shiftRight($rightType);
 	}
 
 	private function optimizeScalarType(Type $type): Type

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1660,55 +1660,13 @@ final class InitializerExprTypeResolver
 
 	public function getMulTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
 	{
-		$leftTypes = $leftType->getConstantScalarTypes();
-		$rightTypes = $rightType->getConstantScalarTypes();
-		$leftTypesCount = count($leftTypes);
-		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
-			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			if (!$generalize) {
-				foreach ($leftTypes as $leftTypeInner) {
-					foreach ($rightTypes as $rightTypeInner) {
-						$leftNumberType = $leftTypeInner->toNumber();
-						$rightNumberType = $rightTypeInner->toNumber();
-
-						if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-							return new ErrorType();
-						}
-
-						if (!$leftNumberType instanceof ConstantScalarType || !$rightNumberType instanceof ConstantScalarType) {
-							throw new ShouldNotHappenException();
-						}
-
-						$resultType = $this->getTypeFromValue($leftNumberType->getValue() * $rightNumberType->getValue());
-						$resultTypes[] = $resultType;
-					}
-				}
-
-				return TypeCombinator::union(...$resultTypes);
-			}
-
-			$leftType = $this->optimizeScalarType($leftType);
-			$rightType = $this->optimizeScalarType($rightType);
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\Mul($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
 		}
 
-		$leftNumberType = $leftType->toNumber();
-		if ($leftNumberType instanceof ConstantIntegerType && $leftNumberType->getValue() === 0) {
-			if ($rightType->isFloat()->yes()) {
-				return new ConstantFloatType(0.0);
-			}
-			return new ConstantIntegerType(0);
-		}
-		$rightNumberType = $rightType->toNumber();
-		if ($rightNumberType instanceof ConstantIntegerType && $rightNumberType->getValue() === 0) {
-			if ($leftType->isFloat()->yes()) {
-				return new ConstantFloatType(0.0);
-			}
-			return new ConstantIntegerType(0);
-		}
-
-		return $this->resolveCommonMath(new BinaryOp\Mul($left, $right), $leftType, $rightType);
+		return $leftType->multiply($rightType);
 	}
 
 	/**

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1260,50 +1260,13 @@ final class InitializerExprTypeResolver
 
 	public function getDivTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
 	{
-		$leftTypes = $leftType->getConstantScalarTypes();
-		$rightTypes = $rightType->getConstantScalarTypes();
-		$leftTypesCount = count($leftTypes);
-		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
-			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			if (!$generalize) {
-				foreach ($leftTypes as $leftTypeInner) {
-					foreach ($rightTypes as $rightTypeInner) {
-						$leftNumberType = $leftTypeInner->toNumber();
-						$rightNumberType = $rightTypeInner->toNumber();
-
-						if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-							return new ErrorType();
-						}
-
-						if (!$leftNumberType instanceof ConstantScalarType || !$rightNumberType instanceof ConstantScalarType) {
-							throw new ShouldNotHappenException();
-						}
-
-						if (in_array($rightNumberType->getValue(), [0, 0.0], true)) {
-							return new ErrorType();
-						}
-
-						$resultType = $this->getTypeFromValue($leftNumberType->getValue() / $rightNumberType->getValue()); // @phpstan-ignore binaryOp.invalid
-						$resultTypes[] = $resultType;
-					}
-				}
-				return TypeCombinator::union(...$resultTypes);
-			}
-
-			$leftType = $this->optimizeScalarType($leftType);
-			$rightType = $this->optimizeScalarType($rightType);
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\Div($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
 		}
 
-		$rightScalarValues = $rightType->toNumber()->getConstantScalarValues();
-		foreach ($rightScalarValues as $scalarValue) {
-			if (in_array($scalarValue, [0, 0.0], true)) {
-				return new ErrorType();
-			}
-		}
-
-		return $this->resolveCommonMath(new BinaryOp\Div($left, $right), $leftType, $rightType);
+		return $leftType->divide($rightType);
 	}
 
 	/**

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -104,24 +104,18 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_values;
-use function assert;
-use function ceil;
 use function count;
 use function dirname;
-use function floor;
 use function in_array;
 use function intval;
-use function is_finite;
 use function is_float;
 use function is_int;
 use function is_numeric;
 use function is_string;
 use function max;
-use function min;
 use function sprintf;
 use function str_starts_with;
 use function strtolower;
-use const INF;
 
 #[AutowiredService]
 final class InitializerExprTypeResolver
@@ -1779,66 +1773,18 @@ final class InitializerExprTypeResolver
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
 
+		return $this->getShiftLeftTypeFromTypes($left, $right, $leftType, $rightType);
+	}
+
+	public function getShiftLeftTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
+	{
 		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
 			->callOperatorTypeSpecifyingExtensions(new BinaryOp\ShiftLeft($left, $right), $leftType, $rightType);
 		if ($specifiedTypes !== null) {
 			return $specifiedTypes;
 		}
 
-		return $this->getShiftLeftTypeFromTypes($left, $right, $leftType, $rightType);
-	}
-
-	public function getShiftLeftTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
-	{
-		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
-			return $this->getNeverType($leftType, $rightType);
-		}
-
-		$leftTypes = $leftType->getConstantScalarTypes();
-		$rightTypes = $rightType->getConstantScalarTypes();
-		$leftTypesCount = count($leftTypes);
-		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
-			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			if (!$generalize) {
-				foreach ($leftTypes as $leftTypeInner) {
-					foreach ($rightTypes as $rightTypeInner) {
-						$leftNumberType = $leftTypeInner->toNumber();
-						$rightNumberType = $rightTypeInner->toNumber();
-
-						if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-							return new ErrorType();
-						}
-
-						if (!$leftNumberType instanceof ConstantScalarType || !$rightNumberType instanceof ConstantScalarType) {
-							throw new ShouldNotHappenException();
-						}
-
-						if ($rightNumberType->getValue() < 0) {
-							return new ErrorType();
-						}
-
-						$resultType = $this->getTypeFromValue(intval($leftNumberType->getValue()) << intval($rightNumberType->getValue()));
-						$resultTypes[] = $resultType;
-					}
-				}
-
-				return TypeCombinator::union(...$resultTypes);
-			}
-
-			$leftType = $this->optimizeScalarType($leftType);
-			$rightType = $this->optimizeScalarType($rightType);
-		}
-
-		$leftNumberType = $leftType->toNumber();
-		$rightNumberType = $rightType->toNumber();
-
-		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-			return new ErrorType();
-		}
-
-		return $this->resolveCommonMath(new Expr\BinaryOp\ShiftLeft($left, $right), $leftType, $rightType);
+		return $leftType->shiftLeft($rightType);
 	}
 
 	/**
@@ -2053,336 +1999,7 @@ final class InitializerExprTypeResolver
 			return $specifiedTypes;
 		}
 
-		$types = TypeCombinator::union($leftType, $rightType);
-		$leftNumberType = $leftType->toNumber();
-		$rightNumberType = $rightType->toNumber();
-
-		if (
-			!$types instanceof MixedType
-			&& (
-				$rightNumberType instanceof IntegerRangeType
-				|| $rightNumberType instanceof ConstantIntegerType
-				|| $rightNumberType instanceof UnionType
-			)
-		) {
-			if ($leftNumberType instanceof IntegerRangeType || $leftNumberType instanceof ConstantIntegerType) {
-				return $this->integerRangeMath(
-					$leftNumberType,
-					$expr,
-					$rightNumberType,
-				);
-			} elseif ($leftNumberType instanceof UnionType) {
-				$unionParts = [];
-
-				foreach ($leftNumberType->getTypes() as $type) {
-					$numberType = $type->toNumber();
-					if ($numberType instanceof IntegerRangeType || $numberType instanceof ConstantIntegerType) {
-						$unionParts[] = $this->integerRangeMath($numberType, $expr, $rightNumberType);
-					} else {
-						$unionParts[] = $numberType;
-					}
-				}
-
-				$union = TypeCombinator::union(...$unionParts);
-				if ($leftNumberType instanceof BenevolentUnionType) {
-					return TypeUtils::toBenevolentUnion($union)->toNumber();
-				}
-
-				return $union->toNumber();
-			}
-		}
-
-		if (
-			$leftType->isArray()->yes()
-			|| $rightType->isArray()->yes()
-			|| $types->isArray()->yes()
-		) {
-			return new ErrorType();
-		}
-
-		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-			return new ErrorType();
-		}
-		if ($leftNumberType instanceof NeverType || $rightNumberType instanceof NeverType) {
-			return $this->getNeverType($leftNumberType, $rightNumberType);
-		}
-
-		if (
-			$leftNumberType->isFloat()->yes()
-			|| $rightNumberType->isFloat()->yes()
-		) {
-			if ($expr instanceof Expr\BinaryOp\ShiftLeft || $expr instanceof Expr\BinaryOp\ShiftRight) {
-				return new IntegerType();
-			}
-			return new FloatType();
-		}
-
-		$resultType = TypeCombinator::union($leftNumberType, $rightNumberType);
-		if ($expr instanceof Expr\BinaryOp\Div) {
-			if ($types instanceof MixedType || $resultType->isInteger()->yes()) {
-				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-			}
-
-			return new UnionType([new IntegerType(), new FloatType()]);
-		}
-
-		if ($types instanceof MixedType
-			|| $leftType instanceof BenevolentUnionType
-			|| $rightType instanceof BenevolentUnionType
-		) {
-			return TypeUtils::toBenevolentUnion($resultType);
-		}
-
-		return $resultType;
-	}
-
-	/**
-	 * @param ConstantIntegerType|IntegerRangeType $range
-	 * @param BinaryOp\Div|BinaryOp\Minus|BinaryOp\Mul|BinaryOp\Plus|BinaryOp\ShiftLeft|BinaryOp\ShiftRight $node
-	 */
-	private function integerRangeMath(Type $range, BinaryOp $node, Type $operand): Type
-	{
-		if ($range instanceof IntegerRangeType) {
-			$rangeMin = $range->getMin();
-			$rangeMax = $range->getMax();
-		} else {
-			$rangeMin = $range->getValue();
-			$rangeMax = $rangeMin;
-		}
-
-		if ($operand instanceof UnionType) {
-
-			$unionParts = [];
-
-			foreach ($operand->getTypes() as $type) {
-				$numberType = $type->toNumber();
-				if ($numberType instanceof IntegerRangeType || $numberType instanceof ConstantIntegerType) {
-					$unionParts[] = $this->integerRangeMath($range, $node, $numberType);
-				} else {
-					$unionParts[] = $type->toNumber();
-				}
-			}
-
-			$union = TypeCombinator::union(...$unionParts);
-			if ($operand instanceof BenevolentUnionType) {
-				return TypeUtils::toBenevolentUnion($union)->toNumber();
-			}
-
-			return $union->toNumber();
-		}
-
-		$operand = $operand->toNumber();
-		if ($operand instanceof IntegerRangeType) {
-			$operandMin = $operand->getMin();
-			$operandMax = $operand->getMax();
-		} elseif ($operand instanceof ConstantIntegerType) {
-			$operandMin = $operand->getValue();
-			$operandMax = $operand->getValue();
-		} else {
-			return $operand;
-		}
-
-		if ($node instanceof BinaryOp\Plus) {
-			if ($operand instanceof ConstantIntegerType) {
-				/** @var int|float|null $min */
-				$min = $rangeMin !== null ? $rangeMin + $operand->getValue() : null;
-
-				/** @var int|float|null $max */
-				$max = $rangeMax !== null ? $rangeMax + $operand->getValue() : null;
-			} else {
-				/** @var int|float|null $min */
-				$min = $rangeMin !== null && $operand->getMin() !== null ? $rangeMin + $operand->getMin() : null;
-
-				/** @var int|float|null $max */
-				$max = $rangeMax !== null && $operand->getMax() !== null ? $rangeMax + $operand->getMax() : null;
-			}
-		} elseif ($node instanceof BinaryOp\Minus) {
-			if ($operand instanceof ConstantIntegerType) {
-				/** @var int|float|null $min */
-				$min = $rangeMin !== null ? $rangeMin - $operand->getValue() : null;
-
-				/** @var int|float|null $max */
-				$max = $rangeMax !== null ? $rangeMax - $operand->getValue() : null;
-			} else {
-				if ($rangeMin === $rangeMax && $rangeMin !== null
-					&& ($operand->getMin() === null || $operand->getMax() === null)) {
-					$min = null;
-					$max = $rangeMin;
-				} else {
-					if ($operand->getMin() === null) {
-						$min = null;
-					} elseif ($rangeMin !== null) {
-						if ($operand->getMax() !== null) {
-							/** @var int|float $min */
-							$min = $rangeMin - $operand->getMax();
-						} else {
-							/** @var int|float $min */
-							$min = $rangeMin - $operand->getMin();
-						}
-					} else {
-						$min = null;
-					}
-
-					if ($operand->getMax() === null) {
-						$min = null;
-						$max = null;
-					} elseif ($rangeMax !== null) {
-						if ($rangeMin !== null && $operand->getMin() === null) {
-							/** @var int|float $min */
-							$min = $rangeMin - $operand->getMax();
-							$max = null;
-						} elseif ($operand->getMin() !== null) {
-							/** @var int|float $max */
-							$max = $rangeMax - $operand->getMin();
-						} else {
-							$max = null;
-						}
-					} else {
-						$max = null;
-					}
-
-					if ($min !== null && $max !== null && $min > $max) {
-						[$min, $max] = [$max, $min];
-					}
-				}
-			}
-		} elseif ($node instanceof Expr\BinaryOp\Mul) {
-			$min1 = $rangeMin === 0 || $operandMin === 0 ? 0 : ($rangeMin ?? -INF) * ($operandMin ?? -INF);
-			$min2 = $rangeMin === 0 || $operandMax === 0 ? 0 : ($rangeMin ?? -INF) * ($operandMax ?? INF);
-			$max1 = $rangeMax === 0 || $operandMin === 0 ? 0 : ($rangeMax ?? INF) * ($operandMin ?? -INF);
-			$max2 = $rangeMax === 0 || $operandMax === 0 ? 0 : ($rangeMax ?? INF) * ($operandMax ?? INF);
-
-			$min = min($min1, $min2, $max1, $max2);
-			$max = max($min1, $min2, $max1, $max2);
-
-			if (!is_finite($min)) {
-				$min = null;
-			}
-			if (!is_finite($max)) {
-				$max = null;
-			}
-		} elseif ($node instanceof Expr\BinaryOp\Div) {
-			if ($operand instanceof ConstantIntegerType) {
-				$min = $rangeMin !== null && $operand->getValue() !== 0 ? $rangeMin / $operand->getValue() : null;
-				$max = $rangeMax !== null && $operand->getValue() !== 0 ? $rangeMax / $operand->getValue() : null;
-			} else {
-				// Avoid division by zero when looking for the min and the max by using the closest int
-				$operandMin = $operandMin !== 0 ? $operandMin : 1;
-				$operandMax = $operandMax !== 0 ? $operandMax : -1;
-
-				if (
-					($operandMin < 0 || $operandMin === null)
-					&& ($operandMax > 0 || $operandMax === null)
-				) {
-					$negativeOperand = IntegerRangeType::fromInterval($operandMin, 0);
-					assert($negativeOperand instanceof IntegerRangeType);
-					$positiveOperand = IntegerRangeType::fromInterval(0, $operandMax);
-					assert($positiveOperand instanceof IntegerRangeType);
-
-					$result = TypeCombinator::union(
-						$this->integerRangeMath($range, $node, $negativeOperand),
-						$this->integerRangeMath($range, $node, $positiveOperand),
-					)->toNumber();
-
-					if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
-						return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-					}
-
-					return $result;
-				}
-				if (
-					($rangeMin < 0 || $rangeMin === null)
-					&& ($rangeMax > 0 || $rangeMax === null)
-				) {
-					$negativeRange = IntegerRangeType::fromInterval($rangeMin, 0);
-					assert($negativeRange instanceof IntegerRangeType);
-					$positiveRange = IntegerRangeType::fromInterval(0, $rangeMax);
-					assert($positiveRange instanceof IntegerRangeType);
-
-					$result = TypeCombinator::union(
-						$this->integerRangeMath($negativeRange, $node, $operand),
-						$this->integerRangeMath($positiveRange, $node, $operand),
-					)->toNumber();
-
-					if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
-						return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-					}
-
-					return $result;
-				}
-
-				$rangeMinSign = ($rangeMin ?? -INF) <=> 0;
-				$rangeMaxSign = ($rangeMax ?? INF) <=> 0;
-
-				$min1 = $operandMin !== null ? ($rangeMin ?? -INF) / $operandMin : $rangeMinSign * -0.1;
-				$min2 = $operandMax !== null ? ($rangeMin ?? -INF) / $operandMax : $rangeMinSign * 0.1;
-				$max1 = $operandMin !== null ? ($rangeMax ?? INF) / $operandMin : $rangeMaxSign * -0.1;
-				$max2 = $operandMax !== null ? ($rangeMax ?? INF) / $operandMax : $rangeMaxSign * 0.1;
-
-				$min = min($min1, $min2, $max1, $max2);
-				$max = max($min1, $min2, $max1, $max2);
-
-				if ($min === -INF) {
-					$min = null;
-				}
-				if ($max === INF) {
-					$max = null;
-				}
-			}
-
-			if ($min !== null && $max !== null && $min > $max) {
-				[$min, $max] = [$max, $min];
-			}
-
-			if (is_float($min)) {
-				$min = (int) ceil($min);
-			}
-			if (is_float($max)) {
-				$max = (int) floor($max);
-			}
-
-			// invert maximas on division with negative constants
-			if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
-					|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
-				&& ($min === null || $max === null)) {
-				[$min, $max] = [$max, $min];
-			}
-
-			if ($min === null && $max === null) {
-				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-			}
-
-			return TypeCombinator::union(IntegerRangeType::fromInterval($min, $max), new FloatType());
-		} elseif ($node instanceof Expr\BinaryOp\ShiftLeft) {
-			if (!$operand instanceof ConstantIntegerType) {
-				return new IntegerType();
-			}
-			if ($operand->getValue() < 0) {
-				return new ErrorType();
-			}
-			$min = $rangeMin !== null ? intval($rangeMin) << $operand->getValue() : null;
-			$max = $rangeMax !== null ? intval($rangeMax) << $operand->getValue() : null;
-		} elseif ($node instanceof Expr\BinaryOp\ShiftRight) {
-			if (!$operand instanceof ConstantIntegerType) {
-				return new IntegerType();
-			}
-			if ($operand->getValue() < 0) {
-				return new ErrorType();
-			}
-			$min = $rangeMin !== null ? intval($rangeMin) >> $operand->getValue() : null;
-			$max = $rangeMax !== null ? intval($rangeMax) >> $operand->getValue() : null;
-		} else {
-			throw new ShouldNotHappenException();
-		}
-
-		if (is_float($min)) {
-			$min = null;
-		}
-		if (is_float($max)) {
-			$max = null;
-		}
-
-		return IntegerRangeType::fromInterval($min, $max);
+		return ArithmeticOpHelper::commonMath($expr->getOperatorSigil(), $leftType, $rightType);
 	}
 
 	/**

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1638,40 +1638,13 @@ final class InitializerExprTypeResolver
 
 	public function getMinusTypeFromTypes(Expr $left, Expr $right, Type $leftType, Type $rightType): Type
 	{
-		$leftTypes = $leftType->getConstantScalarTypes();
-		$rightTypes = $rightType->getConstantScalarTypes();
-		$leftTypesCount = count($leftTypes);
-		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
-			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			if (!$generalize) {
-				foreach ($leftTypes as $leftTypeInner) {
-					foreach ($rightTypes as $rightTypeInner) {
-						$leftNumberType = $leftTypeInner->toNumber();
-						$rightNumberType = $rightTypeInner->toNumber();
-
-						if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-							return new ErrorType();
-						}
-
-						if (!$leftNumberType instanceof ConstantScalarType || !$rightNumberType instanceof ConstantScalarType) {
-							throw new ShouldNotHappenException();
-						}
-
-						$resultType = $this->getTypeFromValue($leftNumberType->getValue() - $rightNumberType->getValue());
-						$resultTypes[] = $resultType;
-					}
-				}
-
-				return TypeCombinator::union(...$resultTypes);
-			}
-
-			$leftType = $this->optimizeScalarType($leftType);
-			$rightType = $this->optimizeScalarType($rightType);
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\Minus($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
 		}
 
-		return $this->resolveCommonMath(new BinaryOp\Minus($left, $right), $leftType, $rightType);
+		return $leftType->minus($rightType);
 	}
 
 	/**

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -53,6 +53,7 @@ use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
 use PHPStan\Type\Accessory\HasOffsetValueType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArithmeticOpHelper;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
@@ -1912,29 +1913,7 @@ final class InitializerExprTypeResolver
 
 	private function optimizeScalarType(Type $type): Type
 	{
-		$types = [];
-		if ($type->isInteger()->yes()) {
-			$types[] = new IntegerType();
-		}
-		if ($type->isString()->yes()) {
-			$types[] = new StringType();
-		}
-		if ($type->isFloat()->yes()) {
-			$types[] = new FloatType();
-		}
-		if ($type->isNull()->yes()) {
-			$types[] = new NullType();
-		}
-
-		if (count($types) === 0) {
-			return new ErrorType();
-		}
-
-		if (count($types) === 1) {
-			return $types[0];
-		}
-
-		return new UnionType($types);
+		return ArithmeticOpHelper::optimizeScalarType($type);
 	}
 
 	/**
@@ -2722,14 +2701,7 @@ final class InitializerExprTypeResolver
 
 	private function getNeverType(Type $leftType, Type $rightType): Type
 	{
-		// make sure we don't lose the explicit flag in the process
-		if ($leftType instanceof NeverType && $leftType->isExplicit()) {
-			return $leftType;
-		}
-		if ($rightType instanceof NeverType && $rightType->isExplicit()) {
-			return $rightType;
-		}
-		return new NeverType();
+		return ArithmeticOpHelper::getNeverType($leftType, $rightType);
 	}
 
 }

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -540,6 +540,16 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -545,6 +545,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -545,6 +545,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -545,6 +545,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -545,6 +545,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -545,6 +545,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -545,6 +545,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -375,6 +375,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -375,6 +375,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -375,6 +375,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -375,6 +375,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -375,6 +375,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -370,6 +370,16 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return new StringType();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new BenevolentUnionType([

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -375,6 +375,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -375,6 +375,16 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 		return new StringType();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new BenevolentUnionType([

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -384,6 +384,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -384,6 +384,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -379,6 +379,16 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new BenevolentUnionType([

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -384,6 +384,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -384,6 +384,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -384,6 +384,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -384,6 +384,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -376,6 +376,16 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return new StringType();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new BenevolentUnionType([

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -381,6 +381,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -381,6 +381,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -381,6 +381,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -381,6 +381,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -381,6 +381,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -381,6 +381,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -384,6 +384,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -384,6 +384,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -384,6 +384,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -384,6 +384,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -379,6 +379,16 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new BenevolentUnionType([

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -384,6 +384,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -384,6 +384,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -375,6 +375,16 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 		return new StringType();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new BenevolentUnionType([

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -380,6 +380,11 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -326,6 +326,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -326,6 +326,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -326,6 +326,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -326,6 +326,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -321,6 +321,16 @@ class HasMethodType implements AccessoryType, CompoundType
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -326,6 +326,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -326,6 +326,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -447,6 +447,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -447,6 +447,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -447,6 +447,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -447,6 +447,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -442,6 +442,16 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -447,6 +447,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -447,6 +447,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -536,6 +536,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -536,6 +536,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -536,6 +536,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -536,6 +536,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -536,6 +536,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -531,6 +531,16 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new self($this->offsetType, $newValueType);
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -536,6 +536,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -304,6 +304,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -304,6 +304,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -304,6 +304,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -299,6 +299,16 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -304,6 +304,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -304,6 +304,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -304,6 +304,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -528,6 +528,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -528,6 +528,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -523,6 +523,16 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -528,6 +528,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -528,6 +528,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -528,6 +528,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -528,6 +528,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -500,6 +500,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -500,6 +500,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -500,6 +500,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -500,6 +500,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -495,6 +495,16 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -500,6 +500,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -500,6 +500,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use function assert;
 use function ceil;
@@ -51,6 +52,32 @@ final class ArithmeticOpHelper
 	public static function minus(Type $leftType, Type $rightType): Type
 	{
 		return self::numericOp($leftType, $rightType, self::OP_MINUS, static fn ($left, $right) => $left - $right);
+	}
+
+	public static function multiply(Type $leftType, Type $rightType): Type
+	{
+		$zero = self::multiplyByZero($leftType, $rightType) ?? self::multiplyByZero($rightType, $leftType);
+		if ($zero !== null) {
+			return $zero;
+		}
+
+		return self::numericOp($leftType, $rightType, self::OP_MUL, static fn ($left, $right) => $left * $right);
+	}
+
+	/**
+	 * x * 0 collapses to exactly 0 (0.0 when the other operand is a float), but only when the other
+	 * operand is non-constant — two constants are left to the fold so that e.g. 0 * INF stays NAN.
+	 */
+	private static function multiplyByZero(Type $zeroCandidate, Type $other): ?Type
+	{
+		if ($zeroCandidate->toNumber()->getConstantScalarValues() !== [0]) {
+			return null;
+		}
+		if ($other->toNumber()->getConstantScalarValues() !== []) {
+			return null;
+		}
+
+		return $other->isFloat()->yes() ? new ConstantFloatType(0.0) : new ConstantIntegerType(0);
 	}
 
 	/**
@@ -159,22 +186,44 @@ final class ArithmeticOpHelper
 			$rightNumber = self::optimizeScalarType($rightNumber);
 		}
 
-		$leftPieces = self::integerPieces($leftNumber);
-		$rightPieces = self::integerPieces($rightNumber);
-		if ($leftPieces !== [] && $rightPieces !== []) {
-			$results = [];
-			foreach ($leftPieces as [$leftPieceMin, $leftPieceMax]) {
-				foreach ($rightPieces as [$rightPieceMin, $rightPieceMax]) {
-					$results[] = self::combineIntegerRanges($leftPieceMin, $leftPieceMax, $rightPieceMin, $rightPieceMax, $op);
+		// Integer-range math is skipped for mixed operands, which fall straight through to the
+		// benevolent/mixed promotion in numericGeneral() (mirrors the old commonMath()).
+		if (!TypeCombinator::union($leftType, $rightType) instanceof MixedType) {
+			// A union right operand is mapped member by member: the left operand dispatches via Type::op(),
+			// but a union on the right (e.g. float|int<min, 6> from a division) has to be distributed here so
+			// its non-integer members are not dropped by the integer-range decomposition below.
+			if ($rightNumber instanceof UnionType) {
+				$results = [];
+				foreach ($rightNumber->getTypes() as $rightMember) {
+					$results[] = self::numericOp($leftNumber, $rightMember, $op, $scalarFold);
 				}
+
+				$union = TypeCombinator::union(...$results);
+				if ($rightNumber instanceof BenevolentUnionType) {
+					return TypeUtils::toBenevolentUnion($union)->toNumber();
+				}
+
+				return $union;
 			}
 
-			$union = TypeCombinator::union(...$results);
-			if ($leftNumber instanceof BenevolentUnionType || $rightNumber instanceof BenevolentUnionType) {
-				return TypeUtils::toBenevolentUnion($union)->toNumber();
-			}
+			$leftPieces = self::integerPieces($leftNumber);
+			$rightPieces = self::integerPieces($rightNumber);
+			if ($leftPieces !== [] && $rightPieces !== []) {
+				$results = [];
+				foreach ($leftPieces as [$leftPieceMin, $leftPieceMax]) {
+					foreach ($rightPieces as [$rightPieceMin, $rightPieceMax]) {
+						$results[] = self::combineIntegerRanges($leftPieceMin, $leftPieceMax, $rightPieceMin, $rightPieceMax, $op);
+					}
+				}
 
-			return $union;
+				$union = TypeCombinator::union(...$results);
+				// rightNumber is no longer a union here (mapped above), so only leftNumber can be benevolent
+				if ($leftNumber instanceof BenevolentUnionType) {
+					return TypeUtils::toBenevolentUnion($union)->toNumber();
+				}
+
+				return $union;
+			}
 		}
 
 		return self::numericGeneral($op, $leftType, $rightType, $leftNumber, $rightNumber);

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -82,6 +82,107 @@ final class ArithmeticOpHelper
 		});
 	}
 
+	public static function modulo(Type $leftType, Type $rightType): Type
+	{
+		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
+			return self::getNeverType($leftType, $rightType);
+		}
+
+		$leftNumber = $leftType->toNumber();
+		$rightNumber = $rightType->toNumber();
+		if ($leftNumber instanceof ErrorType || $rightNumber instanceof ErrorType) {
+			return new ErrorType();
+		}
+
+		$leftValues = $leftNumber->getConstantScalarValues();
+		$rightValues = $rightNumber->getConstantScalarValues();
+		if (
+			$leftValues !== [] && $rightValues !== []
+			&& count($leftValues) * count($rightValues) <= InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT
+		) {
+			$results = [];
+			foreach ($leftValues as $leftValue) {
+				foreach ($rightValues as $rightValue) {
+					$rightIntegerValue = (int) $rightValue;
+					if ($rightIntegerValue === 0) {
+						return new ErrorType();
+					}
+					$results[] = ConstantTypeHelper::getTypeFromValue((int) $leftValue % $rightIntegerValue);
+				}
+			}
+
+			return TypeCombinator::union(...$results);
+		}
+
+		// x % 1 is always 0
+		if ($rightType->toInteger()->getConstantScalarValues() === [1]) {
+			return new ConstantIntegerType(0);
+		}
+
+		// modulo by a type that includes a constant 0 is a runtime error
+		foreach ($rightValues as $rightValue) {
+			if (in_array($rightValue, [0, 0.0], true)) {
+				return new ErrorType();
+			}
+		}
+
+		$positiveInt = IntegerRangeType::fromInterval(0, null);
+		if (!$rightType->isInteger()->yes()) {
+			if ($positiveInt->isSuperTypeOf($leftType)->yes()) {
+				return IntegerRangeType::fromInterval(0, null);
+			}
+
+			return new IntegerType();
+		}
+
+		$rangeMax = self::moduloRangeMax($rightType);
+		$rangeMin = null;
+		if ($positiveInt->isSuperTypeOf($leftType)->yes()) {
+			$rangeMin = 0;
+		} elseif ($rangeMax !== null) {
+			$rangeMin = $rangeMax * -1;
+		}
+
+		return IntegerRangeType::fromInterval($rangeMin, $rangeMax);
+	}
+
+	/**
+	 * The upper bound for x % divisor, derived from the divisor's integer bounds via getIntegerRanges()
+	 * and getConstantScalarValues() rather than by inspecting operand classes.
+	 */
+	private static function moduloRangeMax(Type $rightType): ?int
+	{
+		if ($rightType instanceof UnionType) {
+			$rangeMax = null;
+			foreach ($rightType->getTypes() as $member) {
+				$ranges = $member->getIntegerRanges();
+				if ($ranges !== []) {
+					$memberMax = $ranges[0]->getMax();
+					$rangeMax = $memberMax === null ? null : max($rangeMax, $memberMax);
+				} else {
+					foreach ($member->toInteger()->getConstantScalarValues() as $value) {
+						$rangeMax = max($rangeMax, (int) $value - 1);
+					}
+				}
+			}
+
+			return $rangeMax;
+		}
+
+		$ranges = $rightType->getIntegerRanges();
+		if ($ranges !== []) {
+			$max = $ranges[0]->getMax();
+			return $max !== null ? $max - 1 : null;
+		}
+
+		$constValues = $rightType->toInteger()->getConstantScalarValues();
+		if ($constValues !== []) {
+			return (int) $constValues[0] - 1;
+		}
+
+		return null;
+	}
+
 	/**
 	 * x * 0 collapses to exactly 0 (0.0 when the other operand is a float), but only when the other
 	 * operand is non-constant — two constants are left to the fold so that e.g. 0 * INF stays NAN.

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -4,14 +4,16 @@ namespace PHPStan\Type;
 
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\HasOffsetValueType;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
-use function assert;
 use function ceil;
 use function count;
 use function floor;
 use function in_array;
-use function intval;
 use function is_finite;
 use function is_float;
 use function is_int;
@@ -36,8 +38,6 @@ final class ArithmeticOpHelper
 	private const OP_MINUS = '-';
 	private const OP_MUL = '*';
 	private const OP_DIV = '/';
-	private const OP_SHIFT_LEFT = '<<';
-	private const OP_SHIFT_RIGHT = '>>';
 
 	public static function shiftLeft(Type $leftType, Type $rightType): Type
 	{
@@ -52,6 +52,180 @@ final class ArithmeticOpHelper
 	public static function minus(Type $leftType, Type $rightType): Type
 	{
 		return self::numericOp($leftType, $rightType, self::OP_MINUS, static fn ($left, $right) => $left - $right);
+	}
+
+	public static function plus(Type $leftType, Type $rightType): Type
+	{
+		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
+			return self::getNeverType($leftType, $rightType);
+		}
+
+		// The + operator unions arrays; only when neither operand is array-shaped does it add numbers.
+		$arrayResult = self::plusArrays($leftType, $rightType);
+		if ($arrayResult !== null) {
+			return $arrayResult;
+		}
+
+		return self::numericOp($leftType, $rightType, self::OP_PLUS, static fn ($left, $right) => $left + $right);
+	}
+
+	/**
+	 * The array semantics of the + operator (constant-array merge, array union with accessories, and the
+	 * array/non-array error and mixed cases). Returns null when neither operand is array-shaped, so the
+	 * caller falls back to numeric addition. Inspects operands via getConstantArrays()/isArray()/etc.
+	 */
+	private static function plusArrays(Type $leftType, Type $rightType): ?Type
+	{
+		$leftConstantArrays = $leftType->getConstantArrays();
+		$rightConstantArrays = $rightType->getConstantArrays();
+
+		$leftCount = count($leftConstantArrays);
+		$rightCount = count($rightConstantArrays);
+		if ($leftCount > 0 && $rightCount > 0
+			&& ($leftCount + $rightCount < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
+			$resultTypes = [];
+			foreach ($rightConstantArrays as $rightConstantArray) {
+				foreach ($leftConstantArrays as $leftConstantArray) {
+					$newArrayBuilder = ConstantArrayTypeBuilder::createFromConstantArray($rightConstantArray);
+					foreach ($leftConstantArray->getKeyTypes() as $i => $leftKeyType) {
+						$optional = $leftConstantArray->isOptionalKey($i);
+						$valueType = $leftConstantArray->getOffsetValueType($leftKeyType);
+						if (!$optional) {
+							if ($rightConstantArray->hasOffsetValueType($leftKeyType)->maybe()) {
+								$valueType = TypeCombinator::union($valueType, $rightConstantArray->getOffsetValueType($leftKeyType));
+							}
+						}
+						$newArrayBuilder->setOffsetValueType(
+							$leftKeyType,
+							$valueType,
+							$optional,
+						);
+					}
+					$resultTypes[] = $newArrayBuilder->getArray();
+				}
+			}
+			return TypeCombinator::union(...$resultTypes);
+		}
+
+		$leftIsArray = $leftType->isArray();
+		$rightIsArray = $rightType->isArray();
+		if ($leftIsArray->yes() && $rightIsArray->yes()) {
+			if ($leftType->getIterableKeyType()->equals($rightType->getIterableKeyType())) {
+				// to preserve BenevolentUnionType
+				$keyType = $leftType->getIterableKeyType();
+			} else {
+				$keyTypes = [];
+				foreach ([
+					$leftType->getIterableKeyType(),
+					$rightType->getIterableKeyType(),
+				] as $keyType) {
+					$keyTypes[] = $keyType;
+				}
+				$keyType = TypeCombinator::union(...$keyTypes);
+			}
+
+			$leftIterableValueType = $leftType->getIterableValueType();
+			$arrayType = new ArrayType(
+				$keyType,
+				TypeCombinator::union($leftIterableValueType, $rightType->getIterableValueType()),
+			);
+
+			$accessories = [];
+			if ($leftCount > 0) {
+				// Use the first constant array as a reference to list potential offsets.
+				// We only need to check the first array because we're looking for offsets that exist in ALL arrays.
+				$constantArray = $leftConstantArrays[0];
+				foreach ($constantArray->getKeyTypes() as $offsetType) {
+					if (!$leftType->hasOffsetValueType($offsetType)->yes()) {
+						continue;
+					}
+
+					$valueType = $leftType->getOffsetValueType($offsetType);
+					$accessories[] = new HasOffsetValueType($offsetType, $valueType);
+				}
+			}
+
+			if ($rightCount > 0) {
+				// Use the first constant array as a reference to list potential offsets.
+				// We only need to check the first array because we're looking for offsets that exist in ALL arrays.
+				$constantArray = $rightConstantArrays[0];
+				foreach ($constantArray->getKeyTypes() as $offsetType) {
+					if (!$rightType->hasOffsetValueType($offsetType)->yes()) {
+						continue;
+					}
+
+					$valueType = TypeCombinator::union($leftIterableValueType, $rightType->getOffsetValueType($offsetType));
+					$accessories[] = new HasOffsetValueType($offsetType, $valueType);
+				}
+			}
+
+			if ($leftType->isIterableAtLeastOnce()->yes() || $rightType->isIterableAtLeastOnce()->yes()) {
+				$accessories[] = new NonEmptyArrayType();
+			}
+			if ($leftType->isList()->yes() && $rightType->isList()->yes()) {
+				$accessories[] = new AccessoryArrayListType();
+			}
+
+			if (count($accessories) > 0) {
+				$arrayType = TypeCombinator::intersect($arrayType, ...$accessories);
+			}
+
+			return $arrayType;
+		}
+
+		if ($leftType instanceof MixedType && $rightType instanceof MixedType) {
+			if ($leftIsArray->no() && $rightIsArray->no()) {
+				return null;
+			}
+			return new BenevolentUnionType([
+				new FloatType(),
+				new IntegerType(),
+				new ArrayType(new MixedType(), new MixedType()),
+			]);
+		}
+
+		if (
+			($leftIsArray->yes() && $rightIsArray->no())
+			|| ($leftIsArray->no() && $rightIsArray->yes())
+		) {
+			return new ErrorType();
+		}
+
+		if (
+			($leftIsArray->yes() && $rightIsArray->maybe())
+			|| ($leftIsArray->maybe() && $rightIsArray->yes())
+		) {
+			$resultType = new ArrayType(new MixedType(), new MixedType());
+			if ($leftType->isIterableAtLeastOnce()->yes() || $rightType->isIterableAtLeastOnce()->yes()) {
+				return TypeCombinator::intersect($resultType, new NonEmptyArrayType());
+			}
+
+			return $resultType;
+		}
+
+		if ($leftIsArray->maybe() && $rightIsArray->maybe()) {
+			$plusable = new UnionType([
+				new StringType(),
+				new FloatType(),
+				new IntegerType(),
+				new ArrayType(new MixedType(), new MixedType()),
+				new BooleanType(),
+			]);
+
+			$plusableSuperTypeOfLeft = $plusable->isSuperTypeOf($leftType)->yes();
+			$plusableSuperTypeOfRight = $plusable->isSuperTypeOf($rightType)->yes();
+			if ($plusableSuperTypeOfLeft && $plusableSuperTypeOfRight) {
+				return TypeCombinator::union($leftType, $rightType);
+			}
+			if ($plusableSuperTypeOfLeft && $rightType instanceof MixedType) {
+				return $leftType;
+			}
+			if ($plusableSuperTypeOfRight && $leftType instanceof MixedType) {
+				return $rightType;
+			}
+		}
+
+		return null;
 	}
 
 	public static function multiply(Type $leftType, Type $rightType): Type
@@ -562,343 +736,6 @@ final class ArithmeticOpHelper
 		}
 
 		return TypeCombinator::union(IntegerRangeType::fromInterval($min, $max), new FloatType());
-	}
-
-	/**
-	 * Post-fold numeric core: integer-range math, float promotion and benevolent/mixed handling.
-	 * Public during the migration of the remaining operators out of InitializerExprTypeResolver.
-	 */
-	public static function commonMath(string $op, Type $leftType, Type $rightType): Type
-	{
-		$types = TypeCombinator::union($leftType, $rightType);
-		$leftNumberType = $leftType->toNumber();
-		$rightNumberType = $rightType->toNumber();
-
-		if (
-			!$types instanceof MixedType
-			&& (
-				$rightNumberType instanceof IntegerRangeType
-				|| $rightNumberType instanceof ConstantIntegerType
-				|| $rightNumberType instanceof UnionType
-			)
-		) {
-			if ($leftNumberType instanceof IntegerRangeType || $leftNumberType instanceof ConstantIntegerType) {
-				return self::integerRangeMath(
-					$leftNumberType,
-					$op,
-					$rightNumberType,
-				);
-			} elseif ($leftNumberType instanceof UnionType) {
-				$unionParts = [];
-
-				foreach ($leftNumberType->getTypes() as $type) {
-					$numberType = $type->toNumber();
-					if ($numberType instanceof IntegerRangeType || $numberType instanceof ConstantIntegerType) {
-						$unionParts[] = self::integerRangeMath($numberType, $op, $rightNumberType);
-					} else {
-						$unionParts[] = $numberType;
-					}
-				}
-
-				$union = TypeCombinator::union(...$unionParts);
-				if ($leftNumberType instanceof BenevolentUnionType) {
-					return TypeUtils::toBenevolentUnion($union)->toNumber();
-				}
-
-				return $union->toNumber();
-			}
-		}
-
-		if (
-			$leftType->isArray()->yes()
-			|| $rightType->isArray()->yes()
-			|| $types->isArray()->yes()
-		) {
-			return new ErrorType();
-		}
-
-		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
-			return new ErrorType();
-		}
-		if ($leftNumberType instanceof NeverType || $rightNumberType instanceof NeverType) {
-			return self::getNeverType($leftNumberType, $rightNumberType);
-		}
-
-		if (
-			$leftNumberType->isFloat()->yes()
-			|| $rightNumberType->isFloat()->yes()
-		) {
-			if (in_array($op, [self::OP_SHIFT_LEFT, self::OP_SHIFT_RIGHT], true)) {
-				return new IntegerType();
-			}
-			return new FloatType();
-		}
-
-		$resultType = TypeCombinator::union($leftNumberType, $rightNumberType);
-		if ($op === self::OP_DIV) {
-			if ($types instanceof MixedType || $resultType->isInteger()->yes()) {
-				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-			}
-
-			return new UnionType([new IntegerType(), new FloatType()]);
-		}
-
-		if ($types instanceof MixedType
-			|| $leftType instanceof BenevolentUnionType
-			|| $rightType instanceof BenevolentUnionType
-		) {
-			return TypeUtils::toBenevolentUnion($resultType);
-		}
-
-		return $resultType;
-	}
-
-	/**
-	 * @param ConstantIntegerType|IntegerRangeType $range
-	 */
-	private static function integerRangeMath(Type $range, string $op, Type $operand): Type
-	{
-		if ($range instanceof IntegerRangeType) {
-			$rangeMin = $range->getMin();
-			$rangeMax = $range->getMax();
-		} else {
-			$rangeMin = $range->getValue();
-			$rangeMax = $rangeMin;
-		}
-
-		if ($operand instanceof UnionType) {
-
-			$unionParts = [];
-
-			foreach ($operand->getTypes() as $type) {
-				$numberType = $type->toNumber();
-				if ($numberType instanceof IntegerRangeType || $numberType instanceof ConstantIntegerType) {
-					$unionParts[] = self::integerRangeMath($range, $op, $numberType);
-				} else {
-					$unionParts[] = $type->toNumber();
-				}
-			}
-
-			$union = TypeCombinator::union(...$unionParts);
-			if ($operand instanceof BenevolentUnionType) {
-				return TypeUtils::toBenevolentUnion($union)->toNumber();
-			}
-
-			return $union->toNumber();
-		}
-
-		$operand = $operand->toNumber();
-		if ($operand instanceof IntegerRangeType) {
-			$operandMin = $operand->getMin();
-			$operandMax = $operand->getMax();
-		} elseif ($operand instanceof ConstantIntegerType) {
-			$operandMin = $operand->getValue();
-			$operandMax = $operand->getValue();
-		} else {
-			return $operand;
-		}
-
-		if ($op === self::OP_PLUS) {
-			if ($operand instanceof ConstantIntegerType) {
-				/** @var int|float|null $min */
-				$min = $rangeMin !== null ? $rangeMin + $operand->getValue() : null;
-
-				/** @var int|float|null $max */
-				$max = $rangeMax !== null ? $rangeMax + $operand->getValue() : null;
-			} else {
-				/** @var int|float|null $min */
-				$min = $rangeMin !== null && $operand->getMin() !== null ? $rangeMin + $operand->getMin() : null;
-
-				/** @var int|float|null $max */
-				$max = $rangeMax !== null && $operand->getMax() !== null ? $rangeMax + $operand->getMax() : null;
-			}
-		} elseif ($op === self::OP_MINUS) {
-			if ($operand instanceof ConstantIntegerType) {
-				/** @var int|float|null $min */
-				$min = $rangeMin !== null ? $rangeMin - $operand->getValue() : null;
-
-				/** @var int|float|null $max */
-				$max = $rangeMax !== null ? $rangeMax - $operand->getValue() : null;
-			} else {
-				if ($rangeMin === $rangeMax && $rangeMin !== null
-					&& ($operand->getMin() === null || $operand->getMax() === null)) {
-					$min = null;
-					$max = $rangeMin;
-				} else {
-					if ($operand->getMin() === null) {
-						$min = null;
-					} elseif ($rangeMin !== null) {
-						if ($operand->getMax() !== null) {
-							/** @var int|float $min */
-							$min = $rangeMin - $operand->getMax();
-						} else {
-							/** @var int|float $min */
-							$min = $rangeMin - $operand->getMin();
-						}
-					} else {
-						$min = null;
-					}
-
-					if ($operand->getMax() === null) {
-						$min = null;
-						$max = null;
-					} elseif ($rangeMax !== null) {
-						if ($rangeMin !== null && $operand->getMin() === null) {
-							/** @var int|float $min */
-							$min = $rangeMin - $operand->getMax();
-							$max = null;
-						} elseif ($operand->getMin() !== null) {
-							/** @var int|float $max */
-							$max = $rangeMax - $operand->getMin();
-						} else {
-							$max = null;
-						}
-					} else {
-						$max = null;
-					}
-
-					if ($min !== null && $max !== null && $min > $max) {
-						[$min, $max] = [$max, $min];
-					}
-				}
-			}
-		} elseif ($op === self::OP_MUL) {
-			$min1 = $rangeMin === 0 || $operandMin === 0 ? 0 : ($rangeMin ?? -INF) * ($operandMin ?? -INF);
-			$min2 = $rangeMin === 0 || $operandMax === 0 ? 0 : ($rangeMin ?? -INF) * ($operandMax ?? INF);
-			$max1 = $rangeMax === 0 || $operandMin === 0 ? 0 : ($rangeMax ?? INF) * ($operandMin ?? -INF);
-			$max2 = $rangeMax === 0 || $operandMax === 0 ? 0 : ($rangeMax ?? INF) * ($operandMax ?? INF);
-
-			$min = min($min1, $min2, $max1, $max2);
-			$max = max($min1, $min2, $max1, $max2);
-
-			if (!is_finite($min)) {
-				$min = null;
-			}
-			if (!is_finite($max)) {
-				$max = null;
-			}
-		} elseif ($op === self::OP_DIV) {
-			if ($operand instanceof ConstantIntegerType) {
-				$min = $rangeMin !== null && $operand->getValue() !== 0 ? $rangeMin / $operand->getValue() : null;
-				$max = $rangeMax !== null && $operand->getValue() !== 0 ? $rangeMax / $operand->getValue() : null;
-			} else {
-				// Avoid division by zero when looking for the min and the max by using the closest int
-				$operandMin = $operandMin !== 0 ? $operandMin : 1;
-				$operandMax = $operandMax !== 0 ? $operandMax : -1;
-
-				if (
-					($operandMin < 0 || $operandMin === null)
-					&& ($operandMax > 0 || $operandMax === null)
-				) {
-					$negativeOperand = IntegerRangeType::fromInterval($operandMin, 0);
-					assert($negativeOperand instanceof IntegerRangeType);
-					$positiveOperand = IntegerRangeType::fromInterval(0, $operandMax);
-					assert($positiveOperand instanceof IntegerRangeType);
-
-					$result = TypeCombinator::union(
-						self::integerRangeMath($range, $op, $negativeOperand),
-						self::integerRangeMath($range, $op, $positiveOperand),
-					)->toNumber();
-
-					if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
-						return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-					}
-
-					return $result;
-				}
-				if (
-					($rangeMin < 0 || $rangeMin === null)
-					&& ($rangeMax > 0 || $rangeMax === null)
-				) {
-					$negativeRange = IntegerRangeType::fromInterval($rangeMin, 0);
-					assert($negativeRange instanceof IntegerRangeType);
-					$positiveRange = IntegerRangeType::fromInterval(0, $rangeMax);
-					assert($positiveRange instanceof IntegerRangeType);
-
-					$result = TypeCombinator::union(
-						self::integerRangeMath($negativeRange, $op, $operand),
-						self::integerRangeMath($positiveRange, $op, $operand),
-					)->toNumber();
-
-					if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
-						return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-					}
-
-					return $result;
-				}
-
-				$rangeMinSign = ($rangeMin ?? -INF) <=> 0;
-				$rangeMaxSign = ($rangeMax ?? INF) <=> 0;
-
-				$min1 = $operandMin !== null ? ($rangeMin ?? -INF) / $operandMin : $rangeMinSign * -0.1;
-				$min2 = $operandMax !== null ? ($rangeMin ?? -INF) / $operandMax : $rangeMinSign * 0.1;
-				$max1 = $operandMin !== null ? ($rangeMax ?? INF) / $operandMin : $rangeMaxSign * -0.1;
-				$max2 = $operandMax !== null ? ($rangeMax ?? INF) / $operandMax : $rangeMaxSign * 0.1;
-
-				$min = min($min1, $min2, $max1, $max2);
-				$max = max($min1, $min2, $max1, $max2);
-
-				if ($min === -INF) {
-					$min = null;
-				}
-				if ($max === INF) {
-					$max = null;
-				}
-			}
-
-			if ($min !== null && $max !== null && $min > $max) {
-				[$min, $max] = [$max, $min];
-			}
-
-			if (is_float($min)) {
-				$min = (int) ceil($min);
-			}
-			if (is_float($max)) {
-				$max = (int) floor($max);
-			}
-
-			// invert maximas on division with negative constants
-			if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
-					|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
-				&& ($min === null || $max === null)) {
-				[$min, $max] = [$max, $min];
-			}
-
-			if ($min === null && $max === null) {
-				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
-			}
-
-			return TypeCombinator::union(IntegerRangeType::fromInterval($min, $max), new FloatType());
-		} elseif ($op === self::OP_SHIFT_LEFT) {
-			if (!$operand instanceof ConstantIntegerType) {
-				return new IntegerType();
-			}
-			if ($operand->getValue() < 0) {
-				return new ErrorType();
-			}
-			$min = $rangeMin !== null ? intval($rangeMin) << $operand->getValue() : null;
-			$max = $rangeMax !== null ? intval($rangeMax) << $operand->getValue() : null;
-		} elseif ($op === self::OP_SHIFT_RIGHT) {
-			if (!$operand instanceof ConstantIntegerType) {
-				return new IntegerType();
-			}
-			if ($operand->getValue() < 0) {
-				return new ErrorType();
-			}
-			$min = $rangeMin !== null ? intval($rangeMin) >> $operand->getValue() : null;
-			$max = $rangeMax !== null ? intval($rangeMax) >> $operand->getValue() : null;
-		} else {
-			throw new ShouldNotHappenException();
-		}
-
-		if (is_float($min)) {
-			$min = null;
-		}
-		if (is_float($max)) {
-			$max = null;
-		}
-
-		return IntegerRangeType::fromInterval($min, $max);
 	}
 
 	/**

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -42,6 +42,11 @@ final class ArithmeticOpHelper
 		return self::shift($leftType, $rightType, static fn (int $value, int $amount): int => $value << $amount);
 	}
 
+	public static function shiftRight(Type $leftType, Type $rightType): Type
+	{
+		return self::shift($leftType, $rightType, static fn (int $value, int $amount): int => $value >> $amount);
+	}
+
 	/**
 	 * Shared implementation of the << and >> operators. The shift amount must be one or more constant
 	 * non-negative integers, otherwise the result is a plain int (shifting always yields an int). The

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -2,7 +2,20 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\Reflection\InitializerExprTypeResolver;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use function assert;
+use function ceil;
 use function count;
+use function floor;
+use function in_array;
+use function intval;
+use function is_finite;
+use function is_float;
+use function max;
+use function min;
+use const INF;
 
 /**
  * Shared implementation of the arithmetic/shift binary operators (+, -, *, /, %, <<, >>)
@@ -11,11 +24,419 @@ use function count;
  * InitializerExprTypeResolver before they were made polymorphic; this helper keeps them in a
  * single place so the leaf Type implementations stay one-liners.
  *
- * The GMP/BcMath operator-extension dispatch and NeverType wrapping stay in
- * InitializerExprTypeResolver (see getPowTypeFromTypes for the same split with exponentiate()).
+ * The GMP/BcMath operator-extension dispatch stays in InitializerExprTypeResolver (see
+ * getPowTypeFromTypes for the same split with exponentiate()).
  */
 final class ArithmeticOpHelper
 {
+
+	private const OP_PLUS = '+';
+	private const OP_MINUS = '-';
+	private const OP_MUL = '*';
+	private const OP_DIV = '/';
+	private const OP_SHIFT_LEFT = '<<';
+	private const OP_SHIFT_RIGHT = '>>';
+
+	public static function shiftLeft(Type $leftType, Type $rightType): Type
+	{
+		return self::shift($leftType, $rightType, static fn (int $value, int $amount): int => $value << $amount);
+	}
+
+	/**
+	 * Shared implementation of the << and >> operators. The shift amount must be one or more constant
+	 * non-negative integers, otherwise the result is a plain int (shifting always yields an int). The
+	 * operands are decomposed polymorphically via getConstantScalarValues() and getIntegerRanges()
+	 * rather than by inspecting their classes.
+	 *
+	 * @param callable(int, int): int $operation
+	 */
+	private static function shift(Type $leftType, Type $rightType, callable $operation): Type
+	{
+		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
+			return self::getNeverType($leftType, $rightType);
+		}
+
+		$leftNumber = $leftType->toNumber();
+		$rightNumber = $rightType->toNumber();
+		if ($leftNumber instanceof ErrorType || $rightNumber instanceof ErrorType) {
+			return new ErrorType();
+		}
+
+		$amounts = $rightNumber->getConstantScalarValues();
+		if ($amounts === []) {
+			return new IntegerType();
+		}
+		foreach ($amounts as $amount) {
+			if ($amount < 0) {
+				return new ErrorType();
+			}
+		}
+
+		$leftValues = $leftNumber->getConstantScalarValues();
+		$leftRanges = $leftNumber->getIntegerRanges();
+		if ($leftValues === [] && $leftRanges === []) {
+			return new IntegerType();
+		}
+
+		if (count($leftValues) * count($amounts) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
+			return new IntegerType();
+		}
+
+		$results = [];
+		foreach ($amounts as $amount) {
+			$amount = (int) $amount;
+			foreach ($leftValues as $leftValue) {
+				$results[] = new ConstantIntegerType($operation((int) $leftValue, $amount));
+			}
+			foreach ($leftRanges as $range) {
+				$min = $range->getMin();
+				$max = $range->getMax();
+				$results[] = IntegerRangeType::fromInterval(
+					$min !== null ? $operation($min, $amount) : null,
+					$max !== null ? $operation($max, $amount) : null,
+				);
+			}
+		}
+
+		return TypeCombinator::union(...$results);
+	}
+
+	/**
+	 * Post-fold numeric core: integer-range math, float promotion and benevolent/mixed handling.
+	 * Public during the migration of the remaining operators out of InitializerExprTypeResolver.
+	 */
+	public static function commonMath(string $op, Type $leftType, Type $rightType): Type
+	{
+		$types = TypeCombinator::union($leftType, $rightType);
+		$leftNumberType = $leftType->toNumber();
+		$rightNumberType = $rightType->toNumber();
+
+		if (
+			!$types instanceof MixedType
+			&& (
+				$rightNumberType instanceof IntegerRangeType
+				|| $rightNumberType instanceof ConstantIntegerType
+				|| $rightNumberType instanceof UnionType
+			)
+		) {
+			if ($leftNumberType instanceof IntegerRangeType || $leftNumberType instanceof ConstantIntegerType) {
+				return self::integerRangeMath(
+					$leftNumberType,
+					$op,
+					$rightNumberType,
+				);
+			} elseif ($leftNumberType instanceof UnionType) {
+				$unionParts = [];
+
+				foreach ($leftNumberType->getTypes() as $type) {
+					$numberType = $type->toNumber();
+					if ($numberType instanceof IntegerRangeType || $numberType instanceof ConstantIntegerType) {
+						$unionParts[] = self::integerRangeMath($numberType, $op, $rightNumberType);
+					} else {
+						$unionParts[] = $numberType;
+					}
+				}
+
+				$union = TypeCombinator::union(...$unionParts);
+				if ($leftNumberType instanceof BenevolentUnionType) {
+					return TypeUtils::toBenevolentUnion($union)->toNumber();
+				}
+
+				return $union->toNumber();
+			}
+		}
+
+		if (
+			$leftType->isArray()->yes()
+			|| $rightType->isArray()->yes()
+			|| $types->isArray()->yes()
+		) {
+			return new ErrorType();
+		}
+
+		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
+			return new ErrorType();
+		}
+		if ($leftNumberType instanceof NeverType || $rightNumberType instanceof NeverType) {
+			return self::getNeverType($leftNumberType, $rightNumberType);
+		}
+
+		if (
+			$leftNumberType->isFloat()->yes()
+			|| $rightNumberType->isFloat()->yes()
+		) {
+			if (in_array($op, [self::OP_SHIFT_LEFT, self::OP_SHIFT_RIGHT], true)) {
+				return new IntegerType();
+			}
+			return new FloatType();
+		}
+
+		$resultType = TypeCombinator::union($leftNumberType, $rightNumberType);
+		if ($op === self::OP_DIV) {
+			if ($types instanceof MixedType || $resultType->isInteger()->yes()) {
+				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+			}
+
+			return new UnionType([new IntegerType(), new FloatType()]);
+		}
+
+		if ($types instanceof MixedType
+			|| $leftType instanceof BenevolentUnionType
+			|| $rightType instanceof BenevolentUnionType
+		) {
+			return TypeUtils::toBenevolentUnion($resultType);
+		}
+
+		return $resultType;
+	}
+
+	/**
+	 * @param ConstantIntegerType|IntegerRangeType $range
+	 */
+	private static function integerRangeMath(Type $range, string $op, Type $operand): Type
+	{
+		if ($range instanceof IntegerRangeType) {
+			$rangeMin = $range->getMin();
+			$rangeMax = $range->getMax();
+		} else {
+			$rangeMin = $range->getValue();
+			$rangeMax = $rangeMin;
+		}
+
+		if ($operand instanceof UnionType) {
+
+			$unionParts = [];
+
+			foreach ($operand->getTypes() as $type) {
+				$numberType = $type->toNumber();
+				if ($numberType instanceof IntegerRangeType || $numberType instanceof ConstantIntegerType) {
+					$unionParts[] = self::integerRangeMath($range, $op, $numberType);
+				} else {
+					$unionParts[] = $type->toNumber();
+				}
+			}
+
+			$union = TypeCombinator::union(...$unionParts);
+			if ($operand instanceof BenevolentUnionType) {
+				return TypeUtils::toBenevolentUnion($union)->toNumber();
+			}
+
+			return $union->toNumber();
+		}
+
+		$operand = $operand->toNumber();
+		if ($operand instanceof IntegerRangeType) {
+			$operandMin = $operand->getMin();
+			$operandMax = $operand->getMax();
+		} elseif ($operand instanceof ConstantIntegerType) {
+			$operandMin = $operand->getValue();
+			$operandMax = $operand->getValue();
+		} else {
+			return $operand;
+		}
+
+		if ($op === self::OP_PLUS) {
+			if ($operand instanceof ConstantIntegerType) {
+				/** @var int|float|null $min */
+				$min = $rangeMin !== null ? $rangeMin + $operand->getValue() : null;
+
+				/** @var int|float|null $max */
+				$max = $rangeMax !== null ? $rangeMax + $operand->getValue() : null;
+			} else {
+				/** @var int|float|null $min */
+				$min = $rangeMin !== null && $operand->getMin() !== null ? $rangeMin + $operand->getMin() : null;
+
+				/** @var int|float|null $max */
+				$max = $rangeMax !== null && $operand->getMax() !== null ? $rangeMax + $operand->getMax() : null;
+			}
+		} elseif ($op === self::OP_MINUS) {
+			if ($operand instanceof ConstantIntegerType) {
+				/** @var int|float|null $min */
+				$min = $rangeMin !== null ? $rangeMin - $operand->getValue() : null;
+
+				/** @var int|float|null $max */
+				$max = $rangeMax !== null ? $rangeMax - $operand->getValue() : null;
+			} else {
+				if ($rangeMin === $rangeMax && $rangeMin !== null
+					&& ($operand->getMin() === null || $operand->getMax() === null)) {
+					$min = null;
+					$max = $rangeMin;
+				} else {
+					if ($operand->getMin() === null) {
+						$min = null;
+					} elseif ($rangeMin !== null) {
+						if ($operand->getMax() !== null) {
+							/** @var int|float $min */
+							$min = $rangeMin - $operand->getMax();
+						} else {
+							/** @var int|float $min */
+							$min = $rangeMin - $operand->getMin();
+						}
+					} else {
+						$min = null;
+					}
+
+					if ($operand->getMax() === null) {
+						$min = null;
+						$max = null;
+					} elseif ($rangeMax !== null) {
+						if ($rangeMin !== null && $operand->getMin() === null) {
+							/** @var int|float $min */
+							$min = $rangeMin - $operand->getMax();
+							$max = null;
+						} elseif ($operand->getMin() !== null) {
+							/** @var int|float $max */
+							$max = $rangeMax - $operand->getMin();
+						} else {
+							$max = null;
+						}
+					} else {
+						$max = null;
+					}
+
+					if ($min !== null && $max !== null && $min > $max) {
+						[$min, $max] = [$max, $min];
+					}
+				}
+			}
+		} elseif ($op === self::OP_MUL) {
+			$min1 = $rangeMin === 0 || $operandMin === 0 ? 0 : ($rangeMin ?? -INF) * ($operandMin ?? -INF);
+			$min2 = $rangeMin === 0 || $operandMax === 0 ? 0 : ($rangeMin ?? -INF) * ($operandMax ?? INF);
+			$max1 = $rangeMax === 0 || $operandMin === 0 ? 0 : ($rangeMax ?? INF) * ($operandMin ?? -INF);
+			$max2 = $rangeMax === 0 || $operandMax === 0 ? 0 : ($rangeMax ?? INF) * ($operandMax ?? INF);
+
+			$min = min($min1, $min2, $max1, $max2);
+			$max = max($min1, $min2, $max1, $max2);
+
+			if (!is_finite($min)) {
+				$min = null;
+			}
+			if (!is_finite($max)) {
+				$max = null;
+			}
+		} elseif ($op === self::OP_DIV) {
+			if ($operand instanceof ConstantIntegerType) {
+				$min = $rangeMin !== null && $operand->getValue() !== 0 ? $rangeMin / $operand->getValue() : null;
+				$max = $rangeMax !== null && $operand->getValue() !== 0 ? $rangeMax / $operand->getValue() : null;
+			} else {
+				// Avoid division by zero when looking for the min and the max by using the closest int
+				$operandMin = $operandMin !== 0 ? $operandMin : 1;
+				$operandMax = $operandMax !== 0 ? $operandMax : -1;
+
+				if (
+					($operandMin < 0 || $operandMin === null)
+					&& ($operandMax > 0 || $operandMax === null)
+				) {
+					$negativeOperand = IntegerRangeType::fromInterval($operandMin, 0);
+					assert($negativeOperand instanceof IntegerRangeType);
+					$positiveOperand = IntegerRangeType::fromInterval(0, $operandMax);
+					assert($positiveOperand instanceof IntegerRangeType);
+
+					$result = TypeCombinator::union(
+						self::integerRangeMath($range, $op, $negativeOperand),
+						self::integerRangeMath($range, $op, $positiveOperand),
+					)->toNumber();
+
+					if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
+						return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+					}
+
+					return $result;
+				}
+				if (
+					($rangeMin < 0 || $rangeMin === null)
+					&& ($rangeMax > 0 || $rangeMax === null)
+				) {
+					$negativeRange = IntegerRangeType::fromInterval($rangeMin, 0);
+					assert($negativeRange instanceof IntegerRangeType);
+					$positiveRange = IntegerRangeType::fromInterval(0, $rangeMax);
+					assert($positiveRange instanceof IntegerRangeType);
+
+					$result = TypeCombinator::union(
+						self::integerRangeMath($negativeRange, $op, $operand),
+						self::integerRangeMath($positiveRange, $op, $operand),
+					)->toNumber();
+
+					if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
+						return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+					}
+
+					return $result;
+				}
+
+				$rangeMinSign = ($rangeMin ?? -INF) <=> 0;
+				$rangeMaxSign = ($rangeMax ?? INF) <=> 0;
+
+				$min1 = $operandMin !== null ? ($rangeMin ?? -INF) / $operandMin : $rangeMinSign * -0.1;
+				$min2 = $operandMax !== null ? ($rangeMin ?? -INF) / $operandMax : $rangeMinSign * 0.1;
+				$max1 = $operandMin !== null ? ($rangeMax ?? INF) / $operandMin : $rangeMaxSign * -0.1;
+				$max2 = $operandMax !== null ? ($rangeMax ?? INF) / $operandMax : $rangeMaxSign * 0.1;
+
+				$min = min($min1, $min2, $max1, $max2);
+				$max = max($min1, $min2, $max1, $max2);
+
+				if ($min === -INF) {
+					$min = null;
+				}
+				if ($max === INF) {
+					$max = null;
+				}
+			}
+
+			if ($min !== null && $max !== null && $min > $max) {
+				[$min, $max] = [$max, $min];
+			}
+
+			if (is_float($min)) {
+				$min = (int) ceil($min);
+			}
+			if (is_float($max)) {
+				$max = (int) floor($max);
+			}
+
+			// invert maximas on division with negative constants
+			if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
+					|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
+				&& ($min === null || $max === null)) {
+				[$min, $max] = [$max, $min];
+			}
+
+			if ($min === null && $max === null) {
+				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+			}
+
+			return TypeCombinator::union(IntegerRangeType::fromInterval($min, $max), new FloatType());
+		} elseif ($op === self::OP_SHIFT_LEFT) {
+			if (!$operand instanceof ConstantIntegerType) {
+				return new IntegerType();
+			}
+			if ($operand->getValue() < 0) {
+				return new ErrorType();
+			}
+			$min = $rangeMin !== null ? intval($rangeMin) << $operand->getValue() : null;
+			$max = $rangeMax !== null ? intval($rangeMax) << $operand->getValue() : null;
+		} elseif ($op === self::OP_SHIFT_RIGHT) {
+			if (!$operand instanceof ConstantIntegerType) {
+				return new IntegerType();
+			}
+			if ($operand->getValue() < 0) {
+				return new ErrorType();
+			}
+			$min = $rangeMin !== null ? intval($rangeMin) >> $operand->getValue() : null;
+			$max = $rangeMax !== null ? intval($rangeMax) >> $operand->getValue() : null;
+		} else {
+			throw new ShouldNotHappenException();
+		}
+
+		if (is_float($min)) {
+			$min = null;
+		}
+		if (is_float($max)) {
+			$max = null;
+		}
+
+		return IntegerRangeType::fromInterval($min, $max);
+	}
 
 	/**
 	 * Collapses a union of constant scalars into its base scalar categories. Used when a

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -64,6 +64,24 @@ final class ArithmeticOpHelper
 		return self::numericOp($leftType, $rightType, self::OP_MUL, static fn ($left, $right) => $left * $right);
 	}
 
+	public static function divide(Type $leftType, Type $rightType): Type
+	{
+		// dividing by a type that includes a constant 0 is a runtime error
+		foreach ($rightType->toNumber()->getConstantScalarValues() as $value) {
+			if (in_array($value, [0, 0.0], true)) {
+				return new ErrorType();
+			}
+		}
+
+		return self::numericOp($leftType, $rightType, self::OP_DIV, static function ($left, $right) {
+			if (in_array($right, [0, 0.0], true)) {
+				return null;
+			}
+
+			return $left / $right;
+		});
+	}
+
 	/**
 	 * x * 0 collapses to exactly 0 (0.0 when the other operand is a float), but only when the other
 	 * operand is non-constant — two constants are left to the fold so that e.g. 0 * INF stays NAN.
@@ -339,6 +357,8 @@ final class ArithmeticOpHelper
 			if (!is_finite($max)) {
 				$max = null;
 			}
+		} elseif ($op === self::OP_DIV) {
+			return self::divideIntegerRanges($leftMin, $leftMax, $rightMin, $rightMax);
 		} else {
 			throw new ShouldNotHappenException();
 		}
@@ -351,6 +371,96 @@ final class ArithmeticOpHelper
 		}
 
 		return IntegerRangeType::fromInterval($min, $max);
+	}
+
+	/**
+	 * Integer-range division, including the splits around zero crossings. Operates purely on bounds —
+	 * the constant-divisor optimisation is min === max, no operand classes are inspected.
+	 */
+	private static function divideIntegerRanges(?int $leftMin, ?int $leftMax, ?int $rightMin, ?int $rightMax): Type
+	{
+		$leftIsNegativeConstant = $leftMin === $leftMax && $leftMin !== null && $leftMin < 0;
+		$rightIsNegativeConstant = $rightMin === $rightMax && $rightMin !== null && $rightMin < 0;
+
+		if ($rightMin === $rightMax && $rightMin !== null) {
+			$min = $leftMin !== null && $rightMin !== 0 ? $leftMin / $rightMin : null;
+			$max = $leftMax !== null && $rightMin !== 0 ? $leftMax / $rightMin : null;
+		} else {
+			// Avoid division by zero when looking for the min and the max by using the closest int
+			$operandMin = $rightMin !== 0 ? $rightMin : 1;
+			$operandMax = $rightMax !== 0 ? $rightMax : -1;
+
+			if (
+				($operandMin < 0 || $operandMin === null)
+				&& ($operandMax > 0 || $operandMax === null)
+			) {
+				$result = TypeCombinator::union(
+					self::divideIntegerRanges($leftMin, $leftMax, $operandMin, 0),
+					self::divideIntegerRanges($leftMin, $leftMax, 0, $operandMax),
+				)->toNumber();
+
+				if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
+					return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+				}
+
+				return $result;
+			}
+			if (
+				($leftMin < 0 || $leftMin === null)
+				&& ($leftMax > 0 || $leftMax === null)
+			) {
+				$result = TypeCombinator::union(
+					self::divideIntegerRanges($leftMin, 0, $rightMin, $rightMax),
+					self::divideIntegerRanges(0, $leftMax, $rightMin, $rightMax),
+				)->toNumber();
+
+				if ($result->equals(new UnionType([new IntegerType(), new FloatType()]))) {
+					return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+				}
+
+				return $result;
+			}
+
+			$rangeMinSign = ($leftMin ?? -INF) <=> 0;
+			$rangeMaxSign = ($leftMax ?? INF) <=> 0;
+
+			$min1 = $operandMin !== null ? ($leftMin ?? -INF) / $operandMin : $rangeMinSign * -0.1;
+			$min2 = $operandMax !== null ? ($leftMin ?? -INF) / $operandMax : $rangeMinSign * 0.1;
+			$max1 = $operandMin !== null ? ($leftMax ?? INF) / $operandMin : $rangeMaxSign * -0.1;
+			$max2 = $operandMax !== null ? ($leftMax ?? INF) / $operandMax : $rangeMaxSign * 0.1;
+
+			$min = min($min1, $min2, $max1, $max2);
+			$max = max($min1, $min2, $max1, $max2);
+
+			if ($min === -INF) {
+				$min = null;
+			}
+			if ($max === INF) {
+				$max = null;
+			}
+		}
+
+		if ($min !== null && $max !== null && $min > $max) {
+			[$min, $max] = [$max, $min];
+		}
+
+		if (is_float($min)) {
+			$min = (int) ceil($min);
+		}
+		if (is_float($max)) {
+			$max = (int) floor($max);
+		}
+
+		// invert maximas on division with negative constants
+		if (($leftIsNegativeConstant || $rightIsNegativeConstant) && ($min === null || $max === null)) {
+			[$min, $max] = [$max, $min];
+		}
+
+		if ($min === null && $max === null) {
+			return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+		}
+
+		return TypeCombinator::union(IntegerRangeType::fromInterval($min, $max), new FloatType());
 	}
 
 	/**

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -13,6 +13,7 @@ use function in_array;
 use function intval;
 use function is_finite;
 use function is_float;
+use function is_int;
 use function max;
 use function min;
 use const INF;
@@ -45,6 +46,11 @@ final class ArithmeticOpHelper
 	public static function shiftRight(Type $leftType, Type $rightType): Type
 	{
 		return self::shift($leftType, $rightType, static fn (int $value, int $amount): int => $value >> $amount);
+	}
+
+	public static function minus(Type $leftType, Type $rightType): Type
+	{
+		return self::numericOp($leftType, $rightType, self::OP_MINUS, static fn ($left, $right) => $left - $right);
 	}
 
 	/**
@@ -104,6 +110,198 @@ final class ArithmeticOpHelper
 		}
 
 		return TypeCombinator::union(...$results);
+	}
+
+	/**
+	 * Shared implementation of the +, -, *, / operators on numeric operands. Decomposes both
+	 * operands polymorphically — constant scalars via getConstantScalarValues(), integer ranges via
+	 * getIntegerRanges() — so it never inspects operand classes for IntegerRangeType/ConstantIntegerType.
+	 *
+	 * @param callable(int|float, int|float): (int|float|null) $scalarFold maps a pair of constant
+	 *   operands to the result value, or null to mark the whole operation an error (e.g. division by zero).
+	 */
+	private static function numericOp(Type $leftType, Type $rightType, string $op, callable $scalarFold): Type
+	{
+		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
+			return self::getNeverType($leftType, $rightType);
+		}
+
+		$leftNumber = $leftType->toNumber();
+		$rightNumber = $rightType->toNumber();
+		if ($leftNumber instanceof ErrorType || $rightNumber instanceof ErrorType) {
+			return new ErrorType();
+		}
+
+		$leftValues = $leftNumber->getConstantScalarValues();
+		$rightValues = $rightNumber->getConstantScalarValues();
+		if ($leftValues !== [] && $rightValues !== []) {
+			if (count($leftValues) * count($rightValues) <= InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
+				$results = [];
+				foreach ($leftValues as $leftValue) {
+					foreach ($rightValues as $rightValue) {
+						// toNumber() above guarantees numeric constant values
+						if ((!is_int($leftValue) && !is_float($leftValue)) || (!is_int($rightValue) && !is_float($rightValue))) {
+							throw new ShouldNotHappenException();
+						}
+
+						$folded = $scalarFold($leftValue, $rightValue);
+						if ($folded === null) {
+							return new ErrorType();
+						}
+						$results[] = ConstantTypeHelper::getTypeFromValue($folded);
+					}
+				}
+
+				return TypeCombinator::union(...$results);
+			}
+
+			$leftNumber = self::optimizeScalarType($leftNumber);
+			$rightNumber = self::optimizeScalarType($rightNumber);
+		}
+
+		$leftPieces = self::integerPieces($leftNumber);
+		$rightPieces = self::integerPieces($rightNumber);
+		if ($leftPieces !== [] && $rightPieces !== []) {
+			$results = [];
+			foreach ($leftPieces as [$leftPieceMin, $leftPieceMax]) {
+				foreach ($rightPieces as [$rightPieceMin, $rightPieceMax]) {
+					$results[] = self::combineIntegerRanges($leftPieceMin, $leftPieceMax, $rightPieceMin, $rightPieceMax, $op);
+				}
+			}
+
+			$union = TypeCombinator::union(...$results);
+			if ($leftNumber instanceof BenevolentUnionType || $rightNumber instanceof BenevolentUnionType) {
+				return TypeUtils::toBenevolentUnion($union)->toNumber();
+			}
+
+			return $union;
+		}
+
+		return self::numericGeneral($op, $leftType, $rightType, $leftNumber, $rightNumber);
+	}
+
+	/** Float promotion and benevolent/mixed handling once constant folding and integer-range math do not apply. */
+	private static function numericGeneral(string $op, Type $leftType, Type $rightType, Type $leftNumber, Type $rightNumber): Type
+	{
+		$types = TypeCombinator::union($leftType, $rightType);
+
+		if ($leftNumber instanceof NeverType || $rightNumber instanceof NeverType) {
+			return self::getNeverType($leftNumber, $rightNumber);
+		}
+
+		if ($leftNumber->isFloat()->yes() || $rightNumber->isFloat()->yes()) {
+			return new FloatType();
+		}
+
+		$resultType = TypeCombinator::union($leftNumber, $rightNumber);
+		if ($op === self::OP_DIV) {
+			if ($types instanceof MixedType || $resultType->isInteger()->yes()) {
+				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
+			}
+
+			return new UnionType([new IntegerType(), new FloatType()]);
+		}
+
+		if ($types instanceof MixedType
+			|| $leftType instanceof BenevolentUnionType
+			|| $rightType instanceof BenevolentUnionType
+		) {
+			return TypeUtils::toBenevolentUnion($resultType);
+		}
+
+		return $resultType;
+	}
+
+	/**
+	 * Decomposes a number type into the integer intervals it covers, as [min, max] bounds (null = unbounded).
+	 * Reads ranges via getIntegerRanges() and constant integers via getConstantScalarValues(), so no operand
+	 * class is inspected. Returns an empty array when the type carries no integer interval.
+	 *
+	 * @return list<array{int|null, int|null}>
+	 */
+	private static function integerPieces(Type $type): array
+	{
+		$pieces = [];
+		foreach ($type->getIntegerRanges() as $range) {
+			$pieces[] = [$range->getMin(), $range->getMax()];
+		}
+		foreach ($type->getConstantScalarValues() as $value) {
+			if (!is_int($value)) {
+				continue;
+			}
+
+			$pieces[] = [$value, $value];
+		}
+
+		return $pieces;
+	}
+
+	/** Combines two integer intervals under +, -, * (operating purely on bounds; no operand classes involved). */
+	private static function combineIntegerRanges(?int $leftMin, ?int $leftMax, ?int $rightMin, ?int $rightMax, string $op): Type
+	{
+		if ($op === self::OP_PLUS) {
+			$min = $leftMin !== null && $rightMin !== null ? $leftMin + $rightMin : null;
+			$max = $leftMax !== null && $rightMax !== null ? $leftMax + $rightMax : null;
+		} elseif ($op === self::OP_MINUS) {
+			if ($leftMin === $leftMax && $leftMin !== null && ($rightMin === null || $rightMax === null)) {
+				$min = null;
+				$max = $leftMin;
+			} else {
+				if ($rightMin === null) {
+					$min = null;
+				} elseif ($leftMin !== null) {
+					$min = $rightMax !== null ? $leftMin - $rightMax : $leftMin - $rightMin;
+				} else {
+					$min = null;
+				}
+
+				if ($rightMax === null) {
+					$min = null;
+					$max = null;
+				} elseif ($leftMax !== null) {
+					if ($leftMin !== null && $rightMin === null) {
+						$min = $leftMin - $rightMax;
+						$max = null;
+					} elseif ($rightMin !== null) {
+						$max = $leftMax - $rightMin;
+					} else {
+						$max = null;
+					}
+				} else {
+					$max = null;
+				}
+
+				if ($min !== null && $max !== null && $min > $max) {
+					[$min, $max] = [$max, $min];
+				}
+			}
+		} elseif ($op === self::OP_MUL) {
+			$min1 = $leftMin === 0 || $rightMin === 0 ? 0 : ($leftMin ?? -INF) * ($rightMin ?? -INF);
+			$min2 = $leftMin === 0 || $rightMax === 0 ? 0 : ($leftMin ?? -INF) * ($rightMax ?? INF);
+			$max1 = $leftMax === 0 || $rightMin === 0 ? 0 : ($leftMax ?? INF) * ($rightMin ?? -INF);
+			$max2 = $leftMax === 0 || $rightMax === 0 ? 0 : ($leftMax ?? INF) * ($rightMax ?? INF);
+
+			$min = min($min1, $min2, $max1, $max2);
+			$max = max($min1, $min2, $max1, $max2);
+
+			if (!is_finite($min)) {
+				$min = null;
+			}
+			if (!is_finite($max)) {
+				$max = null;
+			}
+		} else {
+			throw new ShouldNotHappenException();
+		}
+
+		if (is_float($min)) {
+			$min = null;
+		}
+		if (is_float($max)) {
+			$max = null;
+		}
+
+		return IntegerRangeType::fromInterval($min, $max);
 	}
 
 	/**

--- a/src/Type/ArithmeticOpHelper.php
+++ b/src/Type/ArithmeticOpHelper.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use function count;
+
+/**
+ * Shared implementation of the arithmetic/shift binary operators (+, -, *, /, %, <<, >>)
+ * behind the polymorphic Type::plus()/minus()/multiply()/divide()/modulo()/shiftLeft()/shiftRight()
+ * methods. The numeric folding, integer-range math and array-union logic lived in
+ * InitializerExprTypeResolver before they were made polymorphic; this helper keeps them in a
+ * single place so the leaf Type implementations stay one-liners.
+ *
+ * The GMP/BcMath operator-extension dispatch and NeverType wrapping stay in
+ * InitializerExprTypeResolver (see getPowTypeFromTypes for the same split with exponentiate()).
+ */
+final class ArithmeticOpHelper
+{
+
+	/**
+	 * Collapses a union of constant scalars into its base scalar categories. Used when a
+	 * constant-folding cross-product would exceed InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT.
+	 */
+	public static function optimizeScalarType(Type $type): Type
+	{
+		$types = [];
+		if ($type->isInteger()->yes()) {
+			$types[] = new IntegerType();
+		}
+		if ($type->isString()->yes()) {
+			$types[] = new StringType();
+		}
+		if ($type->isFloat()->yes()) {
+			$types[] = new FloatType();
+		}
+		if ($type->isNull()->yes()) {
+			$types[] = new NullType();
+		}
+
+		if (count($types) === 0) {
+			return new ErrorType();
+		}
+
+		if (count($types) === 1) {
+			return $types[0];
+		}
+
+		return new UnionType($types);
+	}
+
+	/** Preserves the explicit flag of an operand NeverType in the operation's result. */
+	public static function getNeverType(Type $leftType, Type $rightType): Type
+	{
+		if ($leftType instanceof NeverType && $leftType->isExplicit()) {
+			return $leftType;
+		}
+		if ($rightType instanceof NeverType && $rightType->isExplicit()) {
+			return $rightType;
+		}
+		return new NeverType();
+	}
+
+}

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -181,6 +181,11 @@ class BooleanType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -181,6 +181,11 @@ class BooleanType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -181,6 +181,11 @@ class BooleanType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -181,6 +181,11 @@ class BooleanType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -176,6 +176,16 @@ class BooleanType implements Type
 		];
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return ExponentiateHelper::exponentiate($this, $exponent);

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -181,6 +181,11 @@ class BooleanType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -181,6 +181,11 @@ class BooleanType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -768,6 +768,11 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -768,6 +768,11 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -768,6 +768,11 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -768,6 +768,11 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -768,6 +768,11 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -768,6 +768,11 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -763,6 +763,16 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return $this->isCommonCallable;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -884,6 +884,11 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -884,6 +884,11 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -879,6 +879,16 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return new BooleanType();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -884,6 +884,11 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -884,6 +884,11 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -884,6 +884,11 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -884,6 +884,11 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -13,7 +13,6 @@ use PHPStan\Type\ClosureType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function array_filter;
 use function array_map;
 use function array_unique;
@@ -253,7 +252,7 @@ final class ConstantArrayTypeBuilder
 
 			$scalarTypes = $offsetType->toArrayKey()->getConstantScalarTypes();
 			if (count($scalarTypes) === 0) {
-				$integerRanges = TypeUtils::getIntegerRanges($offsetType);
+				$integerRanges = $offsetType->getIntegerRanges();
 				if (count($integerRanges) > 0) {
 					foreach ($integerRanges as $integerRange) {
 						$finiteTypes = $integerRange->getFiniteTypes();

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -291,6 +291,11 @@ class FloatType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -291,6 +291,11 @@ class FloatType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -286,6 +286,16 @@ class FloatType implements Type
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return ExponentiateHelper::exponentiate($this, $exponent);

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -291,6 +291,11 @@ class FloatType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -291,6 +291,11 @@ class FloatType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -291,6 +291,11 @@ class FloatType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -291,6 +291,11 @@ class FloatType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -647,6 +647,11 @@ class IntegerRangeType extends IntegerType implements CompoundType
 		return null;
 	}
 
+	public function getIntegerRanges(): array
+	{
+		return [$this];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		if ($exponent instanceof UnionType) {

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -199,6 +199,11 @@ class IntegerType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -199,6 +199,11 @@ class IntegerType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -199,6 +199,11 @@ class IntegerType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -194,6 +194,16 @@ class IntegerType implements Type
 		return [];
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return ExponentiateHelper::exponentiate($this, $exponent);

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -199,6 +199,11 @@ class IntegerType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -199,6 +199,11 @@ class IntegerType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -199,6 +199,11 @@ class IntegerType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1657,6 +1657,11 @@ class IntersectionType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1657,6 +1657,11 @@ class IntersectionType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1652,6 +1652,16 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => TypeCombinator::remove($type, $typeToRemove));
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return $this->intersectTypes(static fn (Type $type): Type => $type->exponentiate($exponent));

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1657,6 +1657,11 @@ class IntersectionType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1657,6 +1657,11 @@ class IntersectionType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1657,6 +1657,11 @@ class IntersectionType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1657,6 +1657,11 @@ class IntersectionType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -510,6 +510,11 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -510,6 +510,11 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -510,6 +510,11 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -510,6 +510,11 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -505,6 +505,16 @@ class IterableType implements CompoundType
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -510,6 +510,11 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -510,6 +510,11 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -1194,6 +1194,11 @@ class MixedType implements CompoundType, SubtractableType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -1194,6 +1194,11 @@ class MixedType implements CompoundType, SubtractableType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -1194,6 +1194,11 @@ class MixedType implements CompoundType, SubtractableType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -1194,6 +1194,11 @@ class MixedType implements CompoundType, SubtractableType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -1194,6 +1194,11 @@ class MixedType implements CompoundType, SubtractableType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -1194,6 +1194,11 @@ class MixedType implements CompoundType, SubtractableType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -1189,6 +1189,16 @@ class MixedType implements CompoundType, SubtractableType
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new BenevolentUnionType([

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -635,6 +635,11 @@ class NeverType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -635,6 +635,11 @@ class NeverType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -630,6 +630,16 @@ class NeverType implements CompoundType
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return $this;

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -635,6 +635,11 @@ class NeverType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -635,6 +635,11 @@ class NeverType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -635,6 +635,11 @@ class NeverType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -635,6 +635,11 @@ class NeverType implements CompoundType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -262,6 +262,11 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -262,6 +262,11 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -262,6 +262,11 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -262,6 +262,11 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -262,6 +262,11 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -257,6 +257,16 @@ class NonexistentParentClassType implements Type
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -262,6 +262,11 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -412,6 +412,11 @@ class NullType implements ConstantScalarType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -412,6 +412,11 @@ class NullType implements ConstantScalarType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -412,6 +412,11 @@ class NullType implements ConstantScalarType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -412,6 +412,11 @@ class NullType implements ConstantScalarType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -412,6 +412,11 @@ class NullType implements ConstantScalarType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -412,6 +412,11 @@ class NullType implements ConstantScalarType
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -407,6 +407,16 @@ class NullType implements ConstantScalarType
 		return [$this];
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new UnionType(

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -530,6 +530,11 @@ class ObjectShapeType implements Type
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -530,6 +530,11 @@ class ObjectShapeType implements Type
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -530,6 +530,11 @@ class ObjectShapeType implements Type
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -525,6 +525,16 @@ class ObjectShapeType implements Type
 		return new self($properties, $this->optionalProperties);
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		if (!$exponent instanceof NeverType && !$this->isSuperTypeOf($exponent)->no()) {

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -530,6 +530,11 @@ class ObjectShapeType implements Type
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -530,6 +530,11 @@ class ObjectShapeType implements Type
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -530,6 +530,11 @@ class ObjectShapeType implements Type
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1931,6 +1931,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1931,6 +1931,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1931,6 +1931,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1931,6 +1931,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1931,6 +1931,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1926,6 +1926,16 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $this->getEnumCases();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		$object = new ObjectWithoutClassType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1931,6 +1931,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -202,6 +202,11 @@ class ObjectWithoutClassType implements SubtractableType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -202,6 +202,11 @@ class ObjectWithoutClassType implements SubtractableType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -202,6 +202,11 @@ class ObjectWithoutClassType implements SubtractableType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -202,6 +202,11 @@ class ObjectWithoutClassType implements SubtractableType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -202,6 +202,11 @@ class ObjectWithoutClassType implements SubtractableType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -197,6 +197,16 @@ class ObjectWithoutClassType implements SubtractableType
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		if (!$exponent instanceof NeverType && !$this->isSuperTypeOf($exponent)->no()) {

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -202,6 +202,11 @@ class ObjectWithoutClassType implements SubtractableType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -120,6 +120,11 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -115,6 +115,16 @@ class ResourceType implements Type
 		return new BooleanType();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -120,6 +120,11 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -120,6 +120,11 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -120,6 +120,11 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -120,6 +120,11 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -120,6 +120,11 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -906,6 +906,16 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return null;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return $this->getStaticObjectType()->exponentiate($exponent);

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -911,6 +911,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -911,6 +911,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -911,6 +911,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -911,6 +911,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -911,6 +911,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -911,6 +911,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -500,6 +500,16 @@ class StrictMixedType implements CompoundType
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -505,6 +505,11 @@ class StrictMixedType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -505,6 +505,11 @@ class StrictMixedType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -505,6 +505,11 @@ class StrictMixedType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -505,6 +505,11 @@ class StrictMixedType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -505,6 +505,11 @@ class StrictMixedType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -505,6 +505,11 @@ class StrictMixedType implements CompoundType
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -317,6 +317,16 @@ class StringType implements Type
 		return [];
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftLeft($this, $otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return ExponentiateHelper::exponentiate($this, $exponent);

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -322,6 +322,11 @@ class StringType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::modulo($this, $otherType);

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -322,6 +322,11 @@ class StringType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::shiftRight($this, $otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -322,6 +322,11 @@ class StringType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::modulo($this, $otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::divide($this, $otherType);

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -322,6 +322,11 @@ class StringType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::multiply($this, $otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::minus($this, $otherType);

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -322,6 +322,11 @@ class StringType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::divide($this, $otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::multiply($this, $otherType);

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -322,6 +322,11 @@ class StringType implements Type
 		return ArithmeticOpHelper::shiftLeft($this, $otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::minus($this, $otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return ArithmeticOpHelper::shiftRight($this, $otherType);

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -200,6 +200,11 @@ trait ArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -195,6 +195,16 @@ trait ArrayTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Traits;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArithmeticOpHelper;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntegerRangeType;
@@ -198,6 +199,11 @@ trait ArrayTypeTrait
 	public function shiftLeft(Type $otherType): Type
 	{
 		return new ErrorType();
+	}
+
+	public function plus(Type $otherType): Type
+	{
+		return ArithmeticOpHelper::plus($this, $otherType);
 	}
 
 	public function modulo(Type $otherType): Type

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -200,6 +200,11 @@ trait ArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -200,6 +200,11 @@ trait ArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -200,6 +200,11 @@ trait ArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -200,6 +200,11 @@ trait ArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -685,6 +685,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->shiftLeft($otherType);
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return $this->resolve()->multiply($otherType);
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return $this->resolve()->minus($otherType);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -685,6 +685,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->shiftLeft($otherType);
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return $this->resolve()->divide($otherType);
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return $this->resolve()->multiply($otherType);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -685,6 +685,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->shiftLeft($otherType);
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return $this->resolve()->modulo($otherType);
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return $this->resolve()->divide($otherType);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -685,6 +685,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->shiftLeft($otherType);
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return $this->resolve()->shiftRight($otherType);
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return $this->resolve()->getIntegerRanges();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -685,6 +685,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->shiftLeft($otherType);
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return $this->resolve()->plus($otherType);
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return $this->resolve()->modulo($otherType);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -680,6 +680,16 @@ trait LateResolvableTypeTrait
 		return $otherType->isSmallerThanOrEqual($result, $phpVersion);
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return $this->resolve()->shiftLeft($otherType);
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return $this->resolve()->getIntegerRanges();
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return $this->resolve()->exponentiate($exponent);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -685,6 +685,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->shiftLeft($otherType);
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return $this->resolve()->minus($otherType);
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return $this->resolve()->shiftRight($otherType);

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -390,6 +390,9 @@ interface Type
 	/** Models the / operator. Returns `ErrorType` for types where the operation is undefined (e.g. division by zero). */
 	public function divide(Type $otherType): Type;
 
+	/** Models the % operator. Returns `ErrorType` for types where the operation is undefined (e.g. modulo by zero). */
+	public function modulo(Type $otherType): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/** @return list<CallableParametersAcceptor> */

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -387,6 +387,9 @@ interface Type
 	/** Models the * operator. Returns `ErrorType` for types where the operation is undefined. */
 	public function multiply(Type $otherType): Type;
 
+	/** Models the / operator. Returns `ErrorType` for types where the operation is undefined (e.g. division by zero). */
+	public function divide(Type $otherType): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/** @return list<CallableParametersAcceptor> */

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -384,6 +384,9 @@ interface Type
 	/** Models the - operator. Returns `ErrorType` for types where the operation is undefined. */
 	public function minus(Type $otherType): Type;
 
+	/** Models the * operator. Returns `ErrorType` for types where the operation is undefined. */
+	public function multiply(Type $otherType): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/** @return list<CallableParametersAcceptor> */

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -365,6 +365,19 @@ interface Type
 	/** Models the ** operator. */
 	public function exponentiate(Type $exponent): Type;
 
+	/**
+	 * The integer ranges (int<a, b>) this type is composed of, used by the arithmetic operators to
+	 * read operand bounds polymorphically. Returns the ranges only when the type is composed entirely
+	 * of integer ranges — a constant or any other non-range member yields an empty array (read
+	 * constants separately via getConstantScalarValues()). Bare non-range types return an empty array.
+	 *
+	 * @return list<IntegerRangeType>
+	 */
+	public function getIntegerRanges(): array;
+
+	/** Models the << operator. Returns `ErrorType` for types where the operation is undefined. */
+	public function shiftLeft(Type $otherType): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/** @return list<CallableParametersAcceptor> */

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -378,6 +378,9 @@ interface Type
 	/** Models the << operator. Returns `ErrorType` for types where the operation is undefined. */
 	public function shiftLeft(Type $otherType): Type;
 
+	/** Models the >> operator. Returns `ErrorType` for types where the operation is undefined. */
+	public function shiftRight(Type $otherType): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/** @return list<CallableParametersAcceptor> */

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -381,6 +381,9 @@ interface Type
 	/** Models the >> operator. Returns `ErrorType` for types where the operation is undefined. */
 	public function shiftRight(Type $otherType): Type;
 
+	/** Models the - operator. Returns `ErrorType` for types where the operation is undefined. */
+	public function minus(Type $otherType): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/** @return list<CallableParametersAcceptor> */

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -393,6 +393,9 @@ interface Type
 	/** Models the % operator. Returns `ErrorType` for types where the operation is undefined (e.g. modulo by zero). */
 	public function modulo(Type $otherType): Type;
 
+	/** Models the + operator (numeric addition or array union). Returns `ErrorType` where it is undefined. */
+	public function plus(Type $otherType): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/** @return list<CallableParametersAcceptor> */

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -30,11 +30,12 @@ final class TypeUtils
 	}
 
 	/**
+	 * @deprecated Use Type::getIntegerRanges() instead
 	 * @return list<IntegerRangeType>
 	 */
 	public static function getIntegerRanges(Type $type): array
 	{
-		return self::map(IntegerRangeType::class, $type, false);
+		return $type->getIntegerRanges();
 	}
 
 	/**

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1327,6 +1327,18 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->shiftLeft($otherType));
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees
+		// the true cross-product; a union mixing constants and ranges must be mapped member by member,
+		// because getConstantScalarValues() yields nothing once a non-constant member is present.
+		if ($this->getConstantScalarValues() !== []) {
+			return ArithmeticOpHelper::multiply($this, $otherType);
+		}
+
+		return $this->unionTypes(static fn (Type $type): Type => $type->multiply($otherType));
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1315,6 +1315,35 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => TypeCombinator::remove($type, $typeToRemove));
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees
+		// the true cross-product; a union mixing constants and ranges must be mapped member by member,
+		// because getConstantScalarValues() yields nothing once a non-constant member is present.
+		if ($this->getConstantScalarValues() !== []) {
+			return ArithmeticOpHelper::shiftLeft($this, $otherType);
+		}
+
+		return $this->unionTypes(static fn (Type $type): Type => $type->shiftLeft($otherType));
+	}
+
+	public function getIntegerRanges(): array
+	{
+		$ranges = [];
+		foreach ($this->types as $type) {
+			$typeRanges = $type->getIntegerRanges();
+			if ($typeRanges === []) {
+				return [];
+			}
+
+			foreach ($typeRanges as $range) {
+				$ranges[] = $range;
+			}
+		}
+
+		return $ranges;
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return $this->unionTypes(static fn (Type $type): Type => $type->exponentiate($exponent));

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1327,6 +1327,18 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->shiftLeft($otherType));
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees
+		// the true cross-product; a union mixing constants and ranges must be mapped member by member,
+		// because getConstantScalarValues() yields nothing once a non-constant member is present.
+		if ($this->getConstantScalarValues() !== []) {
+			return ArithmeticOpHelper::shiftRight($this, $otherType);
+		}
+
+		return $this->unionTypes(static fn (Type $type): Type => $type->shiftRight($otherType));
+	}
+
 	public function getIntegerRanges(): array
 	{
 		$ranges = [];

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1327,6 +1327,23 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->shiftLeft($otherType));
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		// The + operator unions arrays, so an array-shaped union must be handled as a whole type.
+		// A fully-constant numeric union also folds as a whole so the CALCULATE_SCALARS_LIMIT
+		// generalization sees the true cross-product; only a mixed numeric union is mapped member by
+		// member, because getConstantScalarValues() yields nothing once a range member is present.
+		if (
+			!$this->isArray()->no()
+			|| !$otherType->isArray()->no()
+			|| $this->getConstantScalarValues() !== []
+		) {
+			return ArithmeticOpHelper::plus($this, $otherType);
+		}
+
+		return $this->unionTypes(static fn (Type $type): Type => $type->plus($otherType));
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1327,6 +1327,18 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->shiftLeft($otherType));
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees
+		// the true cross-product; a union mixing constants and ranges must be mapped member by member,
+		// because getConstantScalarValues() yields nothing once a non-constant member is present.
+		if ($this->getConstantScalarValues() !== []) {
+			return ArithmeticOpHelper::minus($this, $otherType);
+		}
+
+		return $this->unionTypes(static fn (Type $type): Type => $type->minus($otherType));
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1327,6 +1327,18 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->shiftLeft($otherType));
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees
+		// the true cross-product; a union mixing constants and ranges must be mapped member by member,
+		// because getConstantScalarValues() yields nothing once a non-constant member is present.
+		if ($this->getConstantScalarValues() !== []) {
+			return ArithmeticOpHelper::modulo($this, $otherType);
+		}
+
+		return $this->unionTypes(static fn (Type $type): Type => $type->modulo($otherType));
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1327,6 +1327,18 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->shiftLeft($otherType));
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees
+		// the true cross-product; a union mixing constants and ranges must be mapped member by member,
+		// because getConstantScalarValues() yields nothing once a non-constant member is present.
+		if ($this->getConstantScalarValues() !== []) {
+			return ArithmeticOpHelper::divide($this, $otherType);
+		}
+
+		return $this->unionTypes(static fn (Type $type): Type => $type->divide($otherType));
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		// A fully-constant union folds as a whole so the CALCULATE_SCALARS_LIMIT generalization sees

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -264,6 +264,11 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
+	public function plus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function modulo(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -264,6 +264,11 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
+	public function minus(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftRight(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -264,6 +264,11 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
+	public function shiftRight(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIntegerRanges(): array
 	{
 		return [];

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -264,6 +264,11 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
+	public function multiply(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function minus(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -259,6 +259,16 @@ class VoidType implements Type
 		return $this;
 	}
 
+	public function shiftLeft(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getIntegerRanges(): array
+	{
+		return [];
+	}
+
 	public function exponentiate(Type $exponent): Type
 	{
 		return new ErrorType();

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -264,6 +264,11 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
+	public function divide(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function multiply(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -264,6 +264,11 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
+	public function modulo(Type $otherType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function divide(Type $otherType): Type
 	{
 		return new ErrorType();

--- a/tests/PHPStan/Analyser/Fiber/data/fnsr.php
+++ b/tests/PHPStan/Analyser/Fiber/data/fnsr.php
@@ -224,7 +224,7 @@ class Foo
 	public function doShiftLeft($a, $b, int $c, int $d): void
 	{
 		assertType('int', $a << $b);
-		assertNativeType('(float|int)', $a << $b);
+		assertNativeType('int', $a << $b);
 		assertType('8', 1 << 3);
 		assertNativeType('8', 1 << 3);
 		assertType('int', $c << $d);
@@ -239,7 +239,7 @@ class Foo
 	public function doShiftRight($a, $b, int $c, int $d): void
 	{
 		assertType('int', $a >> $b);
-		assertNativeType('(float|int)', $a >> $b);
+		assertNativeType('int', $a >> $b);
 		assertType('0', 1 >> 3);
 		assertNativeType('0', 1 >> 3);
 		assertType('int', $c >> $d);

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -386,7 +386,7 @@ class Foo
 			assertType('*NEVER*', $a % $b);
 			assertType('non-empty-string&numeric-string', $a . $b);
 			assertType('*ERROR*', $a ** $b);
-			assertType('*NEVER*', $a << $b);
+			assertType('*ERROR*', $a << $b);
 			assertType('*NEVER*', $a >> $b);
 			assertType('bool', $a < $b);
 			assertType('bool', $a <= $b);

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -379,8 +379,8 @@ class Foo
 	public function bcVsNever(Number $a): void
 	{
 		for ($b = 1; $b < count([]); $b++) {
-			assertType('*NEVER*', $a + $b);
-			assertType('*ERROR*', $a - $b); // Inconsistency: getPlusType handles never types right at the beginning, getMinusType doesn't.
+			assertType('*ERROR*', $a + $b);
+			assertType('*ERROR*', $a - $b);
 			assertType('*ERROR*', $a * $b);
 			assertType('*ERROR*', $a / $b);
 			assertType('*ERROR*', $a % $b);

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -383,7 +383,7 @@ class Foo
 			assertType('*ERROR*', $a - $b); // Inconsistency: getPlusType handles never types right at the beginning, getMinusType doesn't.
 			assertType('*ERROR*', $a * $b);
 			assertType('*ERROR*', $a / $b);
-			assertType('*NEVER*', $a % $b);
+			assertType('*ERROR*', $a % $b);
 			assertType('non-empty-string&numeric-string', $a . $b);
 			assertType('*ERROR*', $a ** $b);
 			assertType('*ERROR*', $a << $b);

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -183,7 +183,7 @@ class Foo
 		$b = null;
 		assertType('*ERROR*', $a + $b);
 		assertType('*ERROR*', $a - $b);
-		assertType('0', $a * $b); // BUG: This throws type error, but getMulType assumes that since null (mostly) behaves like zero, it will be zero.
+		assertType('*ERROR*', $a * $b); // BcMath\Number * null is a runtime type error
 		assertType('*ERROR*', $a / $b);
 		assertType('*ERROR*', $a % $b);
 		assertType('non-empty-string&numeric-string', $a . $b);

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -387,7 +387,7 @@ class Foo
 			assertType('non-empty-string&numeric-string', $a . $b);
 			assertType('*ERROR*', $a ** $b);
 			assertType('*ERROR*', $a << $b);
-			assertType('*NEVER*', $a >> $b);
+			assertType('*ERROR*', $a >> $b);
 			assertType('bool', $a < $b);
 			assertType('bool', $a <= $b);
 			assertType('bool', $a > $b);

--- a/tests/PHPStan/Analyser/nsrt/binary.php
+++ b/tests/PHPStan/Analyser/nsrt/binary.php
@@ -326,11 +326,11 @@ class Foo
 		assertType('float', $float + $float);
 		assertType('float', $float + $number);
 		assertType('(float|int)', 1 / $mixed);
-		assertType('float|int', 1 / $number);
+		assertType('(float|int)', 1 / $number);
 		assertType('float', 1.0 / $mixed);
 		assertType('float', 1.0 / $number);
 		assertType('(float|int)', $mixed / 1);
-		assertType('float|int', $number / 1);
+		assertType('(float|int)', $number / 1);
 		assertType('float', $mixed / 1.0);
 		assertType('float', $number / 1.0);
 		assertType('float', 1.0 + $mixed);


### PR DESCRIPTION
## What

Moves the per-operand logic for the binary operators `+`, `-`, `*`, `/`, `%`, `<<`, `>>` out of the centralized `instanceof`-dispatch in `InitializerExprTypeResolver` and onto polymorphic methods of the `Type` interface — following the existing `Type::exponentiate()` (`**`) precedent. Each `Type` implementation now decides its own arithmetic, so union/intersection/accessory/late-resolvable types are handled correctly by construction rather than by central `instanceof` chains.

New `Type` methods: `plus()`, `minus()`, `multiply()`, `divide()`, `modulo()`, `shiftLeft()`, `shiftRight()`, plus a `getIntegerRanges(): list<IntegerRangeType>` accessor so the bilateral range math reads operand bounds polymorphically instead of `instanceof IntegerRangeType`/`ConstantIntegerType`. The shared, genuinely-bilateral logic (constant folding with `CALCULATE_SCALARS_LIMIT`, integer-range math, array union for `+`) lives in a single `ArithmeticOpHelper`; `InitializerExprTypeResolver`'s `getXxxType`/`getXxxTypeFromTypes` remain as thin BC wrappers that keep the GMP/BcMath operator-extension dispatch and then delegate to the polymorphic method.

`TypeUtils::getIntegerRanges()` now delegates to `Type::getIntegerRanges()` and is `@deprecated`.

## `instanceof` cleanup

Operands are decomposed via `getConstantScalarValues()` + `getIntegerRanges()`, eliminating every deprecated `instanceof ConstantScalarType` from the migrated operators (`InitializerExprTypeResolver` went from 18 to 4; the 4 left are in the still-centralized bitwise/spaceship operators, which were intentionally out of scope). The only `instanceof` left in `ArithmeticOpHelper` are the sentinel/structural checks `ApiInstanceofTypeRule` permits (`Never`/`Error`/`Mixed`/`Union`/`BenevolentUnion`). The old `integerRangeMath` `@var` band-aids are gone.

## Behavior changes (improvements; expectations updated)

- `object + never` (and `- * / %`) now yields `*ERROR*` consistently — previously `modulo`/`plus` were inconsistently `*NEVER*`.
- `mixed << mixed` / `mixed >> mixed` is `int` (shift always yields int), not `float|int`.
- `1 / (int|float)` is benevolent `(float|int)` — division now applies to each union member instead of passing non-range members through unchanged.

## Scope

Out of scope (left in `InitializerExprTypeResolver`): concat `.`, bitwise `& | ^`, spaceship `<=>`. `**` was already polymorphic.

## Verification

- Full test suite: 12151 tests, 0 failures.
- `make phpstan`: no errors.
- The change is behavior-preserving except for the documented improvements above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)