### PR TITLE
Fix PHPUnit "incomplete version requirement" warning

### DIFF
--- a/tests/PHPStan/Reflection/ConstantToFunctionParameterMapTest.php
+++ b/tests/PHPStan/Reflection/ConstantToFunctionParameterMapTest.php
@@ -13,7 +13,7 @@ use function implode;
 use function sprintf;
 use function str_contains;
 
-#[RequiresPhp('>= 8.0')]
+#[RequiresPhp('>= 8.0.0')]
 class ConstantToFunctionParameterMapTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/ParameterAllowedConstantsTest.php
+++ b/tests/PHPStan/Reflection/ParameterAllowedConstantsTest.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
-#[RequiresPhp('>= 8.0')]
+#[RequiresPhp('>= 8.0.0')]
 class ParameterAllowedConstantsTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -475,7 +475,7 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9946.php'], []);
 	}
 
-	#[RequiresPhp('< 8.0')]
+	#[RequiresPhp('< 8.0.0')]
 	public function testBug10324(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-10324.php'], [
@@ -486,7 +486,7 @@ class InstantiationRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug10324On80(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-10324.php'], [

--- a/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
@@ -82,7 +82,7 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.2')]
+	#[RequiresPhp('>= 8.2.0')]
 	public function testInTrait(): void
 	{
 		$this->analyse([__DIR__ . '/data/do-while-in-trait.php'], [

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -157,7 +157,7 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.2')]
+	#[RequiresPhp('>= 8.2.0')]
 	public function testInTrait(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1216,14 +1216,14 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9095.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.1')]
+	#[RequiresPhp('>= 8.1.0')]
 	public function testBug7599(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-7599.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug13474(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;
@@ -1236,7 +1236,7 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13687.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.1')]
+	#[RequiresPhp('>= 8.1.0')]
 	public function testBug12798(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
@@ -77,7 +77,7 @@ class LogicalXorConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.2')]
+	#[RequiresPhp('>= 8.2.0')]
 	public function testInTrait(): void
 	{
 		$this->analyse([__DIR__ . '/data/logical-xor-in-trait.php'], [

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -513,7 +513,7 @@ class MatchExpressionRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testInTrait(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1058,7 +1058,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8060.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.2')]
+	#[RequiresPhp('>= 8.2.0')]
 	public function testBug9515(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-9515.php'], []);

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -106,7 +106,7 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7580.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.1')]
+	#[RequiresPhp('>= 8.1.0')]
 	public function testBug11949(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
@@ -50,7 +50,7 @@ class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.2')]
+	#[RequiresPhp('>= 8.2.0')]
 	public function testInTrait(): void
 	{
 		$this->analyse([__DIR__ . '/data/while-false-in-trait.php'], [

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
@@ -466,7 +466,7 @@ class UnusedPrivatePropertyRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.1')]
+	#[RequiresPhp('>= 8.1.0')]
 	public function testBug14703(): void
 	{
 		$this->alwaysWrittenTags = [];

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -364,7 +364,7 @@ class CallCallablesRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testConstantParameterCheckCallables(): void
 	{
 		$this->checkExplicitMixed = false;

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1605,7 +1605,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/benevolent-superglobal-keys.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testFileParams(): void
 	{
 		$this->analyse([__DIR__ . '/data/file.php'], [
@@ -1620,7 +1620,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testFlockParams(): void
 	{
 		$this->analyse([__DIR__ . '/data/flock.php'], [
@@ -2831,7 +2831,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14312b.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testConstantParameterCheck(): void
 	{
 		$this->analyse([__DIR__ . '/data/constant-parameter-check.php'], [
@@ -2890,13 +2890,13 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.4')]
+	#[RequiresPhp('>= 8.4.0')]
 	public function testBug14716(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-14716.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug12850(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-12850.php'], [

--- a/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
@@ -183,7 +183,7 @@ class CallUserFuncRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testConstantParameterCheckCallUserFunc(): void
 	{
 		$this->analyse([__DIR__ . '/data/constant-parameter-check-call-user-func.php'], [

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -1017,7 +1017,7 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testConstantParameterCheckStatic(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 /**
  * @extends RuleTestCase<CompositeRule>
  */
-#[RequiresPhp('>= 8.0')]
+#[RequiresPhp('>= 8.0.0')]
 class MethodCallWithPossiblyRenamedNamedArgumentRuleTest extends RuleTestCase
 {
 

--- a/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
+++ b/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
@@ -373,7 +373,7 @@ class MissingReturnRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12722.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.1')]
+	#[RequiresPhp('>= 8.1.0')]
 	public function testBug14638(): void
 	{
 		$this->checkExplicitMixedMissingReturn = true;

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -757,7 +757,7 @@ class DefinedVariableRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/variable-nullsafe-isset.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug7291(): void
 	{
 		$this->cliArgumentsVariablesRegistered = true;


### PR DESCRIPTION
should fix

```
There were 40 PHPUnit test runner warnings:
1) Incomplete version requirement "8.0" used by PHPStan\Reflection\ConstantToFunctionParameterMapTest::testMapIsValid()
2) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testJsonEncodeFlagsAllowsJsonConstant()
3) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testJsonDecodeDoesNotAllowEncodeOnlyConstants()
4) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testSortFlagsExclusiveGroups()
5) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testHtmlspecialcharsMultipleExclusiveGroups()
6) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testSingleTypeParameter()
7) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testUnmappedParameterReturnsOk()
8) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testMethodWithGlobalConstants()
9) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testMethodWithClassConstants()
10) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testClassConstantNotAllowedWhenGlobalConstantsExpected()
11) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testViolatedExclusiveGroupsSortFlags()
12) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testViolatedExclusiveGroupsHtmlEntities()
13) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testBitmaskNotAllowedOnSingleParameter()
14) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testBitmaskAllowedOnBitmaskParameter()
15) Incomplete version requirement "8.0" used by PHPStan\Reflection\ParameterAllowedConstantsTest::testBothDisallowedAndExclusiveViolation()
16) Incomplete version requirement "8.0" used by PHPStan\Rules\Classes\InstantiationRuleTest::testBug10324()
17) Incomplete version requirement "8.0" used by PHPStan\Rules\Classes\InstantiationRuleTest::testBug10324On80()
18) Incomplete version requirement "8.2" used by PHPStan\Rules\Comparison\DoWhileLoopConstantConditionRuleTest::testInTrait()
19) Incomplete version requirement "8.2" used by PHPStan\Rules\Comparison\ElseIfConstantConditionRuleTest::testInTrait()
20) Incomplete version requirement "8.1" used by PHPStan\Rules\Comparison\ImpossibleCheckTypeFunctionCallRuleTest::testBug7599()
21) Incomplete version requirement "8.0" used by PHPStan\Rules\Comparison\ImpossibleCheckTypeFunctionCallRuleTest::testBug13474()
22) Incomplete version requirement "8.1" used by PHPStan\Rules\Comparison\ImpossibleCheckTypeFunctionCallRuleTest::testBug12798()
23) Incomplete version requirement "8.2" used by PHPStan\Rules\Comparison\LogicalXorConstantConditionRuleTest::testInTrait()
24) Incomplete version requirement "8.0" used by PHPStan\Rules\Comparison\MatchExpressionRuleTest::testInTrait()
25) Incomplete version requirement "8.2" used by PHPStan\Rules\Comparison\StrictComparisonOfDifferentTypesRuleTest::testBug9515()
26) Incomplete version requirement "8.1" used by PHPStan\Rules\Comparison\TernaryOperatorConstantConditionRuleTest::testBug11949()
27) Incomplete version requirement "8.2" used by PHPStan\Rules\Comparison\WhileLoopAlwaysFalseConditionRuleTest::testInTrait()
28) Incomplete version requirement "8.1" used by PHPStan\Rules\DeadCode\UnusedPrivatePropertyRuleTest::testBug14703()
29) Incomplete version requirement "8.0" used by PHPStan\Rules\Functions\CallCallablesRuleTest::testConstantParameterCheckCallables()
30) Incomplete version requirement "8.0" used by PHPStan\Rules\Functions\CallToFunctionParametersRuleTest::testFileParams()
31) Incomplete version requirement "8.0" used by PHPStan\Rules\Functions\CallToFunctionParametersRuleTest::testFlockParams()
32) Incomplete version requirement "8.0" used by PHPStan\Rules\Functions\CallToFunctionParametersRuleTest::testConstantParameterCheck()
33) Incomplete version requirement "8.4" used by PHPStan\Rules\Functions\CallToFunctionParametersRuleTest::testBug14716()
34) Incomplete version requirement "8.0" used by PHPStan\Rules\Functions\CallToFunctionParametersRuleTest::testBug12850()
35) Incomplete version requirement "8.0" used by PHPStan\Rules\Functions\CallUserFuncRuleTest::testConstantParameterCheckCallUserFunc()
36) Incomplete version requirement "8.0" used by PHPStan\Rules\Methods\CallStaticMethodsRuleTest::testConstantParameterCheckStatic()
37) Incomplete version requirement "8.0" used by PHPStan\Rules\Methods\MethodCallWithPossiblyRenamedNamedArgumentRuleTest::testRule()
38) Incomplete version requirement "8.0" used by PHPStan\Rules\Methods\MethodCallWithPossiblyRenamedNamedArgumentRuleTest::testBug7434()
39) Incomplete version requirement "8.1" used by PHPStan\Rules\Missing\MissingReturnRuleTest::testBug14638()
40) Incomplete version requirement "8.0" used by PHPStan\Rules\Variables\DefinedVariableRuleTest::testBug7291()
```