### PR TITLE
Keep a single memoization layer for located reflections

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -126,7 +126,6 @@ parameters:
 		nodesByStringCountMax: 256
 		resolvedPhpDocBlockCacheCountMax: 2048
 		nameScopeMapMemoryCacheCountMax: 512
-		memoizingSourceLocatorEntriesCountMax: 0
 		phpStormStubsNodesCountMax: 64
 	reportUnmatchedIgnoredErrors: true
 	reportIgnoresWithoutComments: false

--- a/conf/config.stubValidator.neon
+++ b/conf/config.stubValidator.neon
@@ -19,19 +19,16 @@ services:
 		arguments:
 			allStubFiles: %allStubFiles%
 			php8Parser: @php8PhpParser
-			memoizingSourceLocatorEntriesCountMax: %cache.memoizingSourceLocatorEntriesCountMax%
 
 	# overrides service from parsers.neon
 	defaultAnalysisParser!:
 		factory: @stubParser
 
-	# overrides service from services.neon
-	nodeScopeResolverReflector:
-		factory: @stubReflector
-
-	# overrides service from services.neon so that Reflector autowires to stubReflector
-	originalBetterReflectionReflector!:
-		factory: @stubReflector
+	# overrides service from services.neon so that the reflector
+	# (and everything above it) reflects only the stub files
+	betterReflectionSourceLocator!:
+		factory: @stubSourceLocator
+		autowired: false
 
 	# overrides service from services.neon
 	reflectionProvider:
@@ -52,14 +49,8 @@ services:
 	stubBetterReflectionProvider:
 		class: PHPStan\Reflection\BetterReflection\BetterReflectionProvider
 		arguments:
-			reflector: @stubReflector
+			reflector: @betterReflectionReflector
 			universalObjectCratesClasses: %universalObjectCratesClasses%
-		autowired: false
-
-	stubReflector:
-		class: PHPStan\BetterReflection\Reflector\DefaultReflector
-		arguments:
-			sourceLocator: @stubSourceLocator
 		autowired: false
 
 	stubSourceLocator:

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -150,7 +150,6 @@ parametersSchema:
 		nodesByStringCountMax: int(),
 		resolvedPhpDocBlockCacheCountMax: int(),
 		nameScopeMapMemoryCacheCountMax: int(),
-		memoizingSourceLocatorEntriesCountMax: int(),
 		phpStormStubsNodesCountMax: int()
 	])
 	reportUnmatchedIgnoredErrors: bool()

--- a/conf/services.neon
+++ b/conf/services.neon
@@ -42,13 +42,6 @@ services:
 		autowired:
 			- PHPStan\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber
 
-	originalBetterReflectionReflector:
-		class: PHPStan\BetterReflection\Reflector\DefaultReflector
-		arguments:
-			sourceLocator: @betterReflectionSourceLocator
-		autowired: false
-
-
 	# not registered using attributes because we don't want to apply service tags automatically
 	-
 		class: PHPStan\Dependency\ExportedNodeVisitor

--- a/conf/services.neon
+++ b/conf/services.neon
@@ -246,10 +246,6 @@ services:
 		autowired:
 			- PHPStan\Reflection\ReflectionProvider
 
-	nodeScopeResolverReflector:
-		factory: @betterReflectionReflector
-		autowired: false
-
 	# not registered using attributes because people often override it
 
 	exceptionTypeResolver:

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -214,7 +214,6 @@ class NodeScopeResolver
 		private readonly Container $container,
 		private readonly ReflectionProvider $reflectionProvider,
 		private readonly InitializerExprTypeResolver $initializerExprTypeResolver,
-		#[AutowiredParameter(ref: '@nodeScopeResolverReflector')]
 		private readonly Reflector $reflector,
 		private readonly ClassReflectionFactory $classReflectionFactory,
 		private readonly ParameterOutTypeExtensionProvider $parameterOutTypeExtensionProvider,

--- a/src/PhpDoc/StubSourceLocatorFactory.php
+++ b/src/PhpDoc/StubSourceLocatorFactory.php
@@ -7,7 +7,6 @@ use PHPStan\BetterReflection\SourceLocator\Ast\Locator;
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
 use PHPStan\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\Composer\Psr\Psr4Mapping;
-use PHPStan\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedPsrAutoloaderLocatorFactory;
@@ -26,7 +25,6 @@ final class StubSourceLocatorFactory
 		private OptimizedSingleFileSourceLocatorRepository $optimizedSingleFileSourceLocatorRepository,
 		private OptimizedPsrAutoloaderLocatorFactory $optimizedPsrAutoloaderLocatorFactory,
 		private array $allStubFiles,
-		private int $memoizingSourceLocatorEntriesCountMax,
 	)
 	{
 	}
@@ -52,10 +50,9 @@ final class StubSourceLocatorFactory
 
 		$locators[] = new PhpInternalSourceLocator($astPhp8Locator, $this->phpStormStubsSourceStubber);
 
-		return new MemoizingSourceLocator(
-			new AggregateSourceLocator($locators),
-			$this->memoizingSourceLocatorEntriesCountMax === 0 ? null : $this->memoizingSourceLocatorEntriesCountMax,
-		);
+		// no MemoizingSourceLocator here - located reflections are already memoized
+		// by MemoizingReflector, a second cache layer would only pin them in memory twice
+		return new AggregateSourceLocator($locators);
 	}
 
 }

--- a/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
@@ -10,7 +10,6 @@ use PHPStan\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber
 use PHPStan\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\Composer\Psr\Psr4Mapping;
 use PHPStan\BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
-use PHPStan\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\DependencyInjection\AutowiredParameter;
@@ -75,8 +74,6 @@ final class BetterReflectionSourceLocatorFactory
 		private bool $playgroundMode, // makes all PHPStan classes in the PHAR discoverable with PSR-4
 		#[AutowiredParameter]
 		private ?string $singleReflectionFile,
-		#[AutowiredParameter(ref: '%cache.memoizingSourceLocatorEntriesCountMax%')]
-		private int $memoizingSourceLocatorEntriesCountMax,
 	)
 	{
 	}
@@ -175,10 +172,9 @@ final class BetterReflectionSourceLocatorFactory
 			return new AggregateSourceLocator($locators);
 		};
 
-		return new MemoizingSourceLocator(
-			new LazySourceLocator($initializer),
-			$this->memoizingSourceLocatorEntriesCountMax === 0 ? null : $this->memoizingSourceLocatorEntriesCountMax,
-		);
+		// no MemoizingSourceLocator here - located reflections are already memoized
+		// by MemoizingReflector, a second cache layer would only pin them in memory twice
+		return new LazySourceLocator($initializer);
 	}
 
 }

--- a/src/Reflection/BetterReflection/Reflector/MemoizingReflector.php
+++ b/src/Reflection/BetterReflection/Reflector/MemoizingReflector.php
@@ -10,8 +10,10 @@ use PHPStan\BetterReflection\Reflection\ReflectionConstant;
 use PHPStan\BetterReflection\Reflection\ReflectionFunction;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\BetterReflection\Reflector\Reflector;
+use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\ShouldNotHappenException;
 use function array_key_exists;
 use function strtolower;
 
@@ -29,8 +31,8 @@ final class MemoizingReflector implements Reflector
 	private array $functionReflections = [];
 
 	public function __construct(
-		#[AutowiredParameter(ref: '@originalBetterReflectionReflector')]
-		private Reflector $reflector,
+		#[AutowiredParameter(ref: '@betterReflectionSourceLocator')]
+		private SourceLocator $sourceLocator,
 	)
 	{
 	}
@@ -51,13 +53,22 @@ final class MemoizingReflector implements Reflector
 			return $classReflection;
 		}
 
-		try {
-			return $this->classReflections[$lowerClassName] = $this->reflector->reflectClass($className);
-		} catch (IdentifierNotFound $e) {
+		// located directly, without a DefaultReflector - created reflections capture
+		// the reflector passed here and resolve e.g. parent classes and interfaces
+		// through it, so passing $this routes those lookups through this cache too
+		$identifier = new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+		$classReflection = $this->sourceLocator->locateIdentifier($this, $identifier);
+		if ($classReflection === null) {
 			$this->classReflections[$className] = null;
 
-			throw $e;
+			throw IdentifierNotFound::fromIdentifier($identifier);
 		}
+
+		if (!$classReflection instanceof ReflectionClass) {
+			throw new ShouldNotHappenException();
+		}
+
+		return $this->classReflections[$lowerClassName] = $classReflection;
 	}
 
 	#[Override]
@@ -72,13 +83,19 @@ final class MemoizingReflector implements Reflector
 			return $constantReflection;
 		}
 
-		try {
-			return $this->constantReflections[$constantName] = $this->reflector->reflectConstant($constantName);
-		} catch (IdentifierNotFound $e) {
+		$identifier = new Identifier($constantName, new IdentifierType(IdentifierType::IDENTIFIER_CONSTANT));
+		$constantReflection = $this->sourceLocator->locateIdentifier($this, $identifier);
+		if ($constantReflection === null) {
 			$this->constantReflections[$constantName] = null;
 
-			throw $e;
+			throw IdentifierNotFound::fromIdentifier($identifier);
 		}
+
+		if (!$constantReflection instanceof ReflectionConstant) {
+			throw new ShouldNotHappenException();
+		}
+
+		return $this->constantReflections[$constantName] = $constantReflection;
 	}
 
 	#[Override]
@@ -94,31 +111,49 @@ final class MemoizingReflector implements Reflector
 			return $functionReflection;
 		}
 
-		try {
-			return $this->functionReflections[$lowerFunctionName] = $this->reflector->reflectFunction($functionName);
-		} catch (IdentifierNotFound $e) {
+		$identifier = new Identifier($functionName, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
+		$functionReflection = $this->sourceLocator->locateIdentifier($this, $identifier);
+		if ($functionReflection === null) {
 			$this->functionReflections[$lowerFunctionName] = null;
 
-			throw $e;
+			throw IdentifierNotFound::fromIdentifier($identifier);
 		}
+
+		if (!$functionReflection instanceof ReflectionFunction) {
+			throw new ShouldNotHappenException();
+		}
+
+		return $this->functionReflections[$lowerFunctionName] = $functionReflection;
 	}
 
+	/**
+	 * @return list<ReflectionClass>
+	 */
 	#[Override]
 	public function reflectAllClasses(): iterable
 	{
-		return $this->reflector->reflectAllClasses();
+		/** @var list<ReflectionClass> */
+		return $this->sourceLocator->locateIdentifiersByType($this, new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 	}
 
+	/**
+	 * @return list<ReflectionFunction>
+	 */
 	#[Override]
 	public function reflectAllFunctions(): iterable
 	{
-		return $this->reflector->reflectAllFunctions();
+		/** @var list<ReflectionFunction> */
+		return $this->sourceLocator->locateIdentifiersByType($this, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
 	}
 
+	/**
+	 * @return list<ReflectionConstant>
+	 */
 	#[Override]
 	public function reflectAllConstants(): iterable
 	{
-		return $this->reflector->reflectAllConstants();
+		/** @var list<ReflectionConstant> */
+		return $this->sourceLocator->locateIdentifiersByType($this, new IdentifierType(IdentifierType::IDENTIFIER_CONSTANT));
 	}
 
 }

--- a/src/Testing/TestCase.neon
+++ b/src/Testing/TestCase.neon
@@ -9,7 +9,6 @@ services:
 			php8Parser: @php8PhpParser
 			fileExtensions: %fileExtensions%
 			excludePaths: %excludePaths%
-			memoizingSourceLocatorEntriesCountMax: %cache.memoizingSourceLocatorEntriesCountMax%
 
 	# overrides service from parsers.neon
 	currentPhpVersionSimpleParser!:

--- a/src/Testing/TestCaseSourceLocatorFactory.php
+++ b/src/Testing/TestCaseSourceLocatorFactory.php
@@ -9,7 +9,6 @@ use PHPStan\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStub
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber;
 use PHPStan\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
-use PHPStan\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\Php\PhpVersion;
@@ -47,7 +46,6 @@ final class TestCaseSourceLocatorFactory
 		private PhpVersion $phpVersion,
 		private array $fileExtensions,
 		private ?array $excludePaths,
-		private int $memoizingSourceLocatorEntriesCountMax,
 	)
 	{
 	}
@@ -98,10 +96,9 @@ final class TestCaseSourceLocatorFactory
 		$locators[] = new PhpVersionBlacklistSourceLocator(new PhpInternalSourceLocator($astLocator, $this->reflectionSourceStubber), $this->phpstormStubsSourceStubber);
 		$locators[] = new PhpVersionBlacklistSourceLocator(new EvaledCodeSourceLocator($astLocator, $this->reflectionSourceStubber), $this->phpstormStubsSourceStubber);
 
-		return new MemoizingSourceLocator(
-			new AggregateSourceLocator($locators),
-			$this->memoizingSourceLocatorEntriesCountMax === 0 ? null : $this->memoizingSourceLocatorEntriesCountMax,
-		);
+		// no MemoizingSourceLocator here - located reflections are already memoized
+		// by MemoizingReflector, a second cache layer would only pin them in memory twice
+		return new AggregateSourceLocator($locators);
 	}
 
 }


### PR DESCRIPTION
Located reflections were cached twice — by `MemoizingReflector` (keyed by name) and again by the `MemoizingSourceLocator` wrapper (keyed by identifier), pinning every reflection object graph in memory twice per worker process.

The locator-level cache could not simply be dropped: created reflections capture the reflector passed to `SourceLocator::locateIdentifier()` and resolve parent classes, interfaces and prototypes through it, bypassing `MemoizingReflector` entirely — the memoizing locator was the only cache absorbing those internal lookups (removing it naively OOMs workers because every parent/interface lookup re-locates from scratch).

Instead of wrapping `DefaultReflector`, `MemoizingReflector` now locates identifiers itself and passes `$this` to the source locator, so created reflections capture the memoizing reflector and route their internal lookups through the same name-keyed cache. This makes the `MemoizingSourceLocator` wrappers redundant for real:

- removed from `BetterReflectionSourceLocatorFactory`, `StubSourceLocatorFactory` and `TestCaseSourceLocatorFactory`, together with the `cache.memoizingSourceLocatorEntriesCountMax` parameter (measurements showed capping that layer was counterproductive anyway),
- the `originalBetterReflectionReflector` service is gone,
- the stub validator container relied on the removed wrapper as its only memoization, so it now overrides `betterReflectionSourceLocator!` with the stub source locator instead of swapping reflectors — `stubReflector` is gone too.

**Results** (self-analysis, warm caches, 8 workers; "Used memory" = sum of per-worker peaks):

| | Used memory | elapsed |
|---|---|---|
| 2.2.x | 2.49–2.52 GB | ~26 s |
| with this PR | **2.11–2.13 GB** | ~26 s |

Full test suite passes. No BetterReflection change needed — works with the released 6.70.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DjgMHgfvwhD4ogdTaRtLp