### PR TITLE
Infer parameter names from ReflectionMethod::getParameters()

### DIFF
--- a/src/Type/Php/ReflectionMethodConstructorReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionMethodConstructorReturnTypeExtension.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use ReflectionMethod;
+use function count;
+use function strpos;
+use function substr;
+
+#[AutowiredService]
+final class ReflectionMethodConstructorReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+
+	public function __construct(private ReflectionProvider $reflectionProvider)
+	{
+	}
+
+	public function getClass(): string
+	{
+		return ReflectionMethod::class;
+	}
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === '__construct';
+	}
+
+	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+	{
+		$args = $methodCall->getArgs();
+		if (count($args) === 0) {
+			return null;
+		}
+
+		$firstArgType = $scope->getType($args[0]->value);
+
+		// new ReflectionMethod($objectOrClassString, $method)
+		if (count($args) >= 2) {
+			$className = $this->resolveClassName($firstArgType);
+			if ($className === null) {
+				return null;
+			}
+
+			$methodNameType = $scope->getType($args[1]->value);
+			$methodNames = $methodNameType->getConstantStrings();
+			if (count($methodNames) !== 1) {
+				return null;
+			}
+
+			return $this->build($className, $methodNames[0]->getValue());
+		}
+
+		// new ReflectionMethod('Class::method')
+		$classAndMethod = $firstArgType->getConstantStrings();
+		if (count($classAndMethod) !== 1) {
+			return null;
+		}
+
+		$value = $classAndMethod[0]->getValue();
+		$separatorPos = strpos($value, '::');
+		if ($separatorPos === false) {
+			return null;
+		}
+
+		return $this->build(substr($value, 0, $separatorPos), substr($value, $separatorPos + 2));
+	}
+
+	private function resolveClassName(Type $type): ?string
+	{
+		// new ReflectionMethod($classString, ...) — covers both Foo::class and class-string<Foo>
+		$classStringObjectNames = $type->getClassStringObjectType()->getObjectClassNames();
+		if (count($classStringObjectNames) === 1) {
+			return $classStringObjectNames[0];
+		}
+
+		// new ReflectionMethod($object, ...)
+		$objectClassNames = $type->getObjectClassNames();
+		return count($objectClassNames) === 1 ? $objectClassNames[0] : null;
+	}
+
+	private function build(string $className, string $methodName): ?Type
+	{
+		if (!$this->reflectionProvider->hasClass($className)) {
+			return null;
+		}
+
+		$classReflection = $this->reflectionProvider->getClass($className);
+		if (!$classReflection->hasMethod($methodName)) {
+			return null;
+		}
+
+		return new GenericObjectType(ReflectionMethod::class, [
+			new ObjectType($className),
+			new ConstantStringType($methodName),
+		]);
+	}
+
+}

--- a/src/Type/Php/ReflectionMethodGetParametersReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionMethodGetParametersReturnTypeExtension.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Type;
+use ReflectionMethod;
+use ReflectionParameter;
+use function count;
+
+#[AutowiredService]
+final class ReflectionMethodGetParametersReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function __construct(private ReflectionProvider $reflectionProvider)
+	{
+	}
+
+	public function getClass(): string
+	{
+		return ReflectionMethod::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getParameters';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+	{
+		$calledOnType = $scope->getType($methodCall->var);
+
+		$classType = $calledOnType->getTemplateType(ReflectionMethod::class, 'TClass');
+		$classNames = $classType->getObjectClassNames();
+		if (count($classNames) !== 1) {
+			return null;
+		}
+
+		$nameType = $calledOnType->getTemplateType(ReflectionMethod::class, 'TName');
+		$methodNames = $nameType->getConstantStrings();
+		if (count($methodNames) !== 1) {
+			return null;
+		}
+
+		if (!$this->reflectionProvider->hasClass($classNames[0])) {
+			return null;
+		}
+
+		$classReflection = $this->reflectionProvider->getClass($classNames[0]);
+		if (!$classReflection->hasNativeMethod($methodNames[0]->getValue())) {
+			return null;
+		}
+
+		$methodReflection = $classReflection->getNativeMethod($methodNames[0]->getValue());
+
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		foreach ($methodReflection->getOnlyVariant()->getParameters() as $parameter) {
+			$builder->setOffsetValueType(
+				null,
+				new GenericObjectType(ReflectionParameter::class, [
+					new ConstantStringType($parameter->getName()),
+				]),
+			);
+		}
+
+		return $builder->getArray();
+	}
+
+}

--- a/stubs/ReflectionMethod.stub
+++ b/stubs/ReflectionMethod.stub
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @template-covariant TClass of object = object
+ * @template-covariant TName of string = string
+ */
 class ReflectionMethod
 {
 

--- a/stubs/ReflectionParameter.stub
+++ b/stubs/ReflectionParameter.stub
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @template-covariant TName of string = string
+ */
 class ReflectionParameter
 {
     /**
@@ -15,5 +18,10 @@ class ReflectionParameter
 	public function hasType(): bool
 	{
 	}
+
+	/**
+	 * @return TName
+	 */
+	public function getName(): string {}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-7056.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7056.php
@@ -23,7 +23,7 @@ class HelloWorld
 		assertType('non-empty-string', $m->getName());
 
 		$params = $m->getParameters();
-		assertType('non-empty-string', $params[0]->getName());
+		assertType('\'x\'', $params[0]->getName());
 
 		$rf = new \ReflectionFunction('Bug7056\fooo');
 		assertType('non-empty-string', $rf->getName());

--- a/tests/PHPStan/Analyser/nsrt/reflection-method-get-parameters.php
+++ b/tests/PHPStan/Analyser/nsrt/reflection-method-get-parameters.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types = 1);
+
+namespace ReflectionMethodGetParameters;
+
+use function PHPStan\Testing\assertType;
+
+class User
+{
+	public function __construct(
+		public int $id,
+		public ?string $email,
+	) {
+	}
+
+	public function noParams(): void
+	{
+	}
+
+	public function variadic(int $first, string ...$rest): void
+	{
+	}
+}
+
+function testConstructorEncodesClassAndName(): void
+{
+	$m = new \ReflectionMethod(User::class, '__construct');
+	assertType('ReflectionMethod<ReflectionMethodGetParameters\\User, \'__construct\'>', $m);
+}
+
+function testGetParametersIsTuple(): void
+{
+	$m = new \ReflectionMethod(User::class, '__construct');
+	$params = $m->getParameters();
+	assertType('array{ReflectionParameter<\'id\'>, ReflectionParameter<\'email\'>}', $params);
+}
+
+function testGetNameReturnsLiteralInLoop(): void
+{
+	$m = new \ReflectionMethod(User::class, '__construct');
+	foreach ($m->getParameters() as $param) {
+		assertType('\'email\'|\'id\'', $param->getName());
+	}
+}
+
+function testRebuildArrayShape(User $user): void
+{
+	$props = [];
+	$m = new \ReflectionMethod(User::class, '__construct');
+	foreach ($m->getParameters() as $param) {
+		$props[$param->getName()] = $user->{$param->getName()};
+	}
+	assertType('array{id: int, email: string|null}', $props);
+}
+
+/** @param class-string<User> $className */
+function testClassStringArgument(string $className): void
+{
+	$m = new \ReflectionMethod($className, '__construct');
+	assertType('array{ReflectionParameter<\'id\'>, ReflectionParameter<\'email\'>}', $m->getParameters());
+}
+
+function testObjectArgument(User $user): void
+{
+	$m = new \ReflectionMethod($user, '__construct');
+	assertType('array{ReflectionParameter<\'id\'>, ReflectionParameter<\'email\'>}', $m->getParameters());
+}
+
+function testCombinedStringArgument(): void
+{
+	$m = new \ReflectionMethod('ReflectionMethodGetParameters\\User::__construct');
+	assertType('array{ReflectionParameter<\'id\'>, ReflectionParameter<\'email\'>}', $m->getParameters());
+}
+
+function testNoParameters(): void
+{
+	$m = new \ReflectionMethod(User::class, 'noParams');
+	assertType('array{}', $m->getParameters());
+}
+
+function testVariadic(): void
+{
+	$m = new \ReflectionMethod(User::class, 'variadic');
+	assertType('array{ReflectionParameter<\'first\'>, ReflectionParameter<\'rest\'>}', $m->getParameters());
+}
+
+function testDynamicMethodNameFallsBack(string $method): void
+{
+	$m = new \ReflectionMethod(User::class, $method);
+	assertType('list<ReflectionParameter>', $m->getParameters());
+}
+
+function testUnknownMethodFallsBack(): void
+{
+	$m = new \ReflectionMethod(User::class, 'doesNotExist');
+	assertType('list<ReflectionParameter>', $m->getParameters());
+}
+
+function testUnknownObjectFallsBack(object $object): void
+{
+	$m = new \ReflectionMethod($object, 'foo');
+	assertType('list<ReflectionParameter>', $m->getParameters());
+}


### PR DESCRIPTION
Closes phpstan/phpstan#14726

## What this does

When a `ReflectionMethod` is constructed on a **statically known** class and method name, `getParameters()` now returns a constant array of `ReflectionParameter` objects whose `getName()` resolves to the **literal** parameter name.

This lets PHPStan precisely type the common pattern of rebuilding an array keyed by a method's parameter names:

```php
$props = [];
foreach ((new ReflectionMethod(Foo::class, '__construct'))->getParameters() as $p) {
    $props[$p->getName()] = $obj->{$p->getName()};
}
```

Before, `$props` was inferred as `array<non-empty-string, mixed>`, producing false-positive "offset might not exist" errors and `mixed` values. Now it is inferred as an array shape correlated with `Foo`'s constructor signature, e.g. `array{id: int, email: string|null}`.

## How

- `ReflectionMethod` / `ReflectionParameter` stubs gain a `@template-covariant` parameter so the resolved class/method/name can be carried as a generic argument; `ReflectionParameter::getName()` returns `TName`.
- `ReflectionMethodConstructorReturnTypeExtension` encodes the class + method name into `ReflectionMethod<TClass, TName>` at construction. It supports every constructor form: `(Foo::class, 'm')`, `($object, 'm')`, `(class-string, 'm')` and `('Foo::m')`.
- `ReflectionMethodGetParametersReturnTypeExtension` reads those template args, looks the method up via `ReflectionProvider`, and builds a constant array of `ReflectionParameter<'name'>`.

When the class or method name is not statically resolvable, everything falls back to the original `list<ReflectionParameter>` — no regression for dynamic usage.

## Tests

- New `nsrt/reflection-method-get-parameters.php` covers: constructor encoding, tuple shape, `getName()` literal in a loop, the array-shape rebuild, the four constructor argument forms, variadic, zero-parameter, and the dynamic-name / unknown-method / unknown-object fallbacks.
- `nsrt/bug-7056.php` had one assertion become more precise (`non-empty-string` → `'x'` for a resolvable `getParameters()[0]->getName()`); updated accordingly.
- Full `NodeScopeResolverTest` suite is green (no other regressions).

## Out of scope (follow-up)

`ReflectionFunction::getParameters()` could get the same treatment (including closures). Kept out of this PR to stay focused on the issue; happy to add it in a follow-up.
