### PR TITLE
ci: bump bashunit from 0.20.0 to 0.37.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -363,7 +363,7 @@ jobs:
         run: "patch src/Analyser/Error.php < e2e/PHPStanErrorPatch.patch"
 
       - name: "Install bashunit"
-        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.22.0"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.37.0"
 
       - name: "Test"
         run: "${{ matrix.script }}"
@@ -512,7 +512,7 @@ jobs:
       - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
 
       - name: "Install bashunit"
-        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.22.0"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.37.0"
 
       - name: "Test"
         run: ${{ matrix.script }}


### PR DESCRIPTION
Bumps the bashunit version used in E2E tests from `0.20.0` to the latest stable `0.37.0`.

Supersedes #5799, which vendored bashunit into the repo. Per review feedback we keep the existing on-demand install and just update the pinned version instead of committing third-party code.

Closes #5799