### PR TITLE
install bashunit via pinned github action

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -399,6 +399,8 @@ jobs:
 
       - name: "Install bashunit"
         uses: "TypedDevs/bashunit@38fd81415a622ec084aaf2c7a71a543470581437" # 0.38.0
+        with:
+          directory: "e2e"
 
       - name: "Test"
         run: "${{ matrix.script }}"
@@ -548,6 +550,8 @@ jobs:
 
       - name: "Install bashunit"
         uses: "TypedDevs/bashunit@38fd81415a622ec084aaf2c7a71a543470581437" # 0.38.0
+        with:
+          directory: "e2e"
 
       - name: "Test"
         run: ${{ matrix.script }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -398,7 +398,7 @@ jobs:
         run: "patch src/Analyser/Error.php < e2e/PHPStanErrorPatch.patch"
 
       - name: "Install bashunit"
-        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.37.0"
+        uses: "TypedDevs/bashunit@38fd81415a622ec084aaf2c7a71a543470581437" # 0.38.0
 
       - name: "Test"
         run: "${{ matrix.script }}"
@@ -547,7 +547,7 @@ jobs:
       - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
 
       - name: "Install bashunit"
-        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.37.0"
+        uses: "TypedDevs/bashunit@38fd81415a622ec084aaf2c7a71a543470581437" # 0.38.0
 
       - name: "Test"
         run: ${{ matrix.script }}


### PR DESCRIPTION
- install via newly published [bashunit github action](https://github.com/marketplace/actions/install-bashunit)
- no need to blindly rely on `curl ... | bash` commands.
- as of now, updates will be shipped by renovate/dependabot like any other action
- we can use a pinned release, so we know which version will be installed
- zizmor will statically analyse bashunit 