### PR TITLE
Stripe size-sorted files across parallel jobs

### DIFF
--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -16,6 +16,7 @@ use function array_filter;
 use function array_unshift;
 use function array_values;
 use function count;
+use function filesize;
 use function function_exists;
 use function is_file;
 use function memory_get_peak_usage;
@@ -73,7 +74,7 @@ final class AnalyserRunner
 		}
 
 		if (!$debug && $allowParallel && function_exists('proc_open')) {
-			$schedule = $this->scheduler->scheduleWork($this->cpuCoreCounter->getNumberOfCpuCores(), $files);
+			$schedule = $this->scheduler->scheduleWork($this->cpuCoreCounter->getNumberOfCpuCores(), $files, static fn (string $file): int => (int) @filesize($file));
 
 			$mainScript = null;
 			if (isset($_SERVER['argv'][0]) && is_file($_SERVER['argv'][0])) {

--- a/src/Command/FixerWorkerRunner.php
+++ b/src/Command/FixerWorkerRunner.php
@@ -26,6 +26,7 @@ use function array_diff;
 use function array_key_exists;
 use function count;
 use function filemtime;
+use function filesize;
 use function in_array;
 use function is_file;
 use function memory_get_peak_usage;
@@ -351,7 +352,7 @@ final class FixerWorkerRunner
 			));
 		}
 
-		$schedule = $this->scheduler->scheduleWork($this->cpuCoreCounter->getNumberOfCpuCores(), $files);
+		$schedule = $this->scheduler->scheduleWork($this->cpuCoreCounter->getNumberOfCpuCores(), $files, static fn (string $file): int => (int) @filesize($file));
 		$mainScript = null;
 		if (isset($_SERVER['argv'][0]) && is_file($_SERVER['argv'][0])) {
 			$mainScript = $_SERVER['argv'][0];

--- a/src/Parallel/Scheduler.php
+++ b/src/Parallel/Scheduler.php
@@ -6,12 +6,14 @@ use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Diagnose\DiagnoseExtension;
-use function array_chunk;
+use function array_values;
+use function ceil;
 use function count;
 use function floor;
 use function max;
 use function min;
 use function sprintf;
+use function usort;
 
 #[AutowiredService]
 final class Scheduler implements DiagnoseExtension
@@ -38,13 +40,30 @@ final class Scheduler implements DiagnoseExtension
 
 	/**
 	 * @param array<string> $files
+	 * @param callable(string): int $fileSizeCallback
 	 */
 	public function scheduleWork(
 		int $cpuCores,
 		array $files,
+		callable $fileSizeCallback,
 	): Schedule
 	{
-		$jobs = array_chunk($files, $this->jobSize);
+		// sort by size and deal files round-robin across jobs so every job mixes
+		// large and small files - chunking a sorted list would concentrate the
+		// heaviest files into a single job and create one long-running straggler
+		$fileSizes = [];
+		foreach ($files as $file) {
+			$fileSizes[$file] = $fileSizeCallback($file);
+		}
+		usort($files, static fn (string $a, string $b): int => $fileSizes[$b] <=> $fileSizes[$a]);
+
+		$numberOfJobs = (int) ceil(count($files) / $this->jobSize);
+		$stripedJobs = [];
+		foreach ($files as $i => $file) {
+			$stripedJobs[$i % $numberOfJobs][] = $file;
+		}
+
+		$jobs = array_values($stripedJobs);
 		$numberOfProcesses = min(
 			max((int) floor(count($jobs) / $this->minimumNumberOfJobsPerProcess), 1),
 			$cpuCores,

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -5,8 +5,12 @@ namespace PHPStan\Parallel;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use function array_fill;
+use function array_keys;
 use function array_map;
+use function array_merge;
 use function count;
+use function sort;
+use function sprintf;
 
 class SchedulerTest extends TestCase
 {
@@ -21,7 +25,7 @@ class SchedulerTest extends TestCase
 				50,
 				115,
 				1,
-				[50, 50, 15],
+				[39, 38, 38],
 			],
 			[
 				16,
@@ -30,7 +34,7 @@ class SchedulerTest extends TestCase
 				30,
 				124,
 				5,
-				[30, 30, 30, 30, 4],
+				[25, 25, 25, 25, 24],
 			],
 			[
 				16,
@@ -39,7 +43,7 @@ class SchedulerTest extends TestCase
 				30,
 				124,
 				3,
-				[30, 30, 30, 30, 4],
+				[25, 25, 25, 25, 24],
 			],
 			[
 				16,
@@ -48,7 +52,7 @@ class SchedulerTest extends TestCase
 				10,
 				298,
 				16,
-				[10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 8],
+				[10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 9, 9],
 			],
 			[
 				16,
@@ -57,7 +61,7 @@ class SchedulerTest extends TestCase
 				30,
 				124,
 				2,
-				[30, 30, 30, 30, 4],
+				[25, 25, 25, 25, 24],
 			],
 			[
 				16,
@@ -91,11 +95,57 @@ class SchedulerTest extends TestCase
 	{
 		$files = array_fill(0, $numberOfFiles, 'file.php');
 		$scheduler = new Scheduler($jobSize, $maximumNumberOfProcesses, $minimumNumberOfJobsPerProcess);
-		$schedule = $scheduler->scheduleWork($cpuCores, $files);
+		$schedule = $scheduler->scheduleWork($cpuCores, $files, static fn (string $file): int => 0);
 
 		$this->assertSame($expectedNumberOfProcesses, $schedule->getNumberOfProcesses());
 		$jobSizes = array_map(static fn (array $job): int => count($job), $schedule->getJobs());
 		$this->assertSame($expectedJobSizes, $jobSizes);
+	}
+
+	public function testHeaviestFilesAreSpreadAcrossJobs(): void
+	{
+		$fileSizes = [
+			'a.php' => 100,
+			'b.php' => 200,
+			'c.php' => 300,
+			'd.php' => 400,
+			'e.php' => 500,
+			'f.php' => 600,
+		];
+
+		$scheduler = new Scheduler(2, 16, 1);
+		$schedule = $scheduler->scheduleWork(16, array_keys($fileSizes), static fn (string $file): int => $fileSizes[$file] ?? 0);
+
+		// six files, job size 2 -> three jobs; the three heaviest files must not
+		// share a job, and every job pairs one heavy file with one light file
+		$this->assertSame([
+			['f.php', 'c.php'],
+			['e.php', 'b.php'],
+			['d.php', 'a.php'],
+		], $schedule->getJobs());
+	}
+
+	public function testEveryFileIsScheduledExactlyOnce(): void
+	{
+		$files = [];
+		$sizes = [];
+		for ($i = 0; $i < 47; $i++) {
+			$file = sprintf('file-%d.php', $i);
+			$files[] = $file;
+			$sizes[$file] = ($i * 37) % 1000;
+		}
+
+		$scheduler = new Scheduler(10, 16, 1);
+		$schedule = $scheduler->scheduleWork(16, $files, static fn (string $file): int => $sizes[$file]);
+
+		$scheduled = array_merge(...$schedule->getJobs());
+		sort($scheduled);
+		sort($files);
+		$this->assertSame($files, $scheduled);
+
+		foreach ($schedule->getJobs() as $job) {
+			$this->assertLessThanOrEqual(10, count($job));
+		}
 	}
 
 }


### PR DESCRIPTION
## What & why

The scheduler chunks files into jobs in path order. Directories tend to cluster files of
similar weight, so one job can collect a directory's heaviest files and become the
straggler the whole run waits for while other workers sit idle.

This change sorts the files by size and deals them round-robin across the jobs, so every
job gets the same size profile. Job count and the per-job ceiling (`jobSize`) stay the
same; only the composition changes. File sizes are supplied from the outside
(`callable(string): int`), so the Scheduler itself stays unit-testable without touching
the filesystem.

## Benchmarks

Complete `make phpstan` on phpstan-src (clears the result cache itself, so every run is
a full analysis of 2,364 files), two clean worktrees with primed file caches,
`hyperfine --warmup 1 --runs 6`, Apple M4 Pro / PHP 8.5.7:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| base ff2647a — `make phpstan` | 19.047 ± 0.100 | 18.921 | 19.215 | 1.08 ± 0.01 |
| PR — `make phpstan` | 17.573 ± 0.068 | 17.454 | 17.635 | 1.00 |

−1.47 s, 1.08× faster; user CPU unchanged within noise (111.3 s vs 113.3 s) — the win is
load balance, not less work. A reversed-order pass reproduces it (17.77 ± 0.24 s vs
19.04 ± 0.23 s), so it is not an ordering or thermal artifact.

One detail worth knowing: sorting *without* striping makes things considerably worse
(+46% wall on a smaller corpus), because plain chunking of a sorted list concentrates all
heavy files into the first job. The striping is what makes the sort pay off, and
`testHeaviestFilesAreSpreadAcrossJobs` pins exactly that property.

File size is a proxy for analysis cost, not a perfect predictor, but across repeated runs
it consistently beat path-order chunking and never lost to it.

## Tests

`make tests` (12,713, green), `make phpstan`, `make cs`, `make lint` and
`make composer-dependency-analyser` all pass. Analysis output is byte-identical to the
baseline; only the distribution of files over worker jobs changes. `SchedulerTest` covers
the striped layout exactly (six distinctly-sized files: the three heaviest land in three
different jobs) and that every file is scheduled exactly once with jobs ≤ jobSize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
