### PR TITLE
Support `::class` magic constant in array shape keys and const types

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -1276,6 +1276,14 @@ final class TypeNodeResolver
 			}
 
 			$constantName = $constExpr->name;
+			if (strtolower($constantName) === 'class') {
+				if ($isStatic) {
+					return new GenericClassStringType(new StaticType($classReflection));
+				}
+
+				return new ConstantStringType($classReflection->getName(), true);
+			}
+
 			if (!$classReflection->hasConstant($constantName)) {
 				return new ErrorType();
 			}
@@ -1380,6 +1388,14 @@ final class TypeNodeResolver
 			}
 
 			$constantName = $constExpr->name;
+			if (strtolower($constantName) === 'class') {
+				if ($isStatic) {
+					return new GenericClassStringType(new StaticType($classReflection));
+				}
+
+				return new ConstantStringType($classReflection->getName(), true);
+			}
+
 			if (Strings::contains($constantName, '*')) {
 				// convert * into .*? and escape everything else so the constants can be matched against the pattern
 				$pattern = '{^' . str_replace('\\*', '.*?', preg_quote($constantName)) . '$}D';

--- a/tests/PHPStan/Analyser/nsrt/array-shape-class-constant-key.php
+++ b/tests/PHPStan/Analyser/nsrt/array-shape-class-constant-key.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace ArrayShapeClassConstantKey;
+
+use function PHPStan\Testing\assertType;
+
+class Test
+{
+
+	/**
+	 * @return array{
+	 *      Test::class: int
+	 * }
+	 */
+	public static function foo(): array
+	{
+		$r = [self::class => 1];
+		assertType('array{ArrayShapeClassConstantKey\\Test: 1}', $r);
+
+		return $r;
+	}
+
+	/** @return Test::class */
+	public static function classConstant(): string
+	{
+		return self::class;
+	}
+
+	/** @return array{Test::class, int} */
+	public static function inTuple(): array
+	{
+		return [self::class, 1];
+	}
+
+}
+
+final class FinalTest
+{
+
+	/** @return array{static::class: int} */
+	public static function staticInFinal(): array
+	{
+		return [self::class => 1];
+	}
+
+}
+
+class Base
+{
+}
+
+class Child extends Base
+{
+
+	/** @return array{parent::class: int} */
+	public static function parentKey(): array
+	{
+		return [parent::class => 1];
+	}
+
+	/** @return static::class */
+	public static function staticClassConstant(): string
+	{
+		return static::class;
+	}
+
+}
+
+function test(): void
+{
+	assertType('array{ArrayShapeClassConstantKey\\Test: int}', Test::foo());
+	assertType('\'ArrayShapeClassConstantKey\\\\Test\'', Test::classConstant());
+	assertType('array{\'ArrayShapeClassConstantKey\\\\Test\', int}', Test::inTuple());
+	assertType('array{ArrayShapeClassConstantKey\\FinalTest: int}', FinalTest::staticInFinal());
+	assertType('array{ArrayShapeClassConstantKey\\Base: int}', Child::parentKey());
+	assertType('class-string<ArrayShapeClassConstantKey\\Child>', Child::staticClassConstant());
+}

--- a/tests/PHPStan/Analyser/nsrt/array-shape-class-constant-key.php
+++ b/tests/PHPStan/Analyser/nsrt/array-shape-class-constant-key.php
@@ -58,6 +58,12 @@ class Child extends Base
 		return [parent::class => 1];
 	}
 
+	/** @return array{static::class: int} */
+	public static function staticKey(): array
+	{
+		return [static::class => 1];
+	}
+
 	/** @return static::class */
 	public static function staticClassConstant(): string
 	{
@@ -73,5 +79,6 @@ function test(): void
 	assertType('array{\'ArrayShapeClassConstantKey\\\\Test\', int}', Test::inTuple());
 	assertType('array{ArrayShapeClassConstantKey\\FinalTest: int}', FinalTest::staticInFinal());
 	assertType('array{ArrayShapeClassConstantKey\\Base: int}', Child::parentKey());
+	assertType('non-empty-array<class-string<ArrayShapeClassConstantKey\\Child>, int>', Child::staticKey());
 	assertType('class-string<ArrayShapeClassConstantKey\\Child>', Child::staticClassConstant());
 }


### PR DESCRIPTION
PHPStan didn't support the `::class` magic constant as a value or key in PHPDoc array shapes.

```php
class Test {
    /** @return array{Test::class: int} */
    static function foo(): array {
        $r = [self::class => 1];
        // inferred directly: array{X\Test: 1}  ✅
        return $r;
    }
}

\PHPStan\dumpType(Test::foo()); // was: non-empty-array<int>  ❌
```

The inferred type inside the method was correct (`array{X\Test: 1}`), but the declared `@return` resolved the `Test::class` key to `ErrorType`, collapsing the whole shape into `non-empty-array<int>`.

**Cause:** both PHPDoc resolution paths for `Foo::CONST` (`resolveArrayShapeOffsetType()` for keys, `resolveConstTypeNode()` for value types) look the constant up via `$classReflection->hasConstant($constantName)`. But `::class` is a magic pseudo-constant, not a declared one, so `hasConstant('class')` is `false` and resolution falls through to `ErrorType`. Regular class constants as keys (`array{Foo::BAR: int}`, already documented) were unaffected.

**Fix:** handle `::class` in both paths, mirroring `InitializerExprTypeResolver::getClassConstFetchTypeByReflection()`:
- `static::class` on a non-final class → `class-string<static>`
- everything else (`self`, `parent`, literal names, `static` on final) → a constant class-string

This also unblocks consumers that rely on exact `Class::class` keys surviving through `array_merge`, e.g. shipmonk-rnd/dead-code-detector#374 (https://github.com/shipmonk-rnd/dead-code-detector/issues/374#issuecomment-4727320867).

Co-Authored-By: Claude Code


Docs: phpstan/phpstan#14837
