### PR TITLE
Revert PHPBench Update

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -6,22 +6,12 @@
   "storage.xml_storage_path": "tests/bench/storage",
   "report.generators": {
     "my-report": {
-      "generator": "expression",
-      "aggregate": [
-        "iteration_index"
-      ],
-      "expressions": {
-        "_mode": "mode(result_time_avg)"
-      },
-      "cols": [
-        "set",
-        "mem_peak",
-        "mode",
-        "rstdev",
-        "diff"
-      ],
-      "derivations": {
-        "diff": "if(min(table['_mode']) > 0, format('%.2fx', row['_mode'] / min(table['_mode'])), 'N/A')"
+      "extends": "aggregate",
+      "cols": {
+        "set": null,
+        "mem_peak": null,
+        "mode": null,
+        "rstdev": null
       }
     }
   }

--- a/tests/bench/RegressionBench.php
+++ b/tests/bench/RegressionBench.php
@@ -4,7 +4,6 @@ namespace PHPStan\Benchmark;
 
 use PhpBench\Attributes as Bench;
 use Symfony\Component\Finder\Finder;
-use function array_first;
 
 #[Bench\Revs(revs: 1)]
 #[Bench\Iterations(iterations: 5)]
@@ -33,8 +32,7 @@ class RegressionBench extends BenchCase
 	 */
 	public function provideFiles(): iterable
 	{
-		$arr = self::findTestDataFilesFromDirectory(__DIR__ . '/data');
-		yield array_first($arr);
+		yield from self::findTestDataFilesFromDirectory(__DIR__ . '/data');
 	}
 
 	private static function findTestDataFilesFromDirectory(string $directory): array

--- a/tests/bench/RegressionBench.php
+++ b/tests/bench/RegressionBench.php
@@ -4,6 +4,7 @@ namespace PHPStan\Benchmark;
 
 use PhpBench\Attributes as Bench;
 use Symfony\Component\Finder\Finder;
+use function array_first;
 
 #[Bench\Revs(revs: 1)]
 #[Bench\Iterations(iterations: 5)]
@@ -32,7 +33,8 @@ class RegressionBench extends BenchCase
 	 */
 	public function provideFiles(): iterable
 	{
-		yield from self::findTestDataFilesFromDirectory(__DIR__ . '/data');
+		$arr = self::findTestDataFilesFromDirectory(__DIR__ . '/data');
+		yield array_first($arr);
 	}
 
 	private static function findTestDataFilesFromDirectory(string $directory): array

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -664,16 +664,16 @@
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.7.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "3d13c0d5dcf8730a67b70fa7fb03b4556b5cc0fe"
+                "reference": "9a28fd0833f11171b949843c6fd663eb69b6d14c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/3d13c0d5dcf8730a67b70fa7fb03b4556b5cc0fe",
-                "reference": "3d13c0d5dcf8730a67b70fa7fb03b4556b5cc0fe",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/9a28fd0833f11171b949843c6fd663eb69b6d14c",
+                "reference": "9a28fd0833f11171b949843c6fd663eb69b6d14c",
                 "shasum": ""
             },
             "require": {
@@ -698,14 +698,14 @@
             "require-dev": {
                 "dantleech/invoke": "^2.0",
                 "ergebnis/composer-normalize": "^2.39",
-                "jangregor/phpstan-prophecy": "^2.0",
+                "jangregor/phpstan-prophecy": "^1.0",
                 "php-cs-fixer/shim": "^3.9",
                 "phpspec/prophecy": "^1.22",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
                 "phpunit/phpunit": "^11.5",
-                "rector/rector": "^2.2",
+                "rector/rector": "^1.2",
                 "sebastian/exporter": "^6.3.2",
                 "symfony/error-handler": "^6.1 || ^7.0 || ^8.0",
                 "symfony/var-dumper": "^6.1 || ^7.0 || ^8.0"
@@ -751,7 +751,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.7.0"
+                "source": "https://github.com/phpbench/phpbench/tree/1.5.1"
             },
             "funding": [
                 {
@@ -759,7 +759,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-08T19:09:20+00:00"
+            "time": "2026-03-05T08:18:58+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
This reverts commit 21bde62 & c5a25851c5274f2e7616c065c2a8a654bc19bcaa

after the update the results table did no longer show all rows for all benchmarks