### PR TITLE
PHPBench: use custom report format

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,4 +90,4 @@ jobs:
           working-directory: "tests/"
 
       - name: "Run phpbench test"
-        run: "tests/vendor/bin/phpbench run --file=tests/bench/storage/baseline.xml --report=aggregate --ansi"
+        run: "tests/vendor/bin/phpbench run --file=tests/bench/storage/baseline.xml --report=my-report --ansi"

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ infection:
 .PHONY: phpbench
 phpbench:
 	@find tests/bench/storage/local-baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file does not exist or is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
-	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=aggregate
+	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=my-report
 
 .PHONY: phpbench-baseline
 phpbench-baseline:

--- a/phpbench.json
+++ b/phpbench.json
@@ -11,7 +11,6 @@
         "set": null,
         "mem_peak": null,
         "mode": null,
-        "time_diff": "format('%.2fx', mean(result_time_avg) / min(suite['result_time_avg']))",
         "rstdev": null
       }
     }

--- a/phpbench.json
+++ b/phpbench.json
@@ -6,10 +6,7 @@
   "storage.xml_storage_path": "tests/bench/storage",
   "report.generators": {
     "my-report": {
-      "generator": "expression",
-      "aggregate": [
-        "iteration_index"
-      ],
+      "extends": "aggregate",
       "cols": {
         "set": null,
         "mem_peak": null,

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,7 +1,22 @@
 {
-	"$schema":"./tests/vendor/phpbench/phpbench/phpbench.schema.json",
-	"runner.bootstrap": "vendor/autoload.php",
-	"runner.path": "tests/bench",
-	"runner.file_pattern": "*Bench.php",
-	"storage.xml_storage_path": "tests/bench/storage"
+  "$schema": "./tests/vendor/phpbench/phpbench/phpbench.schema.json",
+  "runner.bootstrap": "vendor/autoload.php",
+  "runner.path": "tests/bench",
+  "runner.file_pattern": "*Bench.php",
+  "storage.xml_storage_path": "tests/bench/storage",
+  "report.generators": {
+    "my-report": {
+      "generator": "expression",
+      "aggregate": [
+        "iteration_index"
+      ],
+      "cols": {
+        "set": null,
+        "mem_peak": null,
+        "mode": null,
+        "time_diff": "format('%.2fx', mean(result_time_avg) / min(suite['result_time_avg']))",
+        "rstdev": null
+      }
+    }
+  }
 }


### PR DESCRIPTION
to ease reading the very long and information loaded table, I think it would be helpful if the summary table would contain less data (and therefore better fit into the github actions log viewer). the line break because of long lines, makes it hard to read.

atm we have a lot of redundant information (see screen below)

---

report before this PR:

<img width="2964" height="1692" alt="grafik" src="https://github.com/user-attachments/assets/9d2c08e2-c78f-4e68-83bb-36f47b54f963" />

- all tests have the same `benchmark` name (same string in column1 for all rows)
- all tests have the same `subject` name (same string in column2 for all rows)
- all tests have the same `revs` (same string in column4 for all rows)
- all tests have the same `its` (same string in column5 for all rows)

----

report after PR:
```
➜  phpstan-src git:(2.2.x) ✗ make phpbench
tests/bench/storage/local-baseline.xml
XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=my-report
PHPBench (1.5.1) running benchmarks... #standwithukraine
with configuration file: /Users/staabm/workspace/phpstan-src/phpbench.json
with PHP version 8.3.31, xdebug ❌, opcache ❌
comparing [actual vs. ]

\PHPStan\Benchmark\RegressionBench

    benchRunAnalyse # and-chain-truthy-blow.I4 ✔ [Mo118.006ms vs. Mo118.105ms] -0.08% (±0.68%)
    benchRunAnalyse # bug-1388.php..........I4 ✔ [Mo61.760ms vs. Mo62.238ms] -0.77% (±1.65%)
    benchRunAnalyse # bug-1447.php..........I4 ✔ [Mo12.732ms vs. Mo12.928ms] -1.52% (±1.20%)
    benchRunAnalyse # bug-3686.php..........I4 ✔ [Mo7.092ms vs. Mo7.132ms] -0.56% (±4.43%)

Subjects: 1, Assertions: 4, Failures: 0, Errors: 0
+-----------------------------+------------------+------------------+----------------+
| set                         | mem_peak         | mode             | rstdev         |
+-----------------------------+------------------+------------------+----------------+
| and-chain-truthy-blowup.php | 63.300mb -11.47% | 116.480ms -1.38% | ±2.33% +87.79% |
| bug-1388.php                | 70.667mb -0.26%  | 60.115ms -3.41%  | ±1.23% -35.56% |
| bug-1447.php                | 67.936mb 0.00%   | 12.825ms -0.80%  | ±0.77% +38.14% |
| bug-3686.php                | 67.476mb 0.00%   | 7.093ms -0.55%   | ±0.93% -54.37% |
...
```