### PR TITLE
Memoize file contents by path in CachedParser to skip redundant reads

### DIFF
--- a/src/Internal/LruCache.php
+++ b/src/Internal/LruCache.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use PHPStan\ShouldNotHappenException;
+use function array_key_exists;
+use function array_key_first;
+use function count;
+use function sprintf;
+
+/**
+ * A least-recently-used cache backed by an array, bounded by entry count, by the total
+ * weight of its entries, or by both.
+ *
+ * PHP arrays keep insertion order, so the least recently used entry is the first one and
+ * touching an entry means re-inserting it at the end. Callers decide what an entry weighs:
+ * for a cache of file contents that is the length of the contents, for one keyed by source
+ * code it is the length of the key.
+ *
+ * @template TValue
+ */
+final class LruCache
+{
+
+	/** @var array<string, TValue> insertion order is the LRU order, oldest first */
+	private array $values = [];
+
+	/** @var array<string, int> */
+	private array $weights = [];
+
+	private int $weight = 0;
+
+	/**
+	 * @param int $maxCount maximum number of entries, 0 for no limit
+	 * @param int $maxWeight maximum total weight, 0 for no limit
+	 * @param int $weightEvictionFloorCount weight eviction stops at this many entries, so a
+	 * single entry heavier than $maxWeight cannot flush the whole cache on every insertion
+	 */
+	public function __construct(
+		private int $maxCount = 0,
+		private int $maxWeight = 0,
+		private int $weightEvictionFloorCount = 0,
+	)
+	{
+	}
+
+	/**
+	 * The entry, touched so it becomes the most recently used one, or null when there is none.
+	 *
+	 * @return TValue|null
+	 */
+	public function get(string $key): mixed
+	{
+		if (!array_key_exists($key, $this->values)) {
+			return null;
+		}
+
+		$value = $this->values[$key];
+		unset($this->values[$key]);
+		$this->values[$key] = $value;
+
+		return $value;
+	}
+
+	/**
+	 * Stores an entry, evicting least recently used ones until it fits.
+	 *
+	 * An entry already stored under this key is replaced, its weight accounted for again, and
+	 * the entry becomes the most recently used one.
+	 *
+	 * @param TValue $value
+	 * @return list<string> the keys evicted to make room, so a caller keeping data alongside
+	 * this cache can drop the same entries
+	 */
+	public function set(string $key, mixed $value, int $weight): array
+	{
+		if (array_key_exists($key, $this->values)) {
+			$this->weight -= $this->weights[$key];
+			unset($this->values[$key], $this->weights[$key]);
+		}
+
+		$evicted = $this->evict($weight);
+
+		$this->values[$key] = $value;
+		$this->weights[$key] = $weight;
+		$this->weight += $weight;
+
+		return $evicted;
+	}
+
+	/**
+	 * Replaces the value of an existing entry and touches it, leaving its weight as it was.
+	 *
+	 * This is for a value that grew a better representation rather than different contents -
+	 * nothing is evicted, because nothing new is taking up room.
+	 *
+	 * @param TValue $value
+	 */
+	public function replace(string $key, mixed $value): void
+	{
+		if (!array_key_exists($key, $this->values)) {
+			throw new ShouldNotHappenException(sprintf('Cannot replace %s, it is not in the cache.', $key));
+		}
+
+		unset($this->values[$key]);
+		$this->values[$key] = $value;
+	}
+
+	public function count(): int
+	{
+		return count($this->values);
+	}
+
+	/**
+	 * @return array<string, TValue> in LRU order, oldest first
+	 */
+	public function all(): array
+	{
+		return $this->values;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function evict(int $incomingWeight): array
+	{
+		$evicted = [];
+		while (
+			($this->maxCount > 0 && count($this->values) >= $this->maxCount)
+			|| (
+				$this->maxWeight > 0
+				&& $this->weight + $incomingWeight > $this->maxWeight
+				&& count($this->values) > $this->weightEvictionFloorCount
+			)
+		) {
+			$oldestKey = array_key_first($this->values);
+			if ($oldestKey === null) {
+				break;
+			}
+
+			$this->weight -= $this->weights[$oldestKey];
+			unset($this->values[$oldestKey], $this->weights[$oldestKey]);
+			$evicted[] = $oldestKey;
+		}
+
+		return $evicted;
+	}
+
+}

--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -5,6 +5,9 @@ namespace PHPStan\Parser;
 use PhpParser\Node;
 use PHPStan\File\FileReader;
 use function array_key_first;
+use function clearstatcache;
+use function filemtime;
+use function filesize;
 use function strlen;
 
 final class CachedParser implements Parser
@@ -37,6 +40,20 @@ final class CachedParser implements Parser
 	private array $parsedByString = [];
 
 	/**
+	 * parseFile() is called once per class using a trait, so the same file
+	 * is read from disk over and over (one hot trait file was read 94,000
+	 * times in a cold run of a large Laravel project). Memoizing the contents
+	 * by path skips those redundant reads; the total memoized source size is
+	 * bounded the same way as the AST cache above.
+	 */
+	private const MEMOIZED_SOURCE_BYTES_LIMIT = 524_288;
+
+	/** @var array<string, array{int, int, string}> path => [mtime, size, source code] */
+	private array $cachedSourceByFile = [];
+
+	private int $memoizedSourceBytes = 0;
+
+	/**
 	 * The AST of a parsed file takes up roughly 50-60x more memory than the
 	 * source code itself, so alongside the entry count limit, the total source
 	 * size of the cached ASTs is capped by $cachedSourceBytesMax (0 = unlimited)
@@ -59,7 +76,7 @@ final class CachedParser implements Parser
 	 */
 	public function parseFile(string $file): array
 	{
-		$sourceCode = FileReader::read($file);
+		$sourceCode = $this->readFile($file);
 		$isCached = isset($this->cachedNodesByString[$sourceCode]);
 		if ($isCached && !isset($this->parsedByString[$sourceCode])) {
 			return $this->markRecentlyUsed($sourceCode);
@@ -98,6 +115,61 @@ final class CachedParser implements Parser
 		$this->parsedByString[$sourceCode] = true;
 
 		return $nodes;
+	}
+
+	/**
+	 * Read a file's contents, memoized by path and keyed by mtime; clearstatcache
+	 * keeps this correct when a file changes between calls in a long-running
+	 * process (PHPStan Pro, fixer worker). Bounded by MEMOIZED_SOURCE_BYTES_LIMIT
+	 * with least-recently-used eviction.
+	 */
+	private function readFile(string $file): string
+	{
+		// mtime alone has one-second granularity, so a same-second edit could be
+		// served stale in a long-running process (PHPStan Pro, fixer worker);
+		// keying by size as well catches edits that change the length. filesize()
+		// is served from PHP's stat cache populated by filemtime(), so it costs
+		// no extra syscall.
+		clearstatcache(true, $file);
+		$mtime = @filemtime($file);
+		$size = @filesize($file);
+		if ($mtime === false || $size === false) {
+			return FileReader::read($file);
+		}
+
+		if (
+			isset($this->cachedSourceByFile[$file])
+			&& $this->cachedSourceByFile[$file][0] === $mtime
+			&& $this->cachedSourceByFile[$file][1] === $size
+		) {
+			$entry = $this->cachedSourceByFile[$file];
+			unset($this->cachedSourceByFile[$file]);
+			$this->cachedSourceByFile[$file] = $entry;
+
+			return $entry[2];
+		}
+
+		$sourceCode = FileReader::read($file);
+		$incomingBytes = strlen($sourceCode);
+		if ($incomingBytes <= self::MEMOIZED_SOURCE_BYTES_LIMIT) {
+			if (isset($this->cachedSourceByFile[$file])) {
+				// stale entry for this path (mtime or size changed)
+				$this->memoizedSourceBytes -= strlen($this->cachedSourceByFile[$file][2]);
+				unset($this->cachedSourceByFile[$file]);
+			}
+			while ($this->memoizedSourceBytes + $incomingBytes > self::MEMOIZED_SOURCE_BYTES_LIMIT) {
+				$oldestPath = array_key_first($this->cachedSourceByFile);
+				if ($oldestPath === null) {
+					break;
+				}
+				$this->memoizedSourceBytes -= strlen($this->cachedSourceByFile[$oldestPath][2]);
+				unset($this->cachedSourceByFile[$oldestPath]);
+			}
+			$this->cachedSourceByFile[$file] = [$mtime, $size, $sourceCode];
+			$this->memoizedSourceBytes += $incomingBytes;
+		}
+
+		return $sourceCode;
 	}
 
 	/**

--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -4,7 +4,7 @@ namespace PHPStan\Parser;
 
 use PhpParser\Node;
 use PHPStan\File\FileReader;
-use function array_key_first;
+use PHPStan\Internal\LruCache;
 use function clearstatcache;
 use function filemtime;
 use function filesize;
@@ -14,7 +14,7 @@ final class CachedParser implements Parser
 {
 
 	/**
-	 * Size-based eviction never shrinks the cache below this many entries.
+	 * Size-based eviction never shrinks the AST cache below this many entries.
 	 * Without this floor, a single source larger than $cachedSourceBytesMax
 	 * would flush the whole cache on every insertion, degenerating the cache
 	 * to a single entry whenever such a source is hot.
@@ -29,29 +29,23 @@ final class CachedParser implements Parser
 	 */
 	private const CACHED_SOURCE_BYTES_DEFAULT_LIMIT = 4_194_304;
 
-	/** @var array<string, Node\Stmt[]>*/
-	private array $cachedNodesByString = [];
-
-	private int $cachedNodesByStringCount = 0;
-
-	private int $cachedSourceBytes = 0;
-
-	/** @var array<string, true> */
-	private array $parsedByString = [];
-
 	/**
 	 * parseFile() is called once per class using a trait, so the same file
 	 * is read from disk over and over (one hot trait file was read 94,000
 	 * times in a cold run of a large Laravel project). Memoizing the contents
 	 * by path skips those redundant reads; the total memoized source size is
-	 * bounded the same way as the AST cache above.
+	 * bounded the same way as the AST cache.
 	 */
 	private const MEMOIZED_SOURCE_BYTES_LIMIT = 524_288;
 
-	/** @var array<string, array{int, int, string}> path => [mtime, size, source code] */
-	private array $cachedSourceByFile = [];
+	/** @var LruCache<Node\Stmt[]> keyed by source code, weighing the length of that source */
+	private LruCache $cachedNodesByString;
 
-	private int $memoizedSourceBytes = 0;
+	/** @var array<string, true> */
+	private array $parsedByString = [];
+
+	/** @var LruCache<array{int, int, string}> path => [mtime, size, source code] */
+	private LruCache $cachedSourceByFile;
 
 	/**
 	 * The AST of a parsed file takes up roughly 50-60x more memory than the
@@ -68,6 +62,12 @@ final class CachedParser implements Parser
 		private int $cachedSourceBytesMax = self::CACHED_SOURCE_BYTES_DEFAULT_LIMIT,
 	)
 	{
+		$this->cachedNodesByString = new LruCache(
+			$this->cachedNodesByStringCountMax,
+			$this->cachedSourceBytesMax,
+			self::SIZE_EVICTION_FLOOR_LIMIT,
+		);
+		$this->cachedSourceByFile = new LruCache(maxWeight: self::MEMOIZED_SOURCE_BYTES_LIMIT);
 	}
 
 	/**
@@ -77,23 +77,22 @@ final class CachedParser implements Parser
 	public function parseFile(string $file): array
 	{
 		$sourceCode = $this->readFile($file);
-		$isCached = isset($this->cachedNodesByString[$sourceCode]);
-		if ($isCached && !isset($this->parsedByString[$sourceCode])) {
-			return $this->markRecentlyUsed($sourceCode);
+		$cachedNodes = $this->cachedNodesByString->get($sourceCode);
+		if ($cachedNodes !== null && !isset($this->parsedByString[$sourceCode])) {
+			return $cachedNodes;
 		}
 
 		$nodes = $this->originalParser->parseFile($file);
-		if ($isCached) {
+		if ($cachedNodes !== null) {
 			// upgrade an entry previously produced by parseString() in place -
 			// no net change to the entry count, just refresh its LRU position
-			unset($this->cachedNodesByString[$sourceCode], $this->parsedByString[$sourceCode]);
-		} else {
-			$this->evictLeastRecentlyUsed(strlen($sourceCode));
-			$this->cachedNodesByStringCount++;
-			$this->cachedSourceBytes += strlen($sourceCode);
+			$this->cachedNodesByString->replace($sourceCode, $nodes);
+			unset($this->parsedByString[$sourceCode]);
+
+			return $nodes;
 		}
 
-		$this->cachedNodesByString[$sourceCode] = $nodes;
+		$this->store($sourceCode, $nodes);
 
 		return $nodes;
 	}
@@ -103,26 +102,28 @@ final class CachedParser implements Parser
 	 */
 	public function parseString(string $sourceCode): array
 	{
-		if (isset($this->cachedNodesByString[$sourceCode])) {
-			return $this->markRecentlyUsed($sourceCode);
+		$cachedNodes = $this->cachedNodesByString->get($sourceCode);
+		if ($cachedNodes !== null) {
+			return $cachedNodes;
 		}
 
 		$nodes = $this->originalParser->parseString($sourceCode);
-		$this->evictLeastRecentlyUsed(strlen($sourceCode));
-		$this->cachedNodesByString[$sourceCode] = $nodes;
-		$this->cachedNodesByStringCount++;
-		$this->cachedSourceBytes += strlen($sourceCode);
+		$this->store($sourceCode, $nodes);
 		$this->parsedByString[$sourceCode] = true;
 
 		return $nodes;
 	}
 
 	/**
-	 * Read a file's contents, memoized by path and keyed by mtime; clearstatcache
-	 * keeps this correct when a file changes between calls in a long-running
-	 * process (PHPStan Pro, fixer worker). Bounded by MEMOIZED_SOURCE_BYTES_LIMIT
-	 * with least-recently-used eviction.
+	 * @param Node\Stmt[] $nodes
 	 */
+	private function store(string $sourceCode, array $nodes): void
+	{
+		foreach ($this->cachedNodesByString->set($sourceCode, $nodes, strlen($sourceCode)) as $evictedSourceCode) {
+			unset($this->parsedByString[$evictedSourceCode]);
+		}
+	}
+
 	private function readFile(string $file): string
 	{
 		// mtime alone has one-second granularity, so a same-second edit could be
@@ -137,84 +138,23 @@ final class CachedParser implements Parser
 			return FileReader::read($file);
 		}
 
-		if (
-			isset($this->cachedSourceByFile[$file])
-			&& $this->cachedSourceByFile[$file][0] === $mtime
-			&& $this->cachedSourceByFile[$file][1] === $size
-		) {
-			$entry = $this->cachedSourceByFile[$file];
-			unset($this->cachedSourceByFile[$file]);
-			$this->cachedSourceByFile[$file] = $entry;
-
-			return $entry[2];
+		$cached = $this->cachedSourceByFile->get($file);
+		if ($cached !== null && $cached[0] === $mtime && $cached[1] === $size) {
+			return $cached[2];
 		}
 
 		$sourceCode = FileReader::read($file);
-		$incomingBytes = strlen($sourceCode);
-		if ($incomingBytes <= self::MEMOIZED_SOURCE_BYTES_LIMIT) {
-			if (isset($this->cachedSourceByFile[$file])) {
-				// stale entry for this path (mtime or size changed)
-				$this->memoizedSourceBytes -= strlen($this->cachedSourceByFile[$file][2]);
-				unset($this->cachedSourceByFile[$file]);
-			}
-			while ($this->memoizedSourceBytes + $incomingBytes > self::MEMOIZED_SOURCE_BYTES_LIMIT) {
-				$oldestPath = array_key_first($this->cachedSourceByFile);
-				if ($oldestPath === null) {
-					break;
-				}
-				$this->memoizedSourceBytes -= strlen($this->cachedSourceByFile[$oldestPath][2]);
-				unset($this->cachedSourceByFile[$oldestPath]);
-			}
-			$this->cachedSourceByFile[$file] = [$mtime, $size, $sourceCode];
-			$this->memoizedSourceBytes += $incomingBytes;
+		if (strlen($sourceCode) <= self::MEMOIZED_SOURCE_BYTES_LIMIT) {
+			// set() replaces a stale entry for this path (mtime or size changed) as well
+			$this->cachedSourceByFile->set($file, [$mtime, $size, $sourceCode], strlen($sourceCode));
 		}
 
 		return $sourceCode;
 	}
 
-	/**
-	 * LRU bookkeeping: re-insert the entry at the end so genuinely cold sources
-	 * are evicted first, not the ones inserted earliest.
-	 *
-	 * @return Node\Stmt[]
-	 */
-	private function markRecentlyUsed(string $sourceCode): array
-	{
-		$nodes = $this->cachedNodesByString[$sourceCode];
-		unset($this->cachedNodesByString[$sourceCode]);
-		$this->cachedNodesByString[$sourceCode] = $nodes;
-
-		return $nodes;
-	}
-
-	private function evictLeastRecentlyUsed(int $incomingSourceBytes): void
-	{
-		if ($this->cachedNodesByStringCountMax === 0) {
-			return;
-		}
-
-		while (
-			$this->cachedNodesByStringCount >= $this->cachedNodesByStringCountMax
-			|| (
-				$this->cachedSourceBytesMax > 0
-				&& $this->cachedSourceBytes + $incomingSourceBytes > $this->cachedSourceBytesMax
-				&& $this->cachedNodesByStringCount > self::SIZE_EVICTION_FLOOR_LIMIT
-			)
-		) {
-			$oldestKey = array_key_first($this->cachedNodesByString);
-			if ($oldestKey === null) {
-				break;
-			}
-
-			unset($this->cachedNodesByString[$oldestKey], $this->parsedByString[$oldestKey]);
-			$this->cachedNodesByStringCount--;
-			$this->cachedSourceBytes -= strlen($oldestKey);
-		}
-	}
-
 	public function getCachedNodesByStringCount(): int
 	{
-		return $this->cachedNodesByStringCount;
+		return $this->cachedNodesByString->count();
 	}
 
 	public function getCachedNodesByStringCountMax(): int
@@ -227,7 +167,7 @@ final class CachedParser implements Parser
 	 */
 	public function getCachedNodesByString(): array
 	{
-		return $this->cachedNodesByString;
+		return $this->cachedNodesByString->all();
 	}
 
 }

--- a/tests/PHPStan/Internal/LruCacheTest.php
+++ b/tests/PHPStan/Internal/LruCacheTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\PHPStanTestCase;
+use function array_keys;
+
+class LruCacheTest extends PHPStanTestCase
+{
+
+	public function testMissingEntry(): void
+	{
+		$cache = new LruCache();
+
+		$this->assertNull($cache->get('a'));
+		$this->assertSame(0, $cache->count());
+	}
+
+	public function testGetTouchesTheEntry(): void
+	{
+		$cache = new LruCache();
+		$cache->set('a', 'A', 1);
+		$cache->set('b', 'B', 1);
+
+		$this->assertSame(['a', 'b'], array_keys($cache->all()));
+
+		$this->assertSame('A', $cache->get('a'));
+		$this->assertSame(['b', 'a'], array_keys($cache->all()));
+	}
+
+	public function testCountEvictionDropsTheLeastRecentlyUsed(): void
+	{
+		$cache = new LruCache(maxCount: 2);
+		$this->assertSame([], $cache->set('a', 'A', 1));
+		$this->assertSame([], $cache->set('b', 'B', 1));
+
+		// 'a' is touched, so 'b' becomes the oldest and goes first
+		$cache->get('a');
+		$this->assertSame(['b'], $cache->set('c', 'C', 1));
+		$this->assertSame(['a', 'c'], array_keys($cache->all()));
+		$this->assertSame(2, $cache->count());
+	}
+
+	public function testWeightEvictionMakesRoomForTheIncomingEntry(): void
+	{
+		$cache = new LruCache(maxWeight: 10);
+		$cache->set('a', 'A', 6);
+		$this->assertSame([], $cache->set('b', 'B', 4));
+
+		$this->assertSame(['a', 'b'], $cache->set('c', 'C', 10));
+		$this->assertSame(['c'], array_keys($cache->all()));
+	}
+
+	public function testWeightEvictionStopsAtTheFloor(): void
+	{
+		$cache = new LruCache(maxWeight: 10, weightEvictionFloorCount: 2);
+		$cache->set('a', 'A', 5);
+		$cache->set('b', 'B', 5);
+
+		// the floor keeps two entries even though the incoming one does not fit
+		$this->assertSame([], $cache->set('c', 'C', 100));
+		$this->assertSame(['a', 'b', 'c'], array_keys($cache->all()));
+	}
+
+	public function testSetReplacesAnEntryAndAccountsForItsNewWeight(): void
+	{
+		$cache = new LruCache(maxWeight: 10);
+		$cache->set('a', 'A', 9);
+		$cache->set('a', 'AA', 2);
+
+		// the 9 bytes of the replaced entry are free again, so 8 more fit
+		$this->assertSame([], $cache->set('b', 'B', 8));
+		$this->assertSame(['a' => 'AA', 'b' => 'B'], $cache->all());
+	}
+
+	public function testReplaceKeepsTheWeightAndEvictsNothing(): void
+	{
+		$cache = new LruCache(maxCount: 2, maxWeight: 10);
+		$cache->set('a', 'A', 5);
+		$cache->set('b', 'B', 5);
+
+		$cache->replace('a', 'AAA');
+
+		$this->assertSame(['b' => 'B', 'a' => 'AAA'], $cache->all());
+		$this->assertSame(2, $cache->count());
+	}
+
+	public function testReplacingAMissingEntryIsABug(): void
+	{
+		$cache = new LruCache();
+
+		$this->expectException(ShouldNotHappenException::class);
+		$cache->replace('a', 'A');
+	}
+
+	public function testNoLimitsMeansNoEviction(): void
+	{
+		$cache = new LruCache();
+		for ($i = 0; $i < 100; $i++) {
+			$this->assertSame([], $cache->set('k' . $i, $i, 1_000_000));
+		}
+
+		$this->assertSame(100, $cache->count());
+	}
+
+}

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -5,13 +5,21 @@ namespace PHPStan\Parser;
 use Generator;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Nop;
 use PHPStan\BetterReflection\Reflection\ExprCacheHelper;
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
+use function file_put_contents;
 use function sprintf;
+use function str_repeat;
+use function sys_get_temp_dir;
+use function time;
+use function touch;
+use function uniqid;
+use function unlink;
 
 class CachedParserTest extends PHPStanTestCase
 {
@@ -235,6 +243,86 @@ class CachedParserTest extends PHPStanTestCase
 		$reImported = ExprCacheHelper::import($exported);
 		// assert that we get back the default start-line instead of a stale cached startLine of previous same value expression
 		$this->assertSame(['startLine' => 1, 'startTokenPos' => 35, 'startFilePos' => 137, 'endLine' => 10, 'endTokenPos' => 35, 'endFilePos' => 143, 'kind' => 1, 'rawValue' => "'hello'"], $reImported->getAttributes());
+	}
+
+	public function testParseFileSkipsReadingUnchangedFileAndRereadsAfterChange(): void
+	{
+		$parser = new CachedParser($this->getContentEchoingParserStub(), 500);
+		$path = sys_get_temp_dir() . '/phpstan-cached-parser-' . uniqid() . '.php';
+		$baseTime = time() - 10;
+
+		try {
+			file_put_contents($path, 'contents A');
+			touch($path, $baseTime);
+			$this->assertSame('contents A', $parser->parseFile($path)[0]->getAttribute('content'));
+
+			// Same-length contents change with an unchanged mtime is not detectable
+			// by the [mtime, size] key: the memoized contents are returned without re-reading.
+			file_put_contents($path, 'contents B');
+			touch($path, $baseTime);
+			$this->assertSame('contents A', $parser->parseFile($path)[0]->getAttribute('content'));
+
+			// A size change invalidates the memo even when the mtime is unchanged.
+			file_put_contents($path, 'contents B longer');
+			touch($path, $baseTime);
+			$this->assertSame('contents B longer', $parser->parseFile($path)[0]->getAttribute('content'));
+
+			// A newer mtime invalidates the memo, so the file is read again.
+			file_put_contents($path, 'contents C longer');
+			touch($path, $baseTime + 10);
+			$this->assertSame('contents C longer', $parser->parseFile($path)[0]->getAttribute('content'));
+		} finally {
+			@unlink($path);
+		}
+	}
+
+	public function testFileContentsMemoIsBoundedByTotalSourceBytes(): void
+	{
+		$parser = new CachedParser($this->getContentEchoingParserStub(), 500);
+		$baseTime = time() - 10;
+		$bigA = sys_get_temp_dir() . '/phpstan-cached-parser-a-' . uniqid() . '.php';
+		$bigB = sys_get_temp_dir() . '/phpstan-cached-parser-b-' . uniqid() . '.php';
+		$huge = sys_get_temp_dir() . '/phpstan-cached-parser-h-' . uniqid() . '.php';
+
+		try {
+			// A file larger than the memo limit is never memoized: a content change
+			// with an unchanged mtime is still picked up because the file is re-read.
+			file_put_contents($huge, 'huge first ' . str_repeat('x', 600_000));
+			touch($huge, $baseTime);
+			$this->assertStringStartsWith('huge first', $parser->parseFile($huge)[0]->getAttribute('content'));
+			file_put_contents($huge, 'huge second ' . str_repeat('x', 600_000));
+			touch($huge, $baseTime);
+			$this->assertStringStartsWith('huge second', $parser->parseFile($huge)[0]->getAttribute('content'));
+
+			// Two ~300 KB files exceed the limit together: memoizing the second
+			// evicts the first (least recently used), so a content change to the
+			// first with an unchanged mtime is picked up by the forced re-read.
+			file_put_contents($bigA, 'big-a first ' . str_repeat('a', 300_000));
+			touch($bigA, $baseTime);
+			$this->assertStringStartsWith('big-a first', $parser->parseFile($bigA)[0]->getAttribute('content'));
+
+			file_put_contents($bigB, 'big-b ' . str_repeat('b', 300_000));
+			touch($bigB, $baseTime);
+			$this->assertStringStartsWith('big-b', $parser->parseFile($bigB)[0]->getAttribute('content'));
+
+			file_put_contents($bigA, 'big-a second ' . str_repeat('a', 300_000));
+			touch($bigA, $baseTime);
+			$this->assertStringStartsWith('big-a second', $parser->parseFile($bigA)[0]->getAttribute('content'));
+		} finally {
+			@unlink($bigA);
+			@unlink($bigB);
+			@unlink($huge);
+		}
+	}
+
+	private function getContentEchoingParserStub(): Parser&Stub
+	{
+		$mock = $this->createStub(Parser::class);
+		$mock->method('parseFile')->willReturnCallback(
+			static fn (string $file): array => [new Nop(['content' => FileReader::read($file)])],
+		);
+
+		return $mock;
 	}
 
 }


### PR DESCRIPTION
`CachedParser::parseFile()` reads the whole file via `FileReader::read()` on every call, because the contents are the key of the AST cache. The same file is parsed many times (a trait file once per class that uses it), so the read repeats even when nothing changed. Measured on current 2.2.x with an instrumented build, cold: a large Laravel project does 143,613 `parseFile()` reads for 6,624 distinct files, with one hot trait file read 94,007 times; a large doctrine/symfony project does 24,155 reads for 6,251 distinct files.

This memoizes the contents by path, keyed by mtime and size, and skips the re-read when the file is unchanged. Following the direction of the recent cache work (LRU eviction, source-byte caps), the memo is bounded: total memoized source is capped at 512 KB (`MEMOIZED_SOURCE_BYTES_LIMIT`) with least-recently-used eviction, and files larger than the cap are never memoized. Hot trait files stay resident by definition, so the bound costs little: the read counts drop to 8,444 on the Laravel project (94% fewer) and 8,266 on the doctrine/symfony one (66% fewer).

Keying by size as well as mtime catches same-second edits that change the length in long-running processes (PHPStan Pro, fixer worker); `filesize()` is served from the stat cache populated by `filemtime()`, so it costs no extra syscall. A same-second, same-length edit is the remaining undetectable case, pinned in a test.

Effect, measured on Shopware `v6.7.6.2` (9205 files, 9 workers, cold result cache), phars built from `2.2.x` and from this branch:

| | 2.2.x | this PR |
|---|---|---|
| real | 155.6 s | 146.3 s |
| user | 666.5 s | 613.3 s |
| sys | 103.9 s | 54.4 s |
| total CPU | 770.4 s | 667.7 s (-13.3%) |
| `FileReader::read()` calls | 1,970,713 | 54,149 |
| bytes read | 15,269 MB | 217 MB |
| max RSS | 851 MB | 782 MB |

Output is byte-identical. `block input operations` is 0 in both runs, so none of that 15 GB reaches the disk - the page cache serves it, and what the memo removes is the syscall round trips, the copy into a fresh userspace buffer and PHP's stream/string overhead. Re-reading a warm 929-byte file costs ~13.5 us per call against ~0.8 us for the stat pair the memo replaces it with, so the cost is per call rather than per byte.

A trait-light project sees much less: the same PR is flat on a Doctrine/Symfony application, and was within noise on the Laravel project this PR was originally measured against (sys 7.3 s -> 5.4 s, total CPU unchanged).

Memory: at most 512 KB per process (the earlier revision of this PR held contents unbounded, about +4 MB; that is gone). Sweeping the cap on Shopware shows the knee is at or below 64 KB - 64 KB already captures 98.0% of the achievable read reduction and every larger cap up to unbounded lands on the same 98.3% plateau - so 512 KB is on the plateau rather than at a cliff, and is 0.06% of the run's footprint.

Tests cover: unchanged file not re-read, size change detected with unchanged mtime, newer mtime re-read, oversized files never memoized, and LRU eviction at the byte cap.

