### PR TITLE
Do not report function_exists as always-true conditions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1588,12 +1588,6 @@ parameters:
 			path: src/Type/Php/FilterFunctionReturnTypeHelper.php
 
 		-
-			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
-
-		-
 			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantArrayType is error-prone and deprecated. Use Type::getConstantArrays() instead.'
 			identifier: phpstanApi.instanceofType
 			count: 1

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -81,6 +81,7 @@ final class ImpossibleCheckTypeHelper
 					'interface_exists',
 					'trait_exists',
 					'enum_exists',
+					'function_exists',
 				], true)) {
 					return null;
 				}

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -81,7 +81,6 @@ final class ImpossibleCheckTypeHelper
 					'interface_exists',
 					'trait_exists',
 					'enum_exists',
-					'function_exists',
 				], true)) {
 					return null;
 				}

--- a/src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
@@ -15,8 +15,8 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use function count;
 use function ltrim;
 
 #[AutowiredService]
@@ -37,15 +37,23 @@ final class FunctionExistsFunctionTypeSpecifyingExtension implements FunctionTyp
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
 		$argType = $scope->getType($node->getArgs()[0]->value);
-		if ($argType instanceof ConstantStringType) {
-			return $this->typeSpecifier->create(
-				new FuncCall(new FullyQualified('function_exists'), [
-					new Arg(new String_(ltrim($argType->getValue(), '\\'))),
-				]),
-				new ConstantBooleanType(true),
-				$context,
-				$scope,
-			);
+
+		$constantStrings = $argType->getConstantStrings();
+		if (count($constantStrings) > 0) {
+			$specifiedTypes = new SpecifiedTypes();
+
+			foreach ($constantStrings as $constantString) {
+				$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
+					new FuncCall(new FullyQualified('function_exists'), [
+						new Arg(new String_(ltrim($constantString->getValue(), '\\'))),
+					]),
+					new ConstantBooleanType(true),
+					$context,
+					$scope,
+				));
+			}
+
+			return $specifiedTypes;
 		}
 
 		return $this->typeSpecifier->create(

--- a/src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
@@ -39,7 +39,7 @@ final class FunctionExistsFunctionTypeSpecifyingExtension implements FunctionTyp
 		$argType = $scope->getType($node->getArgs()[0]->value);
 
 		$constantStrings = $argType->getConstantStrings();
-		if (count($constantStrings) > 0) {
+		if (count($constantStrings) === 1) {
 			$specifiedTypes = new SpecifiedTypes();
 
 			foreach ($constantStrings as $constantString) {

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -261,4 +261,15 @@ class IfConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5020.php'], []);
 	}
 
+	public function testBug8980(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8980.php'], [
+			[
+				'If condition is always true.',
+				23,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1236,6 +1236,12 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8217.php'], []);
 	}
 
+	public function testBug8980(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8980.php'], []);
+	}
+
 	public function testBug6211(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/data/bug-8980.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8980.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8980;
+
+use function function_exists;
+
+// actual bug report snippet: function_exists inside array_filter callback
+$undefined_curl_functions = array_filter(
+	[
+		'curl_multi_add_handle',
+		'curl_multi_exec',
+		'curl_multi_init',
+	],
+	static function( $function_name ) {
+		return ! function_exists( $function_name );
+	}
+);

--- a/tests/PHPStan/Rules/Comparison/data/bug-8980.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8980.php
@@ -15,3 +15,12 @@ $undefined_curl_functions = array_filter(
 		return ! function_exists( $function_name );
 	}
 );
+
+function testFunctionExistsGuardReturn(): void {
+	if (!function_exists('curl_init')) {
+		return;
+	}
+	if (function_exists('curl_init')) {
+		echo 'exists';
+	}
+}

--- a/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
@@ -264,4 +264,20 @@ class CallToNonExistentFunctionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14384.php'], []);
 	}
 
+	public function testBug8980(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8980.php'], [
+			[
+				'Function funcA not found.',
+				12,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
+			[
+				'Function funcB not found.',
+				13,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
@@ -269,12 +269,12 @@ class CallToNonExistentFunctionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8980.php'], [
 			[
 				'Function funcA not found.',
-				12,
+				13,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
 			[
 				'Function funcB not found.',
-				13,
+				14,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/data/bug-8980.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8980.php
@@ -11,4 +11,5 @@ function doFoo():void {
 
 	funcA();
 	funcB();
+	$func();
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-8980.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8980.php
@@ -9,6 +9,7 @@ function doFoo():void {
 		throw new \Exception();
 	}
 
+	// the function_exists() will only assure one of the functions to exist.
 	funcA();
 	funcB();
 	$func();

--- a/tests/PHPStan/Rules/Functions/data/bug-8980.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8980.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8980;
+
+function doFoo():void {
+	$func = rand(0,1) ? 'funcA' : 'funcB';
+
+	if (!function_exists($func)) {
+		throw new \Exception();
+	}
+
+	funcA();
+	funcB();
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8980

extracted from https://github.com/phpstan/phpstan-src/pull/5737 which went too far