### PR TITLE
Check static method calls through constant class-name strings and class-string unions

### DIFF
--- a/src/Rules/Methods/StaticMethodCallCheck.php
+++ b/src/Rules/Methods/StaticMethodCallCheck.php
@@ -11,6 +11,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Internal\SprintfHelper;
+use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\Native\NativeMethodReflection;
@@ -32,6 +33,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 use function array_merge;
+use function count;
 use function in_array;
 use function sprintf;
 use function strtolower;
@@ -183,9 +185,24 @@ final class StaticMethodCallCheck
 				}
 			}
 		} else {
+			$exprToCheck = NullsafeOperatorHelper::getNullsafeShortcircuitedExprRespectingScope($scope, $class);
+			$exprType = $scope->getType($exprToCheck);
+			if ($exprType->isClassString()->yes() && !$exprType->hasMethod($methodName)->yes()) {
+				// A constant class-name string or a class-string type describes the
+				// object it names, so route the check through that object type. This
+				// makes constant-string / class-string unions behave exactly like
+				// object unions with regard to rule levels (member filtering when
+				// checkUnionTypes is off, whole-union check when it is on).
+				$objectType = $exprType->getClassStringObjectType();
+				if (count($objectType->getObjectClassNames()) === 0) {
+					// plain class-string resolves to ObjectWithoutClassType, keep silent
+					return [[], null];
+				}
+				$exprToCheck = new TypeExpr($objectType);
+			}
 			$classTypeResult = $this->ruleLevelHelper->findTypeToCheck(
 				$scope,
-				NullsafeOperatorHelper::getNullsafeShortcircuitedExprRespectingScope($scope, $class),
+				$exprToCheck,
 				sprintf('Call to static method %s() on an unknown class %%s.', SprintfHelper::escapeFormatString($methodName)),
 				static fn (Type $type): bool => $type->canCallMethods()->yes() && $type->hasMethod($methodName)->yes(),
 			);

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -25,9 +25,13 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 
 	private bool $checkThisOnly;
 
+	private bool $checkUnionTypes = true;
+
 	private bool $checkExplicitMixed = false;
 
 	private bool $checkImplicitMixed = false;
+
+	private bool $reportMagicMethods = true;
 
 	protected function getRule(): Rule
 	{
@@ -36,7 +40,7 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 			$reflectionProvider,
 			checkNullables: true,
 			checkThisOnly: $this->checkThisOnly,
-			checkUnionTypes: true,
+			checkUnionTypes: $this->checkUnionTypes,
 			checkExplicitMixed: $this->checkExplicitMixed,
 			checkImplicitMixed: $this->checkImplicitMixed,
 			checkBenevolentUnionTypes: false,
@@ -58,7 +62,7 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 				),
 				checkFunctionNameCase: true,
 				discoveringSymbolsTip: true,
-				reportMagicMethods: true,
+				reportMagicMethods: $this->reportMagicMethods,
 			),
 			new FunctionCallParametersCheck(
 				$ruleLevelHelper,
@@ -1055,6 +1059,116 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 	{
 		$this->checkThisOnly = false;
 		$this->analyse([__DIR__ . '/data/class-exists-on-static-call.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
+	public function testBug11353(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/bug-11353.php'], [
+			[
+				'Call to an undefined static method Bug11353\A|Bug11353\B|Bug11353\C::create().',
+				46,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
+	public function testStaticCallsOnStringUnions(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/static-call-string-unions.php'], [
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz::create().',
+				53,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz|StaticCallStringUnions\Foo::create().',
+				59,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz|StaticCallStringUnions\Foo::create().',
+				71,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz|StaticCallStringUnions\Foo::create().',
+				79,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz::create().',
+				87,
+			],
+			[
+				'Static call to instance method StaticCallStringUnions\Foo::doBar().',
+				101,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\WithMagic::whatever().',
+				107,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Foo|StaticCallStringUnions\WithMagic::create().',
+				115,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
+	public function testStaticCallsOnStringUnionsWithoutCheckUnionTypes(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = false;
+		$this->analyse([__DIR__ . '/data/static-call-string-unions.php'], [
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz::create().',
+				53,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz::create().',
+				87,
+			],
+			[
+				'Static call to instance method StaticCallStringUnions\Foo::doBar().',
+				101,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\WithMagic::whatever().',
+				107,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
+	public function testStaticCallsOnStringUnionsWithoutReportMagicMethods(): void
+	{
+		$this->checkThisOnly = false;
+		$this->reportMagicMethods = false;
+		$this->analyse([__DIR__ . '/data/static-call-string-unions.php'], [
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz::create().',
+				53,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz|StaticCallStringUnions\Foo::create().',
+				59,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz|StaticCallStringUnions\Foo::create().',
+				71,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz|StaticCallStringUnions\Foo::create().',
+				79,
+			],
+			[
+				'Call to an undefined static method StaticCallStringUnions\Baz::create().',
+				87,
+			],
+			[
+				'Static call to instance method StaticCallStringUnions\Foo::doBar().',
+				101,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
@@ -105,6 +105,10 @@ class StaticMethodCallableRuleTest extends RuleTestCase
 				'Cannot call static method doFoo() on int.',
 				22,
 			],
+			[
+				'Call to an undefined static method StaticMethodCallable\Bar|StaticMethodCallable\Foo::doFoo().',
+				77,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/bug-11353.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-11353.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug11353;
+
+enum Identifier: string
+{
+	case A = 'identifier_a';
+	case B = 'identifier_b';
+	case C = 'identifier_c';
+}
+
+class A
+{
+	public static function create(): self
+	{
+		return new self();
+	}
+}
+
+class B
+{
+	public static function create(): self
+	{
+		return new self();
+	}
+}
+
+class C
+{
+	// missing static function create(): self
+}
+
+class SomeCliCommand
+{
+	public function execute(string $input): void
+	{
+		$identifier = Identifier::from($input);
+
+		$classFQCN = match ($identifier) {
+			Identifier::A => A::class,
+			Identifier::B => B::class,
+			Identifier::C => C::class,
+		};
+
+		// No warning that C::create() does not exist
+		$class = $classFQCN::create();
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/static-call-string-unions.php
+++ b/tests/PHPStan/Rules/Methods/data/static-call-string-unions.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace StaticCallStringUnions;
+
+class Foo
+{
+
+	public static function create(): self
+	{
+		return new self();
+	}
+
+	public function doBar(): void
+	{
+	}
+
+}
+
+class Bar
+{
+
+	public static function create(): self
+	{
+		return new self();
+	}
+
+}
+
+class Baz
+{
+
+}
+
+class WithMagic
+{
+
+	/**
+	 * @param array<mixed> $args
+	 */
+	public static function __callStatic(string $name, array $args): mixed
+	{
+		return null;
+	}
+
+}
+
+class Runner
+{
+
+	public function singleConstantString(): void
+	{
+		$class = Baz::class;
+		$class::create();
+	}
+
+	public function unionOfConstantStrings(bool $flag): void
+	{
+		$class = $flag ? Foo::class : Baz::class;
+		$class::create();
+	}
+
+	public function unionOfConstantStringsAllValid(bool $flag): void
+	{
+		$class = $flag ? Foo::class : Bar::class;
+		$class::create();
+	}
+
+	public function getClassUnion(Foo|Baz $object): void
+	{
+		$class = get_class($object);
+		$class::create();
+	}
+
+	/**
+	 * @param class-string<Foo>|class-string<Baz> $class
+	 */
+	public function genericClassStringUnion(string $class): void
+	{
+		$class::create();
+	}
+
+	/**
+	 * @param class-string<Baz> $class
+	 */
+	public function singleGenericClassString(string $class): void
+	{
+		$class::create();
+	}
+
+	/**
+	 * @param class-string $class
+	 */
+	public function plainClassString(string $class): void
+	{
+		$class::create();
+	}
+
+	public function instanceMethodThroughConstantString(): void
+	{
+		$class = Foo::class;
+		$class::doBar();
+	}
+
+	public function magicCallStaticThroughConstantString(): void
+	{
+		$class = WithMagic::class;
+		$class::whatever();
+	}
+
+	/**
+	 * @param class-string<Foo>|class-string<WithMagic> $class
+	 */
+	public function unionWithMagicMember(string $class): void
+	{
+		$class::create();
+	}
+
+	/**
+	 * @param class-string<Foo> $class
+	 */
+	public function methodExistsNarrowing(string $class): void
+	{
+		if (method_exists($class, 'doSomethingElse')) {
+			$class::doSomethingElse();
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/static-method-callable.php
+++ b/tests/PHPStan/Rules/Methods/data/static-method-callable.php
@@ -67,3 +67,14 @@ class Ipsum
 	}
 
 }
+
+class Dolor
+{
+
+	public function doFoo(bool $flag): void
+	{
+		$class = $flag ? Foo::class : Bar::class;
+		$class::doFoo(...);
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/11353

## Description

`$classFQCN::create()` was silently skipped by `CallStaticMethodsRule` whenever `$classFQCN` held a union of constant class-name strings (`'Test\A'|'Test\B'|'Test\C'`), a union of `class-string<A>|class-string<C>` (e.g. from `get_class()`), or even a single constant class-name string in a variable — no error even when one of the classes has no such method.

## Root cause

`StaticMethodCallCheck` has a legacy special case that predates the modern class-string API (`Type::isClassString()` / `Type::getClassStringObjectType()`): after `RuleLevelHelper::findTypeToCheck()`, only `$classType instanceof GenericClassStringType` (a single `class-string<T>`) was unwrapped to its object type; every other stringy type fell into the `isString()->yes()` bail and returned no errors. Type inference (`MutatingScope`) already resolves such calls correctly, and `InstantiationRule` already checks `new $classFQCN()` for these shapes via `isClassString()->yes()` + `getClassStringObjectType()` — only the static method call rule was left behind.

## Fix

Before calling `RuleLevelHelper::findTypeToCheck()`, when the expression's type is a class-string (`isClassString()->yes()`), convert it to the object type it describes (`getClassStringObjectType()`) and route it through a virtual `TypeExpr` node. Plain `class-string` (resolving to `objectWithoutClassType`) stays silent as before, and the conversion is skipped when the type already answers `hasMethod()->yes()` — that preserves the `class-string<T>&hasMethod(m)` behavior from `method_exists()` narrowing (#6147), where the dummy method reflection would otherwise produce a bogus "static call to instance method" error.

As a bonus, calls through constant class-name strings now also get the rest of the check pipeline for free: "static call to instance method", protected/private visibility, `__callStatic` handling via `reportMagicMethods`, and unknown classes inside `class-string<T>` are reported as `class.notFound` (consistently with object-typed expressions) instead of `staticMethod.notFound`.

## Question about rule-level semantics (@ondrejmirtes)

One design point I'd like your input on: constant-string unions used to bypass `RuleLevelHelper`'s union member filtering entirely, because `StringType::canCallMethods()` is `No` (`NonObjectTypeTrait`) — so with `checkUnionTypes` off (levels 0–6) the union-filter callback rejected every member and the union passed through whole. A naive fix (unwrapping strings *after* `findTypeToCheck()`) would therefore have reported union errors even at level 0, breaking the "unions reported at level 7+" contract that object unions follow.

I considered two options:

- **(a)** inject `%checkUnionTypes%` into `StaticMethodCallCheck` and skip the multi-member case when it's off;
- **(b)** convert the class-string type to its object type *before* `findTypeToCheck()`, routing it through `PHPStan\Node\Expr\TypeExpr`, so member filtering, benevolent unions, and unknown-class handling behave identically to object unions.

I implemented **(b)** because it reuses the existing level machinery instead of duplicating its logic (error line attribution on the virtual node comes out correct — verified by tests). Tests pin the level semantics: single `class-string<C>` / single constant string are reported with `checkUnionTypes: false`, unions only with `checkUnionTypes: true`. Happy to switch to (a) if you prefer.

## Known follow-up candidates (separate PRs)

The same legacy `instanceof GenericClassStringType` + `isString()` bail pattern exists in `AccessStaticPropertiesCheck` and `ClassConstantRule` — static property fetches and class constant accesses through constant-string/class-string unions are silently skipped the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Fable 5.
