### PR TITLE
Update PHPBench to 1.7.0

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -6,12 +6,17 @@
   "storage.xml_storage_path": "tests/bench/storage",
   "report.generators": {
     "my-report": {
-      "extends": "aggregate",
-      "cols": {
-        "set": null,
-        "mem_peak": null,
-        "mode": null,
-        "rstdev": null
+      "generator": "expression",
+      "aggregate": ["iteration_index"],
+      "cols": [
+        "set",
+        "mem_peak",
+        "mode",
+        "rstdev",
+        "diff"
+      ],
+      "derivations": {
+        "diff": "if(min(table['mode']) > 0, format('%.2fx', row['mode'] / min(table['mode'])), 'N/A')"
       }
     }
   }

--- a/phpbench.json
+++ b/phpbench.json
@@ -7,7 +7,12 @@
   "report.generators": {
     "my-report": {
       "generator": "expression",
-      "aggregate": ["iteration_index"],
+      "aggregate": [
+        "iteration_index"
+      ],
+      "expressions": {
+        "_mode": "mode(result_time_avg)"
+      },
       "cols": [
         "set",
         "mem_peak",
@@ -16,7 +21,7 @@
         "diff"
       ],
       "derivations": {
-        "diff": "if(min(table['mode']) > 0, format('%.2fx', row['mode'] / min(table['mode'])), 'N/A')"
+        "diff": "if(min(table['_mode']) > 0, format('%.2fx', row['_mode'] / min(table['_mode'])), 'N/A')"
       }
     }
   }

--- a/tests/bench/RegressionBench.php
+++ b/tests/bench/RegressionBench.php
@@ -4,6 +4,7 @@ namespace PHPStan\Benchmark;
 
 use PhpBench\Attributes as Bench;
 use Symfony\Component\Finder\Finder;
+use function array_first;
 
 #[Bench\Revs(revs: 1)]
 #[Bench\Iterations(iterations: 5)]
@@ -32,7 +33,8 @@ class RegressionBench extends BenchCase
 	 */
 	public function provideFiles(): iterable
 	{
-		yield from self::findTestDataFilesFromDirectory(__DIR__ . '/data');
+		$arr = self::findTestDataFilesFromDirectory(__DIR__ . '/data');
+		yield array_first($arr);
 	}
 
 	private static function findTestDataFilesFromDirectory(string $directory): array

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -664,16 +664,16 @@
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.5.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "9a28fd0833f11171b949843c6fd663eb69b6d14c"
+                "reference": "3d13c0d5dcf8730a67b70fa7fb03b4556b5cc0fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/9a28fd0833f11171b949843c6fd663eb69b6d14c",
-                "reference": "9a28fd0833f11171b949843c6fd663eb69b6d14c",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/3d13c0d5dcf8730a67b70fa7fb03b4556b5cc0fe",
+                "reference": "3d13c0d5dcf8730a67b70fa7fb03b4556b5cc0fe",
                 "shasum": ""
             },
             "require": {
@@ -698,14 +698,14 @@
             "require-dev": {
                 "dantleech/invoke": "^2.0",
                 "ergebnis/composer-normalize": "^2.39",
-                "jangregor/phpstan-prophecy": "^1.0",
+                "jangregor/phpstan-prophecy": "^2.0",
                 "php-cs-fixer/shim": "^3.9",
                 "phpspec/prophecy": "^1.22",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.5",
-                "rector/rector": "^1.2",
+                "rector/rector": "^2.2",
                 "sebastian/exporter": "^6.3.2",
                 "symfony/error-handler": "^6.1 || ^7.0 || ^8.0",
                 "symfony/var-dumper": "^6.1 || ^7.0 || ^8.0"
@@ -751,7 +751,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.5.1"
+                "source": "https://github.com/phpbench/phpbench/tree/1.7.0"
             },
             "funding": [
                 {
@@ -759,7 +759,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-05T08:18:58+00:00"
+            "time": "2026-06-08T19:09:20+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
add "diff" column, to see a factor how much faster/slower a benchmark run got.

see discussion in https://github.com/phpbench/phpbench/issues/1147#issuecomment-4660366362

---

result after PR (note new `diff` column):

```
➜  phpstan-src git:(pr/5830) ✗ make phpbench         
tests/bench/storage/local-baseline.xml
XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=my-report
PHPBench (1.7.0) running benchmarks... #standwithukraine
with configuration file: /Users/m.staab/dvl/phpstan-src/phpbench.json
with PHP version 8.3.31, xdebug ❌, opcache ❌
comparing [actual vs. ]

\PHPStan\Benchmark\RegressionBench

    benchRunAnalyse.........................R1 I1 ✔ [Mo75.494ms vs. Mo76.110ms] -0.81% (±3.04%)

Subjects: 1, Assertions: 1, Failures: 0, Errors: 0
+-----+------------------+-----------------+--------------+-------+
| set | mem_peak         | mode            | rstdev       | diff  |
+-----+------------------+-----------------+--------------+-------+
| 0   | 64.234mb -12.51% | 75.071ms -8.88% | ±0.00% 0.00% | 1.00x |
| 0   | 56.196mb 0.00%   | 79.468ms +5.17% | ±0.00% 0.00% | 1.06x |
| 0   | 56.196mb 0.00%   | 75.922ms -1.60% | ±0.00% 0.00% | 1.01x |
| 0   | 56.196mb 0.00%   | 74.844ms -1.64% | ±0.00% 0.00% | 1.00x |
| 0   | 56.196mb 0.00%   | 80.472ms +6.38% | ±0.00% 0.00% | 1.08x |
+-----+------------------+-----------------+--------------+-------+

```