### PR TITLE
Keep input order of files within striped jobs

### DIFF
--- a/src/Parallel/Scheduler.php
+++ b/src/Parallel/Scheduler.php
@@ -52,8 +52,10 @@ final class Scheduler implements DiagnoseExtension
 		// large and small files - chunking a sorted list would concentrate the
 		// heaviest files into a single job and create one long-running straggler
 		$fileSizes = [];
-		foreach ($files as $file) {
+		$originalOrder = [];
+		foreach ($files as $i => $file) {
 			$fileSizes[$file] = $fileSizeCallback($file);
+			$originalOrder[$file] = $i;
 		}
 		usort($files, static fn (string $a, string $b): int => $fileSizes[$b] <=> $fileSizes[$a]);
 
@@ -62,6 +64,13 @@ final class Scheduler implements DiagnoseExtension
 		foreach ($files as $i => $file) {
 			$stripedJobs[$i % $numberOfJobs][] = $file;
 		}
+
+		// only the job composition should change, not the order in which files
+		// of a job get analysed - analysis results can be sensitive to it
+		foreach ($stripedJobs as &$stripedJob) {
+			usort($stripedJob, static fn (string $a, string $b): int => $originalOrder[$a] <=> $originalOrder[$b]);
+		}
+		unset($stripedJob);
 
 		$jobs = array_values($stripedJobs);
 		$numberOfProcesses = min(

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -117,12 +117,29 @@ class SchedulerTest extends TestCase
 		$schedule = $scheduler->scheduleWork(16, array_keys($fileSizes), static fn (string $file): int => $fileSizes[$file] ?? 0);
 
 		// six files, job size 2 -> three jobs; the three heaviest files must not
-		// share a job, and every job pairs one heavy file with one light file
+		// share a job, and every job pairs one heavy file with one light file,
+		// listed in input order
 		$this->assertSame([
-			['f.php', 'c.php'],
-			['e.php', 'b.php'],
-			['d.php', 'a.php'],
+			['c.php', 'f.php'],
+			['b.php', 'e.php'],
+			['a.php', 'd.php'],
 		], $schedule->getJobs());
+	}
+
+	public function testFilesWithinAJobKeepTheirInputOrder(): void
+	{
+		// a small file followed by a larger one - the size sort must only
+		// influence which job a file lands in, never the analysis order
+		// inside the job (analysis results can be sensitive to it)
+		$fileSizes = [
+			'bootstrap.php' => 327,
+			'src/Middleware.php' => 560,
+		];
+
+		$scheduler = new Scheduler(20, 16, 1);
+		$schedule = $scheduler->scheduleWork(16, array_keys($fileSizes), static fn (string $file): int => $fileSizes[$file] ?? 0);
+
+		$this->assertSame([['bootstrap.php', 'src/Middleware.php']], $schedule->getJobs());
 	}
 
 	public function testEveryFileIsScheduledExactlyOnce(): void


### PR DESCRIPTION
Fixes the bug-14036 e2e regression from #5844, reported by @staabm.

The size sort also changed the order files get analysed in *within* a job, and results can be sensitive to that: the 560-byte middleware file moved before the 327-byte bootstrap file, so `MemoizingReflector` (lowercased keys) resolved `SQLitePlatform` first and the later `SqlitePlatform` lookup reported `class.nameCase` instead of the expected `class.notFound`. (I missed this locally because APFS is case-insensitive, which makes the e2e fail on base too on macOS.)

The sort now only decides which job a file lands in; within each job the original input order is restored. `testFilesWithinAJobKeepTheirInputOrder` pins the bug-14036 shape. `make phpstan` stays at 1.07× (17.73 ± 0.04 s vs 19.00 ± 0.06 s base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
