### PR TITLE
Add false to Redis::mget() return type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -8696,7 +8696,7 @@ return [
 'Redis::lSet' => ['__benevolent<Redis|bool>', 'key'=>'string', 'index'=>'int', 'value'=>'mixed'],
 'Redis::lSize' => ['', 'key'=>'string'],
 'Redis::ltrim' => ['__benevolent<Redis|bool>', 'key'=>'string', 'start'=>'int', 'end'=>'int'],
-'Redis::mget' => ['__benevolent<Redis|array<string, mixed>>', 'keys'=>'string[]'],
+'Redis::mget' => ['__benevolent<Redis|array<string, mixed>|false>', 'keys'=>'string[]'],
 'Redis::migrate' => ['__benevolent<Redis|bool>', 'host'=>'string', 'port'=>'int', 'key'=>'string|string[]', 'dstdb'=>'int', 'timeout'=>'int', 'copy='=>'bool', 'replace='=>'bool', 'credentials='=>'mixed'],
 'Redis::move' => ['__benevolent<Redis|bool>', 'key'=>'string', 'index'=>'int'],
 'Redis::mset' => ['__benevolent<Redis|bool>', 'key_values'=>'array<string, mixed>'],

--- a/tests/PHPStan/Analyser/nsrt/redis-mget.php
+++ b/tests/PHPStan/Analyser/nsrt/redis-mget.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace RedisMget;
+
+use Redis;
+
+use function PHPStan\Testing\assertType;
+
+function func(Redis $redis): void
+{
+	$values = $redis->mget(['key1', 'key2']);
+	assertType('(array<string, mixed>|Redis|false)', $values);
+
+	if ($values === false) {
+		return;
+	}
+
+	assertType('(array<string, mixed>|Redis)', $values);
+}


### PR DESCRIPTION
### Summary

The `functionMap` entry for `Redis::mget()` is missing `false` from its return type:

```php
'Redis::mget' => ['__benevolent<Redis|array<string, mixed>>', 'keys'=>'string[]'],
```

phpredis returns `false` on error. The `false` was **added to `mget()`'s declared return type in phpredis 6.1.0**:

| phpredis | `Redis::mget()` declared return |
|---|---|
| ≤ 6.0.x | `Redis\|array` |
| **≥ 6.1.0** | `Redis\|array\|false` |

This is confirmed by native reflection on a current extension (e.g. ext-redis 6.3.0):

```
ReflectionMethod(Redis::class, 'mget')->getReturnType()  // Redis|array|false
```

It is also inconsistent with the sibling entry right next to it, `Redis::hMget`, which already includes `false`:

```php
'Redis::hMget' => ['__benevolent<Redis|array<string, mixed>|false>', 'key'=>'string', 'fields'=>'string[]'],
```

### Effect

Before this change, PHPStan reports a `=== false` check on an `mget()` result as `identical.alwaysFalse` ("will always evaluate to false"), and a method whose return type correctly includes `false` triggers `return.unusedType`. In practice this hides a real runtime failure mode (`mget()` returning `false` on a transport/error condition) on phpredis 6.1.0+.

### Changes

- `resources/functionMap.php`: add `false` to `Redis::mget()`, mirroring `Redis::hMget`. This matches phpredis 6.1.0+ (the current line); on the older 6.0.x the extension declared `Redis|array`, but the functionMap targets the current extension version.
- `tests/PHPStan/Analyser/nsrt/redis-mget.php`: regression test asserting the return type is `(array<string, mixed>|Redis|false)` and narrows correctly after a `=== false` guard. Verified the test fails without the functionMap change.
