### PR TITLE
Preserve BenevolentUnion through loop generalization

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4200,6 +4200,17 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			return $a;
 		}
 
+		// Track whether either input carries a BenevolentUnion so the result
+		// can be re-wrapped at the end. `flattenTypes` below drops the
+		// BenevolentUnion wrapper, which would silently downgrade e.g.
+		// `(float|int)` (numeric-accepting) to a strict `float|int`. Inside a
+		// loop's fixed-point this propagates into the iterable value type of
+		// an array and turns `return [..., $int]` checks into false positives
+		// when the iteration body's `+ 1` arithmetic was originally produced
+		// by an `ErrorType`-derived `int|float` benevolent union (the typical
+		// case for reads of literally-missing keys inside the body).
+		$wrapBenevolent = $a instanceof BenevolentUnionType || $b instanceof BenevolentUnionType;
+
 		$constantIntegers = ['a' => [], 'b' => []];
 		$constantFloats = ['a' => [], 'b' => []];
 		$constantBooleans = ['a' => [], 'b' => []];
@@ -4554,8 +4565,13 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			TypeUtils::getAccessoryTypes($a),
 		);
 
+		$combined = TypeCombinator::union(...$resultTypes, ...$otherTypes);
+		if ($wrapBenevolent) {
+			$combined = TypeUtils::toBenevolentUnion($combined);
+		}
+
 		return TypeCombinator::union(TypeCombinator::intersect(
-			TypeCombinator::union(...$resultTypes, ...$otherTypes),
+			$combined,
 			...$accessoryTypes,
 		), ...$otherTypes);
 	}

--- a/tests/PHPStan/Analyser/nsrt/myers-diff-loop-widening.php
+++ b/tests/PHPStan/Analyser/nsrt/myers-diff-loop-widening.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MyersDiffLoopWidening;
+
+use function PHPStan\Testing\assertType;
+use function count;
+
+/**
+ * Regression test: a comparison like `$v[$k - 1] < $v[$k + 1]` inside the body
+ * of a nested loop combined with `$k === -$d` style narrowing on the inner
+ * counter used to strip `BenevolentUnionType` off the iterable value type of
+ * the array, downgrading `(int|float)` to a strict `int|float` during loop
+ * fixed-point convergence. That, in turn, caused real return-type false
+ * positives where the function actually returns `int` — see the Myers diff
+ * implementation in phpstan/phpdoc-parser's `Differ::calculateTrace()`.
+ */
+class Foo
+{
+
+	/**
+	 * @param array<int, mixed> $old
+	 * @param array<int, mixed> $new
+	 * @return array{array<int, array<int, int>>, int, int}
+	 */
+	public function calculateTrace(array $old, array $new): array
+	{
+		$n = count($old);
+		$m = count($new);
+		$max = $n + $m;
+		$v = [1 => 0];
+		$trace = [];
+		for ($d = 0; $d <= $max; $d++) {
+			$trace[] = $v;
+			for ($k = -$d; $k <= $d; $k += 2) {
+				if ($k === -$d || ($k !== $d && $v[$k - 1] < $v[$k + 1])) {
+					$x = $v[$k + 1];
+				} else {
+					$x = $v[$k - 1] + 1;
+				}
+
+				$y = $x - $k;
+				while ($x < $n && $y < $m) {
+					$x++;
+					$y++;
+				}
+
+				assertType('(float|int)', $x);
+				assertType('(float|int)', $y);
+
+				$v[$k] = $x;
+				if ($x >= $n && $y >= $m) {
+					return [$trace, $x, $y];
+				}
+			}
+		}
+
+		throw new \Exception('Should not happen');
+	}
+
+}


### PR DESCRIPTION
## Summary

`MutatingScope::generalizeType` runs each input through `TypeUtils::flattenTypes`, which drops the `BenevolentUnionType` wrapper before the result is reassembled. Inside a loop's fixed-point this silently downgrades `(int|float)` to a strict `int|float` once it enters an array's iterable value type, so `return [..., $intExpr]` type checks start tripping on a phantom `float` — even though the benevolent union was produced by intentional `ErrorType`-derived arithmetic (e.g. `$v[-1] + 1` when `$v` is `array{1: 0}` and a literal-but-missing offset is read inside the loop body).

The latent bug surfaced with the new unsealed-array-shape representation introduced earlier in 2.2.x: the loop's converged shape now stays as a CAT with unsealed extras instead of degrading to a general `ArrayType`, so the generalize path is reached with benevolent value unions that previously bypassed it.

Bisect against `2.1.56` (good) → `2.2.x` (bad) landed on `c685b9c7` ("Preserve array shape and make it unsealed when non-constant key is assigned"), confirming the trigger but not the root cause — the actual fix lives one layer up, where the benevolent wrapping was being silently dropped.

The fix tracks whether either input to `generalizeType` carries a `BenevolentUnionType` and re-wraps the assembled result via `TypeUtils::toBenevolentUnion` at the end, mirroring the preservation `TypeCombinator::union` already does internally.

## Reproducer

Reported via the Myers diff in `phpstan/phpdoc-parser`'s `Differ::calculateTrace()`:

```
Method PHPStan\PhpDocParser\Printer\Differ::calculateTrace() should return
array{array<int, array<int, int>>, int, int} but returns
array{non-empty-list<non-empty-array<int<min, 1>, float|int>>,
      float|int<0, max>, float|int<0, max>}.
```

`@return` was correct; the false positive is the phantom `float` polluting the loop's iterable value type.

## Test plan

- [x] Regression test added at `tests/PHPStan/Analyser/nsrt/myers-diff-loop-widening.php` (the actual Myers diff body verbatim — return-type pass + `assertType('(float|int)', $x)` asserting the benevolent wrap survives).
- [x] `tests/PHPStan/Analyser/NodeScopeResolverTest.php` — 1626 tests, all pass.
- [x] `tests/PHPStan/Type/ArrayTypeTest.php`, `tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php`, `tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php` — all pass.
- [x] `tests/PHPStan/Rules/Arrays/*` — all pass (3 pre-existing skips).
- [x] Full `phpdoc-parser` run with patched PHPStan: `[OK] No errors`.
- [ ] Wider suite (`Type/`, `Analyser/`, `Rules/`) currently running — will report.