### PR TITLE
Reduce per-worker memory of long-lived caches

### DIFF
--- a/src/Analyser/IntermediaryNameScope.php
+++ b/src/Analyser/IntermediaryNameScope.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
+use function serialize;
 
 final class IntermediaryNameScope
 {
@@ -113,6 +114,54 @@ final class IntermediaryNameScope
 			$this->typeAliasClassName,
 			$this->traitData,
 		);
+	}
+
+	/**
+	 * Restores sharing of identical property values and parent scopes after hydration from the file cache.
+	 *
+	 * var_export() used by the cache cannot represent shared references, so every hydrated
+	 * scope carries its own copy of the same uses maps and of the whole parent chain.
+	 * Without interning, the name scope map of a file with many members takes up
+	 * many times more memory when loaded from the cache than when freshly created.
+	 *
+	 * @param array<string, self|array<mixed>> $pool
+	 */
+	public function intern(array &$pool): self
+	{
+		$key = serialize($this);
+		if (isset($pool[$key])) {
+			/** @var self */
+			return $pool[$key];
+		}
+
+		$this->uses = self::internArray($pool, $this->uses);
+		$this->templatePhpDocNodes = self::internArray($pool, $this->templatePhpDocNodes);
+		$this->typeAliasesMap = self::internArray($pool, $this->typeAliasesMap);
+		$this->constUses = self::internArray($pool, $this->constUses);
+		if ($this->parent !== null) {
+			$this->parent = $this->parent->intern($pool);
+		}
+
+		return $pool[$key] = $this;
+	}
+
+	/**
+	 * @template T of array<mixed>
+	 * @param array<string, self|array<mixed>> $pool
+	 * @param T $value
+	 * @return T
+	 */
+	private static function internArray(array &$pool, array $value): array
+	{
+		$key = 'a:' . serialize($value);
+		if (isset($pool[$key])) {
+			/** @var T */
+			return $pool[$key];
+		}
+
+		$pool[$key] = $value;
+
+		return $value;
 	}
 
 	/**

--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -5,14 +5,25 @@ namespace PHPStan\Parser;
 use PhpParser\Node;
 use PHPStan\File\FileReader;
 use function array_key_first;
+use function strlen;
 
 final class CachedParser implements Parser
 {
+
+	/**
+	 * The AST of a parsed file takes up roughly 50-60x more memory
+	 * than the source code itself. Together with the entry count limit,
+	 * this caps the total source size of the cached ASTs so that a few
+	 * large files cannot pin hundreds of megabytes in each worker process.
+	 */
+	private const CACHED_SOURCE_BYTES_LIMIT = 524_288;
 
 	/** @var array<string, Node\Stmt[]>*/
 	private array $cachedNodesByString = [];
 
 	private int $cachedNodesByStringCount = 0;
+
+	private int $cachedSourceBytes = 0;
 
 	/** @var array<string, true> */
 	private array $parsedByString = [];
@@ -42,8 +53,9 @@ final class CachedParser implements Parser
 			// no net change to the entry count, just refresh its LRU position
 			unset($this->cachedNodesByString[$sourceCode], $this->parsedByString[$sourceCode]);
 		} else {
-			$this->evictLeastRecentlyUsed();
+			$this->evictLeastRecentlyUsed(strlen($sourceCode));
 			$this->cachedNodesByStringCount++;
+			$this->cachedSourceBytes += strlen($sourceCode);
 		}
 
 		$this->cachedNodesByString[$sourceCode] = $nodes;
@@ -61,9 +73,10 @@ final class CachedParser implements Parser
 		}
 
 		$nodes = $this->originalParser->parseString($sourceCode);
-		$this->evictLeastRecentlyUsed();
+		$this->evictLeastRecentlyUsed(strlen($sourceCode));
 		$this->cachedNodesByString[$sourceCode] = $nodes;
 		$this->cachedNodesByStringCount++;
+		$this->cachedSourceBytes += strlen($sourceCode);
 		$this->parsedByString[$sourceCode] = true;
 
 		return $nodes;
@@ -84,13 +97,16 @@ final class CachedParser implements Parser
 		return $nodes;
 	}
 
-	private function evictLeastRecentlyUsed(): void
+	private function evictLeastRecentlyUsed(int $incomingSourceBytes): void
 	{
 		if ($this->cachedNodesByStringCountMax === 0) {
 			return;
 		}
 
-		while ($this->cachedNodesByStringCount >= $this->cachedNodesByStringCountMax) {
+		while (
+			$this->cachedNodesByStringCount >= $this->cachedNodesByStringCountMax
+			|| $this->cachedSourceBytes + $incomingSourceBytes > self::CACHED_SOURCE_BYTES_LIMIT
+		) {
 			$oldestKey = array_key_first($this->cachedNodesByString);
 			if ($oldestKey === null) {
 				break;
@@ -98,6 +114,7 @@ final class CachedParser implements Parser
 
 			unset($this->cachedNodesByString[$oldestKey], $this->parsedByString[$oldestKey]);
 			$this->cachedNodesByStringCount--;
+			$this->cachedSourceBytes -= strlen($oldestKey);
 		}
 	}
 

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -401,6 +401,11 @@ final class FileTypeMapper
 			}
 
 			if ($useCache) {
+				$pool = [];
+				foreach ($nameScopeMap as $nameScopeKey => $intermediaryNameScope) {
+					$nameScopeMap[$nameScopeKey] = $intermediaryNameScope->intern($pool);
+				}
+
 				return [$nameScopeMap, array_keys($filesWithHashes)];
 			}
 		}


### PR DESCRIPTION
Two independent reductions of per-worker retained memory, found by profiling self-analysis (`make phpstan` reports the *sum of per-worker peak memory*):

**1. Restore value sharing in name scope maps hydrated from the file cache**

`FileTypeMapper` persists name scope maps with `var_export()`, which cannot represent shared references. A freshly created map shares the `uses`/`constUses` arrays and parent `IntermediaryNameScope` objects across all scopes of a file (COW / object references), but a map hydrated from the cache carries a private copy of everything in every scope — e.g. `MutatingScope.php` hydrates as ~200 scopes, each with its own copy of the same ~150-entry `uses` array and its own duplicate of the whole parent chain (~1.7 MB for that one file). Interning the hydrated scopes through a per-load pool restores the sharing: the retained size of `FileTypeMapper::$memoryCache` in an average worker drops from ~70 MB to ~7 MB.

**2. Cap CachedParser by total cached source size**

The AST of a parsed file takes roughly 50–60× more memory than its source text, and the parser cache limit was entry-count-based only — a few very large files (in self-analysis e.g. `NodeScopeResolver.php`, `TypeCombinatorTest.php`) each pinned tens of MB of AST in a worker for the whole run. The cache now also evicts by total source bytes of the cached entries (`CACHED_SOURCE_BYTES_LIMIT`, 512 KB of source ≈ ~30 MB of AST), on top of the existing count limit and LRU order. Eviction happens before insertion, so the entry being inserted is never evicted, and a single oversized file is still cached while it is being analysed.

**Results** (self-analysis, warm caches, 10-core machine / 8 workers):

| | Used memory |
|---|---|
| 2.2.x | 2.72 GB |
| with this PR | 2.30 GB |

Per-worker peaks drop from ~340 MB to ~280 MB; elapsed time is unchanged. Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DjgMHgfvwhD4ogdTaRtLp