### PR TITLE
Store file cache entries with serialize() instead of var_export/include

### DIFF
--- a/src/Cache/FileCacheStorage.php
+++ b/src/Cache/FileCacheStorage.php
@@ -13,10 +13,11 @@ use PHPStan\Internal\DirectoryCreatorException;
 use PHPStan\ShouldNotHappenException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Throwable;
 use function array_keys;
 use function closedir;
 use function dirname;
-use function error_get_last;
+use function file_get_contents;
 use function hash;
 use function is_dir;
 use function is_file;
@@ -24,19 +25,20 @@ use function opendir;
 use function readdir;
 use function rename;
 use function rmdir;
+use function serialize;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
 use function substr;
 use function uksort;
 use function unlink;
-use function var_export;
+use function unserialize;
 use const DIRECTORY_SEPARATOR;
 
 final class FileCacheStorage implements CacheStorage
 {
 
-	private const CACHED_CLEARED_VERSION = 'v2-new';
+	private const CACHED_CLEARED_VERSION = 'v3-serialized';
 
 	public function __construct(private string $directory)
 	{
@@ -49,17 +51,22 @@ final class FileCacheStorage implements CacheStorage
 	{
 		[,, $filePath] = $this->getFilePaths($key);
 
-		return (static function ($variableKey, $filePath) {
-			$cacheItem = @include $filePath;
-			if (!$cacheItem instanceof CacheItem) {
-				return null;
-			}
-			if (!$cacheItem->isVariableKeyValid($variableKey)) {
-				return null;
-			}
+		$contents = @file_get_contents($filePath);
+		if ($contents === false) {
+			return null;
+		}
 
-			return $cacheItem->getData();
-		})($variableKey, $filePath);
+		// entries written by older versions in the var_export/include format
+		// fail to unserialize and simply count as a cache miss
+		$cacheItem = @unserialize($contents);
+		if (!$cacheItem instanceof CacheItem) {
+			return null;
+		}
+		if (!$cacheItem->isVariableKeyValid($variableKey)) {
+			return null;
+		}
+
+		return $cacheItem->getData();
 	}
 
 	/**
@@ -74,16 +81,12 @@ final class FileCacheStorage implements CacheStorage
 		DirectoryCreator::ensureDirectoryExists($secondDirectory, 0777);
 
 		$tmpPath = sprintf('%s/%s.tmp', $this->directory, Random::generate());
-		$errorBefore = error_get_last();
-		$exported = @var_export(new CacheItem($variableKey, $data), true);
-		$errorAfter = error_get_last();
-		if ($errorAfter !== null && $errorBefore !== $errorAfter) {
-			throw new ShouldNotHappenException(sprintf('Error occurred while saving item %s (%s) to cache: %s', $key, $variableKey, $errorAfter['message']));
+		try {
+			$serialized = serialize(new CacheItem($variableKey, $data));
+		} catch (Throwable $e) {
+			throw new ShouldNotHappenException(sprintf('Error occurred while saving item %s (%s) to cache: %s', $key, $variableKey, $e->getMessage()));
 		}
-		FileWriter::write(
-			$tmpPath,
-			"<?php declare(strict_types = 1);\n\n" . '// ' . $key . "\nreturn " . $exported . ';',
-		);
+		FileWriter::write($tmpPath, $serialized);
 
 		$renameSuccess = @rename($tmpPath, $path);
 		if ($renameSuccess) {
@@ -106,7 +109,9 @@ final class FileCacheStorage implements CacheStorage
 		$keyHash = hash('sha256', $key);
 		$firstDirectory = sprintf('%s/%s', $this->directory, substr($keyHash, 0, 2));
 		$secondDirectory = sprintf('%s/%s', $firstDirectory, substr($keyHash, 2, 2));
-		$filePath = sprintf('%s/%s.php', $secondDirectory, $keyHash);
+		// .dat, not .php: an older PHPStan version sharing the same tmpDir would
+		// include a .php cache file and echo the serialized payload to stdout
+		$filePath = sprintf('%s/%s.dat', $secondDirectory, $keyHash);
 
 		return [
 			$firstDirectory,
@@ -136,25 +141,13 @@ final class FileCacheStorage implements CacheStorage
 		$iterator = new RecursiveDirectoryIterator($this->directory);
 		$iterator->setFlags(RecursiveDirectoryIterator::SKIP_DOTS);
 		$files = new RecursiveIteratorIterator($iterator);
-		$beginFunction = sprintf(
-			"<?php declare(strict_types = 1);\n\n%s",
-			sprintf('// %s', 'variadic-function-'),
-		);
-		$beginMethod = sprintf(
-			"<?php declare(strict_types = 1);\n\n%s",
-			sprintf('// %s', 'variadic-method-'),
-		);
-		$beginNew = "<?php declare(strict_types = 1);\n\n//";
+		$serializedPrefix = sprintf('O:%d:"%s"', strlen(CacheItem::class), CacheItem::class);
 		$emptyDirectoriesToCheck = [];
 		foreach ($files as $file) {
 			try {
 				$path = $file->getPathname();
 				$contents = FileReader::read($path);
-				if (
-					!str_starts_with($contents, $beginFunction)
-					&& !str_starts_with($contents, $beginMethod)
-					&& str_starts_with($contents, $beginNew)
-				) {
+				if (str_starts_with($contents, $serializedPrefix)) {
 					continue;
 				}
 

--- a/tests/PHPStan/Cache/FileCacheStorageTest.php
+++ b/tests/PHPStan/Cache/FileCacheStorageTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Cache;
+
+use Override;
+use PHPStan\Internal\DirectoryCreatorException;
+use PHPUnit\Framework\TestCase;
+use function exec;
+use function escapeshellarg;
+use function file_put_contents;
+use function is_file;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+class FileCacheStorageTest extends TestCase
+{
+
+	private string $directory;
+
+	#[Override]
+	protected function setUp(): void
+	{
+		$this->directory = sys_get_temp_dir() . '/phpstan-file-cache-storage-test-' . uniqid();
+		mkdir($this->directory, 0777, true);
+	}
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		exec('rm -rf ' . escapeshellarg($this->directory));
+	}
+
+	/**
+	 * @throws DirectoryCreatorException
+	 */
+	public function testSaveAndLoadRoundTrip(): void
+	{
+		$storage = new FileCacheStorage($this->directory);
+		$storage->save('some-key', 'variable-key', ['data' => [1, 2, 3]]);
+
+		$this->assertSame(['data' => [1, 2, 3]], $storage->load('some-key', 'variable-key'));
+		$this->assertNull($storage->load('some-key', 'different-variable-key'));
+		$this->assertNull($storage->load('unknown-key', 'variable-key'));
+	}
+
+	/**
+	 * @throws DirectoryCreatorException
+	 */
+	public function testClearUnusedFilesKeepsCurrentFormatEntries(): void
+	{
+		$storage = new FileCacheStorage($this->directory);
+		$storage->save('some-key', 'variable-key', 'cached-value');
+
+		// no cache-cleared marker exists yet - cleanup must not treat
+		// current-format entries as legacy garbage
+		$storage->clearUnusedFiles();
+
+		$this->assertSame('cached-value', $storage->load('some-key', 'variable-key'));
+	}
+
+	public function testClearUnusedFilesRemovesLegacyFormatEntries(): void
+	{
+		$storage = new FileCacheStorage($this->directory);
+		$legacyFile = $this->directory . '/ab/cd/legacy.php';
+		mkdir($this->directory . '/ab/cd', 0777, true);
+		file_put_contents($legacyFile, "<?php declare(strict_types = 1);\n\n// legacy-key\nreturn 'legacy';");
+
+		$storage->clearUnusedFiles();
+
+		$this->assertFalse(is_file($legacyFile));
+	}
+
+}


### PR DESCRIPTION
## What & why

`FileCacheStorage` stores entries as var_export'd PHP files loaded via `include`. On CLI,
where opcache is typically off, every cache hit pays full PHP parse plus AST-to-value
construction. A cold run loads thousands of per-file reflection and PHPDoc entries this
way. Storing the `CacheItem` with `serialize()` and reading it back with `unserialize()`
is measurably cheaper: about 2% less total CPU on a cold `src/Type` self-analysis run
(up to 4.7% in an ablation on a larger change set), and the entries shrink on disk.

Migration details, since a format switch deserves scrutiny:

- Serialized entries are written as `.dat` files. An older PHPStan version sharing the
  same tmpDir looks for `.php` files, finds none, and treats it as a plain cache miss.
  Writing the new format into `.php` files would be worse than a miss: `include` of a
  file without a `<?php` tag echoes its raw bytes to stdout.
- Entries written by older versions fail the `CacheItem` instance check on load and
  count as a one-time miss; the cache rebuilds from there.
- `clearUnusedFiles()` now keeps current-format files (the predicate is built from
  `CacheItem::class`) and `CACHED_CLEARED_VERSION` is bumped, so leftover var_export
  entries from before the switch get purged once. Previously the keep-predicate matched
  only the old format, which meant a missing or stale marker file would have deleted
  every current entry as legacy garbage.

`FileCacheStorageTest` covers the round-trip, that cleanup keeps current-format entries
when the marker file is missing, and that legacy `.php` entries get removed.

## Tests

`make tests` (12,714, green), `make phpstan`, `make cs`, `make lint` and
`make composer-dependency-analyser` all pass. Analysis output is byte-identical to the
baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
