### PR TITLE
RequireFileExistsRule: enable __DIR__ only for bleeding edge

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -16,6 +16,7 @@ parameters:
 		reportNestedTooWideType: false # tmp
 		assignToByRefForeachExpr: true
 		curlSetOptArrayTypes: true
+		magicDirInInclude: true
 		checkDateIntervalConstructor: true
 		reportMethodPurityOverride: true
 		checkDynamicConstantNameValues: true

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -43,6 +43,7 @@ parameters:
 		reportNestedTooWideType: false
 		assignToByRefForeachExpr: false
 		curlSetOptArrayTypes: false
+		magicDirInInclude: false
 		checkDateIntervalConstructor: false
 		reportMethodPurityOverride: false
 		checkDynamicConstantNameValues: false

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -45,6 +45,7 @@ parametersSchema:
 		reportNestedTooWideType: bool()
 		assignToByRefForeachExpr: bool()
 		curlSetOptArrayTypes: bool()
+		magicDirInInclude: bool()
 		checkDateIntervalConstructor: bool()
 		reportMethodPurityOverride: bool()
 		checkDynamicConstantNameValues: bool()

--- a/src/Rules/Keywords/RequireFileExistsRule.php
+++ b/src/Rules/Keywords/RequireFileExistsRule.php
@@ -37,6 +37,8 @@ final class RequireFileExistsRule implements Rule
 		#[AutowiredParameter]
 		private string $currentWorkingDirectory,
 		private ExprPrinter $exprPrinter,
+		#[AutowiredParameter(ref: '%featureToggles.magicDirInInclude%')]
+		private bool $checkMagicDirInInclude,
 	)
 	{
 	}
@@ -150,6 +152,10 @@ final class RequireFileExistsRule implements Rule
 	private function resolveFilePaths(Expr $expr, Scope $scope, bool &$magicDirFallback): array
 	{
 		$magicDirFallback = false;
+
+		if (!$this->checkMagicDirInInclude) {
+			return $scope->getType($expr)->getConstantStrings();
+		}
 
 		if (!$expr instanceof Expr\BinaryOp\Concat) {
 			return $scope->getType($expr)->getConstantStrings();

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleNoConstantPathTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleNoConstantPathTest.php
@@ -19,6 +19,7 @@ class RequireFileExistsRuleNoConstantPathTest extends RuleTestCase
 		return new RequireFileExistsRule(
 			$this->currentWorkingDirectory,
 			self::getContainer()->getByType(ExprPrinter::class),
+			true,
 		);
 	}
 

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
@@ -24,6 +24,7 @@ class RequireFileExistsRuleTest extends RuleTestCase
 		return new RequireFileExistsRule(
 			$this->currentWorkingDirectory,
 			self::getContainer()->getByType(ExprPrinter::class),
+			true,
 		);
 	}
 


### PR DESCRIPTION
the rule, which was improved with https://github.com/phpstan/phpstan-src/pull/5862, did only work before when a opt-in `usePathConstantsAsConstantString: true` flag was used. I feel this mean only very few users had it in use.

with the mentioned PR, the rule covers more real world use-cases, because the added behaviour does not depend on the opt-in flag.

to play it save, lets enable the newly added logic only in bleeding edge for now