### PR TITLE
Prevent ENV var tokens from beeing leaked by commited DI containers

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -48,7 +48,6 @@ use function dirname;
 use function error_get_last;
 use function get_class;
 use function getcwd;
-use function getenv;
 use function gettype;
 use function implode;
 use function ini_get;
@@ -270,7 +269,7 @@ final class CommandHelper
 			$defaultParameters = [
 				'rootDir' => $containerFactory->getRootDirectory(),
 				'currentWorkingDirectory' => $containerFactory->getCurrentWorkingDirectory(),
-				'env' => getenv(),
+				'env' => Environment::getCleanedArray(),
 			];
 
 			if (isset($projectConfig['parameters']['tmpDir'])) {

--- a/src/Command/Environment.php
+++ b/src/Command/Environment.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command;
+
+use function getenv;
+use function in_array;
+
+final class Environment
+{
+
+	private const SENSITIVE_ENV_VARIABLES = [
+		'GITHUB_TOKEN',
+		'CI_JOB_TOKEN', // gitlab
+		'PRIVATE-TOKEN', // gitlab
+		'TIDEWAYS_APIKEY',
+	];
+
+	/**
+	 * Prevents known sensitive env vars from being leaked, e.g. when container files committed in repositories
+	 *
+	 * @return array<string, string>
+	 */
+	public static function getCleanedArray(): array
+	{
+		$env = getenv();
+		$cleanedArray = [];
+		foreach ($env as $name => $value) {
+			if (in_array($name, self::SENSITIVE_ENV_VARIABLES, true)) {
+				continue;
+			}
+			$cleanedArray[$name] = $value;
+		}
+		return $cleanedArray;
+	}
+
+}

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -48,7 +48,6 @@ use function count;
 use function defined;
 use function escapeshellarg;
 use function get_class;
-use function getenv;
 use function http_build_query;
 use function ini_get;
 use function is_file;
@@ -269,7 +268,7 @@ final class FixerApplication
 			throw new FixerProcessException();
 		}
 
-		$env = getenv();
+		$env = Environment::getCleanedArray();
 		$env['PHPSTAN_PRO_TMP_DIR'] = $this->proTmpDir;
 		$forcedPort = $_SERVER['PHPSTAN_PRO_WEB_PORT'] ?? null;
 		if ($forcedPort !== null) {

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -96,10 +96,6 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 		unset($staticParameters['env']['SHELL_VERBOSITY']);
 		// make sure invocations via blackfire use the same container
 		unset($staticParameters['env']['BLACKFIRE_AGENT_SOCKET']);
-		// prevent known sensitive parameter from being leaked, when container files committed in repositories
-		unset($staticParameters['env']['GITHUB_TOKEN']);
-		unset($staticParameters['env']['CI_JOB_TOKEN']); // gitlab
-		unset($staticParameters['env']['PRIVATE-TOKEN']); // gitlab
 
 		$containerKey = [
 			$staticParameters,

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -23,6 +23,7 @@ use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\Command\CommandHelper;
+use PHPStan\Command\Environment;
 use PHPStan\File\FileHelper;
 use PHPStan\Node\Printer\Printer;
 use PHPStan\Php\PhpVersion;
@@ -42,7 +43,6 @@ use function array_unique;
 use function count;
 use function dirname;
 use function extension_loaded;
-use function getenv;
 use function implode;
 use function ini_get;
 use function is_array;
@@ -118,7 +118,7 @@ final class ContainerFactory
 			[
 				'rootDir' => $this->rootDirectory,
 				'currentWorkingDirectory' => $this->currentWorkingDirectory,
-				'env' => getenv(),
+				'env' => Environment::getCleanedArray(),
 			],
 		);
 
@@ -146,7 +146,7 @@ final class ContainerFactory
 			'generateBaselineFile' => $generateBaselineFile,
 			'usedLevel' => $usedLevel,
 			'cliAutoloadFile' => $cliAutoloadFile,
-			'env' => getenv(),
+			'env' => Environment::getCleanedArray(),
 		], $additionalParameters));
 		$configurator->addDynamicParameters([
 			'singleReflectionFile' => $singleReflectionFile,

--- a/src/DependencyInjection/LoaderFactory.php
+++ b/src/DependencyInjection/LoaderFactory.php
@@ -3,8 +3,8 @@
 namespace PHPStan\DependencyInjection;
 
 use Nette\DI\Config\Loader;
+use PHPStan\Command\Environment;
 use PHPStan\File\FileHelper;
-use function getenv;
 
 final class LoaderFactory
 {
@@ -32,7 +32,7 @@ final class LoaderFactory
 		$loader->setParameters([
 			'rootDir' => $this->rootDir,
 			'currentWorkingDirectory' => $this->currentWorkingDirectory,
-			'env' => getenv(),
+			'env' => Environment::getCleanedArray(),
 		]);
 
 		return $loader;


### PR DESCRIPTION
followup to https://github.com/phpstan/phpstan-src/pull/5818

I double checked the containers in `tmp/cache/nette.configurator` and these now no longer contain e.g. the TIDEWAYS_APIKEY