### PR TITLE
Added regression test

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -1033,4 +1033,10 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testClassExistOnCall(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/class-exists-on-static-call.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/class-exists-on-static-call.php
+++ b/tests/PHPStan/Rules/Methods/data/class-exists-on-static-call.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ClassExistsOnStaticCall;
+
+use PluralizationRules;
+
+function doFoo() {
+	if (class_exists(PluralizationRules::class)) {
+		PluralizationRules::set(static function ($number) {
+			return PluralizationRules::get($number, 'sr');
+		}, 'sr_Latn_BA');
+	}
+}


### PR DESCRIPTION
the fix in https://github.com/phpstan/phpstan-src/pull/5746 fixed a bug in Carbon, see https://github.com/phpstan/phpstan-src/pull/5746#issuecomment-4528318294

this code previously emitted

> Call to static method get() on an unknown class Symfony\Component\Translation\PluralizationRules