### PR TITLE
Implement PhpMinorVersionIterator

### DIFF
--- a/build/PHPStan/Build/RequiredPhpVersionVisitor.php
+++ b/build/PHPStan/Build/RequiredPhpVersionVisitor.php
@@ -6,6 +6,7 @@ use Override;
 use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
+use PHPStan\Php\PhpMinorVersionIterator;
 use PHPStan\Php\PhpVersion;
 use function in_array;
 use function strtolower;
@@ -206,17 +207,12 @@ final class RequiredPhpVersionVisitor extends NodeVisitorAbstract
 	 */
 	private function findPhpVersion(callable $callable): int
 	{
-		$phpVersionIds = [
+		$minorVersionIterator = new PhpMinorVersionIterator(
 			new PhpVersion(70400),
-			new PhpVersion(80000),
-			new PhpVersion(80100),
-			new PhpVersion(80200),
-			new PhpVersion(80300),
-			new PhpVersion(80400),
 			new PhpVersion(80500)
-		];
+		);
 
-		foreach($phpVersionIds as $phpVersion) {
+		foreach($minorVersionIterator as $phpVersion) {
 			if ($callable($phpVersion)) {
 				return $phpVersion->getVersionId();
 			}

--- a/src/Php/PhpMinorVersionIterator.php
+++ b/src/Php/PhpMinorVersionIterator.php
@@ -4,6 +4,7 @@ namespace PHPStan\Php;
 
 use IteratorAggregate;
 use Override;
+use PHPStan\ShouldNotHappenException;
 use Traversable;
 use function floor;
 
@@ -22,8 +23,15 @@ final class PhpMinorVersionIterator implements IteratorAggregate
 		private PhpVersion $endVersion,
 	)
 	{
-		if ($startVersion->getMajorVersionId() < 5) {
-			throw new \PHPStan\ShouldNotHappenException();
+		if ($startVersion->getMajorVersionId() < 5
+			|| $startVersion->getMajorVersionId() > 8
+		) {
+			throw new ShouldNotHappenException();
+		}
+		if ($endVersion->getMajorVersionId() < 5
+			|| $endVersion->getMajorVersionId() > 8
+		) {
+			throw new ShouldNotHappenException();
 		}
 
 		$this->currentVersion = $startVersion;

--- a/src/Php/PhpMinorVersionIterator.php
+++ b/src/Php/PhpMinorVersionIterator.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Php;
+
+use IteratorAggregate;
+use Traversable;
+use function floor;
+
+/**
+ * @api
+ *
+ * @implements IteratorAggregate<PhpVersion>
+ */
+final class PhpMinorVersionIterator implements IteratorAggregate
+{
+
+	private PhpVersion $currentVersion;
+
+	public function __construct(
+		PhpVersion $startVersion,
+		private PhpVersion $endVersion,
+	)
+	{
+		$this->currentVersion = $startVersion;
+	}
+
+	public function getIterator(): Traversable
+	{
+		yield $this->currentVersion;
+
+		while (true) {
+			if (
+				$this->currentVersion->getMajorVersionId() === 5
+				&& $this->currentVersion->getMinorVersionId() === 6
+			) {
+				$next = new PhpVersion(70000);
+			} elseif (
+				$this->currentVersion->getMajorVersionId() === 7
+				&& $this->currentVersion->getMinorVersionId() === 4
+			) {
+				$next = new PhpVersion(80000);
+			} else {
+				$nextMinorVersionId = $this->currentVersion->getVersionId() + 100;
+				$nextWithZeroPatch = (int) floor($nextMinorVersionId / 100) * 100;
+				$next = new PhpVersion($nextWithZeroPatch);
+			}
+
+			if ($next->getVersionId() > $this->endVersion->getVersionId()) {
+				break;
+			}
+
+			$this->currentVersion = $next;
+
+			yield $this->currentVersion;
+		}
+
+		if ($this->currentVersion->getVersionId() === $this->endVersion->getVersionId()) {
+			return;
+		}
+
+		yield $this->endVersion;
+	}
+
+}

--- a/src/Php/PhpMinorVersionIterator.php
+++ b/src/Php/PhpMinorVersionIterator.php
@@ -22,6 +22,10 @@ final class PhpMinorVersionIterator implements IteratorAggregate
 		private PhpVersion $endVersion,
 	)
 	{
+		if ($startVersion->getMajorVersionId() < 5) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
 		$this->currentVersion = $startVersion;
 	}
 

--- a/src/Php/PhpMinorVersionIterator.php
+++ b/src/Php/PhpMinorVersionIterator.php
@@ -23,16 +23,19 @@ final class PhpMinorVersionIterator implements IteratorAggregate
 		private PhpVersion $endVersion,
 	)
 	{
-		if ($startVersion->getMajorVersionId() < 5
+		if (
+			$startVersion->getMajorVersionId() < 5
 			|| $startVersion->getMajorVersionId() > 8
 		) {
 			throw new ShouldNotHappenException();
 		}
-		if ($endVersion->getMajorVersionId() < 5
+		if (
+			$endVersion->getMajorVersionId() < 5
 			|| $endVersion->getMajorVersionId() > 8
 		) {
 			throw new ShouldNotHappenException();
 		}
+
 		if ($startVersion->getVersionId() > $this->endVersion->getVersionId()
 		) {
 			throw new ShouldNotHappenException();

--- a/src/Php/PhpMinorVersionIterator.php
+++ b/src/Php/PhpMinorVersionIterator.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Php;
 
 use IteratorAggregate;
+use Override;
 use Traversable;
 use function floor;
 
@@ -24,6 +25,7 @@ final class PhpMinorVersionIterator implements IteratorAggregate
 		$this->currentVersion = $startVersion;
 	}
 
+	#[Override]
 	public function getIterator(): Traversable
 	{
 		yield $this->currentVersion;

--- a/src/Php/PhpMinorVersionIterator.php
+++ b/src/Php/PhpMinorVersionIterator.php
@@ -33,6 +33,10 @@ final class PhpMinorVersionIterator implements IteratorAggregate
 		) {
 			throw new ShouldNotHappenException();
 		}
+		if ($startVersion->getVersionId() > $this->endVersion->getVersionId()
+		) {
+			throw new ShouldNotHappenException();
+		}
 
 		$this->currentVersion = $startVersion;
 	}

--- a/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
+++ b/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
@@ -61,6 +61,13 @@ class PhpMinorVersionIteratorTest extends TestCase
 		new PhpMinorVersionIterator(new PhpVersion(40100), new PhpVersion(70300));
 	}
 
+	public function testStartEndSanity(): void
+	{
+		$this->expectException(ShouldNotHappenException::class);
+
+		new PhpMinorVersionIterator(new PhpVersion(80100), new PhpVersion(70300));
+	}
+
 	public function testSupportsCIVersionId(): void
 	{
 		$versionIterator = new PhpMinorVersionIterator(new PhpVersion(PHP_VERSION_ID), new PhpVersion(PHP_VERSION_ID));

--- a/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
+++ b/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
@@ -2,8 +2,10 @@
 
 namespace PHPStan\Php;
 
+use PHPStan\ShouldNotHappenException;
 use PHPUnit\Framework\TestCase;
 use function iterator_to_array;
+use const PHP_VERSION_ID;
 
 class PhpMinorVersionIteratorTest extends TestCase
 {
@@ -45,11 +47,29 @@ class PhpMinorVersionIteratorTest extends TestCase
 		$this->assertSame(70300, $arr[2]->getVersionId());
 	}
 
+	// test which is expected to fail, when PHP9 is supported
+	public function testPhp9Overflow(): void
+	{
+		$this->expectException(ShouldNotHappenException::class);
+
+		new PhpMinorVersionIterator(new PhpVersion(80900), new PhpVersion(90200));
+	}
+
 	public function testThrowsBeforePhp5(): void
 	{
-		$this->expectException(\PHPStan\ShouldNotHappenException::class);
+		$this->expectException(ShouldNotHappenException::class);
 
 		new PhpMinorVersionIterator(new PhpVersion(40100), new PhpVersion(70300));
+	}
+
+	public function testSupportsCIVersionId(): void
+	{
+		$versionIterator = new PhpMinorVersionIterator(new PhpVersion(PHP_VERSION_ID), new PhpVersion(PHP_VERSION_ID));
+		$it = $versionIterator->getIterator();
+		$arr = iterator_to_array($it);
+
+		$this->assertCount(1, $arr);
+		$this->assertSame(PHP_VERSION_ID, $arr[0]->getVersionId());
 	}
 
 }

--- a/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
+++ b/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
@@ -47,7 +47,6 @@ class PhpMinorVersionIteratorTest extends TestCase
 		$this->assertSame(70300, $arr[2]->getVersionId());
 	}
 
-	// test which is expected to fail, when PHP9 is supported
 	public function testPhp9Overflow(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);

--- a/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
+++ b/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Php;
+
+use PHPUnit\Framework\TestCase;
+use function iterator_to_array;
+
+class PhpMinorVersionIteratorTest extends TestCase
+{
+
+	public function testIterator(): void
+	{
+		$versionIterator = new PhpMinorVersionIterator(new PhpVersion(50104), new PhpVersion(80305));
+		$it = $versionIterator->getIterator();
+		$arr = iterator_to_array($it);
+
+		$this->assertCount(16, $arr);
+		$this->assertSame(50104, $arr[0]->getVersionId());
+		$this->assertSame(50200, $arr[1]->getVersionId());
+		$this->assertSame(50300, $arr[2]->getVersionId());
+		$this->assertSame(50400, $arr[3]->getVersionId());
+		$this->assertSame(50500, $arr[4]->getVersionId());
+		$this->assertSame(50600, $arr[5]->getVersionId());
+		$this->assertSame(70000, $arr[6]->getVersionId());
+		$this->assertSame(70100, $arr[7]->getVersionId());
+		$this->assertSame(70200, $arr[8]->getVersionId());
+		$this->assertSame(70300, $arr[9]->getVersionId());
+		$this->assertSame(70400, $arr[10]->getVersionId());
+		$this->assertSame(80000, $arr[11]->getVersionId());
+		$this->assertSame(80100, $arr[12]->getVersionId());
+		$this->assertSame(80200, $arr[13]->getVersionId());
+		$this->assertSame(80300, $arr[14]->getVersionId());
+		$this->assertSame(80305, $arr[15]->getVersionId());
+	}
+
+	public function testIteratorWith(): void
+	{
+		$versionIterator = new PhpMinorVersionIterator(new PhpVersion(70100), new PhpVersion(70300));
+		$it = $versionIterator->getIterator();
+		$arr = iterator_to_array($it);
+
+		$this->assertCount(3, $arr);
+		$this->assertSame(70100, $arr[0]->getVersionId());
+		$this->assertSame(70200, $arr[1]->getVersionId());
+		$this->assertSame(70300, $arr[2]->getVersionId());
+	}
+
+}

--- a/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
+++ b/tests/PHPStan/Php/PhpMinorVersionIteratorTest.php
@@ -45,4 +45,11 @@ class PhpMinorVersionIteratorTest extends TestCase
 		$this->assertSame(70300, $arr[2]->getVersionId());
 	}
 
+	public function testThrowsBeforePhp5(): void
+	{
+		$this->expectException(\PHPStan\ShouldNotHappenException::class);
+
+		new PhpMinorVersionIterator(new PhpVersion(40100), new PhpVersion(70300));
+	}
+
 }


### PR DESCRIPTION
this class is useful to simplify `RequiredPhpVersionVisitor` and I also need it in https://github.com/phpstan/phpstan-phpunit/pull/269 to iterate over all possible minor versions within PHPStan phpversion min/max config.

goal is to allow iteration over all possible minor PHP versions in a range between two `PHP_VERSION_ID`s (represented by `PhpVersion` class)