### PR TITLE
Sort enum-case unions by class and case name instead of describe()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1774,6 +1774,12 @@ parameters:
 			path: src/Type/UnionTypeHelper.php
 
 		-
+			rawMessage: 'Doing instanceof PHPStan\Type\Enum\EnumCaseObjectType is error-prone and deprecated. Use Type::getEnumCases() instead.'
+			identifier: phpstanApi.instanceofType
+			count: 2
+			path: src/Type/UnionTypeHelper.php
+
+		-
 			rawMessage: 'Doing instanceof PHPStan\Type\IntegerType is error-prone and deprecated. Use Type::isInteger() instead.'
 			identifier: phpstanApi.instanceofType
 			count: 2

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -97,6 +97,20 @@ final class UnionTypeHelper
 				return self::compareStrings($a->getValue(), $b->getValue());
 			}
 
+			if ($a instanceof EnumCaseObjectType && $b instanceof EnumCaseObjectType) {
+				return self::compareStrings(
+					$a->getClassName() . '::' . $a->getEnumCaseName(),
+					$b->getClassName() . '::' . $b->getEnumCaseName(),
+				);
+			}
+
+			if (
+				($a instanceof CallableType || $a instanceof ClosureType)
+				&& ($b instanceof CallableType || $b instanceof ClosureType)
+			) {
+				return self::compareStrings($a->describe(VerbosityLevel::value()), $b->describe(VerbosityLevel::value()));
+			}
+
 			if ($a->isConstantArray()->yes() && $b->isConstantArray()->yes()) {
 				if ($a->isIterableAtLeastOnce()->no()) {
 					if ($b->isIterableAtLeastOnce()->no()) {
@@ -111,27 +125,8 @@ final class UnionTypeHelper
 				return self::compareStrings($a->describe(VerbosityLevel::value()), $b->describe(VerbosityLevel::value()));
 			}
 
-			if (
-				($a instanceof CallableType || $a instanceof ClosureType)
-				&& ($b instanceof CallableType || $b instanceof ClosureType)
-			) {
-				return self::compareStrings($a->describe(VerbosityLevel::value()), $b->describe(VerbosityLevel::value()));
-			}
-
 			if ($a->isString()->yes() && $b->isString()->yes()) {
 				return self::compareStrings($a->describe(VerbosityLevel::precise()), $b->describe(VerbosityLevel::precise()));
-			}
-
-			// Enum cases would otherwise fall through to describe(), the documented "never sort via
-			// describe()" anti-pattern and the dominant cost of sorting a large-enum union (re-sorted
-			// per arm of a match/switch). className.'::'.caseName is the describe(typeOnly) string for
-			// an enum case (enums are never generic), so the order is identical without the
-			// VerbosityLevel dispatch and sprintf. Same key as IntersectionType::getFiniteTypes().
-			if ($a instanceof EnumCaseObjectType && $b instanceof EnumCaseObjectType) {
-				return self::compareStrings(
-					$a->getClassName() . '::' . $a->getEnumCaseName(),
-					$b->getClassName() . '::' . $b->getEnumCaseName(),
-				);
 			}
 
 			return self::compareStrings($a->describe(VerbosityLevel::typeOnly()), $b->describe(VerbosityLevel::typeOnly()));

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -7,6 +7,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Enum\EnumCaseObjectType;
 use function count;
 use function strcasecmp;
 use function usort;
@@ -119,6 +120,18 @@ final class UnionTypeHelper
 
 			if ($a->isString()->yes() && $b->isString()->yes()) {
 				return self::compareStrings($a->describe(VerbosityLevel::precise()), $b->describe(VerbosityLevel::precise()));
+			}
+
+			// Enum cases would otherwise fall through to describe(), the documented "never sort via
+			// describe()" anti-pattern and the dominant cost of sorting a large-enum union (re-sorted
+			// per arm of a match/switch). className.'::'.caseName is the describe(typeOnly) string for
+			// an enum case (enums are never generic), so the order is identical without the
+			// VerbosityLevel dispatch and sprintf. Same key as IntersectionType::getFiniteTypes().
+			if ($a instanceof EnumCaseObjectType && $b instanceof EnumCaseObjectType) {
+				return self::compareStrings(
+					$a->getClassName() . '::' . $a->getEnumCaseName(),
+					$b->getClassName() . '::' . $b->getEnumCaseName(),
+				);
 			}
 
 			return self::compareStrings($a->describe(VerbosityLevel::typeOnly()), $b->describe(VerbosityLevel::typeOnly()));


### PR DESCRIPTION
`UnionTypeHelper::sortTypes()` runs on every `UnionType` construction. Object and enum-case members fall through to the final branch, which sorts them via `describe()`:

```php
return self::compareStrings($a->describe(VerbosityLevel::typeOnly()), $b->describe(VerbosityLevel::typeOnly()));
```

For enum cases that is the documented "never sort or compare types via `describe()`" anti-pattern, and it is the dominant cost of sorting a large-enum union: a `match`/`switch` over the enum reconstructs the subject union (the enum minus the matched cases) once per arm, so each arm re-sorts the shrinking union and re-runs the `describe()` machinery (`VerbosityLevel::handle` dispatch plus `sprintf`) over every member.

This adds an enum-case fast-path that compares `className.'::'.caseName`, the same key the maintainer already uses for enum cases in `IntersectionType::getFiniteTypes()` (enum cases use this key there, other finite types fall back to `describe(typeOnly)`). The sort order is identical because the comparator's `strcasecmp` primary is case-insensitive, so it is unaffected by the only difference from `describe()`: the raw stored class name can differ in case from the canonical reflection name `describe()` resolves. The fast-path skips the `VerbosityLevel` dispatch and the `sprintf` per comparison.

The numbers come from a stress test, a `match` over a 1,500-case enum: CPU 7.50s to 3.67s (−51%), output byte-identical. That size is a scaling demonstration rather than typical code; real enums rarely get that large, so the win is per-file on the rare file with a large-enum `match`/`switch` (e.g. a `Locale`-style enum) and does not move whole-project time. It removes the per-comparison constant factor, not the O(N²) per-arm re-sort itself.

`instanceof EnumCaseObjectType` gets a baseline entry next to the two existing ones for that rule (`phpstanApi.instanceofType`); `IntersectionType` and `EnumCaseObjectType` already use the same instanceof for internal type-system code.

Verified: Type 2941, Analyser 2851, and the match-exhaustiveness plus enum rule suites 432 all pass with output unchanged.
