### PR TITLE
Fix OrChainIdenticalComparisonToInArrayRule

### DIFF
--- a/build/PHPStan/Build/OrChainIdenticalComparisonToInArrayRule.php
+++ b/build/PHPStan/Build/OrChainIdenticalComparisonToInArrayRule.php
@@ -136,7 +136,7 @@ final class OrChainIdenticalComparisonToInArrayRule implements Rule
 	 */
 	private function getSubjectAndValue(Identical $comparison): ?array
 	{
-		if (self::isSubjectNode($comparison->left) && !self::isSubjectNode($comparison->left)) {
+		if (self::isSubjectNode($comparison->left) && !self::isSubjectNode($comparison->right)) {
 			return ['subject' => $comparison->right, 'value' => $comparison->left];
 		}
 

--- a/tests/PHPStan/Build/OrChainIdenticalComparisonToInArrayRuleTest.php
+++ b/tests/PHPStan/Build/OrChainIdenticalComparisonToInArrayRuleTest.php
@@ -38,6 +38,14 @@ final class OrChainIdenticalComparisonToInArrayRuleTest extends RuleTestCase
 				'This chain of identical comparisons can be simplified using in_array().',
 				17,
 			],
+			[
+				'This chain of identical comparisons can be simplified using in_array().',
+				21,
+			],
+			[
+				'This chain of identical comparisons can be simplified using in_array().',
+				25,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Build/data/or-chain-identical-comparison.php
+++ b/tests/PHPStan/Build/data/or-chain-identical-comparison.php
@@ -18,6 +18,14 @@ if ($var === 'foo' || $var === 'bar' || $var === 'buz') {
 	echo 'ok';
 }
 
+if ('foo' === $var || 'bar' === $var) {
+	echo 'ok';
+}
+
+if ('foo' === $var || $var === 'bar') {
+	echo 'ok';
+}
+
 if ($var === 'foo' || $var === 'bar' || $var2 === 'buz') {
 	echo 'no';
 }

--- a/tests/PHPStan/Build/data/or-chain-identical-comparison.php.fixed
+++ b/tests/PHPStan/Build/data/or-chain-identical-comparison.php.fixed
@@ -18,6 +18,14 @@ if (\in_array($var, ['foo', 'bar', 'buz'], true)) {
 	echo 'ok';
 }
 
+if (\in_array($var, ['foo', 'bar'], true)) {
+	echo 'ok';
+}
+
+if (\in_array($var, ['foo', 'bar'], true)) {
+	echo 'ok';
+}
+
 if ($var === 'foo' || $var === 'bar' || $var2 === 'buz') {
 	echo 'no';
 }


### PR DESCRIPTION
**why is this change required?**

The original line was `self::isSubjectNode($comparison->left) && !self::isSubjectNode($comparison->left)` — a self-contradictory `X && !X` that is always `false`. That first branch never executed, so the rule could only ever match the *second* branch (subject on the left, value on the right, e.g. `$var === 'foo'`). Yoda-style comparisons where the literal is on the left (`'foo' === $var`) fell through and returned `null`, so those chains were silently never reported or fixed. Changing the second check to `$comparison->right` makes the first branch correctly handle "value on the left".

**Added a failing-without-the-fix test**

- `tests/PHPStan/Build/data/or-chain-identical-comparison.php`: two new yoda-style chains — `'foo' === $var || 'bar' === $var` and a mixed `'foo' === $var || $var === 'bar'`.
- `...php.fixed`: their expected `in_array()` rewrites.
- `OrChainIdenticalComparisonToInArrayRuleTest`: added the two expected errors at lines 21 and 25.

**Verification**
- With the fix: both `testRule` and `testFix` pass.
- I temporarily reverted the source to the buggy `->left` version and confirmed both tests fail (the line-21/25 errors are missing and the fixer leaves the yoda chains unchanged), then restored the fix.
- `make phpstan`: green.

extracted from https://github.com/phpstan/phpstan-src/pull/5880