### PR TITLE
Prevent ENV var tokens from beeing leaked by commited DI containers

### DIFF
--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -96,7 +96,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 		unset($staticParameters['env']['SHELL_VERBOSITY']);
 		// make sure invocations via blackfire use the same container
 		unset($staticParameters['env']['BLACKFIRE_AGENT_SOCKET']);
-		// drop known sensitive parameter from beeing leaked, when container files committed in repositories
+		// drop known sensitive parameter from being leaked, when container files committed in repositories
 		unset($staticParameters['env']['GITHUB_TOKEN']);
 		unset($staticParameters['env']['CI_JOB_TOKEN']); // gitlab
 		unset($staticParameters['env']['PRIVATE-TOKEN']); // gitlab

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -96,7 +96,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 		unset($staticParameters['env']['SHELL_VERBOSITY']);
 		// make sure invocations via blackfire use the same container
 		unset($staticParameters['env']['BLACKFIRE_AGENT_SOCKET']);
-		// drop known sensitive parameter from being leaked, when container files committed in repositories
+		// prevent known sensitive parameter from being leaked, when container files committed in repositories
 		unset($staticParameters['env']['GITHUB_TOKEN']);
 		unset($staticParameters['env']['CI_JOB_TOKEN']); // gitlab
 		unset($staticParameters['env']['PRIVATE-TOKEN']); // gitlab

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -96,6 +96,10 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 		unset($staticParameters['env']['SHELL_VERBOSITY']);
 		// make sure invocations via blackfire use the same container
 		unset($staticParameters['env']['BLACKFIRE_AGENT_SOCKET']);
+		// drop known sensitive parameter from beeing leaked, when container files committed in repositories
+		unset($staticParameters['env']['GITHUB_TOKEN']);
+		unset($staticParameters['env']['CI_JOB_TOKEN']); // gitlab
+		unset($staticParameters['env']['PRIVATE-TOKEN']); // gitlab
 
 		$containerKey = [
 			$staticParameters,


### PR DESCRIPTION
just to make sure, people accidentally commiting phpstan DI temp files, will not leak security tokens/credentials