### PR TITLE
Skip result cache re-save when nothing changed

### DIFF
--- a/src/Analyser/ResultCache/ResultCache.php
+++ b/src/Analyser/ResultCache/ResultCache.php
@@ -43,8 +43,18 @@ final class ResultCache
 		private array $exportedNodes,
 		private array $projectExtensionFiles,
 		private array $currentFileHashes,
+		private bool $upToDate = false,
 	)
 	{
+	}
+
+	/**
+	 * Whether the cache on disk already matches the current state of the project
+	 * (no changed, new, or deleted files) so re-saving it can be skipped.
+	 */
+	public function isUpToDate(): bool
+	{
+		return $this->upToDate;
 	}
 
 	/**

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -515,6 +515,7 @@ final class ResultCacheManager
 			exportedNodes: $filteredExportedNodes,
 			projectExtensionFiles: $data['projectExtensionFiles'],
 			currentFileHashes: $currentFileHashes,
+			upToDate: $filesToAnalyseCount === 0 && count($deletedFiles) === 0 && !$newFileAppeared,
 		);
 	}
 
@@ -708,7 +709,13 @@ final class ResultCacheManager
 		$unmatchedLineIgnores = $this->mergeUnmatchedLineIgnores($resultCache, $analyserResult->getUnmatchedLineIgnores());
 
 		$saved = false;
-		if ($save !== false) {
+		if ($save !== false && $resultCache->isUpToDate()) {
+			// nothing changed since the cache was written - rewriting it would produce an identical file
+			$saved = true;
+			if ($output->isVeryVerbose()) {
+				$output->writeLineFormatted('Result cache was not saved because it is already up to date.');
+			}
+		} elseif ($save !== false) {
 			$projectExtensionFiles = [];
 			foreach ($resultCache->getProjectExtensionFiles() as $file => [$hash, $isAnalysed, $className]) {
 				if ($isAnalysed) {


### PR DESCRIPTION
## What & why

A fully warm run (no changed, new, or deleted files) rewrites the entire result cache
file even though the result is byte-identical to what is already on disk. For phpstan-src
itself that is an 11 MB (src/Type) to 26 MB (src) var_export file; for larger projects it
grows accordingly.

`restore()` now marks the `ResultCache` as up to date when nothing changed, and
`process()` skips the save in that case. The skip only triggers when the file list,
every file hash, and the project extension files all match the cache, so any change
still goes through the normal merge-and-save path. `isSaved()` reports true because the
cache on disk is current, which keeps the changed-extension-files warning behaviour
unchanged.

## Benchmarks

hyperfine (`--warmup 3 --runs 15`), end-to-end wall time of a fully warm `analyse` run,
self-analysis at level 8, Apple M4 Pro, PHP 8.5.7; caches primed before measuring:

| Corpus | base | PR | Delta |
|:---|---:|---:|---:|
| `src/Type` (383 files, 11 MB cache) | 411.2 ± 4.4 ms | 386.3 ± 3.2 ms | −25 ms (1.06×) |
| `src` (1707 files, 26 MB cache) | 605.1 ± 11.3 ms | 528.6 ± 9.2 ms | −77 ms (1.14×) |

Timing the skipped work directly on the base branch attributes the delta: `save()` takes
22.0 ms (11 MB cache) resp. 56–57 ms (26 MB cache) on a warm run, plus the
`getProjectExtensionFiles()` preparation the up-to-date branch also skips. The saving
scales roughly linearly with result cache size. Cold runs and runs that re-analyse files
are unaffected.

## Tests

`make tests` (12,711, green), `make phpstan`, `make cs`, `make lint` and
`make composer-dependency-analyser` all pass. Analysis output is byte-identical,
including incremental (change + revert) runs, where the cache is correctly re-saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
