### PR TITLE
Do not flatten template benevolent unions in TypeCombinator::union()

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -199,7 +199,6 @@ final class TypeCombinator
 		$alreadyNormalizedCounter = 0;
 
 		$benevolentTypes = [];
-		$benevolentUnionObject = null;
 		$neverCount = 0;
 		// transform A | (B | C) to A | B | C
 		for ($i = 0; $i < $typesCount; $i++) {
@@ -215,10 +214,7 @@ final class TypeCombinator
 				$neverCount++;
 				continue;
 			}
-			if ($types[$i] instanceof BenevolentUnionType) {
-				if ($types[$i] instanceof TemplateBenevolentUnionType && $benevolentUnionObject === null) {
-					$benevolentUnionObject = $types[$i];
-				}
+			if ($types[$i] instanceof BenevolentUnionType && !$types[$i] instanceof TemplateType) {
 				$benevolentTypesCount = 0;
 				$typesInner = $types[$i]->getTypes();
 				foreach ($typesInner as $benevolentInnerType) {
@@ -471,10 +467,6 @@ final class TypeCombinator
 			}
 
 			if ($tempTypes === []) {
-				if ($benevolentUnionObject instanceof TemplateBenevolentUnionType) {
-					return $benevolentUnionObject->withTypes(array_values($types));
-				}
-
 				return new BenevolentUnionType(array_values($types), true);
 			}
 		}

--- a/tests/PHPStan/Analyser/nsrt/bug-7279.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7279.php
@@ -1,0 +1,104 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug7279;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ */
+class Timeline
+{
+
+}
+
+class Percentage
+{
+
+}
+
+/**
+ * @template K of array-key
+ * @template T
+ *
+ * @param array<K, T> $array
+ * @param (callable(T, K): bool) $fn
+ *
+ * @return ($array is non-empty-array ? T|null : null)
+ */
+function find(array $array, callable $fn): mixed
+{
+	foreach ($array as $key => $value) {
+		if ($fn($value, $key)) {
+			return $value;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * @template K of array-key
+ * @template T
+ *
+ * @param array<K, T> $array
+ * @param (callable(T, K): bool) $fn
+ *
+ * @return ($array is non-empty-array ? K|null : null)
+ */
+function findKey(array $array, callable $fn): string|int|null
+{
+	foreach ($array as $key => $value) {
+		if ($fn($value, $key)) {
+			return $key;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * @param callable(mixed): bool $callback
+ * @param array<never, never> $emptyList
+ * @param array{} $emptyMap
+ * @param array<int, string> $unknownList
+ * @param array{id?: int, name?: string} $unknownMap
+ * @param non-empty-array<int, Timeline<Percentage>> $nonEmptyList
+ * @param array{work: Timeline<Percentage>} $nonEmptyMap
+ */
+function assertions(
+	callable $callback,
+	array $emptyList,
+	array $emptyMap,
+	array $unknownList,
+	array $unknownMap,
+	array $nonEmptyList,
+	array $nonEmptyMap,
+): void
+{
+	// Everything works great for find()
+
+	assertType('null', find([], $callback));
+	assertType('null', find($emptyList, $callback));
+	assertType('null', find($emptyMap, $callback));
+
+	assertType('string|null', find($unknownList, $callback));
+	assertType('int|string|null', find($unknownMap, $callback));
+
+	assertType('Bug7279\Timeline<Bug7279\Percentage>|null', find($nonEmptyList, $callback));
+	assertType('Bug7279\Timeline<Bug7279\Percentage>|null', find($nonEmptyMap, $callback));
+
+	// But everything goes to hell for findKey() ?!?
+
+	assertType('null', findKey([], $callback));
+	assertType('null', findKey($emptyList, $callback));
+	assertType('null', findKey($emptyMap, $callback));
+
+	assertType('int|null', findKey($unknownList, $callback));
+	assertType("'id'|'name'|null", findKey($unknownMap, $callback));
+
+	assertType('int|null', findKey($nonEmptyList, $callback));
+	assertType("'work'|null", findKey($nonEmptyMap, $callback));
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7279

## Root cause

`@template K of array-key` produces a `TemplateBenevolentUnionType` (`array-key` = benevolent `int|string`). When resolving a PHPDoc union such as `K|null` (e.g. in a conditional return type `($array is non-empty-array ? K|null : null)`), `TypeCombinator::union()`'s "transform A | (B | C) to A | B | C" loop hit the `instanceof BenevolentUnionType` flattening branch **before** the `instanceof TemplateType → continue` guard that already protects `TemplateUnionType` (which is why `@template K of int|string` worked fine). The template's members were spliced into the outer union, so the template was destroyed at PHPDoc-resolution time — this was never an inference failure; by the time inference ran, `K` no longer existed and only its bound `int|string` remained.

The reconstruction path at the end of `union()` only re-wrapped the template when *all* resulting union members came from the benevolent union, which fails as soon as any other member (here `null`) is present.

## Fix

Exclude `TemplateType` from the benevolent flattening branch, letting `TemplateBenevolentUnionType` fall through to the same `TemplateType` guard as `TemplateUnionType`. This mirrors 57e3cbf90, which fixed the identical problem on the `intersect()` side (templates handled before benevolent flattening and re-wrapped via `TemplateTypeFactory`); `union()` never got the same treatment.

With the guard in place, the `$benevolentUnionObject` re-wrapping machinery in the reconstruction path became unreachable (confirmed by PHPStan self-analysis flagging `instanceof between null and TemplateBenevolentUnionType will always evaluate to false`) and is removed. Plain (non-template) benevolent unions still enter the flattening branch and behave exactly as before.

## Semantic notes

- `union(K of array-key, int)` now yields `int|K` instead of the widened `K` — consistent with how non-benevolent template unions (`K of int|string`) already behave.
- `stubs/ArrayObject.stub` line 23 (`@param TKey|null $offset`) now resolves to a real template union instead of a flattened bound, which can make `ArrayObject`/`ArrayIterator` offset parameter checks slightly stricter.

No existing test expectations needed updating; full `NodeScopeResolverTest`, `AnalyserIntegrationTest`, `TypeCombinatorTest`, `UnionTypeTest`, `BenevolentUnionTypeTest`, generics tests, and PHPStan self-analysis all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Fable 5.