### PR TITLE
Fix "Differing behaviors when requiring or including relatively vs using __DIR__"

### DIFF
--- a/src/Rules/Keywords/RequireFileExistsRule.php
+++ b/src/Rules/Keywords/RequireFileExistsRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Keywords;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Include_;
 use PhpParser\Node\Name\FullyQualified;
@@ -11,10 +12,12 @@ use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\File\FileHelper;
+use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Constant\ConstantStringType;
 use function array_merge;
 use function dirname;
 use function explode;
@@ -33,6 +36,7 @@ final class RequireFileExistsRule implements Rule
 	public function __construct(
 		#[AutowiredParameter]
 		private string $currentWorkingDirectory,
+		private ExprPrinter $exprPrinter,
 	)
 	{
 	}
@@ -49,14 +53,23 @@ final class RequireFileExistsRule implements Rule
 		}
 
 		$errors = [];
-		$paths = $this->resolveFilePaths($node, $scope);
+		$usedMagicDirFallback = false;
+		$paths = $this->resolveFilePaths($node->expr, $scope, $usedMagicDirFallback);
 
 		foreach ($paths as $path) {
+			$path = $path->getValue();
+
 			if ($this->doesFileExist($path, $scope)) {
 				continue;
 			}
 
-			$errors[] = $this->getErrorMessage($node, $path);
+			if ($usedMagicDirFallback) {
+				$pathExpr = $this->exprPrinter->printExpr($node->expr);
+			} else {
+				$pathExpr = '"' . $path . '"';
+			}
+
+			$errors[] = $this->getErrorMessage($node, $pathExpr);
 		}
 
 		return $errors;
@@ -97,7 +110,7 @@ final class RequireFileExistsRule implements Rule
 
 	private function getErrorMessage(Include_ $node, string $filePath): IdentifierRuleError
 	{
-		$message = 'Path in %s() "%s" is not a file or it does not exist.';
+		$message = 'Path in %s() %s is not a file or it does not exist.';
 
 		switch ($node->type) {
 			case Include_::TYPE_REQUIRE:
@@ -132,18 +145,33 @@ final class RequireFileExistsRule implements Rule
 	}
 
 	/**
-	 * @return array<string>
+	 * @return list<ConstantStringType>
 	 */
-	private function resolveFilePaths(Include_ $node, Scope $scope): array
+	private function resolveFilePaths(Expr $expr, Scope $scope, bool &$magicDirFallback): array
 	{
-		$paths = [];
-		$type = $scope->getType($node->expr);
-		$constantStrings = $type->getConstantStrings();
+		$magicDirFallback = false;
 
-		foreach ($constantStrings as $constantString) {
-			$paths[] = $constantString->getValue();
+		if (!$expr instanceof Expr\BinaryOp\Concat) {
+			return $scope->getType($expr)->getConstantStrings();
 		}
 
+		if ($expr->left instanceof Node\Scalar\MagicConst\Dir) {
+			$magicDirFallback = true;
+
+			$paths = [];
+			foreach ($scope->getType($expr->right)->getConstantStrings() as $constantString) {
+				$paths[] = new ConstantStringType(dirname($scope->getFile()) . $constantString->getValue());
+			}
+			return $paths;
+		}
+
+		$paths = [];
+		$rightPaths = $this->resolveFilePaths($expr->right, $scope, $magicDirFallback);
+		foreach ($this->resolveFilePaths($expr->left, $scope, $magicDirFallback) as $left) {
+			foreach ($rightPaths as $rightPath) {
+				$paths[] = new ConstantStringType($left->getValue() . $rightPath->getValue());
+			}
+		}
 		return $paths;
 	}
 

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleNoConstantPathTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleNoConstantPathTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Keywords;
+
+use PHPStan\Node\Printer\ExprPrinter;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<RequireFileExistsRule>
+ */
+class RequireFileExistsRuleNoConstantPathTest extends RuleTestCase
+{
+
+	private string $currentWorkingDirectory = __DIR__ . '/../';
+
+	protected function getRule(): Rule
+	{
+		return new RequireFileExistsRule(
+			$this->currentWorkingDirectory,
+			self::getContainer()->getByType(ExprPrinter::class),
+		);
+	}
+
+	public function testBug12203NoConstantPath(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12203.php'], [
+			[
+				'Path in require_once() "../bug-12203-sure-does-not-exist.php" is not a file or it does not exist.',
+				5,
+			],
+			[
+				"Path in require_once() __DIR__ . '/../bug-12203-sure-does-not-exist.php' is not a file or it does not exist.",
+				6,
+			],
+			[
+				"Path in require_once() __DIR__ . '/' . \$path . '/' . \$file is not a file or it does not exist.",
+				10,
+			],
+			[
+				'Path in require_once() __DIR__ . "{$path}/{$file}" is not a file or it does not exist.',
+				12,
+			],
+		]);
+	}
+
+	public function testInFileExists(): void
+	{
+		$this->analyse([__DIR__ . '/data/include-in-file-exists.php'], []);
+	}
+
+}

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
@@ -2,13 +2,13 @@
 
 namespace PHPStan\Rules\Keywords;
 
+use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use function get_include_path;
 use function implode;
 use function realpath;
 use function set_include_path;
-use const DIRECTORY_SEPARATOR;
 use const PATH_SEPARATOR;
 
 /**
@@ -21,7 +21,10 @@ class RequireFileExistsRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new RequireFileExistsRule($this->currentWorkingDirectory);
+		return new RequireFileExistsRule(
+			$this->currentWorkingDirectory,
+			self::getContainer()->getByType(ExprPrinter::class),
+		);
 	}
 
 	public static function getAdditionalConfigFiles(): array
@@ -130,8 +133,16 @@ class RequireFileExistsRuleTest extends RuleTestCase
 				5,
 			],
 			[
-				'Path in require_once() "' . __DIR__ . DIRECTORY_SEPARATOR . 'data/../bug-12203-sure-does-not-exist.php" is not a file or it does not exist.',
+				"Path in require_once() __DIR__ . '/../bug-12203-sure-does-not-exist.php' is not a file or it does not exist.",
 				6,
+			],
+			[
+				"Path in require_once() __DIR__ . '/' . \$path . '/' . \$file is not a file or it does not exist.",
+				10,
+			],
+			[
+				'Path in require_once() __DIR__ . "{$path}/{$file}" is not a file or it does not exist.',
+				12,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Keywords/data/bug-12203.php
+++ b/tests/PHPStan/Rules/Keywords/data/bug-12203.php
@@ -4,3 +4,9 @@ namespace Bug12203;
 
 require_once '../bug-12203-sure-does-not-exist.php';
 require_once __DIR__ . '/../bug-12203-sure-does-not-exist.php';
+
+$path = '..';
+$file = 'bug-12203-sure-does-not-exist.php';
+require_once __DIR__ . '/'. $path .'/'. $file;
+
+require_once __DIR__ . "$path/$file";


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/12203

before this PR the `RequireFileExistsRule` was only useful with `usePathConstantsAsConstantString: true` in NEON config - a parameter which was/is not documented and is considered internal.

after this PR the `RequireFileExistsRule` can resolve paths which contain `__DIR__` even when `usePathConstantsAsConstantString: false` - which is the PHPStan default. This means the rule actually gets useful in the common case.