### PR TITLE
Do not accept raw ObjectType in intersection as GenericObjectType<TemplateType>

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -339,6 +339,17 @@ class IntersectionType implements CompoundType
 			if ($isSuperType->no()) {
 				return $isSuperType->toAcceptsResult();
 			}
+
+			// A TemplateType member accepts eagerly, so lazyMaxMin's Yes may come solely from it.
+			// A Maybe from the holistic isSuperTypeOf means no member is a definite subtype, so
+			// when a TemplateType member is present the eager Yes is untrustworthy - trust the Maybe.
+			if ($isSuperType->maybe()) {
+				foreach ($this->types as $innerType) {
+					if ($innerType instanceof TemplateType) {
+						return $isSuperType->toAcceptsResult();
+					}
+				}
+			}
 		}
 
 		if ($this->isOversizedArray()->yes()) {

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -451,11 +451,34 @@ class ReturnTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug13190TemplateGeneric(): void
+	{
+		$this->checkNullables = true;
+		$this->checkExplicitMixed = false;
+		// A raw TemplateType value returned as its generic application must not be a false positive.
+		$this->analyse([__DIR__ . '/data/bug-13190-template-generic.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug13190(): void
 	{
 		$this->checkNullables = true;
 		$this->checkExplicitMixed = false;
-		$this->analyse([__DIR__ . '/data/bug-13190.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-13190.php'], [
+			[
+				'Function Bug13190\inbox() should return Bug13190\Box<T> but returns (Bug13190\Box&T)|Bug13190\Box<T>.',
+				51,
+			],
+			[
+				'Function Bug13190\inbox_concrete_impl() should return Bug13190\Box<T> but returns (Bug13190\Box<T>&Bug13190\IntBox)|(Bug13190\IntBox&T).',
+				79,
+			],
+			[
+				'Function Bug13190\inbox_concrete_impl() should return Bug13190\Box<T> but returns Bug13190\BoxImpl<Bug13190\Box<T>|T of mixed>.',
+				81,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-13190-template-generic.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-13190-template-generic.php
@@ -1,0 +1,39 @@
+<?php // lint >= 8.0
+declare(strict_types = 1);
+
+namespace Bug13190TemplateGeneric;
+
+class Promise
+{
+}
+
+interface Result
+{
+}
+
+class ResultA implements Result
+{
+}
+
+/**
+ * @template TypeConcurrent of bool
+ */
+abstract class Communicator
+{
+	/** @param TypeConcurrent $concurrent */
+	public function __construct(private bool $concurrent)
+	{
+	}
+}
+
+/**
+ * @template TypeCommunicator of Communicator
+ * @template TypeConcurrent of bool
+ * @param class-string<TypeCommunicator> $communicatorClass
+ * @param TypeConcurrent $concurrent
+ * @return TypeCommunicator<TypeConcurrent>
+ */
+function communicatorFactory(string $communicatorClass, bool $concurrent): Communicator
+{
+	return new $communicatorClass($concurrent);
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-13190.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-13190.php
@@ -53,3 +53,31 @@ function inbox($to_box): Box
 		return new BoxImpl($to_box);
 	}
 }
+
+/**
+ * @implements Box<int>
+ */
+final class IntBox implements Box
+{
+	#[\Override]
+	public function toInner(): int
+	{
+		return 0;
+	}
+}
+
+/**
+ * @template T
+ *
+ * @param T|Box<T> $to_box
+ *
+ * @return Box<T>
+ */
+function inbox_concrete_impl($to_box): Box
+{
+	if ($to_box instanceof IntBox) {
+		return $to_box;
+	} else {
+		return new BoxImpl($to_box);
+	}
+}


### PR DESCRIPTION
Closes phpstan/phpstan#13190. My previous PR did fix an issue in there but not the actual bug that was reported.

In general AI works wonders but sometimes it strays too much and I didn't catch it this time. Sorry!