### PR TITLE
Narrow `explode()` when the delimiter is a known substring

### DIFF
--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -2,7 +2,9 @@
 
 namespace PHPStan\Type\Php;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
@@ -12,7 +14,9 @@ use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
@@ -25,10 +29,22 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use function count;
+use function is_int;
+use function max;
 
 #[AutowiredService]
 final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	/**
+	 * Functions whose truthy result proves the delimiter is a literal substring
+	 * of the string, so the result of exploding it has at least two elements.
+	 */
+	private const SUBSTRING_PROVING_FUNCTIONS = [
+		'str_contains',
+		'str_starts_with',
+		'str_ends_with',
+	];
 
 	public function __construct(private PhpVersion $phpVersion)
 	{
@@ -74,12 +90,16 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 			$returnValueType = new StringType();
 		}
 
-		$returnType = new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $returnValueType), new AccessoryArrayListType()]);
-		if (
-			!isset($args[2])
-			|| IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($scope->getType($args[2]->value))->yes()
-		) {
-			$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
+		$limitType = isset($args[2]) ? $scope->getType($args[2]->value) : null;
+
+		if ($this->isDelimiterGuaranteedPresent($args, $scope) && ($limitType === null || IntegerRangeType::fromInterval(2, null)->isSuperTypeOf($limitType)->yes())) {
+			$returnType = $this->createGuaranteedSplitType($returnValueType, $limitType);
+		} else {
+			$returnType = new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $returnValueType), new AccessoryArrayListType()]);
+
+			if ($limitType === null || IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($limitType)->yes()) {
+				$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
+			}
 		}
 
 		if (!$this->phpVersion->throwsValueErrorForInternalFunctions() && $isEmptyString->maybe()) {
@@ -91,6 +111,79 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 		}
 
 		return $returnType;
+	}
+
+	/**
+	 * @param Arg[] $args
+	 */
+	private function isDelimiterGuaranteedPresent(array $args, Scope $scope): bool
+	{
+		$delimiter = $args[0]->value;
+		$haystack = $args[1]->value;
+
+		foreach (self::SUBSTRING_PROVING_FUNCTIONS as $functionName) {
+			$condition = new FuncCall(new FullyQualified($functionName), [
+				new Arg($haystack),
+				new Arg($delimiter),
+			]);
+
+			if ($scope->getType($condition)->isTrue()->yes()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The delimiter is guaranteed to occur in the string, so the result has at
+	 * least two elements. With a positive $limit the result has at most $limit
+	 * elements.
+	 */
+	private function createGuaranteedSplitType(Type $valueType, ?Type $limitType): Type
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		$builder->setOffsetValueType(new ConstantIntegerType(0), $valueType);
+		$builder->setOffsetValueType(new ConstantIntegerType(1), $valueType);
+
+		$maxElements = $this->getMaximumElementCount($limitType);
+		if ($maxElements === null) {
+			$builder->makeUnsealed(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $valueType);
+		} else {
+			for ($i = 2; $i < $maxElements; $i++) {
+				$builder->setOffsetValueType(new ConstantIntegerType($i), $valueType, true);
+			}
+		}
+
+		return $builder->getArray();
+	}
+
+	/**
+	 * The greatest number of elements the split can produce, or null when the
+	 * limit is unbounded or too wide to enumerate.
+	 */
+	private function getMaximumElementCount(?Type $limitType): ?int
+	{
+		if ($limitType === null) {
+			return null;
+		}
+
+		$finiteTypes = $limitType->getFiniteTypes();
+		if ($finiteTypes === []) {
+			return null;
+		}
+
+		$max = null;
+		foreach ($finiteTypes as $finiteType) {
+			$values = $finiteType->getConstantScalarValues();
+			if (count($values) !== 1 || !is_int($values[0])) {
+				return null;
+			}
+
+			$max = $max === null ? $values[0] : max($max, $values[0]);
+		}
+
+		return $max;
 	}
 
 }

--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -37,7 +37,7 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 {
 
 	/**
-	 * Functions whose truthy result proves the delimiter is a literal substring
+	 * Functions whose bool result proves the delimiter is a literal substring
 	 * of the string, so the result of exploding it has at least two elements.
 	 */
 	private const SUBSTRING_PROVING_FUNCTIONS = [

--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -29,7 +29,6 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use function count;
-use function is_int;
 use function max;
 
 #[AutowiredService]
@@ -160,7 +159,7 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 
 	/**
 	 * The greatest number of elements the split can produce, or null when the
-	 * limit is unbounded or too wide to enumerate.
+	 * limit is unbounded or larger than the constant array builder handles.
 	 */
 	private function getMaximumElementCount(?Type $limitType): ?int
 	{
@@ -168,19 +167,18 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 			return null;
 		}
 
-		$finiteTypes = $limitType->getFiniteTypes();
-		if ($finiteTypes === []) {
-			return null;
-		}
-
 		$max = null;
-		foreach ($finiteTypes as $finiteType) {
-			$values = $finiteType->getConstantScalarValues();
-			if (count($values) !== 1 || !is_int($values[0])) {
+		foreach ($limitType->getFiniteTypes() as $finiteType) {
+			if (!$finiteType instanceof ConstantIntegerType) {
 				return null;
 			}
 
-			$max = $max === null ? $values[0] : max($max, $values[0]);
+			$value = $finiteType->getValue();
+			if ($value > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+				return null;
+			}
+
+			$max = $max === null ? $value : max($max, $value);
 		}
 
 		return $max;

--- a/src/Type/Php/StrContainingTypeSpecifyingExtension.php
+++ b/src/Type/Php/StrContainingTypeSpecifyingExtension.php
@@ -48,7 +48,7 @@ final class StrContainingTypeSpecifyingExtension implements FunctionTypeSpecifyi
 	];
 
 	/**
-	 * Functions whose truthy result proves the needle is a literal substring of
+	 * Functions whose bool result proves the needle is a literal substring of
 	 * the haystack, so the call value itself is remembered as `true`.
 	 */
 	private const SUBSTRING_PROVING_FUNCTIONS = [

--- a/src/Type/Php/StrContainingTypeSpecifyingExtension.php
+++ b/src/Type/Php/StrContainingTypeSpecifyingExtension.php
@@ -23,6 +23,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use function array_key_exists;
 use function count;
+use function in_array;
 use function strtolower;
 
 #[AutowiredService]
@@ -44,6 +45,16 @@ final class StrContainingTypeSpecifyingExtension implements FunctionTypeSpecifyi
 		'mb_stripos' => [0, 1],
 		'mb_strripos' => [0, 1],
 		'mb_strstr' => [0, 1],
+	];
+
+	/**
+	 * Functions whose truthy result proves the needle is a literal substring of
+	 * the haystack, so the call value itself is remembered as `true`.
+	 */
+	private const SUBSTRING_PROVING_FUNCTIONS = [
+		'str_contains',
+		'str_starts_with',
+		'str_ends_with',
 	];
 
 	private TypeSpecifier $typeSpecifier;
@@ -84,7 +95,7 @@ final class StrContainingTypeSpecifyingExtension implements FunctionTypeSpecifyi
 					$accessories[] = new AccessoryNonEmptyStringType();
 				}
 
-				return $this->typeSpecifier->create(
+				$specifiedTypes = $this->typeSpecifier->create(
 					$args[$hackstackArg]->value,
 					new IntersectionType($accessories),
 					$context,
@@ -98,6 +109,14 @@ final class StrContainingTypeSpecifyingExtension implements FunctionTypeSpecifyi
 						new Arg($args[$needleArg]->value),
 					]),
 				));
+
+				if (in_array($lowerFunctionName, self::SUBSTRING_PROVING_FUNCTIONS, true)) {
+					$specifiedTypes = $specifiedTypes
+						->unionWith($this->typeSpecifier->handleDefaultTruthyOrFalseyContext($context, $node, $scope))
+						->setRootExpr($specifiedTypes->getRootExpr());
+				}
+
+				return $specifiedTypes;
 			}
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-14651.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14651.php
@@ -115,8 +115,11 @@ function unknownLimit(string $s, int $limit): void
 /**
  * @param int<2, 4> $bounded
  * @param int<5, max> $unbounded
+ * @param int<-2, 3> $negativeAndPositive
+ * @param int<-5, -1> $alwaysNegative
+ * @param int<min, -1> $unboundedNegative
  */
-function rangeLimit(string $s, int $bounded, int $unbounded): void
+function rangeLimit(string $s, int $bounded, int $unbounded, int $negativeAndPositive, int $alwaysNegative, int $unboundedNegative): void
 {
 	if (str_contains($s, "\n")) {
 		assertType('non-falsy-string', $s);
@@ -124,6 +127,10 @@ function rangeLimit(string $s, int $bounded, int $unbounded): void
 		assertType('array{0: string, 1: string, 2?: string, 3?: string}', explode("\n", $s, $bounded));
 		// an unbounded range stays a >= 2 list
 		assertType('array{string, string, ...<string>}', explode("\n", $s, $unbounded));
+		// ranges that may be negative are not proven to yield two elements
+		assertType('list<string>', explode("\n", $s, $negativeAndPositive));
+		assertType('list<string>', explode("\n", $s, $alwaysNegative));
+		assertType('list<string>', explode("\n", $s, $unboundedNegative));
 	} else {
 		assertType('string', $s);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-14651.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14651.php
@@ -153,3 +153,16 @@ function zeroAndNegativeLimit(string $s): void
 
 	assertType('string', $s);
 }
+
+function largeConstantLimit(string $s): void
+{
+	if (str_contains($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		// a limit larger than the array builder handles stays a >= 2 list
+		assertType('array{string, string, ...<string>}', explode("\n", $s, 100000));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-14651.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14651.php
@@ -119,10 +119,27 @@ function unknownLimit(string $s, int $limit): void
 function rangeLimit(string $s, int $bounded, int $unbounded): void
 {
 	if (str_contains($s, "\n")) {
+		assertType('non-falsy-string', $s);
 		// a bounded range yields optional keys up to its maximum
 		assertType('array{0: string, 1: string, 2?: string, 3?: string}', explode("\n", $s, $bounded));
 		// an unbounded range stays a >= 2 list
 		assertType('array{string, string, ...<string>}', explode("\n", $s, $unbounded));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}
+
+function zeroAndNegativeLimit(string $s): void
+{
+	if (str_contains($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		// limit 0 is treated as 1, so a single non-empty element
+		assertType('non-empty-list<string>', explode("\n", $s, 0));
+		// a negative limit drops trailing components and may empty the result
+		assertType('list<string>', explode("\n", $s, -1));
+		assertType('list<string>', explode("\n", $s, -2));
 	} else {
 		assertType('string', $s);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-14651.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14651.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Bug14651;
+
+use function PHPStan\Testing\assertType;
+use function str_contains;
+use function str_ends_with;
+use function str_starts_with;
+
+/**
+ * @return list<string>
+ */
+function readLines(string $buffer): array
+{
+	$result = [];
+
+	while (str_contains($buffer, "\n")) {
+		assertType('array{string, string}', explode("\n", $buffer, 2));
+		[$first, $rest] = explode("\n", $buffer, 2);
+		$result[] = $first;
+		$buffer = $rest;
+	}
+
+	return $result;
+}
+
+function inIf(string $s): void
+{
+	if (str_contains($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		assertType('array{string, string}', explode("\n", $s, 2));
+		assertType('array{string, string, ...<string>}', explode("\n", $s));
+		assertType('array{0: string, 1: string, 2?: string}', explode("\n", $s, 3));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}
+
+function startsWith(string $s): void
+{
+	if (str_starts_with($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		assertType('array{string, string}', explode("\n", $s, 2));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}
+
+function endsWith(string $s): void
+{
+	if (str_ends_with($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		assertType('array{string, string}', explode("\n", $s, 2));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}
+
+/**
+ * @param non-empty-string $needle
+ */
+function variableNeedle(string $s, string $needle): void
+{
+	if (str_contains($s, $needle)) {
+		assertType('non-empty-string', $s);
+		assertType('array{string, string}', explode($needle, $s, 2));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}
+
+function notGuaranteed(string $s): void
+{
+	// no guard at all
+	assertType('non-empty-list<string>', explode("\n", $s, 2));
+
+	if (str_contains($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		// different delimiter than the proven substring
+		assertType('non-empty-list<string>', explode(",", $s, 2));
+		// limit 1 always yields a single element
+		assertType('non-empty-list<string>', explode("\n", $s, 1));
+		// negative limit may drop the guaranteed parts
+		assertType('list<string>', explode("\n", $s, -1));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}
+
+function unknownLimit(string $s, int $limit): void
+{
+	// a limit that is not proven to be >= 2 falls back regardless of the guard
+	assertType('list<string>', explode("\n", $s, $limit));
+
+	if (str_contains($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		assertType('list<string>', explode("\n", $s, $limit));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}
+
+/**
+ * @param int<2, 4> $bounded
+ * @param int<5, max> $unbounded
+ */
+function rangeLimit(string $s, int $bounded, int $unbounded): void
+{
+	if (str_contains($s, "\n")) {
+		// a bounded range yields optional keys up to its maximum
+		assertType('array{0: string, 1: string, 2?: string, 3?: string}', explode("\n", $s, $bounded));
+		// an unbounded range stays a >= 2 list
+		assertType('array{string, string, ...<string>}', explode("\n", $s, $unbounded));
+	} else {
+		assertType('string', $s);
+	}
+
+	assertType('string', $s);
+}


### PR DESCRIPTION
## Summary

PHPStan did not narrow `explode($delimiter, $string, 2)` to a two-element list even when a
`str_contains($string, $delimiter)` guard proved the delimiter is present, so destructuring
`[$first, $rest] = explode(...)` reported `Offset 1 might not exist on non-empty-list<string>`
(under `reportPossiblyNonexistentGeneralArrayOffset`). The report framed this as a `while`-only
problem, but it reproduced identically inside a plain `if`. This teaches the `explode`
return-type extension to use a known-present delimiter.

## Changes

- `src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php` — when the scope proves the
  delimiter occurs in the string, return `array{string, string}` for a limit of exactly `2`,
  `array{0: string, 1: string, 2?: string, ...}` for a larger constant limit, and
  `array{string, string, ...<string>}` otherwise. Presence is probed by reconstructing
  `str_contains()`/`str_starts_with()`/`str_ends_with()` on the same haystack and delimiter
  (with a fully-qualified name, so the node key matches the resolved call) and checking whether
  the scope knows the result to be `true`.
- `src/Type/Php/StrContainingTypeSpecifyingExtension.php` — for `str_contains()`,
  `str_starts_with()` and `str_ends_with()`, also remember the call value as `true` in the
  truthy branch, so a bare `if`/`while` guard carries the same information `... === true`
  already did.
- `tests/PHPStan/Analyser/nsrt/bug-14651.php` — type-inference regression covering the
  reporter's `while` reproducer, the `if` form, `str_starts_with`/`str_ends_with` guards, a
  `non-empty-string` variable needle, and the untouched cases (no guard, different delimiter,
  `limit === 1`, negative limit).

## Root cause

Two gaps combined:

1. `ExplodeFunctionDynamicReturnTypeExtension` always returned `non-empty-list<string>`; it
   never consulted whether the delimiter was known to be present, so it could not prove a
   second element exists.
2. A plain `if (str_contains(...))` did not remember the call's truthiness. When a
   `FunctionTypeSpecifyingExtension` handles a call, `FuncCallHandler::specifyTypes()` returns
   the extension's `SpecifiedTypes` directly and never unions
   `handleDefaultTruthyOrFalseyContext()`, so inside the branch `str_contains($x, $y)` stayed
   `bool`. (Contrast `is_numeric()`, which has no extension and is remembered as `true`, and
   `str_contains($x, $y) === true`, where the `Identical` handler pins the call to `true`.)
   With the call unremembered, the guard scope held only the haystack narrowing
   (`non-falsy-string`), which carries no "contains delimiter" information for `explode` to use.

The first gap is fixed in the explode extension; the second by having the string-containment
extension remember the value of the three literal-substring-proving functions. `explode` then
reconstructs the guard call and asks the scope for its type — the reconstructed name must be
fully-qualified because parsed calls are stored under their resolved (`\str_contains(...)`) key.

## Test

- `tests/PHPStan/Analyser/nsrt/bug-14651.php` asserts the inferred `explode()` type across
  guarded and unguarded forms; it fails before the fix (guarded cases inferred
  `non-empty-list<string>`) and passes after.
- Other delimiters, a possibly-empty needle, `limit === 1` and negative limits keep their
  previous types, so no new false positives are introduced.
- Probed the remembering change for fallout: `make phpstan` (self-analysis) is clean, and
  `NodeScopeResolverTest`, `AnalyserIntegrationTest`, and the `Comparison`, `DeadCode`,
  `Functions` and `Variables` rule suites pass — no spurious always-true reports.

Fixes phpstan/phpstan#14651