### PR TITLE
Avoid redundant work in hot type-system and scope paths

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -127,6 +127,7 @@ use function is_string;
 use function ltrim;
 use function md5;
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
@@ -3070,6 +3071,26 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		// Variables will not contain traversable expressions. skip the NodeFinder overhead
 		if ($expr instanceof Variable && is_string($expr->name) && !$requireMoreCharacters) {
 			return $exprStringToInvalidate === $exprString;
+		}
+
+		// getNodeKey() is the pretty-printed expression, and the standard printer is
+		// compositional: the key of any sub-expression appears verbatim as a substring of
+		// the key of the expression containing it. So if the invalidated expression's key
+		// does not appear anywhere in this expression's key, this expression cannot contain
+		// it and we can skip the expensive AST traversal below.
+		// Carve-outs where that invariant does not hold:
+		// - '$this' is special-cased in the visitor to also match self/static/parent,
+		// - PHPStan's virtual nodes (printed as '__phpstan…') use non-compositional printers
+		//   (e.g. a wrapped variable is printed by name, not as '$name'),
+		// - keys carrying a getNodeKey() suffix ('/*…*/') are not plain substrings.
+		if (
+			$exprStringToInvalidate !== '$this'
+			&& !str_contains($exprStringToInvalidate, '__phpstan')
+			&& !str_contains($exprStringToInvalidate, '/*')
+			&& !str_contains($exprString, '__phpstan')
+			&& !str_contains($exprString, $exprStringToInvalidate)
+		) {
+			return false;
 		}
 
 		$nodeFinder = new NodeFinder();

--- a/src/Reflection/ReflectionProvider/MemoizingReflectionProvider.php
+++ b/src/Reflection/ReflectionProvider/MemoizingReflectionProvider.php
@@ -32,7 +32,8 @@ final class MemoizingReflectionProvider implements ReflectionProvider
 
 	public function hasClass(string $className): bool
 	{
-		if (isset($this->knownClasses[strtolower($className)])) {
+		$lowerClassName = strtolower($className);
+		if (isset($this->knownClasses[$lowerClassName])) {
 			return true;
 		}
 
@@ -43,7 +44,7 @@ final class MemoizingReflectionProvider implements ReflectionProvider
 		$result = $this->provider->hasClass($className);
 
 		if ($result) {
-			$this->knownClasses[strtolower($className)] = true;
+			$this->knownClasses[$lowerClassName] = true;
 		} else {
 			$this->unknownClasses[$className] = true;
 		}

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -69,7 +69,10 @@ class ArrayType implements Type
 	/** @api */
 	public function __construct(Type $keyType, private Type $itemType)
 	{
-		if (in_array($keyType->describe(VerbosityLevel::value()), ['(int|string)', '(int|non-decimal-int-string)'], true)) {
+		// Only a BenevolentUnionType describes with the surrounding parentheses of
+		// '(int|string)' / '(int|non-decimal-int-string)' (a plain union has no outer
+		// parens), so skip the expensive describe() call for every other key type.
+		if ($keyType instanceof BenevolentUnionType && in_array($keyType->describe(VerbosityLevel::value()), ['(int|string)', '(int|non-decimal-int-string)'], true)) {
 			$keyType = new MixedType();
 		}
 		if ($keyType instanceof StrictMixedType && !$keyType instanceof TemplateStrictMixedType) {

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -171,7 +171,10 @@ class ConstantArrayType implements Type
 		$this->isList = $isList;
 
 		if ($unsealed !== null) {
-			if (in_array($unsealed[0]->describe(VerbosityLevel::value()), ['(int|string)', '(int|non-decimal-int-string)'], true)) {
+			// Only a BenevolentUnionType describes with the surrounding parentheses of
+			// '(int|string)' / '(int|non-decimal-int-string)', so skip the describe() call
+			// for every other key type.
+			if ($unsealed[0] instanceof BenevolentUnionType && in_array($unsealed[0]->describe(VerbosityLevel::value()), ['(int|string)', '(int|non-decimal-int-string)'], true)) {
 				$unsealed[0] = new MixedType();
 			}
 			if ($unsealed[0] instanceof StrictMixedType && !$unsealed[0] instanceof TemplateStrictMixedType) {
@@ -2504,7 +2507,10 @@ class ConstantArrayType implements Type
 					return $arrayName;
 				}
 				$keyType = $this->getIterableKeyType();
-				if (in_array($keyType->describe(VerbosityLevel::value()), ['(int|string)', '(int|non-decimal-int-string)'], true)) {
+				// Only a BenevolentUnionType describes with the surrounding parentheses of
+				// '(int|string)' / '(int|non-decimal-int-string)', so skip the describe()
+				// call for every other key type.
+				if ($keyType instanceof BenevolentUnionType && in_array($keyType->describe(VerbosityLevel::value()), ['(int|string)', '(int|non-decimal-int-string)'], true)) {
 					return sprintf('%s<%s>', $arrayName, $this->getIterableValueType()->describe($level));
 				}
 				return sprintf('%s<%s, %s>', $arrayName, $keyType->describe($level), $this->getIterableValueType()->describe($level));

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -107,6 +107,9 @@ class IntersectionType implements CompoundType
 	/** @var array<string, TrinaryLogic> */
 	private array $cachedHasOffsetValueType = [];
 
+	/** @var array<int, string> */
+	private array $cachedDescriptions = [];
+
 	/**
 	 * @api
 	 * @param list<Type> $types
@@ -380,7 +383,11 @@ class IntersectionType implements CompoundType
 
 	public function describe(VerbosityLevel $level): string
 	{
-		return $level->handle(
+		if (isset($this->cachedDescriptions[$level->getLevelValue()])) {
+			return $this->cachedDescriptions[$level->getLevelValue()];
+		}
+
+		return $this->cachedDescriptions[$level->getLevelValue()] = $level->handle(
 			fn (): string => $this->describeType($level),
 			fn (): string => $this->describeItself($level, true),
 			fn (): string => $this->describeItself($level, false),

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -1507,7 +1507,21 @@ final class TypeCombinator
 
 			return 0;
 		};
-		usort($types, $sortTypes);
+		// The comparator only orders UnionTypes relative to each other, so sorting is
+		// a no-op unless there are at least two of them. Skip it in the common case.
+		$unionTypesCount = 0;
+		foreach ($types as $type) {
+			if (!$type instanceof UnionType) {
+				continue;
+			}
+			$unionTypesCount++;
+			if ($unionTypesCount >= 2) {
+				break;
+			}
+		}
+		if ($unionTypesCount >= 2) {
+			usort($types, $sortTypes);
+		}
 		// transform A & (B | C) to (A & B) | (A & C)
 		foreach ($types as $i => $type) {
 			if (!$type instanceof UnionType) {
@@ -1516,7 +1530,19 @@ final class TypeCombinator
 
 			$topLevelUnionSubTypes = [];
 			$innerTypes = $type->getTypes();
-			usort($innerTypes, $sortTypes);
+			$innerUnionTypesCount = 0;
+			foreach ($innerTypes as $innerType) {
+				if (!$innerType instanceof UnionType) {
+					continue;
+				}
+				$innerUnionTypesCount++;
+				if ($innerUnionTypesCount >= 2) {
+					break;
+				}
+			}
+			if ($innerUnionTypesCount >= 2) {
+				usort($innerTypes, $sortTypes);
+			}
 			$slice1 = array_slice($types, 0, $i);
 			$slice2 = array_slice($types, $i + 1);
 			foreach ($innerTypes as $innerUnionSubType) {


### PR DESCRIPTION
Profiling self-analysis (`analyse -l 8 src/Analyser src/Rules src/Type`) surfaced several spots that recompute results that are either cacheable or provably unnecessary. **None of these change behaviour** — the full `Type`, `Analyser` and `NodeScopeResolver` suites pass unchanged.

### Changes

- **`MutatingScope::shouldInvalidateExpression`** — `getNodeKey()` is the pretty-printed expression and the printer is compositional, so a sub-expression's key is always a substring of its container's key. When the invalidated key is not a substring of a stored expression's key, that expression cannot contain it and the `NodeFinder` AST traversal is skipped. Carve-outs for `$this` (matches `self`/`static`/`parent`), the non-compositional `__phpstan…` virtual nodes, and `/*…*/` key suffixes keep it exact. Measured ~18% fewer invalidation traversals when analysing `src/Analyser`.

- **`IntersectionType::describe`** — cache the result per `VerbosityLevel`, mirroring `UnionType` and `ObjectType`. `IntersectionType::describe` is a hot cache-key producer (e.g. `ObjectType::isSuperTypeOf`) and was recomputed on every call.

- **`ArrayType` / `ConstantArrayType` (×2)** — only a `BenevolentUnionType` describes with the surrounding parens of `(int|string)` / `(int|non-decimal-int-string)` (a plain union has no outer parens), so gate the `describe()` comparison behind `instanceof BenevolentUnionType` instead of calling `describe()` for every key type.

- **`TypeCombinator::intersect`** — the union-ordering comparator is a no-op unless there are at least two `UnionType`s, so skip the `usort()` in the common case.

- **`MemoizingReflectionProvider::hasClass`** — compute `strtolower()` once.

### Measurement caveat

These were found from an SPX full trace, whose per-call instrumentation over-weights call-frequency-heavy paths. End-to-end cold-run wall/CPU time on the profiled scope is within noise (~65s user CPU either way) — the reductions are real work avoided but a small fraction of un-instrumented cost. Shipping them as safe, idiomatic cleanups that reduce work on hot paths rather than a headline speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)