### PR TITLE
[2.2.3 perf regression fix] PackageDependencyResolver: memoize resolvePackage per file

### DIFF
--- a/src/Dependency/PackageDependencyResolver.php
+++ b/src/Dependency/PackageDependencyResolver.php
@@ -29,6 +29,9 @@ final class PackageDependencyResolver
 	/** @var array<string, string>|null normalized install path => package name, longest path first */
 	private ?array $installPathToPackage = null;
 
+	/** @var array<string, string|null> file => resolved package (or null for none) */
+	private array $resolvedPackages = [];
+
 	/** @param string[] $composerAutoloaderProjectPaths */
 	public function __construct(
 		private array $composerAutoloaderProjectPaths,
@@ -38,6 +41,19 @@ final class PackageDependencyResolver
 	}
 
 	public function resolvePackage(string $file): ?string
+	{
+		// This is called once per dependency file of every analysed file, so the same vendor files
+		// get resolved over and over. Memoize per file: without it this scans every install path
+		// (linear in the number of installed packages) on each call, which dominates cold analysis
+		// of projects with many dependencies.
+		if (array_key_exists($file, $this->resolvedPackages)) {
+			return $this->resolvedPackages[$file];
+		}
+
+		return $this->resolvedPackages[$file] = $this->doResolvePackage($file);
+	}
+
+	private function doResolvePackage(string $file): ?string
 	{
 		// Normalize with a forward slash regardless of platform: normalizePath() defaults to
 		// DIRECTORY_SEPARATOR, so on Windows the paths would use '\' while the prefix check below


### PR DESCRIPTION
Follow-up to #5933, which introduced `PackageDependencyResolver`.

### Problem

`resolvePackage()` maps a file to its owning Composer package by scanning every install path with `str_starts_with()`. It is called from `NodeDependencies::getPackageDependencies()` once per dependency file of every analysed file, so the same vendor files are resolved over and over, and each call is linear in the number of installed packages. The install-path map (`getInstallPathToPackage()`) is already memoized, but the per-file lookup was not.

A cold profile of a project with a large dependency tree (~265 installed packages, ~1800 files) shows 236,905 `resolvePackage()` calls and 62.9M `str_starts_with()` comparisons, all new in 2.2.3.

### Fix

Memoize the result per file. Most dependency files belong to no project package (they are PHPStan's own bundled dependencies), so the common `null` result is cached too, since it otherwise pays a full scan on every call. `PackageDependencyResolver` is a singleton service, so the cache persists across all files in a worker. Same approach as 200a20379 (DependencyResolver: reduce duplicate work).

Output is unchanged: the cache is keyed by file, and a file's owning package cannot change during a run.

### Result

Cold analysis of the same project, result cache cleared before each run, interleaved across builds and repeated to be robust to machine load:

| build | cold CPU (user+sys) | cold wall |
| --- | --- | --- |
| 2.2.2 | 201 s | 29 s |
| 2.2.3 | 293 s | 40 s |
| 2.2.3 + this change | 215 s | 30 s |

This recovers about 85% of the regression. A residual ~7% above 2.2.2 remains after this change and is not `resolvePackage` (memoizing it does not move it further); it is elsewhere in the 2.2.2..2.2.3 range and I am narrowing it down separately.

The full test suite, self-analysis and the coding standard pass. The result-cache e2e scenarios behave identically with and without the change, as expected for a pure memoization.
