### PR TITLE
update phpstan/phpstan-phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2.0",
 		"phpstan/phpstan-deprecation-rules": "^2.0.2",
 		"phpstan/phpstan-nette": "^2.0",
-		"phpstan/phpstan-phpunit": "^2.0.8",
+		"phpstan/phpstan-phpunit": "^2.0.19",
 		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^11.5.23",
 		"shipmonk/composer-dependency-analyser": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "08ef80e73e4b97acde2c6a3543687fad",
+  "content-hash": "f128753d8eedc9b2d387a23643fe5234",
   "packages": [
     {
       "name": "clue/ndjson-react",
@@ -5153,21 +5153,22 @@
     },
     {
       "name": "phpstan/phpstan-phpunit",
-      "version": "2.0.15",
+      "version": "2.0.x-dev",
       "source": {
         "type": "git",
         "url": "https://github.com/phpstan/phpstan-phpunit.git",
-        "reference": "0f6ba8e22a3e919353a8f4615ea3cd2e91626c7f"
+        "reference": "2297f6c4cc1a05ba45eb9d297ed352a44a7a9364"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/0f6ba8e22a3e919353a8f4615ea3cd2e91626c7f",
-        "reference": "0f6ba8e22a3e919353a8f4615ea3cd2e91626c7f",
+        "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/2297f6c4cc1a05ba45eb9d297ed352a44a7a9364",
+        "reference": "2297f6c4cc1a05ba45eb9d297ed352a44a7a9364",
         "shasum": ""
       },
       "require": {
+        "phar-io/version": "^3.2",
         "php": "^7.4 || ^8.0",
-        "phpstan/phpstan": "^2.1.32"
+        "phpstan/phpstan": "^2.2.6"
       },
       "conflict": {
         "phpunit/phpunit": "<7.0"
@@ -5177,8 +5178,10 @@
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "shipmonk/name-collision-detector": "^2.1"
       },
+      "default-branch": true,
       "type": "phpstan-extension",
       "extra": {
         "phpstan": {
@@ -5203,9 +5206,9 @@
       ],
       "support": {
         "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-        "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.15"
+        "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.x"
       },
-      "time": "2026-02-11T14:43:43+00:00"
+      "time": "2026-07-06T17:56:46+00:00"
     },
     {
       "name": "phpstan/phpstan-strict-rules",


### PR DESCRIPTION
fixes the CI build error in `e2e/result-cache-restore-without-reflection` because of a outdated phpstan-phpunit version:

```
In Resolver.php line 677:
                                                                               
  [Nette\DI\ServiceCreationException]                                          
  Service of type PHPStan\Rules\PHPUnit\AttributeRequiresPhpVersionRule: Para  
  meter $deprecationRulesInstalled in AttributeRequiresPhpVersionRule::__cons  
  truct() has no class type or default value, so its value must be specified.  
                                                                               

Exception trace:
  at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:677
 Nette\DI\Resolver::autowireArgument() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:572
 Nette\DI\Resolver::autowireArguments() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:229
 Nette\DI\Resolver->completeStatement() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Definitions/ServiceDefinition.php:178
 Nette\DI\Definitions\ServiceDefinition->complete() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:173
 Nette\DI\Resolver->completeDefinition() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerBuilder.php:338
 Nette\DI\ContainerBuilder->complete() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Compiler.php:275
 Nette\DI\Compiler->processBeforeCompile() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Compiler.php:212
 Nette\DI\Compiler->compile() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerLoader.php:119
 Nette\DI\ContainerLoader->generate() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerLoader.php:80
 Nette\DI\ContainerLoader->loadFile() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerLoader.php:44
 Nette\DI\ContainerLoader->load() at /home/runner/work/phpstan-src/phpstan-src/src/DependencyInjection/Configurator.php:111
 PHPStan\DependencyInjection\Configurator->loadContainer() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/bootstrap/src/Bootstrap/Configurator.php:258
 Nette\Bootstrap\Configurator->createContainer() at /home/runner/work/phpstan-src/phpstan-src/src/DependencyInjection/Configurator.php:226
 PHPStan\DependencyInjection\Configurator->createContainer() at /home/runner/work/phpstan-src/phpstan-src/src/DependencyInjection/ContainerFactory.php:164
 PHPStan\DependencyInjection\ContainerFactory->create() at /home/runner/work/phpstan-src/phpstan-src/src/Command/CommandHelper.php:388
 PHPStan\Command\CommandHelper::begin() at /home/runner/work/phpstan-src/phpstan-src/src/Command/AnalyseCommand.php:179
 PHPStan\Command\AnalyseCommand->execute() at /home/runner/work/phpstan-src/phpstan-src/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at /home/runner/work/phpstan-src/phpstan-src/vendor/symfony/console/Application.php:1040
 Symfony\Component\Console\Application->doRunCommand() at /home/runner/work/phpstan-src/phpstan-src/vendor/symfony/console/Application.php:301
 Symfony\Component\Console\Application->doRun() at /home/runner/work/phpstan-src/phpstan-src/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at /home/runner/work/phpstan-src/phpstan-src/bin/phpstan:139
 {closure}() at /home/runner/work/phpstan-src/phpstan-src/bin/phpstan:140

```