### PR TITLE
Faster `VerbosityLevel`

### DIFF
--- a/src/Type/VerbosityLevel.php
+++ b/src/Type/VerbosityLevel.php
@@ -50,6 +50,14 @@ final class VerbosityLevel
 	/** @var self[] */
 	private static array $registry;
 
+	private static self $TYPE_ONLY;
+
+	private static self $VALUE;
+
+	private static self $PRECISE;
+
+	private static self $CACHE;
+
 	/**
 	 * @param self::* $value
 	 */
@@ -66,19 +74,19 @@ final class VerbosityLevel
 	/** @api */
 	public static function typeOnly(): self
 	{
-		return self::$registry[self::TYPE_ONLY] ??= new self(self::TYPE_ONLY);
+		return self::$TYPE_ONLY ??= self::$registry[self::TYPE_ONLY] ??= new self(self::TYPE_ONLY);
 	}
 
 	/** @api */
 	public static function value(): self
 	{
-		return self::$registry[self::VALUE] ??= new self(self::VALUE);
+		return self::$VALUE ??= self::$registry[self::VALUE] ??= new self(self::VALUE);
 	}
 
 	/** @api */
 	public static function precise(): self
 	{
-		return self::$registry[self::PRECISE] ??= new self(self::PRECISE);
+		return self::$PRECISE ??= self::$registry[self::PRECISE] ??= new self(self::PRECISE);
 	}
 
 	/**
@@ -88,7 +96,7 @@ final class VerbosityLevel
 	 */
 	public static function cache(): self
 	{
-		return  self::$registry[self::CACHE] ??= new self(self::CACHE);
+		return self::$CACHE ??= self::$registry[self::CACHE] ??= new self(self::CACHE);
 	}
 
 	public function isTypeOnly(): bool

--- a/src/Type/VerbosityLevel.php
+++ b/src/Type/VerbosityLevel.php
@@ -74,19 +74,19 @@ final class VerbosityLevel
 	/** @api */
 	public static function typeOnly(): self
 	{
-		return self::$TYPE_ONLY ??= self::$registry[self::TYPE_ONLY] ??= new self(self::TYPE_ONLY);
+		return self::$TYPE_ONLY ??= (self::$registry[self::TYPE_ONLY] ??= new self(self::TYPE_ONLY));
 	}
 
 	/** @api */
 	public static function value(): self
 	{
-		return self::$VALUE ??= self::$registry[self::VALUE] ??= new self(self::VALUE);
+		return self::$VALUE ??= (self::$registry[self::VALUE] ??= new self(self::VALUE));
 	}
 
 	/** @api */
 	public static function precise(): self
 	{
-		return self::$PRECISE ??= self::$registry[self::PRECISE] ??= new self(self::PRECISE);
+		return self::$PRECISE ??= (self::$registry[self::PRECISE] ??= new self(self::PRECISE));
 	}
 
 	/**
@@ -96,7 +96,7 @@ final class VerbosityLevel
 	 */
 	public static function cache(): self
 	{
-		return self::$CACHE ??= self::$registry[self::CACHE] ??= new self(self::CACHE);
+		return self::$CACHE ??= (self::$registry[self::CACHE] ??= new self(self::CACHE));
 	}
 
 	public function isTypeOnly(): bool

--- a/src/Type/VerbosityLevel.php
+++ b/src/Type/VerbosityLevel.php
@@ -57,15 +57,6 @@ final class VerbosityLevel
 	{
 	}
 
-	/**
-	 * @param self::* $value
-	 */
-	private static function create(int $value): self
-	{
-		self::$registry[$value] ??= new self($value);
-		return self::$registry[$value];
-	}
-
 	/** @return self::* */
 	public function getLevelValue(): int
 	{
@@ -75,19 +66,19 @@ final class VerbosityLevel
 	/** @api */
 	public static function typeOnly(): self
 	{
-		return self::create(self::TYPE_ONLY);
+		return self::$registry[self::TYPE_ONLY] ??= new self(self::TYPE_ONLY);
 	}
 
 	/** @api */
 	public static function value(): self
 	{
-		return self::create(self::VALUE);
+		return self::$registry[self::VALUE] ??= new self(self::VALUE);
 	}
 
 	/** @api */
 	public static function precise(): self
 	{
-		return self::create(self::PRECISE);
+		return self::$registry[self::PRECISE] ??= new self(self::PRECISE);
 	}
 
 	/**
@@ -97,7 +88,7 @@ final class VerbosityLevel
 	 */
 	public static function cache(): self
 	{
-		return self::create(self::CACHE);
+		return  self::$registry[self::CACHE] ??= new self(self::CACHE);
 	}
 
 	public function isTypeOnly(): bool


### PR DESCRIPTION
less indirections.

calls are visible in blackfire profiles of https://github.com/phpstan/phpstan-src/pull/5929#issuecomment-4796578180

similar to https://github.com/phpstan/phpstan-src/pull/4833

---

after this PR the `VerbosityLevel` calls disappear from the reproducer blackfire profiles