### PR TITLE
Enter right-side-assign context for `??=` so closures capturing the assigned variable by reference see its assigned type

### DIFF
--- a/src/Analyser/ExprHandler/AssignOpHandler.php
+++ b/src/Analyser/ExprHandler/AssignOpHandler.php
@@ -29,6 +29,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use function array_merge;
 use function get_class;
+use function is_string;
 use function sprintf;
 
 /**
@@ -68,6 +69,13 @@ final class AssignOpHandler implements ExprHandler
 					$scope = $scope->filterByFalseyValue(
 						new BinaryOp\NotIdentical($expr->var, new ConstFetch(new Name('null'))),
 					);
+
+					if ($expr->var instanceof Expr\Variable && is_string($expr->var->name)) {
+						$context = $context->enterRightSideAssign(
+							$expr->var->name,
+							$expr->expr,
+						);
+					}
 				}
 
 				$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());

--- a/tests/PHPStan/Analyser/nsrt/bug-13810.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13810.php
@@ -4,9 +4,22 @@ namespace Bug13810;
 
 use function PHPStan\Testing\assertType;
 
-function test(): void
+function doFoo(): void
 {
 	static $isSupported;
+	assertType('mixed', $isSupported);
+	$isSupported ??= function (mixed $arg) use (&$isSupported): bool {
+		assertType('Closure(mixed): bool', $isSupported);
+		return $isSupported($arg);
+	};
+
+	assertType('mixed~null', $isSupported);
+	$isSupported('foo');
+}
+
+function doBar($isSupported): void
+{
+	assertType('mixed', $isSupported);
 	$isSupported ??= function (mixed $arg) use (&$isSupported): bool {
 		assertType('Closure(mixed): bool', $isSupported);
 		return $isSupported($arg);

--- a/tests/PHPStan/Analyser/nsrt/bug-13810.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13810.php
@@ -28,3 +28,16 @@ function doBar($isSupported): void
 	assertType('mixed~null', $isSupported);
 	$isSupported('foo');
 }
+
+function doFooBar(): void
+{
+	$isSupported = null;
+	assertType('null', $isSupported);
+	$isSupported ??= function (mixed $arg) use (&$isSupported): bool {
+		assertType('Closure(mixed): bool', $isSupported);
+		return $isSupported($arg);
+	};
+
+	assertType('Closure(mixed): bool', $isSupported);
+	$isSupported('foo');
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13810.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13810.php
@@ -43,3 +43,26 @@ function doFooBar(): void
 	assertType('Closure(mixed): bool', $isSupported);
 	$isSupported('foo');
 }
+
+class HelloWorld
+{
+	public function setValue(mixed $value): void
+	{
+		/** @var ?callable $isSupported */
+		static $isSupported = null;
+		$isSupported ??= function(mixed $arg) use (&$isSupported): bool {
+			if (is_array($arg)) {
+				foreach($arg as $value) {
+					if (!$isSupported($value)) {
+						return false;
+					}
+				}
+				return true;
+			}
+			return is_string($arg);
+		};
+		if (!$isSupported($value)) {
+			throw new InvalidArgumentException('only strings/string arrays are supported');
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13810.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13810.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug13810;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-13810.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13810.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13810;
+
+use function PHPStan\Testing\assertType;
+
+function test(): void
+{
+	static $isSupported;
+	$isSupported ??= function (mixed $arg) use (&$isSupported): bool {
+		assertType('Closure(mixed): bool', $isSupported);
+		return $isSupported($arg);
+	};
+
+	assertType('mixed~null', $isSupported);
+	$isSupported('foo');
+}

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -429,4 +429,9 @@ class CallCallablesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/maybe-not-callable.php'], $errors);
 	}
 
+	public function testBug13810(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/nsrt/bug-13810.php'], []);
+	}
+
 }


### PR DESCRIPTION
## Summary

When a closure captured a variable by reference and that same variable was the target of a `??=` assignment, e.g.

```php
static $isSupported;
$isSupported ??= function (mixed $arg) use (&$isSupported): bool {
    return $isSupported($arg);
};
```

PHPStan inferred `$isSupported` as `null` inside the closure body and reported a false `Trying to invoke null but it's not a callable.` error. The exact same pattern written with a plain assignment (`if (!isset($isSupported)) { $isSupported = function () use (&$isSupported) ... }`) worked correctly. This change makes `??=` behave like `=` for this case.

## Changes

- `src/Analyser/ExprHandler/AssignOpHandler.php`: when evaluating the right-hand side of an `Expr\AssignOp\Coalesce` (`??=`) whose target is a simple variable, the handler now calls `ExpressionContext::enterRightSideAssign($var->name, $expr->expr)`, the same call `AssignHandler` already makes for `=`/`=&`.
- `tests/PHPStan/Analyser/nsrt/bug-13810.php`: regression test asserting the closure type is inferred for a `??=` recursive by-reference closure capture.

## Root cause

The by-reference closure-use handling in `NodeScopeResolver::processClosureExpr()` reads `inAssignRightSideVariableName` / `inAssignRightSideExpr` from the current `ExpressionContext`. When the captured variable matches the variable currently being assigned, it resolves the variable to the assigned (closure) type inside the closure body, which is what makes `$x = function () use (&$x) { ... }` resolve `$x` to the closure.

Only `AssignHandler` (plain `=` / `=&`) populated that context. `AssignOpHandler`, which handles `??=` together with the arithmetic/string compound operators, never called `enterRightSideAssign()`, so for `??=` the context stayed empty and the by-reference variable fell back to its pre-assignment type (`null` after the `??=` falsey filter). The fix populates the context for `??=`, the only compound operator for which capturing-and-reassigning the same variable by reference is meaningful.

I probed the sibling assignment operators on the same axis: plain `=`/`=&` already set the context; the arithmetic and string compound ops (`+=`, `-=`, `.=`, ...) require the left-hand variable to already hold a non-closure value and cannot meaningfully reassign it to a captured closure, so they did not need the change.

## Test

- `tests/PHPStan/Analyser/nsrt/bug-13810.php` asserts that inside `$isSupported ??= function (mixed $arg) use (&$isSupported) { ... }` the variable `$isSupported` is `Closure(mixed): bool` (previously `null`), and `mixed~null` in the enclosing scope after the `??=`. Verified to fail before the fix (`Actual: null`) and pass after.

Fixes phpstan/phpstan#13810