### PR TITLE
Don't retain per-pair isSuperTypeOf() reasons in ObjectType::$superTypes

### DIFF
--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -600,7 +600,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 		if ($thisClassReflection->isTrait() || $thatClassReflection->isTrait()) {
 			$traitReflection = $thisClassReflection->isTrait() ? $thisClassReflection : $thatClassReflection;
-			return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createNo([
+			// Deliberately not stored in self::$superTypes: the reason string is specific to this
+			// class pair, so caching it would retain one distinct string per compared pair for the
+			// whole process. On large codebases that adds up to hundreds of MB. The verdict is cheap
+			// to recompute and the reason is only ever read when an error is emitted.
+			return IsSuperTypeOfResult::createNo([
 				sprintf('%s is a trait, which is never a value type.', $traitReflection->getDisplayName()),
 			]);
 		}
@@ -625,7 +629,9 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createMaybe();
 		}
 
-		return self::$superTypes[$thisDescription][$description] = IsSuperTypeOfResult::createNo(
+		// Deliberately not stored in self::$superTypes — see the trait branch above; the per-pair
+		// reason string would otherwise accumulate in the static cache for the whole process.
+		return IsSuperTypeOfResult::createNo(
 			$this->describeUnrelatedClassesReasons($thisClassReflection, $thatClassReflection),
 		);
 	}


### PR DESCRIPTION
## Problem

`a01080ece` ("Explain unresolvable and impossible types with reasons") started building a **class-pair-specific reason string** for the two final `no()` results of `ObjectType::isSuperTypeOf()`:

- one side is a trait used as a value type, and
- two unrelated classes ruled out by single inheritance (incl. a final class not implementing an interface),

and stored the resulting reason-bearing `IsSuperTypeOfResult` in the process-lifetime `self::$superTypes` cache. Before that commit, both paths cached the shared `IsSuperTypeOfResult::createNo()` singleton.

`self::$superTypes` keeps **one entry per ordered pair of type descriptions** compared during the whole run, so it now retains a distinct reason string per distinct unrelated pair instead of sharing one singleton. On a large doctrine/symfony codebase (a huge number of distinct class-pair comparisons) the bisect in phpstan/phpstan#14892 attributes **~1 GB of extra peak memory** to exactly this step.

## Fix

Stop storing those two reason-bearing results in `self::$superTypes`. They are now recomputed per call instead of memoized:

- the verdict itself is cheap to recompute (the reflection checks that lead there are already memoized elsewhere);
- the reason strings become **transient** — freed by refcounting as soon as the caller is done, so this helps even under `gc_disable`;
- every consumer still receives **identical reasons** — only the caching of these two branches changes, so error output is unchanged. All other `yes`/`maybe`/`no` branches keep their memoization.

## Testing

Behavior is covered by existing tests (reasons still surface as tips):

- `tests/PHPStan/Type/ObjectTypeTest.php` — 111 tests ✔
- `tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php` — 29 tests ✔
- `ImpossibleCheckType{Function,Method,StaticMethod}CallRuleTest`, `StrictComparisonOfDifferentTypesRuleTest`, `IncompatiblePhpDocTypeRuleTest`, `IncompatiblePropertyPhpDocTypeRuleTest`, `IncompatibleClassConstantPhpDocTypeRuleTest`, `ExistingClassesInTypehintsRuleTest` — 264 tests ✔

`phpcs` clean on the changed file.

## Trade-off / note

This trades a small amount of recomputation for these two `no()` branches against the memory. A fix that *also* keeps the verdict memoized while producing reasons on demand would require making `IsSuperTypeOfResult::$reasons` lazy — a BC change to an `@api` class — so it's intentionally left out of this 2.2.x-targeted patch. Happy to take that route instead if preferred.

Reported in phpstan/phpstan#14892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrTvR9j1mW2NNNC8RkuTsF
