### PR TITLE
Use xxh128 instead of sha256 for file content hashing

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -21,6 +21,7 @@ use PHPStan\File\FileHelper;
 use PHPStan\File\FileWriter;
 use PHPStan\Internal\ArrayHelper;
 use PHPStan\Internal\ComposerHelper;
+use PHPStan\Internal\FileHashing;
 use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\ShouldNotHappenException;
 use ReflectionClass;
@@ -1206,7 +1207,7 @@ return [
 			return $this->fileHashes[$path];
 		}
 
-		$hash = hash_file('sha256', $path);
+		$hash = hash_file(FileHashing::ALGORITHM, $path);
 		if ($hash === false) {
 			throw new CouldNotReadFileException($path);
 		}

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -11,6 +11,7 @@ use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
 use PHPStan\Collectors\CollectedData;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Internal\BytesHelper;
+use PHPStan\Internal\FileHashing;
 use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\PhpDoc\StubValidator;
 use PHPStan\ShouldNotHappenException;
@@ -160,7 +161,7 @@ final class AnalyseApplication
 						continue;
 					}
 
-					$newHash = hash_file('sha256', $file);
+					$newHash = hash_file(FileHashing::ALGORITHM, $file);
 					if ($newHash === $hash) {
 						continue;
 					}

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -11,6 +11,7 @@ use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\CouldNotWriteFileException;
 use PHPStan\File\FileReader;
 use PHPStan\File\FileWriter;
+use PHPStan\Internal\FileHashing;
 use PHPStan\Turbo\TurboExtensionEnabler;
 use function array_keys;
 use function count;
@@ -106,7 +107,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 			array_keys($this->dynamicParameters),
 			$this->configs,
 			PHP_VERSION_ID - PHP_RELEASE_VERSION,
-			is_file($attributesPhp) ? hash_file('sha256', $attributesPhp) : 'attributes-missing',
+			is_file($attributesPhp) ? hash_file(FileHashing::ALGORITHM, $attributesPhp) : 'attributes-missing',
 			NeonAdapter::CACHE_KEY,
 			$this->getAllConfigFilesHashes(),
 			var_export(TurboExtensionEnabler::isLoaded(), true),
@@ -242,7 +243,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 	{
 		$hashes = [];
 		foreach ($this->allConfigFiles as $file) {
-			$hash = hash_file('sha256', $file);
+			$hash = hash_file(FileHashing::ALGORITHM, $file);
 
 			if ($hash === false) {
 				throw new CouldNotReadFileException($file);

--- a/src/File/FileMonitor.php
+++ b/src/File/FileMonitor.php
@@ -4,6 +4,7 @@ namespace PHPStan\File;
 
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Internal\FileHashing;
 use PHPStan\ShouldNotHappenException;
 use function array_diff;
 use function array_key_exists;
@@ -107,7 +108,7 @@ final class FileMonitor
 
 	private function getFileHash(string $filePath): string
 	{
-		$hash = hash_file('sha256', $filePath);
+		$hash = hash_file(FileHashing::ALGORITHM, $filePath);
 
 		if ($hash === false) {
 			throw new CouldNotReadFileException($filePath);

--- a/src/Internal/FileHashing.php
+++ b/src/Internal/FileHashing.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use const PHP_VERSION_ID;
+
+final class FileHashing
+{
+
+	/**
+	 * Algorithm for file content hashes used as cache-invalidation keys.
+	 *
+	 * xxh128 is ~8.5x faster than sha256 but only available since PHP 8.1.
+	 */
+	public const ALGORITHM = PHP_VERSION_ID >= 80100 ? 'xxh128' : 'sha256';
+
+}

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocator.php
@@ -17,6 +17,7 @@ use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\Cache\Cache;
 use PHPStan\File\CouldNotReadFileException;
 use PHPStan\Internal\ComposerHelper;
+use PHPStan\Internal\FileHashing;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstantNameHelper;
 use PHPStan\ShouldNotHappenException;
@@ -51,7 +52,7 @@ final class OptimizedDirectorySourceLocator implements SourceLocator
 	 */
 	private function getCacheKeys(string $file, Identifier $identifier): array
 	{
-		$fileHash = hash_file('sha256', $file);
+		$fileHash = hash_file(FileHashing::ALGORITHM, $file);
 		if ($fileHash === false) {
 			throw new CouldNotReadFileException($file);
 		}

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -6,6 +6,7 @@ use PHPStan\Cache\Cache;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\File\FileFinder;
+use PHPStan\Internal\FileHashing;
 use PHPStan\Php\PhpVersion;
 use function array_key_exists;
 use function array_keys;
@@ -32,7 +33,7 @@ final class OptimizedDirectorySourceLocatorFactory
 		$files = $this->fileFinder->findFiles([$directory])->getFiles();
 		$fileHashes = [];
 		foreach ($files as $file) {
-			$hash = hash_file('sha256', $file);
+			$hash = hash_file(FileHashing::ALGORITHM, $file);
 			if ($hash === false) {
 				continue;
 			}
@@ -105,7 +106,7 @@ final class OptimizedDirectorySourceLocatorFactory
 	{
 		$fileHashes = [];
 		foreach ($files as $file) {
-			$hash = hash_file('sha256', $file);
+			$hash = hash_file(FileHashing::ALGORITHM, $file);
 			if ($hash === false) {
 				continue;
 			}

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocator.php
@@ -18,6 +18,7 @@ use PHPStan\Cache\Cache;
 use PHPStan\DependencyInjection\GenerateFactory;
 use PHPStan\File\CouldNotReadFileException;
 use PHPStan\Internal\ComposerHelper;
+use PHPStan\Internal\FileHashing;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstantNameHelper;
 use PHPStan\ShouldNotHappenException;
@@ -45,7 +46,7 @@ final class OptimizedSingleFileSourceLocator implements SourceLocator
 
 	private function getVariableCacheKey(string $file): string
 	{
-		$fileHash = hash_file('sha256', $file);
+		$fileHash = hash_file(FileHashing::ALGORITHM, $file);
 		if ($fileHash === false) {
 			throw new CouldNotReadFileException($file);
 		}

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -14,6 +14,7 @@ use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\File\FileHelper;
 use PHPStan\Internal\ComposerHelper;
+use PHPStan\Internal\FileHashing;
 use PHPStan\Parser\Parser;
 use PHPStan\PhpDoc\NameScopeAlreadyBeingCreatedException;
 use PHPStan\PhpDoc\PhpDocNodeResolver;
@@ -344,7 +345,7 @@ final class FileTypeMapper
 				[$nameScopeMap, $files] = $this->createPhpDocNodeMap($fileName, null, null, [], $fileName);
 				$filesWithHashes = [];
 				foreach ($files as $file) {
-					$newHash = hash_file('sha256', $file);
+					$newHash = hash_file(FileHashing::ALGORITHM, $file);
 					$filesWithHashes[$file] = $newHash;
 				}
 				$this->cache->save($cacheKey, $variableCacheKey, [$nameScopeMap, $filesWithHashes]);
@@ -381,7 +382,7 @@ final class FileTypeMapper
 			[$nameScopeMap, $filesWithHashes] = $cached;
 			$useCache = true;
 			foreach ($filesWithHashes as $file => $hash) {
-				$newHash = @hash_file('sha256', $file);
+				$newHash = @hash_file(FileHashing::ALGORITHM, $file);
 				if ($newHash === false) {
 					$useCache = false;
 					break;


### PR DESCRIPTION
## What & why

Every `hash_file()` call changed here produces a cache-invalidation key, not a security
boundary: result cache file hashes, source locator directory scans, per-identifier
reflection cache keys, PHPDoc cache validation, container config hashes, and FileMonitor.

The algorithm is picked per PHP version (`PHPStan\Internal\FileHashing::ALGORITHM`):
xxh128 on PHP 8.1+ where it exists, sha256 below, so 7.4–8.0 behaviour is unchanged.

The win is architecture-dependent. php-src's PHP 8.4 sha256 acceleration
(php/php-src#15152) is x86/x86_64-only (SHA-NI + SSE2); on arm64 — Apple Silicon dev
machines, Graviton CI — sha256 still runs the portable C code at ~268 MB/s vs
~25 GB/s for xxh128 (PHP 8.5.7, M4 Pro). For PHPStan's real workload (many small files,
3.4 KB average in `src/`) file-open overhead dominates, so a full hashing pass over the
1707-file `src/` tree goes from 83 ms to 48 ms.

## Benchmarks

hyperfine end to end on arm64 (base = ff2647a, self-analysis level 8; caches primed for
warm runs, wiped per run for cold):

| scenario | base | PR | delta |
|---|---:|---:|---:|
| cold, `src/Type` (383 files) | 8.778 ± 0.172 s | 8.637 ± 0.092 s | −141 ms wall, −1.15 s user CPU |
| warm, `src` (1707 files) | 583.4 ± 6.4 ms | 571.9 ± 6.8 ms | −12 ms wall, −28 ms user CPU |

Roughly −2% wall / −3% CPU cold and −2% warm on arm64; on x86 with SHA-NI the delta
shrinks accordingly. Modest, but the cost is a one-line change per site. Existing caches
invalidate once because the hash values differ, then rebuild as usual.

## Tests

`make tests` (12,711, green), `make phpstan` (full self-analysis), `make cs`, `make lint`
and `make composer-dependency-analyser` all pass. Analysis output is byte-identical to the
baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
