### PR TITLE
Faster TypeCombinator

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1656,7 +1656,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantArrayType is error-prone and deprecated. Use Type::getConstantArrays() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 21
+			count: 22
 			path: src/Type/TypeCombinator.php
 
 		-

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -1609,8 +1609,13 @@ final class TypeCombinator
 		$newTypes = [];
 		$hasOffsetValueTypeCount = 0;
 		$typesCount = count($types);
+		$typesNeedSorting = false;
 		for ($i = 0; $i < $typesCount; $i++) {
 			$type = $types[$i];
+
+			if ($type instanceof SubtractableType || $type instanceof ConstantArrayType) {
+				$typesNeedSorting = true;
+			}
 
 			if ($type instanceof IntersectionType && !$type instanceof TemplateType) {
 				// transform A & (B & C) to A & B & C
@@ -1629,24 +1634,26 @@ final class TypeCombinator
 			$typesCount = count($types);
 		}
 
-		usort($types, static function (Type $a, Type $b): int {
-			// move subtractables with subtracts before those without to avoid losing them in the union logic
-			if ($a instanceof SubtractableType && $a->getSubtractedType() !== null) {
-				return -1;
-			}
-			if ($b instanceof SubtractableType && $b->getSubtractedType() !== null) {
-				return 1;
-			}
+		if ($typesNeedSorting) {
+			usort($types, static function (Type $a, Type $b): int {
+				// move subtractables with subtracts before those without to avoid losing them in the union logic
+				if ($a instanceof SubtractableType && $a->getSubtractedType() !== null) {
+					return -1;
+				}
+				if ($b instanceof SubtractableType && $b->getSubtractedType() !== null) {
+					return 1;
+				}
 
-			if ($a instanceof ConstantArrayType && !$b instanceof ConstantArrayType) {
-				return -1;
-			}
-			if ($b instanceof ConstantArrayType && !$a instanceof ConstantArrayType) {
-				return 1;
-			}
+				if ($a instanceof ConstantArrayType && !$b instanceof ConstantArrayType) {
+					return -1;
+				}
+				if ($b instanceof ConstantArrayType && !$a instanceof ConstantArrayType) {
+					return 1;
+				}
 
-			return 0;
-		});
+				return 0;
+			});
+		}
 
 		// transform IntegerType & ConstantIntegerType to ConstantIntegerType
 		// transform Child & Parent to Child


### PR DESCRIPTION
the reproducer from https://github.com/phpstan/phpstan/issues/14869 with `n=300` 

before this PR
```
➜  phpstan-src git:(2.2.x) ✗ hyperfine 'php bin/phpstan analyze repro.php --debug' --runs=5
Benchmark 1: php bin/phpstan analyze repro.php --debug
  Time (mean ± σ):      8.525 s ±  0.066 s    [User: 7.835 s, System: 0.271 s]
  Range (min … max):    8.449 s …  8.630 s    5 runs
```

<img width="625" height="314" alt="grafik" src="https://github.com/user-attachments/assets/517a543b-147f-4fd5-8fc9-cc936590616e" />

---

after this PR
```
➜  phpstan-src git:(fast-typec) ✗ hyperfine 'php bin/phpstan analyze repro.php --debug' --runs=5
Benchmark 1: php bin/phpstan analyze repro.php --debug
  Time (mean ± σ):      7.590 s ±  0.241 s    [User: 6.818 s, System: 0.278 s]
  Range (min … max):    7.314 s …  7.953 s    5 runs
```

=> 13 % faster