### PR TITLE
Allow `FILTER_VALIDATE_BOOL` as a valid constant for `filter_var` and `filter_input`

### DIFF
--- a/resources/constantToFunctionParameterMap.php
+++ b/resources/constantToFunctionParameterMap.php
@@ -546,6 +546,7 @@ return [
 			'type' => 'single',
 			'constants' => [
 				'FILTER_VALIDATE_INT',
+				'FILTER_VALIDATE_BOOL',
 				'FILTER_VALIDATE_BOOLEAN',
 				'FILTER_VALIDATE_FLOAT',
 				'FILTER_VALIDATE_REGEXP',
@@ -618,6 +619,7 @@ return [
 			'type' => 'single',
 			'constants' => [
 				'FILTER_VALIDATE_INT',
+				'FILTER_VALIDATE_BOOL',
 				'FILTER_VALIDATE_BOOLEAN',
 				'FILTER_VALIDATE_FLOAT',
 				'FILTER_VALIDATE_REGEXP',


### PR DESCRIPTION
It is an alias of `FILTER_VALIDATE_BOOLEAN` introduced in PHP 8.0.0.

Related to #5256.