### PR TITLE
Retain `class_exists` expression types in closure

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2157,7 +2157,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		return $expr instanceof FuncCall
 			&& !$expr->isFirstClassCallable()
 			&& $expr->name instanceof FullyQualified
-			&& $expr->name->toLowerString() === 'function_exists'
+			&& in_array($expr->name->toLowerString(), ['function_exists', 'class_exists'], true)
 			&& isset($expr->getArgs()[0])
 			&& count($this->getType($expr->getArgs()[0]->value)->getConstantStrings()) === 1
 			&& $type->isTrue()->yes();

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2157,7 +2157,17 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		return $expr instanceof FuncCall
 			&& !$expr->isFirstClassCallable()
 			&& $expr->name instanceof FullyQualified
-			&& in_array($expr->name->toLowerString(), ['function_exists', 'class_exists'], true)
+			&& in_array(
+				$expr->name->toLowerString(),
+				[
+					'class_exists',
+					'interface_exists',
+					'trait_exists',
+					'enum_exists',
+					'function_exists',
+				],
+				true,
+			)
 			&& isset($expr->getArgs()[0])
 			&& count($this->getType($expr->getArgs()[0]->value)->getConstantStrings()) === 1
 			&& $type->isTrue()->yes();

--- a/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
@@ -49,14 +49,30 @@ final class ClassExistsFunctionTypeSpecifyingExtension implements FunctionTypeSp
 		$args = $node->getArgs();
 		$argType = $scope->getType($args[0]->value);
 		if ($argType instanceof ConstantStringType) {
-			$funcCall = new FuncCall(new FullyQualified($functionReflection->getName()), [
-				new Arg(new String_(ltrim($argType->getValue(), '\\'))),
-			]);
 			return $this->typeSpecifier->create(
-				new AlwaysRememberedExpr($funcCall, new BooleanType(), new BooleanType()),
+				new AlwaysRememberedExpr(
+					new FuncCall(new FullyQualified($functionReflection->getName()), [
+						new Arg(new String_(ltrim($argType->getValue(), '\\'))),
+					]),
+					new BooleanType(),
+					new BooleanType(),
+				),
 				new ConstantBooleanType(true),
 				$context,
 				$scope,
+			)->unionWith(
+				$this->typeSpecifier->create(
+					new AlwaysRememberedExpr(
+						new FuncCall(new FullyQualified('class_exists'), [
+							new Arg(new String_(ltrim($argType->getValue(), '\\'))),
+						]),
+						new BooleanType(),
+						new BooleanType(),
+					),
+					new ConstantBooleanType(true),
+					$context,
+					$scope,
+				),
 			);
 		}
 

--- a/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Expr\AlwaysRememberedExpr;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -49,6 +50,9 @@ final class ClassExistsFunctionTypeSpecifyingExtension implements FunctionTypeSp
 		$args = $node->getArgs();
 		$argType = $scope->getType($args[0]->value);
 		if ($argType instanceof ConstantStringType) {
+			if ($functionReflection->getName() === '') {
+				throw new ShouldNotHappenException();
+			}
 			return $this->typeSpecifier->create(
 				new AlwaysRememberedExpr(
 					new FuncCall(new FullyQualified($functionReflection->getName()), [

--- a/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
@@ -49,7 +49,7 @@ final class ClassExistsFunctionTypeSpecifyingExtension implements FunctionTypeSp
 		$args = $node->getArgs();
 		$argType = $scope->getType($args[0]->value);
 		if ($argType instanceof ConstantStringType) {
-			$funcCall = new FuncCall(new FullyQualified('class_exists'), [
+			$funcCall = new FuncCall(new FullyQualified($functionReflection->getName()), [
 				new Arg(new String_(ltrim($argType->getValue(), '\\'))),
 			]);
 			return $this->typeSpecifier->create(

--- a/tests/PHPStan/Analyser/nsrt/closure-retain-expression-types.php
+++ b/tests/PHPStan/Analyser/nsrt/closure-retain-expression-types.php
@@ -21,3 +21,18 @@ function () {
 		};
 	}
 };
+
+function () {
+	assertType('bool', class_exists('foo123'));
+	if (class_exists('foo123')) {
+		assertType('true', class_exists('foo123'));
+		function () {
+			assertType('true', class_exists('foo123'));
+		};
+	} else {
+		assertType('false', class_exists('foo123'));
+		function () {
+			assertType('bool', class_exists('foo123'));
+		};
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/closure-retain-expression-types.php
+++ b/tests/PHPStan/Analyser/nsrt/closure-retain-expression-types.php
@@ -3,7 +3,9 @@
 namespace ClosureRetainExpressionTypes;
 
 use function class_exists;
-use function defined;
+use function interface_exists;
+use function enum_exists;
+use function trait_exists;
 use function function_exists;
 use function PHPStan\Testing\assertType;
 
@@ -23,16 +25,61 @@ function () {
 };
 
 function () {
-	assertType('bool', class_exists('foo123'));
-	if (class_exists('foo123')) {
-		assertType('true', class_exists('foo123'));
+	assertType('bool', class_exists('foo345'));
+	if (class_exists('foo345')) {
+		assertType('true', class_exists('foo345'));
 		function () {
-			assertType('true', class_exists('foo123'));
+			assertType('true', class_exists('foo345'));
 		};
 	} else {
-		assertType('false', class_exists('foo123'));
+		assertType('false', class_exists('foo345'));
 		function () {
-			assertType('bool', class_exists('foo123'));
+			assertType('bool', class_exists('foo345'));
+		};
+	}
+};
+
+function () {
+	assertType('bool', enum_exists('foo567'));
+	if (enum_exists('foo567')) {
+		assertType('true', enum_exists('foo567'));
+		function () {
+			assertType('true', enum_exists('foo567'));
+		};
+	} else {
+		assertType('false', enum_exists('foo567'));
+		function () {
+			assertType('bool', enum_exists('foo567'));
+		};
+	}
+};
+
+function () {
+	assertType('bool', interface_exists('foo890'));
+	if (interface_exists('foo890')) {
+		assertType('true', interface_exists('foo890'));
+		function () {
+			assertType('true', interface_exists('foo890'));
+		};
+	} else {
+		assertType('false', interface_exists('foo890'));
+		function () {
+			assertType('bool', interface_exists('foo890'));
+		};
+	}
+};
+
+function () {
+	assertType('bool', trait_exists('fooabc'));
+	if (trait_exists('fooabc')) {
+		assertType('true', trait_exists('fooabc'));
+		function () {
+			assertType('true', trait_exists('fooabc'));
+		};
+	} else {
+		assertType('false', trait_exists('fooabc'));
+		function () {
+			assertType('bool', trait_exists('fooabc'));
 		};
 	}
 };


### PR DESCRIPTION
analog https://github.com/phpstan/phpstan-src/pull/1929

`class_exists()` is special, because there's no way to unload a class in PHP, so it should "survive" when entering closure.