### PR TITLE
Record top-level PHPStan errors in issue-bot results

### DIFF
--- a/issue-bot/src/Console/RunCommand.php
+++ b/issue-bot/src/Console/RunCommand.php
@@ -240,22 +240,43 @@ class RunCommand extends Command
 				throw new Exception(sprintf('Failed to decode JSON for %s: %s', $hash, $e->getMessage()));
 			}
 
-			$errors = [];
-			foreach ($json['files'] as ['messages' => $messages]) {
-				foreach ($messages as $message) {
-					$messageText = str_replace(sprintf('/%s.php', $hash), '/tmp.php', $message['message']);
-					if (strpos($messageText, 'Internal error') !== false) {
-						throw new Exception(sprintf('While analysing %s: %s', $hash, $messageText));
-					}
-					$errors[] = new PlaygroundError($message['line'] ?? -1, $messageText, $message['identifier'] ?? null);
-				}
-			}
+			$errors = self::extractErrors($json, $hash);
 
 			$elapsedTime = microtime(true) - $startTime;
 			$output->writeln(sprintf('Analysis of %s took %.2f s', $hash, $elapsedTime));
 
 			return $errors;
 		});
+	}
+
+	/**
+	 * @param mixed[] $json
+	 * @return list<PlaygroundError>
+	 */
+	public static function extractErrors(array $json, string $hash): array
+	{
+		$errors = [];
+		foreach ($json['files'] ?? [] as $file) {
+			foreach ($file['messages'] as $message) {
+				$messageText = str_replace(sprintf('/%s.php', $hash), '/tmp.php', $message['message']);
+				if (strpos($messageText, 'Internal error') !== false) {
+					throw new Exception(sprintf('While analysing %s: %s', $hash, $messageText));
+				}
+				$errors[] = new PlaygroundError($message['line'] ?? -1, $messageText, $message['identifier'] ?? null);
+			}
+		}
+
+		// Top-level (non-file) errors: a parallel worker crashing (e.g. out of
+		// memory), a bootstrap failure, etc. PHPStan reports these in $json['errors']
+		// with file_errors === 0, so without recording them here the analysis looks
+		// like it produced zero errors and any expected output silently disappears
+		// from the diff. Record them so they are visible.
+		foreach ($json['errors'] ?? [] as $genericError) {
+			$messageText = str_replace(sprintf('/%s.php', $hash), '/tmp.php', (string) $genericError);
+			$errors[] = new PlaygroundError(-1, $messageText, null);
+		}
+
+		return $errors;
 	}
 
 	private function loadPlaygroundCache(): PlaygroundCache

--- a/issue-bot/tests/Console/RunCommandTest.php
+++ b/issue-bot/tests/Console/RunCommandTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\IssueBot\Console;
+
+use PHPStan\IssueBot\Playground\PlaygroundError;
+use PHPUnit\Framework\TestCase;
+use function serialize;
+use function unserialize;
+
+class RunCommandTest extends TestCase
+{
+
+	public function testExtractFileErrors(): void
+	{
+		$json = [
+			'totals' => ['errors' => 0, 'file_errors' => 2],
+			'files' => [
+				'/tmp/abc.php' => [
+					'errors' => 2,
+					'messages' => [
+						['message' => 'Dumped type: int', 'line' => 5, 'identifier' => 'phpstan.dumpType'],
+						['message' => 'Something else', 'line' => 7, 'identifier' => 'foo.bar'],
+					],
+				],
+			],
+			'errors' => [],
+		];
+
+		$errors = RunCommand::extractErrors($json, 'abc');
+
+		self::assertCount(2, $errors);
+		self::assertSame(5, $errors[0]->getLine());
+		self::assertSame('Dumped type: int', $errors[0]->getMessage());
+		self::assertSame('phpstan.dumpType', $errors[0]->getIdentifier());
+		self::assertSame(7, $errors[1]->getLine());
+	}
+
+	public function testExtractTopLevelErrorsWhenNoFileErrors(): void
+	{
+		// PHPStan reports a crashing parallel worker (e.g. out of memory) as a
+		// top-level error with file_errors === 0 and an empty files array. Without
+		// recording it, the sample would look like it produced zero errors.
+		$json = [
+			'totals' => ['errors' => 1, 'file_errors' => 0],
+			'files' => [],
+			'errors' => [
+				'Child process error (exit code 255): PHP Fatal error: Allowed memory size exhausted',
+			],
+		];
+
+		$errors = RunCommand::extractErrors($json, 'abc');
+
+		self::assertCount(1, $errors);
+		self::assertSame(-1, $errors[0]->getLine());
+		self::assertStringContainsString('Child process error', $errors[0]->getMessage());
+		self::assertNull($errors[0]->getIdentifier());
+	}
+
+	public function testExtractBothFileAndTopLevelErrors(): void
+	{
+		$json = [
+			'totals' => ['errors' => 2, 'file_errors' => 1],
+			'files' => [
+				'/tmp/abc.php' => [
+					'errors' => 1,
+					'messages' => [
+						['message' => 'Dumped type: string', 'line' => 3, 'identifier' => 'phpstan.dumpType'],
+					],
+				],
+			],
+			'errors' => [
+				'Child process error (exit code 255): out of memory',
+			],
+		];
+
+		$errors = RunCommand::extractErrors($json, 'abc');
+
+		self::assertCount(2, $errors);
+		self::assertSame('Dumped type: string', $errors[0]->getMessage());
+		self::assertSame(-1, $errors[1]->getLine());
+		self::assertStringContainsString('Child process error', $errors[1]->getMessage());
+	}
+
+	public function testTopLevelErrorHashPathIsReplaced(): void
+	{
+		$json = [
+			'files' => [],
+			'errors' => [
+				'Child process error while analysing /some/dir/abc.php in worker',
+			],
+		];
+
+		$errors = RunCommand::extractErrors($json, 'abc');
+
+		self::assertCount(1, $errors);
+		self::assertStringContainsString('/tmp.php', $errors[0]->getMessage());
+		self::assertStringNotContainsString('/abc.php', $errors[0]->getMessage());
+	}
+
+	public function testResultsFileShapeIsUnchanged(): void
+	{
+		// The results file written by RunCommand is serialize(['phpVersion' => int,
+		// 'errors' => array<hash, list<PlaygroundError>>]). Recording top-level
+		// errors only adds entries to the per-hash list; the structure is identical.
+		$json = [
+			'files' => [],
+			'errors' => ['Child process error (exit code 255): out of memory'],
+		];
+
+		$allErrors = ['abc' => RunCommand::extractErrors($json, 'abc')];
+		$data = ['phpVersion' => 80100, 'errors' => $allErrors];
+
+		/** @var array{phpVersion: int, errors: array<string, list<PlaygroundError>>} $roundTripped */
+		$roundTripped = unserialize(serialize($data));
+
+		self::assertSame(80100, $roundTripped['phpVersion']);
+		self::assertArrayHasKey('abc', $roundTripped['errors']);
+		self::assertContainsOnlyInstancesOf(PlaygroundError::class, $roundTripped['errors']['abc']);
+		self::assertCount(1, $roundTripped['errors']['abc']);
+		self::assertStringContainsString('Child process error', $roundTripped['errors']['abc'][0]->getMessage());
+	}
+
+}


### PR DESCRIPTION
A crashing parallel worker (e.g. running out of memory) is reported by PHPStan as a **top-level** error in `$json['errors']` with `file_errors === 0` — not as a file-level message. The issue-bot's `RunCommand` only read `$json['files']`, so such a sample was recorded with **zero errors**, and any expected output (e.g. `dumpType`/`assertType` results, or real rule errors) silently disappeared from the diff.

This makes the issue-bot misleading: a sample that actually failed to analyse looks like it "lost" its errors, indistinguishable from a genuine type-inference change.

This PR:

- Extracts the result parsing into `RunCommand::extractErrors()`.
- Also records the top-level `$json['errors']` as `PlaygroundError` entries (`line -1`, no identifier), so a child-process/bootstrap error is visible in the diff instead of masquerading as "no errors".
- The results-file shape is unchanged (`array<hash, list<PlaygroundError>>`), so `evaluate`/the diff keep working.

### Testing

- New `tests/Console/RunCommandTest.php`: file-only (backward compat), top-level-only (the OOM case), mixed, hash-path replacement, and a results-file serialization round-trip.
- End-to-end: ran the real `run` command against a `dumpType` sample with a forced worker OOM. Before this change the sample was recorded with **0** errors; after, it records the `Child process error (exit code 255): PHP Fatal error: Allowed memory size … exhausted` entry, and the serialized results file has the same `['phpVersion' => int, 'errors' => array<hash, list<PlaygroundError>>]` shape as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
