### PR TITLE
Add regression test for calling methods on possibly-null object properties

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -4235,4 +4235,17 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14808.php'], []);
 	}
 
+	public function testCallMethodOnNullableProperty(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/method-call-nullable-property.php'], [
+			[
+				'Cannot call method doWork() on MethodCallNullableProperty\Service|null.',
+				21,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/method-call-nullable-property.php
+++ b/tests/PHPStan/Rules/Methods/data/method-call-nullable-property.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MethodCallNullableProperty;
+
+class Service
+{
+
+	public function doWork(): void
+	{
+	}
+
+}
+
+class Container
+{
+
+	private ?Service $service = null;
+
+	public function callUnchecked(): void
+	{
+		$this->service->doWork();
+	}
+
+	public function callAfterNullCheck(): void
+	{
+		if ($this->service !== null) {
+			$this->service->doWork();
+		}
+	}
+
+	public function callAfterEarlyReturn(): void
+	{
+		if ($this->service === null) {
+			return;
+		}
+
+		$this->service->doWork();
+	}
+
+}


### PR DESCRIPTION
Adds a regression test for `CallMethodsRule` covering method calls on possibly-null object properties.

The data file (`method-call-nullable-property.php`) exercises three cases:

- **Unchecked call** — `$this->service->doWork()` on a `?Service` property reports `Cannot call method doWork() on MethodCallNullableProperty\Service|null.`
- **Null check** — calling inside `if ($this->service !== null)` is safe.
- **Early return** — calling after `if ($this->service === null) { return; }` is safe.

The new test `testCallMethodOnNullableProperty` runs with `checkNullables`/`checkUnionTypes` enabled and asserts the single expected error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)