### PR TITLE
Post issue-bot PR comment from a workflow_run workflow

### DIFF
--- a/.github/workflows/issue-bot-pr-comment.yml
+++ b/.github/workflows/issue-bot-pr-comment.yml
@@ -1,0 +1,97 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+# Posts the issue-bot result as a PR comment.
+#
+# The "Issue bot" workflow runs on the `pull_request` event, whose GITHUB_TOKEN is
+# read-only (and has no secrets) for PRs from forks — so it cannot comment there.
+# This workflow runs on `workflow_run`, which executes in the base-repo context with
+# access to secrets and a writable token, so it can comment on fork PRs too. It only
+# consumes the artifact produced by the analysis run; it never checks out or runs PR code.
+#
+# Posting uses PHPSTAN_BOT_TOKEN so the comment comes from the bot account.
+
+name: "Issue bot PR comment"
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
+    workflows: ["Issue bot"]
+    types:
+      - completed
+
+permissions: {}
+
+concurrency:
+  group: issue-bot-pr-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  comment:
+    name: "Post/update PR comment"
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: "ubuntu-latest"
+    permissions:
+      actions: read # download the pr-comment artifact from the triggering run
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: "Download PR comment artifact"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: pr-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Resolve PR number"
+        id: pr
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          github-token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
+          script: |
+            // Resolve the PR from the triggering run's head SHA. workflow_run.pull_requests
+            // is empty for fork PRs, and the SHA is GitHub-provided (not artifact-controlled),
+            // so this is the trustworthy way to find which PR to comment on.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            });
+            const pr = prs.find(p => p.state === 'open') ?? prs[0];
+            if (pr === undefined) {
+              core.info('No pull request associated with this commit; nothing to comment on.');
+              return;
+            }
+            core.setOutput('number', pr.number);
+
+      - name: "Find existing comment"
+        if: steps.pr.outputs.number != ''
+        id: find-comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        with:
+          token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-includes: "<!-- phpstan-issue-bot -->"
+
+      # Changes detected: create the comment if missing, otherwise update it.
+      - name: "Post/update comment (changes)"
+        if: steps.pr.outputs.number != '' && hashFiles('pr-comment-exit-2') != ''
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          edit-mode: replace
+          body-path: pr-comment.md
+
+      # No changes: only update an already-existing comment, never create a new one.
+      - name: "Update comment (no changes, only if exists)"
+        if: steps.pr.outputs.number != '' && hashFiles('pr-comment-exit-0') != '' && steps.find-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body-path: pr-comment.md

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -25,39 +25,6 @@ permissions:
   contents: read
 
 jobs:
-  pr-comment-init:
-    name: "Init PR comment (if exists)"
-    if: github.event_name == 'pull_request'
-    runs-on: "ubuntu-latest"
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: "Find existing PR comment"
-        id: find-comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: "<!-- phpstan-issue-bot -->"
-
-      - name: "Mark comment as running"
-        if: steps.find-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |
-            <!-- phpstan-issue-bot -->
-
-            :hourglass_flowing_sand: A new issue bot run is in progress: [view job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-
-            This comment will be updated with the latest results when the run completes.
-
   download:
     name: "Download data"
 
@@ -197,9 +164,6 @@ jobs:
 
     runs-on: "ubuntu-latest"
 
-    outputs:
-      pr-evaluate-exit-code: ${{ steps.evaluate-pr.outputs.exit_code }}
-
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
@@ -240,7 +204,6 @@ jobs:
         run: "ls -lA issue-bot/tmp"
 
       - name: "Evaluate results - pull request"
-        id: evaluate-pr
         working-directory: "issue-bot"
         if: github.event_name == 'pull_request'
         env:
@@ -265,13 +228,16 @@ jobs:
             fi
           } > tmp/pr-comment.md
 
-          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          # Exit-code marker carried to the issue-bot-pr-comment workflow inside the pr-comment artifact.
+          case "$exit_code" in
+            0|2) touch "tmp/pr-comment-exit-$exit_code" ;;
+          esac
 
           if [[ "$exit_code" == "2" ]]; then
             echo "::notice file=.github/workflows/issue-bot.yml,line=3 ::Issue bot detected open issues which are affected by this pull request - see $job_url"
           fi
 
-          # Always exit 0 for the PR pathway so the pr-comment-finalize job still receives outputs/artifacts.
+          # Always exit 0 for the PR pathway; the comment itself is posted by the issue-bot-pr-comment workflow.
           exit 0
 
       - name: "Upload step summary"
@@ -286,7 +252,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr-comment
-          path: issue-bot/tmp/pr-comment.md
+          path: |
+            issue-bot/tmp/pr-comment.md
+            issue-bot/tmp/pr-comment-exit-*
 
       - name: "Evaluate results - push"
         working-directory: "issue-bot"
@@ -306,46 +274,3 @@ jobs:
           fi
 
           exit $exit_code
-
-  pr-comment-finalize:
-    name: "Post/update PR comment"
-    needs: evaluate
-    if: github.event_name == 'pull_request' && needs.evaluate.result == 'success'
-    runs-on: "ubuntu-latest"
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-        with:
-          egress-policy: audit
-
-      - name: "Download PR comment body"
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: pr-comment
-
-      - name: "Find PR comment"
-        id: find-comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: "<!-- phpstan-issue-bot -->"
-
-      - name: "Post/update PR comment (changes)"
-        if: needs.evaluate.outputs.pr-evaluate-exit-code == '2'
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body-path: pr-comment.md
-
-      - name: "Update PR comment (no changes, only if exists)"
-        if: needs.evaluate.outputs.pr-evaluate-exit-code == '0' && steps.find-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body-path: pr-comment.md


### PR DESCRIPTION
## Summary

Fixes the issue-bot PR comment failing on **fork PRs** with `403 Resource not accessible by integration` (e.g. [this run](https://github.com/phpstan/phpstan-src/actions/runs/26206785501/job/77108545582)).

Root cause: the "Issue bot" workflow runs on the `pull_request` event, and for PRs from forks GitHub forces `GITHUB_TOKEN` to read-only and withholds secrets — regardless of `permissions:` — so the comment POST is rejected.

This implements the `workflow_run` pattern:

- **New `.github/workflows/issue-bot-pr-comment.yml`** triggered by `workflow_run` on completion of "Issue bot". It runs in the **base-repo context** (writable token + secrets available), so it can comment on fork PRs. It only consumes the `pr-comment` artifact (comment body + exit-code marker); it never checks out or runs PR code, and resolves the PR number from the trusted `workflow_run.head_sha` (`workflow_run.pull_requests` is empty for forks). Posts with **`PHPSTAN_BOT_TOKEN`** so the comment comes from the bot account.
- **`issue-bot.yml`**: removed the `pr-comment-init` and `pr-comment-finalize` jobs and their `pull-requests: write` grants. The `evaluate` job still produces the `pr-comment` artifact; the exit code now travels inside it as a marker file (`pr-comment-exit-0` / `-2`) instead of a job output.
- The push-mode issue commenting (`--post-comments` to `2.2.x`) is unchanged.

Validated locally with `actionlint` and `zizmor --persona=auditor` (the `workflow_run` `dangerous-triggers` finding is suppressed with an inline ignore, justified by the no-checkout / trusted-SHA design).

## Notes / decisions

- **Kept `permissions: contents: read`** at the top of `issue-bot.yml` (it's a read-only hardening default, not a comment-related grant, and removing it would surface security-linter alerts). Removed only the `pull-requests: write` grants. Say the word if you'd rather drop it entirely.
- **Dropped the "mark comment as running at start" behavior.** With `workflow_run` (completed), the comment is posted once, when analysis finishes. It can be re-added via a `workflow_run: [requested]` trigger if you want it back.

## Test plan

- [ ] Re-run issue bot on a **fork** PR that detects changes → comment is posted by the bot account (no 403).
- [ ] Same-repo PR with changes → comment posted/updated.
- [ ] PR with no changes and no prior comment → nothing posted; with a prior comment → it's updated.
- [ ] Push to `2.2.x` → per-issue comments still posted via `PHPSTAN_BOT_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)