### PR TITLE
Support type predicates on callable and Closure types

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -40,6 +40,7 @@ use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\Reflection\Assertions;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
 use PHPStan\Reflection\InitializerExprContext;
 use PHPStan\Reflection\InitializerExprTypeResolver;
@@ -60,6 +61,7 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\CallableAssertionsHelper;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\ClassConstantAccessType;
 use PHPStan\Type\ClassStringType;
@@ -1067,7 +1069,12 @@ final class TypeNodeResolver
 			$typeNode->parameters,
 		));
 
-		$returnType = $this->resolve($typeNode->returnType, $nameScope);
+		$assertions = $this->resolveCallableReturnTypeAssertions($typeNode, $nameScope, $parameters);
+		if ($assertions !== null) {
+			$returnType = new BooleanType();
+		} else {
+			$returnType = $this->resolve($typeNode->returnType, $nameScope);
+		}
 
 		if ($mainType instanceof CallableType) {
 			$pure = $mainType->isPure();
@@ -1075,7 +1082,7 @@ final class TypeNodeResolver
 				return new ErrorType();
 			}
 
-			return new CallableType($parameters, $returnType, $isVariadic, $templateTypeMap, templateTags: $templateTags, isPure: $pure);
+			return new CallableType($parameters, $returnType, $isVariadic, $templateTypeMap, templateTags: $templateTags, isPure: $pure, assertions: $assertions);
 
 		} elseif (
 			$mainType instanceof ObjectType
@@ -1087,9 +1094,9 @@ final class TypeNodeResolver
 					'call to a Closure',
 					false,
 				),
-			]);
+			], assertions: $assertions);
 		} elseif ($mainType instanceof ClosureType) {
-			$closure = new ClosureType($parameters, $returnType, $isVariadic, $templateTypeMap, templateTags: $templateTags, impurePoints: $mainType->getImpurePoints(), invalidateExpressions: $mainType->getInvalidateExpressions(), usedVariables: $mainType->getUsedVariables(), acceptsNamedArguments: $mainType->acceptsNamedArguments(), mustUseReturnValue: $mainType->mustUseReturnValue(), isStatic: $mainType->isStaticClosure());
+			$closure = new ClosureType($parameters, $returnType, $isVariadic, $templateTypeMap, templateTags: $templateTags, impurePoints: $mainType->getImpurePoints(), invalidateExpressions: $mainType->getInvalidateExpressions(), usedVariables: $mainType->getUsedVariables(), acceptsNamedArguments: $mainType->acceptsNamedArguments(), mustUseReturnValue: $mainType->mustUseReturnValue(), assertions: $assertions, isStatic: $mainType->isStaticClosure());
 			if ($closure->isPure()->yes() && $returnType->isVoid()->yes()) {
 				return new ErrorType();
 			}
@@ -1098,6 +1105,36 @@ final class TypeNodeResolver
 		}
 
 		return new ErrorType();
+	}
+
+	/**
+	 * Interprets a conditional return type referencing the callable's own parameter,
+	 * like `callable(mixed $value): ($value is int ? true : false)`, as a type predicate.
+	 *
+	 * @param list<NativeParameterReflection> $parameters
+	 */
+	private function resolveCallableReturnTypeAssertions(CallableTypeNode $typeNode, NameScope $nameScope, array $parameters): ?Assertions
+	{
+		$returnTypeNode = $typeNode->returnType;
+		if (!$returnTypeNode instanceof ConditionalTypeForParameterNode) {
+			return null;
+		}
+
+		foreach ($parameters as $parameter) {
+			if ('$' . $parameter->getName() !== $returnTypeNode->parameterName) {
+				continue;
+			}
+
+			return CallableAssertionsHelper::createAssertionsFromConditional(
+				$returnTypeNode->parameterName,
+				$this->resolve($returnTypeNode->targetType, $nameScope),
+				$returnTypeNode->negated,
+				$this->resolve($returnTypeNode->if, $nameScope),
+				$this->resolve($returnTypeNode->else, $nameScope),
+			);
+		}
+
+		return null;
 	}
 
 	private function resolveArrayShapeNode(ArrayShapeNode $typeNode, NameScope $nameScope): Type

--- a/src/Reflection/Assertions.php
+++ b/src/Reflection/Assertions.php
@@ -186,4 +186,12 @@ final class Assertions
 		return self::create($tags);
 	}
 
+	/**
+	 * @param AssertTag[] $assertTags
+	 */
+	public static function createFromAssertTags(array $assertTags): self
+	{
+		return self::create($assertTags);
+	}
+
 }

--- a/src/Reflection/Callables/FunctionCallableVariant.php
+++ b/src/Reflection/Callables/FunctionCallableVariant.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\ExtendedParameterReflection;
 use PHPStan\Reflection\ExtendedParametersAcceptor;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\CallableAssertionsHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
 use PHPStan\Type\NeverType;
@@ -25,6 +26,8 @@ final class FunctionCallableVariant implements CallableParametersAcceptor, Exten
 
 	/** @var SimpleImpurePoint[]|null  */
 	private ?array $impurePoints = null;
+
+	private ?Assertions $asserts = null;
 
 	public function __construct(
 		private FunctionReflection|ExtendedMethodReflection $function,
@@ -176,7 +179,10 @@ final class FunctionCallableVariant implements CallableParametersAcceptor, Exten
 
 	public function getAsserts(): Assertions
 	{
-		return $this->function->getAsserts();
+		return $this->asserts ??= CallableAssertionsHelper::withConditionalReturnPredicate(
+			$this->function->getAsserts(),
+			$this->variant,
+		);
 	}
 
 	public function isStaticClosure(): TrinaryLogic

--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -2,17 +2,22 @@
 
 namespace PHPStan\Reflection;
 
+use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\Callables\CallableParametersAcceptor;
 use PHPStan\Reflection\Php\ExtendedDummyParameter;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\CallableAssertionsHelper;
 use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 use function array_key_exists;
 use function array_last;
 use function array_map;
@@ -57,6 +62,22 @@ final class GenericParametersAcceptorResolver
 			$namedArgTypes[$i] = $argType;
 		}
 
+		// type predicates of passed callables determine their template types exactly,
+		// so they are inferred first and substituted into the parameter types —
+		// the remaining template types are then inferred from what is left over,
+		// e.g. in partition(iterable<T0|T1> $values, callable(T0|T1): ($value is T0 ? true : false) $predicate)
+		// called with iterable<int|string> and is_int(...), T0 becomes int and T1 string
+		$predicateTypeMap = TemplateTypeMap::createEmpty();
+		foreach ($parameters as $param) {
+			if (!isset($namedArgTypes[$param->getName()])) {
+				continue;
+			}
+
+			$predicateTypeMap = $predicateTypeMap->union(
+				self::inferPredicateTemplateTypes($param->getType(), $namedArgTypes[$param->getName()]),
+			);
+		}
+
 		foreach ($parameters as $param) {
 			if (isset($namedArgTypes[$param->getName()])) {
 				$argType = $namedArgTypes[$param->getName()];
@@ -68,10 +89,12 @@ final class GenericParametersAcceptorResolver
 				continue;
 			}
 
-			$paramType = $param->getType();
+			$paramType = self::resolvePredicateTemplateTypes($param->getType(), $predicateTypeMap);
 			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType));
 			$passedArgs['$' . $param->getName()] = $argType;
 		}
+
+		$typeMap = $typeMap->union($predicateTypeMap);
 
 		$returnType = $parametersAcceptor->getReturnType();
 		if (
@@ -79,7 +102,7 @@ final class GenericParametersAcceptorResolver
 			&& !$returnType->isNegated()
 			&& array_key_exists($returnType->getParameterName(), $passedArgs)
 		) {
-			$paramType = $returnType->getTarget();
+			$paramType = self::resolvePredicateTemplateTypes($returnType->getTarget(), $predicateTypeMap);
 			$argType = $passedArgs[$returnType->getParameterName()];
 			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType));
 		}
@@ -140,6 +163,43 @@ final class GenericParametersAcceptorResolver
 		}
 
 		return $result;
+	}
+
+	private static function inferPredicateTemplateTypes(Type $paramType, Type $argType): TemplateTypeMap
+	{
+		$typeMap = TemplateTypeMap::createEmpty();
+		if (!$argType->isCallable()->yes()) {
+			return $typeMap;
+		}
+
+		foreach ($paramType instanceof UnionType ? $paramType->getTypes() : [$paramType] as $innerType) {
+			if (!$innerType instanceof CallableParametersAcceptor) {
+				continue;
+			}
+			if ($innerType->getAsserts()->getAll() === []) {
+				continue;
+			}
+
+			foreach ($argType->getCallableParametersAcceptors(new OutOfClassScope()) as $receivedAcceptor) {
+				$typeMap = $typeMap->union(CallableAssertionsHelper::inferTemplateTypesOnAsserts($innerType, $receivedAcceptor));
+			}
+		}
+
+		return $typeMap;
+	}
+
+	private static function resolvePredicateTemplateTypes(Type $type, TemplateTypeMap $predicateTypeMap): Type
+	{
+		if ($predicateTypeMap->isEmpty()) {
+			return $type;
+		}
+
+		return TemplateTypeHelper::resolveTemplateTypes(
+			$type,
+			$predicateTypeMap,
+			TemplateTypeVarianceMap::createEmpty(),
+			TemplateTypeVariance::createInvariant(),
+		);
 	}
 
 }

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -56,6 +56,7 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\CallableAssertionsHelper;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -965,7 +966,18 @@ final class InitializerExprTypeResolver
 			}
 
 			$parameters = $variant->getParameters();
-			$assertions = $function !== null ? $function->getAsserts() : Assertions::createEmpty();
+			if ($function !== null) {
+				$assertions = $function->getAsserts();
+			} elseif ($variant instanceof CallableParametersAcceptor) {
+				$assertions = $variant->getAsserts();
+			} else {
+				$assertions = Assertions::createEmpty();
+			}
+
+			// a conditional return type referencing the function's own parameter,
+			// like @return ($value is int ? true : false) on is_int(),
+			// also becomes a type predicate of the resulting Closure
+			$assertions = CallableAssertionsHelper::withConditionalReturnPredicate($assertions, $variant);
 			$closureTypes[] = new ClosureType(
 				$parameters,
 				$returnType,

--- a/src/Type/CallableAssertionsHelper.php
+++ b/src/Type/CallableAssertionsHelper.php
@@ -1,0 +1,282 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\PhpDoc\Tag\AssertTag;
+use PHPStan\PhpDoc\Tag\AssertTagParameter;
+use PHPStan\PhpDocParser\Ast\Type\ConditionalTypeForParameterNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\Reflection\Assertions;
+use PHPStan\Reflection\Callables\CallableParametersAcceptor;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use function count;
+
+/**
+ * Logic shared between CallableType and ClosureType for type predicates
+ * written as a conditional return type referencing the callable's own parameter:
+ *
+ * `callable(mixed $value): ($value is int ? true : false)`
+ *
+ * The predicate is stored as AssertTag(s) — the same representation
+ * as @phpstan-assert-if-true — so that invoking the callable in a condition
+ * narrows the argument via TypeSpecifier, and the template types occurring
+ * in the asserted type can be inferred from the assertions of a passed callable.
+ */
+final class CallableAssertionsHelper
+{
+
+	/**
+	 * Interprets `($parameterName is[ not] $targetType ? $if : $else)` as a type predicate.
+	 *
+	 * Returns null when the conditional does not encode a predicate (non-bool branches
+	 * or branches that allow no conclusion about the parameter).
+	 */
+	public static function createAssertionsFromConditional(string $parameterName, Type $targetType, bool $negated, Type $if, Type $else): ?Assertions
+	{
+		if ($negated) {
+			[$if, $else] = [$else, $if];
+		}
+
+		if (!$if->isBoolean()->yes() || !$else->isBoolean()->yes()) {
+			return null;
+		}
+
+		$ifBranch = $if->isTrue()->yes() ? 'true' : ($if->isFalse()->yes() ? 'false' : 'bool');
+		$elseBranch = $else->isTrue()->yes() ? 'true' : ($else->isFalse()->yes() ? 'false' : 'bool');
+
+		$parameter = new AssertTagParameter($parameterName, null, null);
+
+		switch ($ifBranch . ' : ' . $elseBranch) {
+			case 'true : false':
+				// truthy => is the target type, falsy => is not the target type
+				$tag = new AssertTag(AssertTag::IF_TRUE, $targetType, $parameter, false, false, true);
+				break;
+			case 'false : true':
+				// truthy => is not the target type, falsy => is the target type
+				$tag = new AssertTag(AssertTag::IF_TRUE, $targetType, $parameter, true, false, true);
+				break;
+			case 'bool : false':
+				// truthy => is the target type, falsy proves nothing
+				$tag = new AssertTag(AssertTag::IF_TRUE, $targetType, $parameter, false, true, true);
+				break;
+			case 'false : bool':
+				// truthy => is not the target type, falsy proves nothing
+				$tag = new AssertTag(AssertTag::IF_TRUE, $targetType, $parameter, true, true, true);
+				break;
+			case 'true : bool':
+				// falsy => is not the target type, truthy proves nothing
+				$tag = new AssertTag(AssertTag::IF_FALSE, $targetType, $parameter, true, true, true);
+				break;
+			case 'bool : true':
+				// falsy => is the target type, truthy proves nothing
+				$tag = new AssertTag(AssertTag::IF_FALSE, $targetType, $parameter, false, true, true);
+				break;
+			default:
+				return null;
+		}
+
+		return Assertions::createFromAssertTags([$tag]);
+	}
+
+	/**
+	 * Inverse of createAssertionsFromConditional() — used to print the predicate
+	 * back as a conditional return type in describe() and toPhpDocNode().
+	 *
+	 * Returns null when the assertions cannot be expressed as a single conditional
+	 * return type (multiple tags, property/method assertions, unknown parameter,
+	 * non-bool return type).
+	 *
+	 * @param list<ParameterReflection> $parameters
+	 */
+	public static function toConditionalReturnTypeNode(Assertions $assertions, array $parameters, Type $returnType): ?ConditionalTypeForParameterNode
+	{
+		$tags = $assertions->getAll();
+		if (count($tags) !== 1) {
+			return null;
+		}
+
+		$tag = $tags[0];
+		$parameterName = $tag->getParameter()->getParameterName();
+		if ($tag->getParameter()->describe() !== $parameterName) {
+			return null;
+		}
+
+		$found = false;
+		foreach ($parameters as $parameter) {
+			if ('$' . $parameter->getName() === $parameterName) {
+				$found = true;
+				break;
+			}
+		}
+		if (!$found) {
+			return null;
+		}
+
+		if (!$returnType->equals(new BooleanType())) {
+			return null;
+		}
+
+		$trueNode = new IdentifierTypeNode('true');
+		$falseNode = new IdentifierTypeNode('false');
+		$boolNode = new IdentifierTypeNode('bool');
+
+		if ($tag->getIf() === AssertTag::IF_TRUE) {
+			if (!$tag->isEquality()) {
+				[$if, $else] = $tag->isNegated() ? [$falseNode, $trueNode] : [$trueNode, $falseNode];
+			} else {
+				[$if, $else] = $tag->isNegated() ? [$falseNode, $boolNode] : [$boolNode, $falseNode];
+			}
+		} elseif ($tag->getIf() === AssertTag::IF_FALSE) {
+			if (!$tag->isEquality()) {
+				[$if, $else] = $tag->isNegated() ? [$trueNode, $falseNode] : [$falseNode, $trueNode];
+			} else {
+				[$if, $else] = $tag->isNegated() ? [$trueNode, $boolNode] : [$boolNode, $trueNode];
+			}
+		} else {
+			return null;
+		}
+
+		return new ConditionalTypeForParameterNode(
+			$parameterName,
+			$tag->getType()->toPhpDocNode(),
+			$if,
+			$else,
+			false,
+		);
+	}
+
+	/**
+	 * Adds the predicate encoded in the variant's conditional return type
+	 * (like `@return ($value is int ? true : false)` on is_int()) to the given
+	 * assertions, unless an equal assertion is already present.
+	 */
+	public static function withConditionalReturnPredicate(Assertions $assertions, ParametersAcceptor $variant): Assertions
+	{
+		$returnType = $variant->getReturnType();
+		if (!$returnType instanceof ConditionalTypeForParameter) {
+			return $assertions;
+		}
+
+		foreach ($variant->getParameters() as $parameter) {
+			if ('$' . $parameter->getName() !== $returnType->getParameterName()) {
+				continue;
+			}
+
+			$predicateAssertions = self::createAssertionsFromConditional(
+				$returnType->getParameterName(),
+				$returnType->getTarget(),
+				$returnType->isNegated(),
+				$returnType->getIf(),
+				$returnType->getElse(),
+			);
+			if ($predicateAssertions === null) {
+				return $assertions;
+			}
+
+			foreach ($assertions->getAll() as $tag) {
+				foreach ($predicateAssertions->getAll() as $predicateTag) {
+					if (self::assertTagsEqual($tag, $predicateTag)) {
+						return $assertions;
+					}
+				}
+			}
+
+			return $assertions->union($predicateAssertions);
+		}
+
+		return $assertions;
+	}
+
+	public static function assertionsEqual(Assertions $assertions, Assertions $otherAssertions): bool
+	{
+		$tags = $assertions->getAll();
+		$otherTags = $otherAssertions->getAll();
+		if (count($tags) !== count($otherTags)) {
+			return false;
+		}
+
+		foreach ($tags as $i => $tag) {
+			if (!self::assertTagsEqual($tag, $otherTags[$i])) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static function assertTagsEqual(AssertTag $tag, AssertTag $otherTag): bool
+	{
+		return $tag->getParameter()->describe() === $otherTag->getParameter()->describe()
+			&& $tag->getIf() === $otherTag->getIf()
+			&& $tag->isNegated() === $otherTag->isNegated()
+			&& $tag->isEquality() === $otherTag->isEquality()
+			&& $tag->getType()->equals($otherTag->getType());
+	}
+
+	/**
+	 * Infers template types occurring in the assertions of the declared callable
+	 * from the assertions of the passed callable, matching the asserted parameters
+	 * by position.
+	 */
+	public static function inferTemplateTypesOnAsserts(CallableParametersAcceptor $declared, ParametersAcceptor $received): TemplateTypeMap
+	{
+		$typeMap = TemplateTypeMap::createEmpty();
+		if ($declared->getAsserts()->getAll() === []) {
+			return $typeMap;
+		}
+		if (!$received instanceof CallableParametersAcceptor) {
+			return $typeMap;
+		}
+
+		$declaredAssertions = $declared->getAsserts();
+		$receivedAssertions = $received->getAsserts();
+		if ($receivedAssertions->getAll() === []) {
+			return $typeMap;
+		}
+
+		$declaredParameterIndexes = self::getParameterIndexes($declared);
+		$receivedParameterIndexes = self::getParameterIndexes($received);
+
+		foreach ([
+			[$declaredAssertions->getAssertsIfTrue(), $receivedAssertions->getAssertsIfTrue()],
+			[$declaredAssertions->getAssertsIfFalse(), $receivedAssertions->getAssertsIfFalse()],
+		] as [$declaredTags, $receivedTags]) {
+			foreach ($declaredTags as $declaredTag) {
+				$declaredIndex = $declaredParameterIndexes[$declaredTag->getParameter()->describe()] ?? null;
+				if ($declaredIndex === null) {
+					continue;
+				}
+
+				foreach ($receivedTags as $receivedTag) {
+					if ($receivedTag->isNegated() !== $declaredTag->isNegated()) {
+						continue;
+					}
+					$receivedIndex = $receivedParameterIndexes[$receivedTag->getParameter()->describe()] ?? null;
+					if ($receivedIndex !== $declaredIndex) {
+						continue;
+					}
+
+					$typeMap = $typeMap->union($declaredTag->getType()->inferTemplateTypes($receivedTag->getType()));
+				}
+			}
+		}
+
+		return $typeMap;
+	}
+
+	/**
+	 * @return array<string, int>
+	 */
+	private static function getParameterIndexes(ParametersAcceptor $acceptor): array
+	{
+		$indexes = [];
+		foreach ($acceptor->getParameters() as $i => $parameter) {
+			$indexes['$' . $parameter->getName()] = $i;
+		}
+
+		return $indexes;
+	}
+
+}

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -72,6 +72,8 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 
 	private TrinaryLogic $isPure;
 
+	private Assertions $assertions;
+
 	/**
 	 * @api
 	 * @param list<ParameterReflection>|null $parameters
@@ -85,6 +87,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		?TemplateTypeMap $resolvedTemplateTypeMap = null,
 		private array $templateTags = [],
 		?TrinaryLogic $isPure = null,
+		?Assertions $assertions = null,
 	)
 	{
 		$this->parameters = $parameters ?? [];
@@ -93,6 +96,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		$this->templateTypeMap = $templateTypeMap ?? TemplateTypeMap::createEmpty();
 		$this->resolvedTemplateTypeMap = $resolvedTemplateTypeMap ?? TemplateTypeMap::createEmpty();
 		$this->isPure = $isPure ?? TrinaryLogic::createMaybe();
+		$this->assertions = $assertions ?? Assertions::createEmpty();
 	}
 
 	/**
@@ -113,6 +117,9 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		$classes = [];
 		foreach ($this->parameters as $parameter) {
 			$classes = array_merge($classes, $parameter->getType()->getReferencedClasses());
+		}
+		foreach ($this->assertions->getAll() as $assertTag) {
+			$classes = array_merge($classes, $assertTag->getType()->getReferencedClasses());
 		}
 
 		return array_merge($classes, $this->returnType->getReferencedClasses());
@@ -242,6 +249,10 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			return false;
 		}
 
+		if (!CallableAssertionsHelper::assertionsEqual($this->assertions, $type->assertions)) {
+			return false;
+		}
+
 		if (count($this->parameters) !== count($type->parameters)) {
 			return false;
 		}
@@ -324,9 +335,13 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			static fn (): string => 'callable',
 			function (): string {
 				$printer = new Printer();
+				$assertedParameterNames = [];
+				foreach ($this->assertions->getAll() as $assertTag) {
+					$assertedParameterNames[$assertTag->getParameter()->getParameterName()] = true;
+				}
 				$selfWithoutParameterNames = new self(
 					array_map(static fn (ParameterReflection $p): ParameterReflection => new DummyParameter(
-						'',
+						array_key_exists('$' . $p->getName(), $assertedParameterNames) ? $p->getName() : '',
 						$p->getType(),
 						optional: $p->isOptional() && !$p->isVariadic(),
 						passedByReference: PassedByReference::createNo(),
@@ -339,6 +354,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 					$this->resolvedTemplateTypeMap,
 					$this->templateTags,
 					$this->isPure,
+					$this->assertions,
 				);
 
 				return $printer->print($selfWithoutParameterNames->toPhpDocNode());
@@ -401,7 +417,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 
 	public function getAsserts(): Assertions
 	{
-		return Assertions::createEmpty();
+		return $this->assertions;
 	}
 
 	public function isStaticClosure(): TrinaryLogic
@@ -534,6 +550,8 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType)->convertToLowerBoundTypes());
 		}
 
+		$typeMap = $typeMap->union(CallableAssertionsHelper::inferTemplateTypesOnAsserts($this, $parametersAcceptor));
+
 		return $typeMap->union($this->getReturnType()->inferTemplateTypes($returnType));
 	}
 
@@ -542,6 +560,12 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		$references = $this->getReturnType()->getReferencedTemplateTypes(
 			$positionVariance->compose(TemplateTypeVariance::createCovariant()),
 		);
+
+		foreach ($this->assertions->getAll() as $assertTag) {
+			foreach ($assertTag->getType()->getReferencedTemplateTypes($positionVariance->compose(TemplateTypeVariance::createCovariant())) as $reference) {
+				$references[] = $reference;
+			}
+		}
 
 		$paramVariance = $positionVariance->compose(TemplateTypeVariance::createContravariant());
 
@@ -580,6 +604,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			$this->resolvedTemplateTypeMap,
 			$this->templateTags,
 			$this->isPure,
+			$this->assertions->mapTypes($cb),
 		);
 	}
 
@@ -630,6 +655,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			$this->resolvedTemplateTypeMap,
 			$this->templateTags,
 			$this->isPure,
+			$this->assertions,
 		);
 	}
 
@@ -809,10 +835,13 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			);
 		}
 
+		$returnTypeNode = CallableAssertionsHelper::toConditionalReturnTypeNode($this->assertions, $this->parameters, $this->returnType)
+			?? $this->returnType->toPhpDocNode();
+
 		return new CallableTypeNode(
 			new IdentifierTypeNode($this->isPure->yes() ? 'pure-callable' : 'callable'),
 			$parameters,
-			$this->returnType->toPhpDocNode(),
+			$returnTypeNode,
 			$templateTags,
 		);
 	}
@@ -832,6 +861,12 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 				return true;
 			}
 			if ($parameter->getClosureThisType() !== null && $parameter->getClosureThisType()->hasTemplateOrLateResolvableType()) {
+				return true;
+			}
+		}
+
+		foreach ($this->assertions->getAll() as $assertTag) {
+			if ($assertTag->getType()->hasTemplateOrLateResolvableType()) {
 				return true;
 			}
 		}

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -49,6 +49,7 @@ use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function count;
@@ -206,6 +207,9 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		foreach ($this->parameters as $parameter) {
 			$classes = array_merge($classes, $parameter->getType()->getReferencedClasses());
 		}
+		foreach ($this->assertions->getAll() as $assertTag) {
+			$classes = array_merge($classes, $assertTag->getType()->getReferencedClasses());
+		}
 
 		return array_merge($classes, $this->returnType->getReferencedClasses());
 	}
@@ -305,9 +309,13 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 	private function describeCallable(): string
 	{
 		$printer = new Printer();
+		$assertedParameterNames = [];
+		foreach ($this->assertions->getAll() as $assertTag) {
+			$assertedParameterNames[$assertTag->getParameter()->getParameterName()] = true;
+		}
 		$selfWithoutParameterNames = new self(
 			array_map(static fn (ParameterReflection $p): ParameterReflection => new DummyParameter(
-				'',
+				array_key_exists('$' . $p->getName(), $assertedParameterNames) ? $p->getName() : '',
 				$p->getType(),
 				optional: $p->isOptional() && !$p->isVariadic(),
 				passedByReference: PassedByReference::createNo(),
@@ -687,6 +695,8 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType)->convertToLowerBoundTypes());
 		}
 
+		$typeMap = $typeMap->union(CallableAssertionsHelper::inferTemplateTypesOnAsserts($this, $parametersAcceptor));
+
 		return $typeMap->union($this->getReturnType()->inferTemplateTypes($returnType));
 	}
 
@@ -695,6 +705,12 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		$references = $this->getReturnType()->getReferencedTemplateTypes(
 			$positionVariance->compose(TemplateTypeVariance::createCovariant()),
 		);
+
+		foreach ($this->assertions->getAll() as $assertTag) {
+			foreach ($assertTag->getType()->getReferencedTemplateTypes($positionVariance->compose(TemplateTypeVariance::createCovariant())) as $reference) {
+				$references[] = $reference;
+			}
+		}
 
 		$paramVariance = $positionVariance->compose(TemplateTypeVariance::createContravariant());
 
@@ -737,7 +753,7 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 			$this->usedVariables,
 			$this->acceptsNamedArguments,
 			$this->mustUseReturnValue,
-			$this->assertions,
+			$this->assertions->mapTypes($cb),
 			$this->isStatic,
 		);
 	}
@@ -953,10 +969,13 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 			);
 		}
 
+		$returnTypeNode = CallableAssertionsHelper::toConditionalReturnTypeNode($this->assertions, $this->parameters, $this->returnType)
+			?? $this->returnType->toPhpDocNode();
+
 		return new CallableTypeNode(
 			new IdentifierTypeNode('Closure'),
 			$parameters,
-			$this->returnType->toPhpDocNode(),
+			$returnTypeNode,
 			$templateTags,
 		);
 	}
@@ -976,6 +995,12 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 				return true;
 			}
 			if ($parameter->getClosureThisType() !== null && $parameter->getClosureThisType()->hasTemplateOrLateResolvableType()) {
+				return true;
+			}
+		}
+
+		foreach ($this->assertions->getAll() as $assertTag) {
+			if ($assertTag->getType()->hasTemplateOrLateResolvableType()) {
 				return true;
 			}
 		}

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -131,6 +131,12 @@ final class TemplateTypeHelper
 			}
 
 			if ($type instanceof TemplateType) {
+				// templates declared by a callable<T>(...)/Closure<T>(...) type in the signature
+				// belong to the callable value, not to the entered function
+				if ($type->getScope()->equals(TemplateTypeScope::createWithAnonymousFunction())) {
+					return $traverse($type);
+				}
+
 				return $traverse($type->toArgument());
 			}
 

--- a/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
@@ -56,6 +56,7 @@ final class ClosureFromCallableDynamicReturnTypeExtension implements DynamicStat
 				usedVariables: $variant->getUsedVariables(),
 				acceptsNamedArguments: $variant->acceptsNamedArguments(),
 				mustUseReturnValue: $variant->mustUseReturnValue(),
+				assertions: $variant->getAsserts(),
 				isStatic: $variant->isStaticClosure(),
 			);
 		}

--- a/tests/PHPStan/Analyser/nsrt/callable-type-predicate.php
+++ b/tests/PHPStan/Analyser/nsrt/callable-type-predicate.php
@@ -1,0 +1,451 @@
+<?php // lint >= 8.1
+
+namespace CallableTypePredicate;
+
+use function PHPStan\Testing\assertType;
+
+final class ConfigReader {
+	/**
+	 * @template T of mixed[]
+	 * @param mixed[] $testObj
+	 * @param (callable(T|mixed[] $test): ($test is T ? true : false))|null $validator
+	 * @param T|null $default
+	 * @return ($default is T ? T : T|null)
+	 */
+	public function returnIfValid(array $testObj, ?callable $validator = null, ?array $default = null): ?array {
+		assertType('array<mixed>', $testObj);
+
+		if ($validator !== null && $validator($testObj)) {
+			// the predicate returned true => $testObj is narrowed to T
+			assertType('T of array<mixed> (method CallableTypePredicate\ConfigReader::returnIfValid(), argument)', $testObj);
+			return $testObj;
+		}
+
+		// no narrowing happened (validator absent or returned false)
+		assertType('array<mixed>', $testObj);
+
+		return $default;
+	}
+}
+
+/**
+ * @phpstan-assert-if-true array{name: string, age: int} $value
+ * @param mixed[] $value
+ */
+function isUserShape(array $value): bool {
+	return isset($value['name'], $value['age']) && is_string($value['name']) && is_int($value['age']);
+}
+
+/**
+ * @param mixed[] $data
+ */
+function testCallSites(ConfigReader $reader, array $data): void {
+	// T inferred from a first-class callable to a function with @phpstan-assert-if-true,
+	// $default is null => conditional return type picks the T|null branch
+	$result = $reader->returnIfValid($data, isUserShape(...));
+	assertType('array{name: string, age: int}|null', $result);
+
+	// $default is T => conditional return type picks the T branch
+	$result2 = $reader->returnIfValid($data, isUserShape(...), ['name' => 'John', 'age' => 42]);
+	assertType('array{name: string, age: int}', $result2);
+
+	// no validator, no default => T stays unresolved, falls back to its bound
+	$result3 = $reader->returnIfValid($data);
+	assertType('array<mixed>|null', $result3);
+
+	// plain closure without any predicate information => T cannot be inferred
+	$result5 = $reader->returnIfValid($data, static fn (array $arr): bool => $arr !== []);
+	assertType('array<mixed>|null', $result5);
+}
+
+/**
+ * Two-sided predicate: true => int, false => not int.
+ *
+ * @param callable(mixed $value): ($value is int ? true : false) $isInt
+ * @param mixed $x
+ */
+function testDirectPredicate(callable $isInt, $x): void {
+	assertType('callable(mixed $value): ($value is int ? true : false)', $isInt);
+
+	if ($isInt($x)) {
+		assertType('int', $x);
+	} else {
+		assertType('mixed~int', $x);
+	}
+
+	assertType('mixed', $x);
+}
+
+/**
+ * Negated two-sided predicate.
+ *
+ * @param callable(mixed $value): ($value is not int ? true : false) $isNotInt
+ * @param mixed $x
+ */
+function testNegatedPredicate(callable $isNotInt, $x): void {
+	if ($isNotInt($x)) {
+		assertType('mixed~int', $x);
+	} else {
+		assertType('int', $x);
+	}
+}
+
+/**
+ * One-sided predicate: returning true proves int, returning false proves nothing
+ * (the truthy branch admits any bool).
+ *
+ * @param callable(mixed $value): ($value is int ? bool : false) $maybeInt
+ * @param mixed $x
+ */
+function testIfTrueOnlyPredicate(callable $maybeInt, $x): void {
+	assertType('callable(mixed $value): ($value is int ? bool : false)', $maybeInt);
+
+	if ($maybeInt($x)) {
+		assertType('int', $x);
+	} else {
+		assertType('mixed', $x);
+	}
+}
+
+/**
+ * One-sided predicate: returning false proves NOT int, returning true proves nothing
+ * (the falsy branch admits any bool).
+ *
+ * @param callable(mixed $value): ($value is int ? true : bool) $surelyIntWhenFalse
+ * @param mixed $x
+ */
+function testIfFalseOnlyPredicate(callable $surelyIntWhenFalse, $x): void {
+	assertType('callable(mixed $value): ($value is int ? true : bool)', $surelyIntWhenFalse);
+
+	if ($surelyIntWhenFalse($x)) {
+		assertType('mixed', $x);
+	} else {
+		assertType('mixed~int', $x);
+	}
+}
+
+/**
+ * Closure syntax works the same as callable syntax.
+ *
+ * @param \Closure(mixed $value): ($value is string ? true : false) $isString
+ * @param mixed $x
+ */
+function testClosurePredicate(\Closure $isString, $x): void {
+	assertType('Closure(mixed $value): ($value is string ? true : false)', $isString);
+
+	if ($isString($x)) {
+		assertType('string', $x);
+	} else {
+		assertType('mixed~string', $x);
+	}
+}
+
+/**
+ * First-class callables of native type-checking functions carry the predicate
+ * from their stub's conditional return type.
+ *
+ * @param mixed $x
+ */
+function testNativeFirstClassCallable($x): void {
+	$isInt = is_int(...);
+	assertType('Closure(mixed $value): ($value is int ? true : false)', $isInt);
+
+	if ($isInt($x)) {
+		assertType('int', $x);
+	} else {
+		assertType('mixed~int', $x);
+	}
+}
+
+/**
+ * The partition use case from phpstan/phpstan#11139 — the predicate narrows
+ * the template types inside the function body.
+ *
+ * @template T0
+ * @template T1
+ * @param iterable<T0|T1> $values
+ * @param callable(T0|T1 $value): ($value is T0 ? true : false) $predicate
+ * @return array{list<T0>, list<T1>}
+ */
+function partition(iterable $values, callable $predicate): array {
+	$partitions = [[], []];
+
+	foreach ($values as $value) {
+		if ($predicate($value)) {
+			assertType('T0 (function CallableTypePredicate\partition(), argument)', $value);
+			$partitions[0][] = $value;
+		} else {
+			assertType('T1 (function CallableTypePredicate\partition(), argument)', $value);
+			$partitions[1][] = $value;
+		}
+	}
+
+	return $partitions;
+}
+
+/**
+ * At the call site, the predicate determines T0 = int exactly; T1 is then
+ * inferred as the remainder of the iterable's value type (int|string minus int).
+ *
+ * @param iterable<int|string> $values
+ */
+function testPartition(iterable $values): void {
+	$result = partition($values, is_int(...));
+	assertType('array{list<int>, list<string>}', $result);
+}
+
+/**
+ * The filter use case — separate template for the predicate target — works in full,
+ * like TypeScript's `Array.prototype.filter(predicate: (value: T) => value is S): S[]`.
+ *
+ * @template T
+ * @template S
+ * @param list<T> $items
+ * @param callable(T $item): ($item is S ? true : false) $predicate
+ * @return list<S>
+ */
+function filterBy(array $items, callable $predicate): array {
+	$result = [];
+	foreach ($items as $item) {
+		if ($predicate($item)) {
+			$result[] = $item;
+		}
+	}
+	return $result;
+}
+
+/**
+ * @phpstan-assert-if-true non-empty-string $v
+ * @param mixed $v
+ */
+function isNonEmptyString($v): bool {
+	return is_string($v) && $v !== '';
+}
+
+/**
+ * @param list<int|string> $items
+ */
+function testFilter(array $items): void {
+	assertType('list<int>', filterBy($items, is_int(...)));
+	assertType('list<string>', filterBy($items, is_string(...)));
+	assertType('list<non-empty-string>', filterBy($items, isNonEmptyString(...)));
+}
+
+class GenericValidator {
+
+	/**
+	 * @phpstan-assert-if-true array{name: string} $value
+	 * @param mixed[] $value
+	 */
+	public function isNamed(array $value): bool {
+		return isset($value['name']) && is_string($value['name']);
+	}
+
+	/**
+	 * @param mixed $value
+	 * @return ($value is positive-int ? true : false)
+	 */
+	public static function isPositiveInt($value): bool {
+		return is_int($value) && $value > 0;
+	}
+
+}
+
+/**
+ * @param mixed[] $data
+ * @param mixed $x
+ */
+function testMethodFirstClassCallables(GenericValidator $validator, array $data, $x): void {
+	$isNamed = $validator->isNamed(...);
+	if ($isNamed($data)) {
+		assertType('array{name: string}', $data);
+	}
+
+	$isPositive = GenericValidator::isPositiveInt(...);
+	if ($isPositive($x)) {
+		assertType('int<1, max>', $x);
+	} else {
+		assertType('mixed~int<1, max>', $x);
+	}
+}
+
+/**
+ * @param mixed $x
+ */
+function testClosureFromCallable($x): void {
+	$isInt = \Closure::fromCallable('is_int');
+	if ($isInt($x)) {
+		assertType('int', $x);
+	}
+
+	$isNonEmpty = \Closure::fromCallable('CallableTypePredicate\\isNonEmptyString');
+	if ($isNonEmpty($x)) {
+		assertType('non-empty-string', $x);
+	}
+}
+
+/**
+ * @param mixed $x
+ */
+function testStringCallable($x): void {
+	$isInt = 'is_int';
+	if ($isInt($x)) {
+		assertType('int', $x);
+	}
+
+	$isNonEmpty = 'CallableTypePredicate\\isNonEmptyString';
+	if ($isNonEmpty($x)) {
+		assertType('non-empty-string', $x);
+	}
+}
+
+/**
+ * @param mixed[] $data
+ */
+function testArrayCallable(GenericValidator $validator, array $data): void {
+	$isNamed = [$validator, 'isNamed'];
+	if ($isNamed($data)) {
+		assertType('array{name: string}', $data);
+	}
+}
+
+class IsIntInvokable {
+
+	/**
+	 * @param mixed $value
+	 * @return ($value is int ? true : false)
+	 */
+	public function __invoke($value): bool {
+		return is_int($value);
+	}
+
+}
+
+/**
+ * @param mixed $x
+ */
+function testInvokableObject(IsIntInvokable $isInt, $x): void {
+	if ($isInt($x)) {
+		assertType('int', $x);
+	}
+}
+
+/**
+ * @param list<int|string> $items
+ */
+function testOtherCallableSourcesInference(array $items): void {
+	assertType('list<int>', filterBy($items, 'is_int'));
+	assertType('list<int<1, max>>', filterBy($items, GenericValidator::isPositiveInt(...)));
+	assertType('list<int>', filterBy($items, \Closure::fromCallable('is_int')));
+}
+
+/**
+ * Generic callable whose predicate target is the callable's own template type —
+ * an instanceof-like predicate. The template is resolved from the other argument
+ * when the callable is invoked.
+ *
+ * @param callable<T of object>(mixed $value, class-string<T> $class): ($value is T ? true : false) $isInstanceOf
+ * @param mixed $x
+ */
+function testGenericCallablePredicate(callable $isInstanceOf, $x): void {
+	assertType('callable<T of object>(mixed $value, class-string<T>): ($value is T ? true : false)', $isInstanceOf);
+
+	if ($isInstanceOf($x, \DateTimeImmutable::class)) {
+		assertType('DateTimeImmutable', $x);
+	} else {
+		assertType('mixed~DateTimeImmutable', $x);
+	}
+}
+
+/**
+ * @param \Closure<T of object>(mixed $value, class-string<T> $class): ($value is T ? true : false) $isInstanceOf
+ * @param mixed $x
+ */
+function testGenericClosurePredicate(\Closure $isInstanceOf, $x): void {
+	assertType('Closure<T of object>(mixed $value, class-string<T>): ($value is T ? true : false)', $isInstanceOf);
+
+	if ($isInstanceOf($x, \DateTimeImmutable::class)) {
+		assertType('DateTimeImmutable', $x);
+	}
+}
+
+/**
+ * A conditional return type on the callable's own template type (not on a parameter)
+ * is not a predicate — it resolves through the inferred template type when
+ * the callable is invoked and does not narrow the argument.
+ *
+ * @param callable<T>(T $value): (T is int ? true : false) $isIntTemplate
+ * @param mixed $x
+ */
+function testTemplateSubjectConditional(callable $isIntTemplate, $x): void {
+	assertType('true', $isIntTemplate(1));
+	assertType('false', $isIntTemplate('foo'));
+
+	if ($isIntTemplate($x)) {
+		// not narrowed - the conditional is about T, not about $value
+		assertType('mixed', $x);
+	}
+}
+
+class ShadowedConfigReader {
+
+	/**
+	 * The callable's $test parameter shadows the method's $test parameter —
+	 * inside the callable's conditional return type, the callable's own
+	 * parameter wins.
+	 *
+	 * @template T of mixed[]
+	 * @param mixed[] $test
+	 * @param (callable(T|mixed[] $test): ($test is T ? true : false))|null $validator
+	 * @param T|null $default
+	 * @return ($default is T ? T : T|null)
+	 */
+	public function returnIfValid(array $test, ?callable $validator = null, ?array $default = null): ?array {
+		if ($validator !== null && $validator($test)) {
+			assertType('T of array<mixed> (method CallableTypePredicate\ShadowedConfigReader::returnIfValid(), argument)', $test);
+			return $test;
+		}
+
+		assertType('array<mixed>', $test);
+
+		return $default;
+	}
+
+}
+
+/**
+ * @param mixed[] $data
+ */
+function testShadowedCallSites(ShadowedConfigReader $reader, array $data): void {
+	$result = $reader->returnIfValid($data, isUserShape(...));
+	assertType('array{name: string, age: int}|null', $result);
+}
+
+/**
+ * The predicate's $flag parameter shadows the function's $flag parameter;
+ * the function's own conditional return type still resolves by the outer
+ * $flag argument.
+ *
+ * @param callable(mixed $flag): ($flag is int ? true : false) $isInt
+ * @param mixed $x
+ * @return ($flag is true ? int : string)
+ */
+function shadowedPredicateParameter(bool $flag, callable $isInt, $x) {
+	assertType('callable(mixed $flag): ($flag is int ? true : false)', $isInt);
+
+	if ($isInt($x)) {
+		assertType('int', $x);
+	} else {
+		assertType('mixed~int', $x);
+	}
+
+	return $flag ? 1 : 'a';
+}
+
+/**
+ * @param mixed $x
+ */
+function testShadowedPredicateParameter($x): void {
+	assertType('int', shadowedPredicateParameter(true, is_int(...), $x));
+	assertType('string', shadowedPredicateParameter(false, is_int(...), $x));
+}

--- a/tests/PHPStan/Analyser/nsrt/generic-callables.php
+++ b/tests/PHPStan/Analyser/nsrt/generic-callables.php
@@ -78,3 +78,11 @@ function testNestedClosures(Closure $closure, string $str, int $int): void
 	$result = $closure1($int);
 	assertType('int|string', $result);
 }
+
+/**
+ * @param callable<T of object>(class-string<T> $class): list<T> $factory
+ */
+function templateOnlyInsideParameterType(callable $factory): void
+{
+	assertType('list<DateTimeImmutable>', $factory(\DateTimeImmutable::class));
+}

--- a/tests/PHPStan/PhpDoc/TypeDescriptionTest.php
+++ b/tests/PHPStan/PhpDoc/TypeDescriptionTest.php
@@ -2,12 +2,19 @@
 
 namespace PHPStan\PhpDoc;
 
+use PHPStan\PhpDoc\Tag\AssertTag;
+use PHPStan\PhpDoc\Tag\AssertTagParameter;
+use PHPStan\Reflection\Assertions;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\PassedByReference;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\CallableType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -50,6 +57,25 @@ class TypeDescriptionTest extends PHPStanTestCase
 		$builder->setOffsetValueType(new ConstantStringType('foo'), new IntegerType(), true);
 		$builder->setOffsetValueType(new ConstantStringType('bar'), new StringType());
 		yield ['array{foo?: int, bar: string}', $builder->getArray()];
+
+		$predicateCallable = static fn (AssertTag $assertTag): CallableType => new CallableType(
+			[new NativeParameterReflection('value', false, new MixedType(), PassedByReference::createNo(), false, null)],
+			new BooleanType(),
+			false,
+			assertions: Assertions::createFromAssertTags([$assertTag]),
+		);
+		yield [
+			'callable(mixed $value): ($value is int ? true : false)',
+			$predicateCallable(new AssertTag(AssertTag::IF_TRUE, new IntegerType(), new AssertTagParameter('$value', null, null), false, false, true)),
+		];
+		yield [
+			'callable(mixed $value): ($value is int ? bool : false)',
+			$predicateCallable(new AssertTag(AssertTag::IF_TRUE, new IntegerType(), new AssertTagParameter('$value', null, null), false, true, true)),
+		];
+		yield [
+			'callable(mixed $value): ($value is int ? true : bool)',
+			$predicateCallable(new AssertTag(AssertTag::IF_FALSE, new IntegerType(), new AssertTagParameter('$value', null, null), true, true, true)),
+		];
 
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 		$builder->setOffsetValueType(null, new IntegerType());

--- a/tests/PHPStan/Rules/PhpDoc/FunctionConditionalReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/FunctionConditionalReturnTypeRuleTest.php
@@ -68,4 +68,22 @@ class FunctionConditionalReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8609-function.php'], []);
 	}
 
+	public function testCallableTypePredicate(): void
+	{
+		$this->analyse([__DIR__ . '/data/callable-type-predicate-rule.php'], [
+			[
+				'Conditional return type references unknown parameter $valeu.',
+				16,
+			],
+			[
+				'Condition "int is int" in conditional return type is always true.',
+				24,
+			],
+			[
+				'Conditional return type references unknown parameter $value.',
+				32,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/callable-type-predicate-rule.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/callable-type-predicate-rule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace CallableTypePredicateRule;
+
+/**
+ * @param callable(mixed $value): ($value is int ? true : false) $predicate
+ */
+function predicateReferencingCallableParameter(callable $predicate): void
+{
+
+}
+
+/**
+ * @param callable(mixed $value): ($valeu is int ? true : false) $predicate
+ */
+function predicateWithTypo(callable $predicate): void
+{
+
+}
+
+/**
+ * @param callable(): ($x is int ? true : false) $cb
+ */
+function conditionalReferencingFunctionParameter(int $x, callable $cb): void
+{
+
+}
+
+/**
+ * @param callable(mixed $value): ($value is int ? 'yes' : 'no') $cb
+ */
+function conditionalWithNonBoolBranches(callable $cb): void
+{
+
+}
+
+/**
+ * @param callable(mixed $value): ($value is int ? true : false) $predicate
+ */
+function predicateShadowingFunctionParameter(int $value, callable $predicate): void
+{
+
+}


### PR DESCRIPTION
A conditional return type referencing the callable's own parameter now declares a type predicate — the equivalent of TypeScript's `(value: unknown) => value is T`:

```php
/**
 * @param callable(mixed $value): ($value is int ? true : false) $predicate
 */
```

This is the same syntax the core stubs already use to describe `is_int()` & co. (`@return ($value is int ? true : false)`), extended to inline `callable`/`Closure` types. The predicate is stored as `@phpstan-assert-if-true`-style assertions on `CallableType`/`ClosureType`, so the existing assertion machinery does the heavy lifting.

What works now:

- **Narrowing**: `if ($predicate($x))` narrows `$x` in both branches, including narrowing to template types of the enclosing function (`$test is T`).
- **Template inference**: template types inside the asserted type are inferred from the assertions of a passed callable, enabling the `filter()` pattern:
  ```php
  /**
   * @template T
   * @template S
   * @param list<T> $items
   * @param callable(T $item): ($item is S ? true : false) $predicate
   * @return list<S>
   */
  function filterBy(array $items, callable $predicate): array { ... }

  filterBy($items, is_int(...)); // list<int>
  ```
- **First-class callables** inherit predicates both from `@phpstan-assert-*` tags and from conditional return types in the function signature — `is_int(...)`, `is_string(...)` etc. act as predicates out of the box.
- **Closures and arrow functions** with their own `@phpstan-assert-*` PHPDoc now carry those assertions on their `ClosureType`.
- **One-sided predicates**: `($value is int ? bool : false)` (only `true` is conclusive) and `($value is int ? true : bool)` (only `false` is conclusive), plus `is not` negation.
- The false `parameter.notFound` error ("Conditional return type references unknown parameter") is no longer reported for predicates referencing the callable's own parameter; typos and non-bool-branch conditionals still report. Conditionals referencing the *enclosing* function's parameters keep their existing behavior.
- Predicates display and round-trip in type descriptions: `Closure(mixed $v): ($v is int ? true : false)`.

Known limitation: the `partition()` case from #11139 narrows correctly *inside* the function body, but the call site cannot infer `T1` as the complement of `T0` — that would need set-subtraction inference (TypeScript can't do this either without `Exclude<>`).

No phpdoc-parser changes were needed — the syntax already parses.

Closes https://github.com/phpstan/phpstan/discussions/14800
Closes https://github.com/phpstan/phpstan/discussions/11139

🤖 Generated with [Claude Code](https://claude.com/claude-code)