### PR TITLE
Explain unresolvable and impossible types with reasons

### DIFF
--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -733,7 +733,7 @@ final class PhpDocNodeResolver
 			return false;
 		}
 
-		return $this->unresolvableTypeHelper->containsUnresolvableType($type);
+		return $this->unresolvableTypeHelper->getUnresolvableType($type) !== null;
 	}
 
 	public function resolveAllowPrivateMutation(PhpDocNode $phpDocNode): bool

--- a/src/Rules/Classes/ImpossibleInstanceOfRule.php
+++ b/src/Rules/Classes/ImpossibleInstanceOfRule.php
@@ -106,11 +106,18 @@ final class ImpossibleInstanceOfRule implements Rule
 		if (!$instanceofType->getValue()) {
 			$exprType = $this->treatPhpDocTypesAsCertain ? $scope->getType($node->expr) : $scope->getNativeType($node->expr);
 
-			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'Instanceof between %s and %s will always evaluate to false.',
 				$exprType->describe(VerbosityLevel::typeOnly()),
 				$classType->describe(VerbosityLevel::getRecommendedLevelByType($classType)),
-			)))->identifier('instanceof.alwaysFalse')->build();
+			));
+			$reasons = $classType->isSuperTypeOf($exprType)->reasons;
+			if ($reasons !== []) {
+				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
+			} else {
+				$errorBuilder = $addTip($errorBuilder);
+			}
+			$ruleError = $errorBuilder->identifier('instanceof.alwaysFalse')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
 				return [];

--- a/src/Rules/Classes/ImpossibleInstanceOfRule.php
+++ b/src/Rules/Classes/ImpossibleInstanceOfRule.php
@@ -84,7 +84,14 @@ final class ImpossibleInstanceOfRule implements Rule
 			return [];
 		}
 
-		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
+		$exprType = $this->treatPhpDocTypesAsCertain ? $scope->getType($node->expr) : $scope->getNativeType($node->expr);
+		$reasons = $classType->isSuperTypeOf($exprType)->reasons;
+
+		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $reasons): RuleErrorBuilder {
+			if ($reasons !== []) {
+				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder->acceptsReasonsTip($reasons));
+			}
+
 			if (!$this->treatPhpDocTypesAsCertain) {
 				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 			}
@@ -104,19 +111,11 @@ final class ImpossibleInstanceOfRule implements Rule
 		};
 
 		if (!$instanceofType->getValue()) {
-			$exprType = $this->treatPhpDocTypesAsCertain ? $scope->getType($node->expr) : $scope->getNativeType($node->expr);
-
-			$errorBuilder = RuleErrorBuilder::message(sprintf(
+			$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 				'Instanceof between %s and %s will always evaluate to false.',
 				$exprType->describe(VerbosityLevel::typeOnly()),
 				$classType->describe(VerbosityLevel::getRecommendedLevelByType($classType)),
-			));
-			$reasons = $classType->isSuperTypeOf($exprType)->reasons;
-			if ($reasons !== []) {
-				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
-			} else {
-				$errorBuilder = $addTip($errorBuilder);
-			}
+			)));
 			$ruleError = $errorBuilder->identifier('instanceof.alwaysFalse')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
@@ -132,7 +131,6 @@ final class ImpossibleInstanceOfRule implements Rule
 			return [];
 		}
 
-		$exprType = $this->treatPhpDocTypesAsCertain ? $scope->getType($node->expr) : $scope->getNativeType($node->expr);
 		$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 			'Instanceof between %s and %s will always evaluate to true.',
 			$exprType->describe(VerbosityLevel::typeOnly()),

--- a/src/Rules/Classes/LocalTypeAliasesCheck.php
+++ b/src/Rules/Classes/LocalTypeAliasesCheck.php
@@ -288,10 +288,14 @@ final class LocalTypeAliasesCheck
 				}
 			}
 
-			if ($this->unresolvableTypeHelper->containsUnresolvableType($resolvedType)) {
-				$errors[] = RuleErrorBuilder::message(sprintf('Type alias %s contains unresolvable type.', $aliasName))
-					->identifier('typeAlias.unresolvableType')
-					->build();
+			$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($resolvedType);
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf('Type alias %s contains unresolvable type.', $aliasName))
+					->identifier('typeAlias.unresolvableType');
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 			}
 
 			$escapedTypeAlias = SprintfHelper::escapeFormatString($aliasName);

--- a/src/Rules/Classes/MethodTagCheck.php
+++ b/src/Rules/Classes/MethodTagCheck.php
@@ -250,13 +250,18 @@ final class MethodTagCheck
 			}
 		}
 
-		if ($this->unresolvableTypeHelper->containsUnresolvableType($type)) {
-			$errors[] = RuleErrorBuilder::message(sprintf(
+		$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($type);
+		if ($unresolvableType !== null) {
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'PHPDoc tag @method for method %s::%s() %s contains unresolvable type.',
 				$classReflection->getDisplayName(),
 				$methodName,
 				$description,
-			))->identifier('methodTag.unresolvableType')->build();
+			))->identifier('methodTag.unresolvableType');
+			foreach ($unresolvableType->reasons as $reason) {
+				$errorBuilder->addTip($reason);
+			}
+			$errors[] = $errorBuilder->build();
 		}
 
 		$escapedClassName = SprintfHelper::escapeFormatString($classReflection->getDisplayName());

--- a/src/Rules/Classes/MixinCheck.php
+++ b/src/Rules/Classes/MixinCheck.php
@@ -133,12 +133,14 @@ final class MixinCheck
 		$errors = [];
 		foreach ($phpDoc->getMixinTags() as $mixinTag) {
 			$type = $mixinTag->getType();
-			if (
-				$this->unresolvableTypeHelper->containsUnresolvableType($type)
-			) {
-				$errors[] = RuleErrorBuilder::message('PHPDoc tag @mixin contains unresolvable type.')
-					->identifier('mixin.unresolvableType')
-					->build();
+			$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($type);
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message('PHPDoc tag @mixin contains unresolvable type.')
+					->identifier('mixin.unresolvableType');
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 				continue;
 			}
 

--- a/src/Rules/Classes/PropertyTagCheck.php
+++ b/src/Rules/Classes/PropertyTagCheck.php
@@ -231,13 +231,18 @@ final class PropertyTagCheck
 			}
 		}
 
-		if ($this->unresolvableTypeHelper->containsUnresolvableType($type)) {
-			$errors[] = RuleErrorBuilder::message(sprintf(
+		$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($type);
+		if ($unresolvableType !== null) {
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'PHPDoc tag %s for property %s::$%s contains unresolvable type.',
 				$tagName,
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->identifier('propertyTag.unresolvableType')->build();
+			))->identifier('propertyTag.unresolvableType');
+			foreach ($unresolvableType->reasons as $reason) {
+				$errorBuilder->addTip($reason);
+			}
+			$errors[] = $errorBuilder->build();
 		}
 
 		$escapedClassName = SprintfHelper::escapeFormatString($classReflection->getDisplayName());

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -53,7 +53,11 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 			return [];
 		}
 
-		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
+		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $reasons): RuleErrorBuilder {
+			if ($reasons !== []) {
+				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder->acceptsReasonsTip($reasons));
+			}
+
 			if (!$this->treatPhpDocTypesAsCertain) {
 				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 			}
@@ -72,16 +76,11 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		};
 
 		if (!$isAlways) {
-			$errorBuilder = RuleErrorBuilder::message(sprintf(
+			$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 				'Call to function %s()%s will always evaluate to false.',
 				$functionName,
 				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-			));
-			if ($reasons !== []) {
-				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
-			} else {
-				$errorBuilder = $addTip($errorBuilder);
-			}
+			)));
 			$ruleError = $errorBuilder->identifier('function.impossibleType')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -46,7 +46,8 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		}
 
 		$functionName = (string) $node->name;
-		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
+		$reasons = [];
+		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node, $reasons);
 		if ($isAlways === null) {
 			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
@@ -71,11 +72,17 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		};
 
 		if (!$isAlways) {
-			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'Call to function %s()%s will always evaluate to false.',
 				$functionName,
 				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-			)))->identifier('function.impossibleType')->build();
+			));
+			if ($reasons !== []) {
+				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
+			} else {
+				$errorBuilder = $addTip($errorBuilder);
+			}
+			$ruleError = $errorBuilder->identifier('function.impossibleType')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
 				return [];

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -33,6 +33,8 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_map;
 use function array_pop;
+use function array_unique;
+use function array_values;
 use function count;
 use function implode;
 use function in_array;
@@ -53,12 +55,18 @@ final class ImpossibleCheckTypeHelper
 	{
 	}
 
+	/**
+	 * @param list<string> $reasons populated with human-readable explanations of why the
+	 * result is "always false" (empty for the "always true" / inconclusive results)
+	 */
 	public function findSpecifiedType(
 		Scope $scope,
 		Expr $node,
+		array &$reasons = [],
 	): ?bool
 	{
-		$specifiedValue = $this->getSpecifiedType($scope, $node);
+		$specifiedValue = $this->getSpecifiedType($scope, $node, $reasons);
+		$reasons = array_values(array_unique($reasons));
 
 		/**
 		 * For class_exists()/interface_exists()/trait_exists()/enum_exists() the "always true"
@@ -83,9 +91,13 @@ final class ImpossibleCheckTypeHelper
 		return $specifiedValue;
 	}
 
+	/**
+	 * @param list<string> $reasons
+	 */
 	private function getSpecifiedType(
 		Scope $scope,
 		Expr $node,
+		array &$reasons = [],
 	): ?bool
 	{
 		if ($node instanceof FuncCall) {
@@ -360,7 +372,15 @@ final class ImpossibleCheckTypeHelper
 				$argumentType = $scope->getType($assignedInCallVar->expr);
 			}
 
-			$results[] = $resultType->isSuperTypeOf($argumentType)->result;
+			$isSuperType = $resultType->isSuperTypeOf($argumentType);
+			$results[] = $isSuperType->result;
+			if (!$isSuperType->result->no()) {
+				continue;
+			}
+
+			foreach ($isSuperType->reasons as $reason) {
+				$reasons[] = $reason;
+			}
 		}
 
 		foreach ($sureNotTypes as $sureNotType) {
@@ -378,7 +398,15 @@ final class ImpossibleCheckTypeHelper
 			/** @var Type $resultType */
 			$resultType = $sureNotType[1];
 
-			$results[] = $resultType->isSuperTypeOf($argumentType)->negate()->result;
+			$isSuperType = $resultType->isSuperTypeOf($argumentType)->negate();
+			$results[] = $isSuperType->result;
+			if (!$isSuperType->result->no()) {
+				continue;
+			}
+
+			foreach ($isSuperType->reasons as $reason) {
+				$reasons[] = $reason;
+			}
 		}
 
 		if (count($results) === 0) {

--- a/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
@@ -55,7 +55,11 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 			return [];
 		}
 
-		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
+		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $reasons): RuleErrorBuilder {
+			if ($reasons !== []) {
+				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder->acceptsReasonsTip($reasons));
+			}
+
 			if (!$this->treatPhpDocTypesAsCertain) {
 				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 			}
@@ -75,17 +79,12 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 
 		if (!$isAlways) {
 			$method = $this->getMethod($node->var, $node->name->name, $scope);
-			$errorBuilder = RuleErrorBuilder::message(sprintf(
+			$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 				'Call to method %s::%s()%s will always evaluate to false.',
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName(),
 				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-			));
-			if ($reasons !== []) {
-				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
-			} else {
-				$errorBuilder = $addTip($errorBuilder);
-			}
+			)));
 			$ruleError = $errorBuilder->identifier('method.impossibleType')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);

--- a/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
@@ -48,7 +48,8 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 			return [];
 		}
 
-		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
+		$reasons = [];
+		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node, $reasons);
 		if ($isAlways === null) {
 			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
@@ -74,12 +75,18 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 
 		if (!$isAlways) {
 			$method = $this->getMethod($node->var, $node->name->name, $scope);
-			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'Call to method %s::%s()%s will always evaluate to false.',
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName(),
 				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-			)))->identifier('method.impossibleType')->build();
+			));
+			if ($reasons !== []) {
+				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
+			} else {
+				$errorBuilder = $addTip($errorBuilder);
+			}
+			$ruleError = $errorBuilder->identifier('method.impossibleType')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
 				return [];

--- a/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
@@ -55,7 +55,11 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 			return [];
 		}
 
-		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
+		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $reasons): RuleErrorBuilder {
+			if ($reasons !== []) {
+				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder->acceptsReasonsTip($reasons));
+			}
+
 			if (!$this->treatPhpDocTypesAsCertain) {
 				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 			}
@@ -76,17 +80,12 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 		if (!$isAlways) {
 			$method = $this->getMethod($node->class, $node->name->name, $scope);
 
-			$errorBuilder = RuleErrorBuilder::message(sprintf(
+			$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 				'Call to static method %s::%s()%s will always evaluate to false.',
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName(),
 				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-			));
-			if ($reasons !== []) {
-				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
-			} else {
-				$errorBuilder = $addTip($errorBuilder);
-			}
+			)));
 			$ruleError = $errorBuilder->identifier('staticMethod.impossibleType')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);

--- a/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
@@ -48,7 +48,8 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 			return [];
 		}
 
-		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
+		$reasons = [];
+		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node, $reasons);
 		if ($isAlways === null) {
 			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
@@ -75,12 +76,18 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 		if (!$isAlways) {
 			$method = $this->getMethod($node->class, $node->name->name, $scope);
 
-			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'Call to static method %s::%s()%s will always evaluate to false.',
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName(),
 				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-			)))->identifier('staticMethod.impossibleType')->build();
+			));
+			if ($reasons !== []) {
+				$errorBuilder = $this->possiblyImpureTipHelper->addTip($scope, $node, $errorBuilder->acceptsReasonsTip($reasons));
+			} else {
+				$errorBuilder = $addTip($errorBuilder);
+			}
+			$ruleError = $errorBuilder->identifier('staticMethod.impossibleType')->build();
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
 				return [];

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -415,15 +415,20 @@ final class FunctionCallParametersCheck
 					}
 				}
 
+				$unresolvableParameterType = $this->unresolvableTypeHelper->getUnresolvableType($parameterType);
 				if (
 					$originalParameter !== null
-					&& !$this->unresolvableTypeHelper->containsUnresolvableType($originalParameter->getType())
-					&& $this->unresolvableTypeHelper->containsUnresolvableType($parameterType)
+					&& $this->unresolvableTypeHelper->getUnresolvableType($originalParameter->getType()) === null
+					&& $unresolvableParameterType !== null
 				) {
-					$errors[] = RuleErrorBuilder::message(sprintf(
+					$errorBuilder = RuleErrorBuilder::message(sprintf(
 						$unresolvableParameterTypeMessage,
 						$this->describeParameter($parameter, $argumentName === null ? $i + 1 : null),
-					))->identifier('argument.unresolvableType')->line($argumentLine)->build();
+					))->identifier('argument.unresolvableType')->line($argumentLine);
+					foreach ($unresolvableParameterType->reasons as $reason) {
+						$errorBuilder->addTip($reason);
+					}
+					$errors[] = $errorBuilder->build();
 				}
 
 				if (
@@ -630,14 +635,18 @@ final class FunctionCallParametersCheck
 				}
 			}
 
+			$unresolvableReturnType = $this->unresolvableTypeHelper->getUnresolvableType($parametersAcceptor->getReturnType());
 			if (
-				!$this->unresolvableTypeHelper->containsUnresolvableType($originalParametersAcceptor->getReturnType())
-				&& $this->unresolvableTypeHelper->containsUnresolvableType($parametersAcceptor->getReturnType())
+				$this->unresolvableTypeHelper->getUnresolvableType($originalParametersAcceptor->getReturnType()) === null
+				&& $unresolvableReturnType !== null
 			) {
-				$errors[] = RuleErrorBuilder::message($unresolvableReturnTypeMessage)
+				$errorBuilder = RuleErrorBuilder::message($unresolvableReturnTypeMessage)
 					->identifier(sprintf('%s.unresolvableReturnType', $nodeType))
-					->line($funcCallLine)
-					->build();
+					->line($funcCallLine);
+				foreach ($unresolvableReturnType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 			}
 		}
 

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -157,15 +157,18 @@ final class FunctionDefinitionCheck
 					->nonIgnorable()
 					->build();
 			}
-			if (
-				$this->phpVersion->supportsPureIntersectionTypes()
-				&& $this->unresolvableTypeHelper->containsUnresolvableType($type)
-			) {
-				$errors[] = RuleErrorBuilder::message(sprintf($unresolvableParameterTypeMessage, $param->var->name))
+			$unresolvableType = $this->phpVersion->supportsPureIntersectionTypes()
+				? $this->unresolvableTypeHelper->getUnresolvableType($type)
+				: null;
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf($unresolvableParameterTypeMessage, $param->var->name))
 					->line($param->type->getStartLine())
 					->identifier('parameter.unresolvableNativeType')
-					->nonIgnorable()
-					->build();
+					->nonIgnorable();
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 			}
 
 			foreach ($type->getReferencedClasses() as $class) {
@@ -241,15 +244,18 @@ final class FunctionDefinitionCheck
 		}
 
 		$returnType = $scope->getFunctionType($returnTypeNode, false, false);
-		if (
-			$this->phpVersion->supportsPureIntersectionTypes()
-			&& $this->unresolvableTypeHelper->containsUnresolvableType($returnType)
-		) {
-			$errors[] = RuleErrorBuilder::message($unresolvableReturnTypeMessage)
+		$unresolvableReturnType = $this->phpVersion->supportsPureIntersectionTypes()
+			? $this->unresolvableTypeHelper->getUnresolvableType($returnType)
+			: null;
+		if ($unresolvableReturnType !== null) {
+			$errorBuilder = RuleErrorBuilder::message($unresolvableReturnTypeMessage)
 				->line($returnTypeNode->getStartLine())
 				->identifier('return.unresolvableNativeType')
-				->nonIgnorable()
-				->build();
+				->nonIgnorable();
+			foreach ($unresolvableReturnType->reasons as $reason) {
+				$errorBuilder->addTip($reason);
+			}
+			$errors[] = $errorBuilder->build();
 		}
 
 		foreach ($returnType->getReferencedClasses() as $returnTypeClass) {
@@ -435,15 +441,18 @@ final class FunctionDefinitionCheck
 					->nonIgnorable()
 					->build();
 			}
-			if (
-				$this->phpVersion->supportsPureIntersectionTypes()
-				&& $this->unresolvableTypeHelper->containsUnresolvableType($parameter->getNativeType())
-			) {
-				$errors[] = RuleErrorBuilder::message(sprintf($unresolvableParameterTypeMessage, $parameterVar->name))
+			$unresolvableType = $this->phpVersion->supportsPureIntersectionTypes()
+				? $this->unresolvableTypeHelper->getUnresolvableType($parameter->getNativeType())
+				: null;
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf($unresolvableParameterTypeMessage, $parameterVar->name))
 					->line($parameterNodeCallback()->getStartLine())
 					->identifier('parameter.unresolvableNativeType')
-					->nonIgnorable()
-					->build();
+					->nonIgnorable();
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 			}
 			foreach ($referencedClasses as $class) {
 				if (!$this->reflectionProvider->hasClass($class)) {
@@ -512,12 +521,16 @@ final class FunctionDefinitionCheck
 
 		if ($this->phpVersion->supportsPureIntersectionTypes() && $functionNode->getReturnType() !== null) {
 			$nativeReturnType = ParserNodeTypeToPHPStanType::resolve($functionNode->getReturnType(), $scope->isInClass() ? $scope->getClassReflection() : null);
-			if ($this->unresolvableTypeHelper->containsUnresolvableType($nativeReturnType)) {
-				$errors[] = RuleErrorBuilder::message($unresolvableReturnTypeMessage)
+			$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($nativeReturnType);
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message($unresolvableReturnTypeMessage)
 					->nonIgnorable()
 					->line($returnTypeNode->getStartLine())
-					->identifier('return.unresolvableNativeType')
-					->build();
+					->identifier('return.unresolvableNativeType');
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 			}
 		}
 		if ($parametersAcceptor->mustUseReturnValue()->yes()) {

--- a/src/Rules/Generics/GenericAncestorsCheck.php
+++ b/src/Rules/Generics/GenericAncestorsCheck.php
@@ -109,10 +109,14 @@ final class GenericAncestorsCheck
 			);
 			$messages = array_merge($messages, $genericObjectTypeCheckMessages);
 
-			if ($this->unresolvableTypeHelper->containsUnresolvableType($ancestorType)) {
-				$messages[] = RuleErrorBuilder::message($unresolvableTypeMessage)
-					->identifier('generics.unresolvable')
-					->build();
+			$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($ancestorType);
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message($unresolvableTypeMessage)
+					->identifier('generics.unresolvable');
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$messages[] = $errorBuilder->build();
 			}
 
 			foreach ($ancestorType->getReferencedClasses() as $referencedClass) {

--- a/src/Rules/PhpDoc/AssertRuleHelper.php
+++ b/src/Rules/PhpDoc/AssertRuleHelper.php
@@ -98,12 +98,17 @@ final class AssertRuleHelper
 				AssertTag::IF_FALSE => '@phpstan-assert-if-false',
 			][$assert->getIf()];
 
-			if ($this->unresolvableTypeHelper->containsUnresolvableType($assertedType)) {
-				$errors[] = RuleErrorBuilder::message(sprintf(
+			$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($assertedType);
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf(
 					'PHPDoc tag %s for %s contains unresolvable type.',
 					$tagName,
 					$assertedExprString,
-				))->identifier('assert.unresolvableType')->build();
+				))->identifier('assert.unresolvableType');
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 				continue;
 			}
 

--- a/src/Rules/PhpDoc/IncompatibleClassConstantPhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatibleClassConstantPhpDocTypeRule.php
@@ -71,14 +71,17 @@ final class IncompatibleClassConstantPhpDocTypeRule implements Rule
 		}
 
 		$errors = [];
-		if (
-			$this->unresolvableTypeHelper->containsUnresolvableType($phpDocType)
-		) {
-			$errors[] = RuleErrorBuilder::message(sprintf(
+		$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($phpDocType);
+		if ($unresolvableType !== null) {
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'PHPDoc tag @var for constant %s::%s contains unresolvable type.',
 				$constantReflection->getDeclaringClass()->getName(),
 				$constantName,
-			))->identifier('classConstant.unresolvableType')->build();
+			))->identifier('classConstant.unresolvableType');
+			foreach ($unresolvableType->reasons as $reason) {
+				$errorBuilder->addTip($reason);
+			}
+			$errors[] = $errorBuilder->build();
 		} elseif ($nativeType !== null) {
 			$isSuperType = $nativeType->isSuperTypeOf($phpDocType);
 			if ($isSuperType->no()) {

--- a/src/Rules/PhpDoc/IncompatiblePhpDocTypeCheck.php
+++ b/src/Rules/PhpDoc/IncompatiblePhpDocTypeCheck.php
@@ -52,6 +52,7 @@ final class IncompatiblePhpDocTypeCheck
 		foreach (['@param' => $resolvedPhpDoc->getParamTags(), '@param-out' => $resolvedPhpDoc->getParamOutTags(), '@param-closure-this' => $resolvedPhpDoc->getParamClosureThisTags()] as $tagName => $parameters) {
 			foreach ($parameters as $parameterName => $phpDocParamTag) {
 				$phpDocParamType = $phpDocParamTag->getType();
+				$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($phpDocParamType);
 
 				if (!isset($nativeParameterTypes[$parameterName])) {
 					$errors[] = RuleErrorBuilder::message(sprintf(
@@ -60,14 +61,16 @@ final class IncompatiblePhpDocTypeCheck
 						$parameterName,
 					))->identifier('parameter.notFound')->build();
 
-				} elseif (
-					$this->unresolvableTypeHelper->containsUnresolvableType($phpDocParamType)
-				) {
-					$errors[] = RuleErrorBuilder::message(sprintf(
+				} elseif ($unresolvableType !== null) {
+					$errorBuilder = RuleErrorBuilder::message(sprintf(
 						'PHPDoc tag %s for parameter $%s contains unresolvable type.',
 						$tagName,
 						$parameterName,
-					))->identifier('parameter.unresolvableType')->build();
+					))->identifier('parameter.unresolvableType');
+					foreach ($unresolvableType->reasons as $reason) {
+						$errorBuilder->addTip($reason);
+					}
+					$errors[] = $errorBuilder->build();
 
 				} else {
 					$nativeParamType = $nativeParameterTypes[$parameterName];
@@ -183,11 +186,14 @@ final class IncompatiblePhpDocTypeCheck
 
 		if ($resolvedPhpDoc->getReturnTag() !== null) {
 			$phpDocReturnType = $resolvedPhpDoc->getReturnTag()->getType();
+			$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($phpDocReturnType);
 
-			if (
-				$this->unresolvableTypeHelper->containsUnresolvableType($phpDocReturnType)
-			) {
-				$errors[] = RuleErrorBuilder::message('PHPDoc tag @return contains unresolvable type.')->identifier('return.unresolvableType')->build();
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message('PHPDoc tag @return contains unresolvable type.')->identifier('return.unresolvableType');
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 
 			} else {
 				$isReturnSuperType = $nativeReturnType->isSuperTypeOf($phpDocReturnType);

--- a/src/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRule.php
@@ -54,15 +54,18 @@ final class IncompatiblePropertyPhpDocTypeRule implements Rule
 		$classReflection = $node->getClassReflection();
 
 		$messages = [];
-		if (
-			$this->unresolvableTypeHelper->containsUnresolvableType($phpDocType)
-		) {
-			$messages[] = RuleErrorBuilder::message(sprintf(
+		$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($phpDocType);
+		if ($unresolvableType !== null) {
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'%s for property %s::$%s contains unresolvable type.',
 				$description,
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->identifier('property.unresolvableType')->build();
+			))->identifier('property.unresolvableType');
+			foreach ($unresolvableType->reasons as $reason) {
+				$errorBuilder->addTip($reason);
+			}
+			$messages[] = $errorBuilder->build();
 		}
 
 		$nativeType = $node->getNativeType();

--- a/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
@@ -65,12 +65,17 @@ final class IncompatibleSelfOutTypeRule implements Rule
 				->build();
 		}
 
-		if ($this->unresolvableTypeHelper->containsUnresolvableType($selfOutType)) {
-			$errors[] = RuleErrorBuilder::message(sprintf(
+		$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($selfOutType);
+		if ($unresolvableType !== null) {
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'PHPDoc tag @phpstan-self-out for method %s::%s() contains unresolvable type.',
 				$classReflection->getDisplayName(),
 				$method->getName(),
-			))->identifier('selfOut.unresolvableType')->build();
+			))->identifier('selfOut.unresolvableType');
+			foreach ($unresolvableType->reasons as $reason) {
+				$errorBuilder->addTip($reason);
+			}
+			$errors[] = $errorBuilder->build();
 		}
 
 		$escapedTagName = SprintfHelper::escapeFormatString('@phpstan-self-out');

--- a/src/Rules/PhpDoc/InvalidPhpDocVarTagTypeRule.php
+++ b/src/Rules/PhpDoc/InvalidPhpDocVarTagTypeRule.php
@@ -87,13 +87,15 @@ final class InvalidPhpDocVarTagTypeRule implements Rule
 			if (is_string($name)) {
 				$identifier .= sprintf(' for variable $%s', $name);
 			}
-			if (
-				$this->unresolvableTypeHelper->containsUnresolvableType($varTagType)
-			) {
-				$errors[] = RuleErrorBuilder::message(sprintf('%s contains unresolvable type.', $identifier))
+			$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($varTagType);
+			if ($unresolvableType !== null) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf('%s contains unresolvable type.', $identifier))
 					->line($docComment->getStartLine())
-					->identifier('varTag.unresolvableType')
-					->build();
+					->identifier('varTag.unresolvableType');
+				foreach ($unresolvableType->reasons as $reason) {
+					$errorBuilder->addTip($reason);
+				}
+				$errors[] = $errorBuilder->build();
 				continue;
 			}
 

--- a/src/Rules/PhpDoc/UnresolvableTypeHelper.php
+++ b/src/Rules/PhpDoc/UnresolvableTypeHelper.php
@@ -7,26 +7,40 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
+use function array_unique;
+use function array_values;
 
 #[AutowiredService]
 final class UnresolvableTypeHelper
 {
 
-	public function containsUnresolvableType(Type $type): bool
+	public function getUnresolvableType(Type $type): ?UnresolvableTypeResult
 	{
 		$containsUnresolvable = false;
-		TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$containsUnresolvable): Type {
+		$reasons = [];
+		TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$containsUnresolvable, &$reasons): Type {
+			$reason = null;
 			if ($type instanceof ErrorType) {
 				$containsUnresolvable = true;
+				$reason = $type->getReason();
 			}
 			if ($type instanceof NeverType && !$type->isExplicit()) {
 				$containsUnresolvable = true;
+				$reason = $type->getReason();
+			}
+
+			if ($reason !== null) {
+				$reasons[] = $reason;
 			}
 
 			return $containsUnresolvable ? $type : $traverse($type);
 		});
 
-		return $containsUnresolvable;
+		if (!$containsUnresolvable) {
+			return null;
+		}
+
+		return new UnresolvableTypeResult(array_values(array_unique($reasons)));
 	}
 
 }

--- a/src/Rules/PhpDoc/UnresolvableTypeResult.php
+++ b/src/Rules/PhpDoc/UnresolvableTypeResult.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+final class UnresolvableTypeResult
+{
+
+	/** @param list<string> $reasons */
+	public function __construct(public readonly array $reasons)
+	{
+	}
+
+}

--- a/src/Rules/Properties/ExistingClassesInPropertiesRule.php
+++ b/src/Rules/Properties/ExistingClassesInPropertiesRule.php
@@ -101,15 +101,19 @@ final class ExistingClassesInPropertiesRule implements Rule
 			),
 		);
 
-		if (
-			$this->phpVersion->supportsPureIntersectionTypes()
-			&& $this->unresolvableTypeHelper->containsUnresolvableType($propertyReflection->getNativeType())
-		) {
-			$errors[] = RuleErrorBuilder::message(sprintf(
+		$unresolvableType = $this->phpVersion->supportsPureIntersectionTypes()
+			? $this->unresolvableTypeHelper->getUnresolvableType($propertyReflection->getNativeType())
+			: null;
+		if ($unresolvableType !== null) {
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
 				'Property %s::$%s has unresolvable native type.',
 				$propertyReflection->getDeclaringClass()->getDisplayName(),
 				$node->getName(),
-			))->identifier('property.unresolvableNativeType')->build();
+			))->identifier('property.unresolvableNativeType');
+			foreach ($unresolvableType->reasons as $reason) {
+				$errorBuilder->addTip($reason);
+			}
+			$errors[] = $errorBuilder->build();
 		}
 
 		return $errors;

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -108,6 +108,7 @@ class ConstantArrayType implements Type
 
 	private const DESCRIBE_LIMIT = 8;
 	private const CHUNK_FINITE_TYPES_LIMIT = 5;
+	private const UNSEALED_ARRAY_SHAPES_LINK = 'https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys';
 
 	private TrinaryLogic $isList;
 
@@ -758,6 +759,9 @@ class ConstantArrayType implements Type
 				}
 				if ($hasOffset->no()) {
 					if (!$this->isOptionalKey($i)) {
+						if ($thisUnsealedness->no() && $typeUnsealedness->no()) {
+							return IsSuperTypeOfResult::createNo([$this->sealedArrayShapesCannotBeIntersectedReason($type)]);
+						}
 						return IsSuperTypeOfResult::createNo();
 					}
 
@@ -792,6 +796,9 @@ class ConstantArrayType implements Type
 
 					if ($thisUnsealedness->no()) {
 						if (!$type->isOptionalKey($i)) {
+							if ($typeUnsealedness->no()) {
+								return IsSuperTypeOfResult::createNo([$this->sealedArrayShapesCannotBeIntersectedReason($type)]);
+							}
 							return IsSuperTypeOfResult::createNo();
 						}
 						$results[] = IsSuperTypeOfResult::createMaybe();
@@ -852,6 +859,16 @@ class ConstantArrayType implements Type
 		}
 
 		return IsSuperTypeOfResult::createNo();
+	}
+
+	private function sealedArrayShapesCannotBeIntersectedReason(self $type): string
+	{
+		return sprintf(
+			'Sealed array shapes %s and %s cannot be intersected. Unseal at least one of them with ... syntax. Learn more: %s',
+			$this->describe(VerbosityLevel::value()),
+			$type->describe(VerbosityLevel::value()),
+			self::UNSEALED_ARRAY_SHAPES_LINK,
+		);
 	}
 
 	public function looseCompare(Type $type, PhpVersion $phpVersion): BooleanType

--- a/src/Type/ErrorType.php
+++ b/src/Type/ErrorType.php
@@ -7,9 +7,14 @@ class ErrorType extends MixedType
 {
 
 	/** @api */
-	public function __construct()
+	public function __construct(private ?string $reason = null)
 	{
 		parent::__construct();
+	}
+
+	public function getReason(): ?string
+	{
+		return $this->reason;
 	}
 
 	public function describe(VerbosityLevel $level): string

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -33,13 +33,18 @@ class NeverType implements CompoundType
 	use NonGeneralizableTypeTrait;
 
 	/** @api */
-	public function __construct(private bool $isExplicit = false)
+	public function __construct(private bool $isExplicit = false, private ?string $reason = null)
 	{
 	}
 
 	public function isExplicit(): bool
 	{
 		return $this->isExplicit;
+	}
+
+	public function getReason(): ?string
+	{
+		return $this->reason;
 	}
 
 	public function getReferencedClasses(): array

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -295,7 +295,18 @@ class ObjectShapeType implements Type
 		$result = IsSuperTypeOfResult::createYes();
 		$scope = new OutOfClassScope();
 		foreach ($this->properties as $propertyName => $propertyType) {
-			$hasProperty = new IsSuperTypeOfResult($type->hasInstanceProperty((string) $propertyName), []);
+			$typeHasProperty = $type->hasInstanceProperty((string) $propertyName);
+			$hasProperty = new IsSuperTypeOfResult(
+				$typeHasProperty,
+				$typeHasProperty->yes() ? [] : [
+					sprintf(
+						'%s %s have property $%s.',
+						$type->describe(VerbosityLevel::typeOnly()),
+						$typeHasProperty->no() ? 'does not' : 'might not',
+						$propertyName,
+					),
+				],
+			);
 			if ($hasProperty->no()) {
 				if (in_array($propertyName, $this->optionalProperties, true)) {
 					continue;
@@ -320,15 +331,21 @@ class ObjectShapeType implements Type
 			}
 
 			if (!$otherProperty->isPublic()) {
-				return IsSuperTypeOfResult::createNo();
+				return IsSuperTypeOfResult::createNo([
+					sprintf('Property %s::$%s is not public.', $otherProperty->getDeclaringClass()->getDisplayName(), $propertyName),
+				]);
 			}
 
 			if ($otherProperty->isStatic()) {
-				return IsSuperTypeOfResult::createNo();
+				return IsSuperTypeOfResult::createNo([
+					sprintf('Property %s::$%s is static.', $otherProperty->getDeclaringClass()->getDisplayName(), $propertyName),
+				]);
 			}
 
 			if (!$otherProperty->isReadable()) {
-				return IsSuperTypeOfResult::createNo();
+				return IsSuperTypeOfResult::createNo([
+					sprintf('Property %s::$%s is not readable.', $otherProperty->getDeclaringClass()->getDisplayName(), $propertyName),
+				]);
 			}
 
 			$otherPropertyType = $otherProperty->getReadableType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -599,7 +599,10 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		if ($thisClassReflection->isTrait() || $thatClassReflection->isTrait()) {
-			return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createNo();
+			$traitReflection = $thisClassReflection->isTrait() ? $thisClassReflection : $thatClassReflection;
+			return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createNo([
+				sprintf('%s is a trait, which is never a value type.', $traitReflection->getDisplayName()),
+			]);
 		}
 
 		if ($thisClassReflection->getName() === $thatClassReflection->getName()) {
@@ -622,7 +625,38 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createMaybe();
 		}
 
-		return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createNo();
+		return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createNo(
+			$this->describeUnrelatedClassesReasons($thisClassReflection, $thatClassReflection),
+		);
+	}
+
+	/**
+	 * Explains why two distinct, non-trait class reflections that are not in an
+	 * inheritance relationship can never share an instance. Reached only from the
+	 * final `createNo()` of isSuperTypeOf(): one side being an interface implies
+	 * the other is a final class that does not implement it; otherwise both are
+	 * classes and PHP's single inheritance rules them out.
+	 *
+	 * @return list<string>
+	 */
+	private function describeUnrelatedClassesReasons(ClassReflection $a, ClassReflection $b): array
+	{
+		if ($a->isInterface() !== $b->isInterface()) {
+			$interfaceReflection = $a->isInterface() ? $a : $b;
+			$classReflection = $a->isInterface() ? $b : $a;
+
+			return [sprintf(
+				'Final class %s does not implement interface %s.',
+				$classReflection->getDisplayName(),
+				$interfaceReflection->getDisplayName(),
+			)];
+		}
+
+		return [sprintf(
+			'Classes %s and %s are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
+			$a->getDisplayName(),
+			$b->getDisplayName(),
+		)];
 	}
 
 	public function equals(Type $type): bool

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -1783,6 +1783,12 @@ final class TypeCombinator
 						) {
 							$merged = self::intersectDefiniteConstantArrays($constArray, $otherArray);
 							if ($merged instanceof NeverType) {
+								if ($merged->getReason() === null) {
+									$reasons = array_merge($isSuperTypeA->reasons, $isSuperTypeB->reasons);
+									if ($reasons !== []) {
+										return new NeverType(reason: $reasons[0]);
+									}
+								}
 								return $merged;
 							}
 							$newArrayType = $merged;
@@ -1875,7 +1881,7 @@ final class TypeCombinator
 				}
 
 				if ($isSuperTypeA->no()) {
-					return new NeverType();
+					return new NeverType(reason: $isSuperTypeA->reasons[0] ?? null);
 				}
 			}
 		}

--- a/tests/PHPStan/Rules/Classes/ClassAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassAttributesRuleTest.php
@@ -152,6 +152,7 @@ class ClassAttributesRuleTest extends RuleTestCase
 			[
 				'Parameter $repositoryClass of attribute class Bug7171\Entity constructor expects class-string<Bug7171\EntityRepository<T of object>>|null, \'stdClass\' given.',
 				66,
+				'Type #1 from the union: Classes Bug7171\EntityRepository<T of object> and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -620,6 +620,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				sprintf('Instanceof between Bug13469\Foo and Stringable will always evaluate to %s.', PHP_VERSION_ID >= 80000 ? 'true' : 'false'),
 				23,
+				PHP_VERSION_ID < 80000 ? 'Final class Bug13469\Foo does not implement interface Stringable.' : null,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -78,6 +78,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 				[
 					'Instanceof between ImpossibleInstanceOf\Dolor and ImpossibleInstanceOf\Lorem will always evaluate to false.',
 					71,
+					'Classes ImpossibleInstanceOf\Lorem and ImpossibleInstanceOf\Dolor are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 				],
 				[
 					'Instanceof between ImpossibleInstanceOf\FooImpl and ImpossibleInstanceOf\Foo will always evaluate to true.',
@@ -102,6 +103,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 				[
 					'Instanceof between ImpossibleInstanceOf\Test|null and ImpossibleInstanceOf\Lorem will always evaluate to false.',
 					119,
+					'Classes ImpossibleInstanceOf\Lorem and ImpossibleInstanceOf\Test are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 				],
 				[
 					'Instanceof between ImpossibleInstanceOf\Test and ImpossibleInstanceOf\Test will always evaluate to true.',
@@ -110,6 +112,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 				[
 					'Instanceof between ImpossibleInstanceOf\Test|null and ImpossibleInstanceOf\Lorem will always evaluate to false.',
 					137,
+					'Classes ImpossibleInstanceOf\Lorem and ImpossibleInstanceOf\Test are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 				],
 				[
 					'Instanceof between ImpossibleInstanceOf\Test and ImpossibleInstanceOf\Test will always evaluate to true.',
@@ -118,6 +121,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 				[
 					'Instanceof between ImpossibleInstanceOf\Test|null and ImpossibleInstanceOf\Lorem will always evaluate to false.',
 					155,
+					'Classes ImpossibleInstanceOf\Lorem and ImpossibleInstanceOf\Test are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 				],
 				[
 					'Instanceof between ImpossibleInstanceOf\Test and ImpossibleInstanceOf\Test will always evaluate to true.',
@@ -224,6 +228,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between stdClass and Exception will always evaluate to false.',
 				15,
+				'Classes Exception and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Instanceof between DateTimeInterface and DateTimeInterface will always evaluate to true.',
@@ -232,6 +237,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between DateTimeInterface and ImpossibleInstanceofNotPhpDoc\SomeFinalClass will always evaluate to false.',
 				30,
+				'Final class ImpossibleInstanceofNotPhpDoc\SomeFinalClass does not implement interface DateTimeInterface.',
 			],
 		]);
 	}
@@ -247,6 +253,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between stdClass and Exception will always evaluate to false.',
 				15,
+				'Classes Exception and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Instanceof between DateTimeImmutable and DateTimeInterface will always evaluate to true.',
@@ -255,6 +262,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between DateTimeImmutable and ImpossibleInstanceofNotPhpDoc\SomeFinalClass will always evaluate to false.',
 				30,
+				'Classes ImpossibleInstanceofNotPhpDoc\SomeFinalClass and DateTimeImmutable are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Instanceof between DateTimeImmutable and DateTimeImmutable will always evaluate to true.',
@@ -264,6 +272,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between DateTimeImmutable and DateTime will always evaluate to false.',
 				36,
+				'Classes DateTime and DateTimeImmutable are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 				//'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);
@@ -569,30 +578,37 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.',
 				17,
+				'Final class ImpossibleInstanceofNewIsAlwaysFinal\Bar does not implement interface ImpossibleInstanceofNewIsAlwaysFinal\Foo.',
 			],
 			[
 				'Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.',
 				33,
+				'Final class ImpossibleInstanceofNewIsAlwaysFinal\Bar does not implement interface ImpossibleInstanceofNewIsAlwaysFinal\Foo.',
 			],
 			[
 				'Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.',
 				43,
+				'Final class ImpossibleInstanceofNewIsAlwaysFinal\Bar does not implement interface ImpossibleInstanceofNewIsAlwaysFinal\Foo.',
 			],
 			[
 				'Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.',
 				53,
+				'Final class ImpossibleInstanceofNewIsAlwaysFinal\Bar does not implement interface ImpossibleInstanceofNewIsAlwaysFinal\Foo.',
 			],
 			[
 				'Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.',
 				63,
+				'Final class ImpossibleInstanceofNewIsAlwaysFinal\Bar does not implement interface ImpossibleInstanceofNewIsAlwaysFinal\Foo.',
 			],
 			[
 				'Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar|null and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.',
 				73,
+				'Final class ImpossibleInstanceofNewIsAlwaysFinal\Bar does not implement interface ImpossibleInstanceofNewIsAlwaysFinal\Foo.',
 			],
 			[
 				'Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar|null and ImpossibleInstanceofNewIsAlwaysFinal\Baz will always evaluate to false.',
 				88,
+				'Classes ImpossibleInstanceofNewIsAlwaysFinal\Baz and ImpossibleInstanceofNewIsAlwaysFinal\Bar are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 		]);
 	}
@@ -644,17 +660,16 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 	public function testInTrait(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;
-		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		$this->analyse([__DIR__ . '/data/impossible-instanceof-in-trait.php'], [
 			[
 				'Instanceof between ImpossibleInstanceofInTrait\Cat and stdClass will always evaluate to false.',
 				25,
-				$tipText,
+				'Classes stdClass and ImpossibleInstanceofInTrait\Cat are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Instanceof between ImpossibleInstanceofInTrait\Dog and stdClass will always evaluate to false.',
 				25,
-				$tipText,
+				'Classes stdClass and ImpossibleInstanceofInTrait\Dog are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/MixinRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinRuleTest.php
@@ -52,6 +52,7 @@ class MixinRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @mixin contains unresolvable type.',
 				24,
+				'Classes Exception and SplFileInfo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @mixin contains generic type Exception<MixinRule\Foo> but class Exception is not generic.',

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -290,6 +290,23 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7898.php'], []);
 	}
 
+	public function testReasons(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/check-type-function-call-reasons.php'], [
+			[
+				'Call to function is_a() with CheckTypeFunctionCallReasons\Foo and \'CheckTypeFunctionCallReasons\\\\Bar\' will always evaluate to false.',
+				23,
+				'Final class CheckTypeFunctionCallReasons\Foo does not implement interface CheckTypeFunctionCallReasons\Bar.',
+			],
+			[
+				'Call to function is_a() with CheckTypeFunctionCallReasons\Baz and \'CheckTypeFunctionCallReasons\\\\Foo\' will always evaluate to false.',
+				28,
+				'Classes CheckTypeFunctionCallReasons\Foo and CheckTypeFunctionCallReasons\Baz are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
+			],
+		]);
+	}
+
 	#[RequiresPhp('>= 8.1.0')]
 	public function testStructExists(): void
 	{

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -581,7 +581,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 			[
 				'Strict comparison using === between class-string<$this(Bug3633\HelloWorld)> and \'Bug3633\\\OtherClass\' will always evaluate to false.',
 				37,
-				$tipText,
+				'Classes Bug3633\HelloWorld and Bug3633\OtherClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Strict comparison using === between \'Bug3633\\\HelloWorld\' and \'Bug3633\\\HelloWorld\' will always evaluate to true.',
@@ -595,7 +595,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 			[
 				'Strict comparison using === between class-string<$this(Bug3633\OtherClass)> and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
 				64,
-				$tipText,
+				'Classes Bug3633\OtherClass and Bug3633\HelloWorld are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Strict comparison using === between \'Bug3633\\\OtherClass\' and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
@@ -610,12 +610,12 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 			[
 				'Strict comparison using === between class-string<$this(Bug3633\FinalClass)> and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
 				93,
-				$tipText,
+				'Classes Bug3633\FinalClass and Bug3633\HelloWorld are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Strict comparison using === between class-string<$this(Bug3633\FinalClass)> and \'Bug3633\\\OtherClass\' will always evaluate to false.',
 				96,
-				$tipText,
+				'Classes Bug3633\FinalClass and Bug3633\OtherClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Strict comparison using === between \'Bug3633\\\FinalClass\' and \'Bug3633\\\FinalClass\' will always evaluate to true.',

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call-reasons.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call-reasons.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace CheckTypeFunctionCallReasons;
+
+final class Foo
+{
+
+}
+
+interface Bar
+{
+
+}
+
+class Baz
+{
+
+}
+
+function doFoo(Foo $foo, Baz $baz): void
+{
+	// Foo is final and does not implement interface Bar -> always false, with a reason
+	if (is_a($foo, Bar::class)) {
+		echo 'never';
+	}
+
+	// two unrelated classes -> always false, with a reason
+	if (is_a($baz, Foo::class)) {
+		echo 'never';
+	}
+}

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -262,10 +262,12 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 					[
 						'Parameter $a of anonymous function has unresolvable native type.',
 						27,
+						'Classes ArrowFunctionIntersectionTypes\Ipsum and ArrowFunctionIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Anonymous function has unresolvable native return type.',
 						27,
+						'Classes ArrowFunctionIntersectionTypes\Ipsum and ArrowFunctionIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Parameter $a of anonymous function has unresolvable native type.',

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -321,10 +321,12 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 					[
 						'Parameter $a of anonymous function has unresolvable native type.',
 						30,
+						'Classes ClosureIntersectionTypes\Ipsum and ClosureIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Anonymous function has unresolvable native return type.',
 						30,
+						'Classes ClosureIntersectionTypes\Ipsum and ClosureIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Parameter $a of anonymous function has unresolvable native type.',

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -391,10 +391,12 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Parameter $a of function FunctionIntersectionTypes\doBar() has unresolvable native type.',
 						30,
+						'Classes FunctionIntersectionTypes\Ipsum and FunctionIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Function FunctionIntersectionTypes\doBar() has unresolvable native return type.',
 						30,
+						'Classes FunctionIntersectionTypes\Ipsum and FunctionIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Parameter $a of function FunctionIntersectionTypes\doBaz() has unresolvable native type.',

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2211,10 +2211,12 @@ class CallMethodsRuleTest extends RuleTestCase
 			[
 				'Return type of call to method GenericReturnTypeNever\Foo::doBar() contains unresolvable type.',
 				70,
+				'Classes GenericReturnTypeNever\Dolor and GenericReturnTypeNever\Sit are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Return type of call to method GenericReturnTypeNever\Foo::doBazBaz() contains unresolvable type.',
 				73,
+				'Classes GenericReturnTypeNever\Dolor and GenericReturnTypeNever\Sit are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -391,10 +391,12 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Parameter $a of method MethodIntersectionTypes\FooClass::doBar() has unresolvable native type.',
 						33,
+						'Classes MethodIntersectionTypes\Ipsum and MethodIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Method MethodIntersectionTypes\FooClass::doBar() has unresolvable native return type.',
 						33,
+						'Classes MethodIntersectionTypes\Ipsum and MethodIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Parameter $a of method MethodIntersectionTypes\FooClass::doBaz() has unresolvable native type.',

--- a/tests/PHPStan/Rules/PhpDoc/IncompatibleClassConstantPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatibleClassConstantPhpDocTypeRuleTest.php
@@ -24,6 +24,7 @@ class IncompatibleClassConstantPhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var for constant IncompatibleClassConstantPhpDoc\Foo::FOO contains unresolvable type.',
 				9,
+				'Classes stdClass and IncompatibleClassConstantPhpDoc\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @var for constant IncompatibleClassConstantPhpDoc\Foo::DOLOR contains generic type IncompatibleClassConstantPhpDoc\Foo<int> but class IncompatibleClassConstantPhpDoc\Foo is not generic.',

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -89,10 +89,12 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @param for parameter $foo contains unresolvable type.',
 				126,
+				'Classes InvalidPhpDoc\Bar and InvalidPhpDoc\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @return contains unresolvable type.',
 				126,
+				'Classes InvalidPhpDoc\Bar and InvalidPhpDoc\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @param for parameter $a with type T is not subtype of native type int.',
@@ -218,6 +220,7 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @param for parameter $foo contains unresolvable type.',
 				20,
+				'Classes Bug3753\Bar and Bug3753\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 		]);
 	}
@@ -428,6 +431,7 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @param-closure-this for parameter $i contains unresolvable type.',
 				34,
+				'Classes Exception and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @param-closure-this is for parameter $i with non-Closure type string.',
@@ -503,7 +507,7 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @param for parameter $a contains unresolvable type.',
 				11,
-				'Sealed array shapes array{foo: int} and array{bar: string} cannot be intersected. Unseal at least one of them with ... syntax. Learn more: https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys',
+				'Sealed array shapes array{bar: string} and array{foo: int} cannot be intersected. Unseal at least one of them with ... syntax. Learn more: https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -497,4 +497,15 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11463b.php'], []);
 	}
 
+	public function testExplainUnresolvable(): void
+	{
+		$this->analyse([__DIR__ . '/data/explain-unresolvable-method-parameter.php'], [
+			[
+				'PHPDoc tag @param for parameter $a contains unresolvable type.',
+				11,
+				'Sealed array shapes array{foo: int} and array{bar: string} cannot be intersected. Unseal at least one of them with ... syntax. Learn more: https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys',
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyHookPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyHookPhpDocTypeRuleTest.php
@@ -70,6 +70,7 @@ class IncompatiblePropertyHookPhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @param for parameter $value contains unresolvable type.',
 				34,
+				'Classes Exception and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @param for parameter $value contains generic type Exception<int> but class Exception is not generic.',

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
@@ -49,6 +49,7 @@ class IncompatiblePropertyPhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$bar contains unresolvable type.',
 				12,
+				'Classes InvalidPhpDoc\Bar and InvalidPhpDoc\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$classStringInt contains unresolvable type.',
@@ -123,6 +124,7 @@ class IncompatiblePropertyPhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$bar contains unresolvable type.',
 				16,
+				'Classes InvalidPhpDoc\Bar and InvalidPhpDoc\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$classStringInt contains unresolvable type.',

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -46,10 +46,12 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var for variable $test contains unresolvable type.',
 				13,
+				'Classes stdClass and InvalidVarTagType\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @var contains unresolvable type.',
 				16,
+				'Classes stdClass and InvalidVarTagType\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @var for variable $test contains unknown class InvalidVarTagType\aray.',
@@ -63,6 +65,7 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var for variable $staticVar contains unresolvable type.',
 				27,
+				'Classes stdClass and InvalidVarTagType\Foo are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Class InvalidVarTagType\Foo referenced with incorrect case: InvalidVarTagType\foo.',

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -258,6 +258,7 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var with type stdClass is not subtype of native type SplObjectStorage<object, mixed>.',
 				23,
+				'Classes SplObjectStorage<object,mixed> and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @var with type int is not subtype of native type \'foo\'.',
@@ -315,6 +316,7 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var with type stdClass is not subtype of native type SplObjectStorage<object, mixed>.',
 				23,
+				'Classes SplObjectStorage<object,mixed> and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @var with type int is not subtype of native type \'foo\'.',
@@ -406,6 +408,7 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var with type stdClass is not subtype of native type SplObjectStorage<object, mixed>.',
 				23,
+				'Classes SplObjectStorage<object,mixed> and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'PHPDoc tag @var with type int is not subtype of native type \'foo\'.',

--- a/tests/PHPStan/Rules/PhpDoc/data/explain-unresolvable-method-parameter.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/explain-unresolvable-method-parameter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ExplainUnresolvableMethodParameter;
+
+class Foo
+{
+
+	/**
+	 * @param array{foo: int}&array{bar: string} $a
+	 */
+	public function doFoo(array $a): void
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/ExistingClassesInPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ExistingClassesInPropertiesRuleTest.php
@@ -158,6 +158,7 @@ class ExistingClassesInPropertiesRuleTest extends RuleTestCase
 					[
 						'Property PropertyIntersectionTypes\Test::$prop2 has unresolvable native type.',
 						30,
+						'Classes PropertyIntersectionTypes\Ipsum and PropertyIntersectionTypes\Lorem are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 					],
 					[
 						'Property PropertyIntersectionTypes\Test::$prop3 has unresolvable native type.',

--- a/tests/PHPStan/Rules/Properties/ExistingClassesInPropertyHookTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ExistingClassesInPropertyHookTypehintsRuleTest.php
@@ -51,6 +51,7 @@ class ExistingClassesInPropertyHookTypehintsRuleTest extends RuleTestCase
 			[
 				'Parameter $v of set hook for property ExistingClassesPropertyHooks\Foo::$j has unresolvable native type.',
 				15,
+				'Classes Exception and stdClass are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Get hook for property ExistingClassesPropertyHooks\Foo::$k has invalid return type ExistingClassesPropertyHooks\Undefined.',

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -215,6 +215,7 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 			[
 				'Property Bug3777\Bar::$foo (Bug3777\Foo<stdClass>) does not accept Bug3777\Fooo<object>.',
 				58,
+				'Classes Bug3777\Foo<stdClass> and Bug3777\Fooo<object> are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Property Bug3777\Ipsum::$ipsum (Bug3777\Lorem<stdClass, Exception>) does not accept Bug3777\Lorem<Exception, stdClass>.',
@@ -238,6 +239,7 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 			[
 				'Static property Bug3777Static\Bar::$foo (Bug3777Static\Foo<stdClass>) does not accept Bug3777Static\Fooo<object>.',
 				58,
+				'Classes Bug3777Static\Foo<stdClass> and Bug3777Static\Fooo<object> are not in an inheritance relationship and because of single inheritance no object can be an instance of both.',
 			],
 			[
 				'Static property Bug3777Static\Ipsum::$ipsum (Bug3777Static\Lorem<stdClass, Exception>) does not accept Bug3777Static\Lorem<Exception, stdClass>.',

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -494,6 +494,25 @@ class ObjectTypeTest extends PHPStanTestCase
 		);
 	}
 
+	public function testIsSuperTypeOfReasons(): void
+	{
+		// final class can never implement an interface it does not already implement
+		$finalClassVsInterface = (new ObjectType(Throwable::class))->isSuperTypeOf(new ObjectType(Closure::class));
+		$this->assertTrue($finalClassVsInterface->no());
+		$this->assertSame(
+			['Final class Closure does not implement interface Throwable.'],
+			$finalClassVsInterface->reasons,
+		);
+
+		// two unrelated classes can never share an instance because of single inheritance
+		$classVsClass = (new ObjectType(DateTime::class))->isSuperTypeOf(new ObjectType(DateTimeImmutable::class));
+		$this->assertTrue($classVsClass->no());
+		$this->assertSame(
+			['Classes DateTime and DateTimeImmutable are not in an inheritance relationship and because of single inheritance no object can be an instance of both.'],
+			$classVsClass->reasons,
+		);
+	}
+
 	public static function dataAccepts(): array
 	{
 		return [


### PR DESCRIPTION
Surfaces the `reasons` that `IsSuperTypeOfResult` already carries all the way from the type layer into rule errors as tips, so "unresolvable type" / "always false" errors explain *why*.

## Type layer
- `NeverType`/`ErrorType` gain an optional `reason`.
- `ConstantArrayType::isSuperTypeOf()` explains why two **sealed array shapes** cannot be intersected; the reason rides the `NeverType` produced by `TypeCombinator::intersect()`, and `UnresolvableTypeHelper` now returns an `UnresolvableTypeResult` carrying it.
- `ObjectType`/`ObjectShapeType::isSuperTypeOf()` explain non-obvious `no()` results:
  - a trait used as a value type,
  - two unrelated classes (single inheritance means no shared instance),
  - a **final class that does not implement an interface**,
  - inaccessible object-shape properties (not public / static / not readable), mirrored from `accepts()`.

## Rules
- Every `*contains unresolvable type*` rule now attaches the reason as a tip.
- `ImpossibleInstanceofRule` computes `classType->isSuperTypeOf(exprType)->reasons` in its always-false branch (kept using `$scope->getType()` to *decide*).
- `ImpossibleCheckTypeHelper::findSpecifiedType()` collects reasons from the deciding `isSuperTypeOf` comparisons (new `&$reasons` out-param); the `ImpossibleCheckType{Function,Method,StaticMethod}CallRule` family surfaces them.
- Strict-comparison, intersection-typehint and other rules pick the reasons up automatically via `acceptsReasonsTip()`.

## Example

```
Call to function is_a() with Foo and 'Bar' will always evaluate to false.
  💡 Final class Foo does not implement interface Bar.
```

New unit test in `ObjectTypeTest` plus rule-level tests; `make tests`, `make phpstan` and the coding standard are green (only pre-existing, unrelated DOM/ReflectionClass/signature-map failures remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)