### PR TITLE
Model TypeError throw points for illegal array key offsets

### DIFF
--- a/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
@@ -13,7 +13,9 @@ use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
+use PHPStan\Analyser\ExprHandler\Helper\IllegalOffsetTypeHelper;
 use PHPStan\Analyser\ExprHandler\Helper\NullsafeShortCircuitingHelper;
+use PHPStan\Analyser\InternalThrowPoint;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\NoopNodeCallback;
@@ -23,9 +25,11 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use TypeError;
 use function array_merge;
 
 /**
@@ -34,6 +38,10 @@ use function array_merge;
 #[AutowiredService]
 final class ArrayDimFetchHandler implements ExprHandler
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -107,6 +115,16 @@ final class ArrayDimFetchHandler implements ExprHandler
 				new NoopNodeCallback(),
 				$context,
 			)->getThrowPoints());
+		}
+
+		if (
+			$this->phpVersion->throwsTypeErrorForIllegalOffsets()
+			// only array and string offset reads throw TypeError for illegal offsets,
+			// reads on null and other scalars emit a warning, ArrayAccess objects go through offsetGet()
+			&& (!$varType->isArray()->no() || !$varType->isString()->no())
+			&& IllegalOffsetTypeHelper::mayOffsetThrowTypeError($scope->getType($expr->dim))
+		) {
+			$throwPoints[] = InternalThrowPoint::createExplicit($scope, new ObjectType(TypeError::class), $expr, false);
 		}
 
 		return new ExpressionResult(

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -28,6 +28,7 @@ use PHPStan\Analyser\ExpressionResult;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExpressionTypeHolder;
 use PHPStan\Analyser\ExprHandler;
+use PHPStan\Analyser\ExprHandler\Helper\IllegalOffsetTypeHelper;
 use PHPStan\Analyser\ImpurePoint;
 use PHPStan\Analyser\InternalThrowPoint;
 use PHPStan\Analyser\MutatingScope;
@@ -605,6 +606,24 @@ final class AssignHandler implements ExprHandler
 					if ($enterExpressionAssign) {
 						$scope = $scope->exitExpressionAssign($dimExpr);
 					}
+				}
+			}
+
+			if ($this->phpVersion->throwsTypeErrorForIllegalOffsets()) {
+				foreach ($offsetTypes as [$offsetType, $offsetDimFetch]) {
+					// $arr[] = ... never throws for the offset
+					if ($offsetType === null) {
+						continue;
+					}
+					if (!IllegalOffsetTypeHelper::mayOffsetThrowTypeError($offsetType)) {
+						continue;
+					}
+					// writes to ArrayAccess objects go through offsetSet() whose throw points are modelled below
+					$containerType = $scope->getType($offsetDimFetch->var);
+					if ((new ObjectType(ArrayAccess::class))->isSuperTypeOf($containerType)->yes()) {
+						continue;
+					}
+					$throwPoints[] = InternalThrowPoint::createExplicit($scope, new ObjectType(TypeError::class), $offsetDimFetch, false);
 				}
 			}
 

--- a/src/Analyser/ExprHandler/Helper/IllegalOffsetTypeHelper.php
+++ b/src/Analyser/ExprHandler/Helper/IllegalOffsetTypeHelper.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ExprHandler\Helper;
+
+use PHPStan\Type\Type;
+
+final class IllegalOffsetTypeHelper
+{
+
+	/**
+	 * On PHP 8.0+ using an array or an object as an array/string offset throws TypeError
+	 * (https://wiki.php.net/rfc/engine_warnings). Float, bool and null keys are coerced
+	 * with at most a deprecation, resource keys with a warning - no TypeError.
+	 */
+	public static function mayOffsetThrowTypeError(Type $offsetType): bool
+	{
+		return !$offsetType->isArray()->no() || !$offsetType->isObject()->no();
+	}
+
+}

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -186,6 +186,12 @@ final class PhpVersion
 		return $this->versionId >= 80000;
 	}
 
+	// see https://wiki.php.net/rfc/engine_warnings - "Illegal offset type" family
+	public function throwsTypeErrorForIllegalOffsets(): bool
+	{
+		return $this->versionId >= 80000;
+	}
+
 	public function supportsHhPrintfSpecifier(): bool
 	{
 		return $this->versionId >= 80000;

--- a/tests/PHPStan/Analyser/nsrt/throw-points/array-dim-fetch.php
+++ b/tests/PHPStan/Analyser/nsrt/throw-points/array-dim-fetch.php
@@ -4,17 +4,7 @@ namespace ThrowPoints\ArrayDimFetch;
 
 use PHPStan\TrinaryLogic;
 use function PHPStan\Testing\assertVariableCertainty;
-use function ThrowPoints\Helpers\doesntThrow;
 use function ThrowPoints\Helpers\maybeThrows;
-
-function () {
-	try {
-		[][doesntThrow()];
-		$foo = 1;
-	} finally {
-		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
-	}
-};
 
 function () {
 	try {

--- a/tests/PHPStan/Analyser/nsrt/throw-points/assign-op.php
+++ b/tests/PHPStan/Analyser/nsrt/throw-points/assign-op.php
@@ -43,14 +43,6 @@ function () {
 
 function () {
 	try {
-		$foo[doesntThrow()] .= 0;
-	} finally {
-		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
-	}
-};
-
-function () {
-	try {
 		$foo[maybeThrows()] .= 0;
 	} finally {
 		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);

--- a/tests/PHPStan/Analyser/nsrt/throw-points/assign.php
+++ b/tests/PHPStan/Analyser/nsrt/throw-points/assign.php
@@ -51,14 +51,6 @@ function () {
 
 function () {
 	try {
-		$foo[doesntThrow()] = 0;
-	} finally {
-		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
-	}
-};
-
-function () {
-	try {
 		$foo[maybeThrows()] = 0;
 	} finally {
 		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
@@ -150,14 +142,6 @@ function () {
 		[$foo] = maybeThrows();
 	} finally {
 		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
-	}
-};
-
-function () {
-	try {
-		[$foo[doesntThrow()]] = 1;
-	} finally {
-		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
 	}
 };
 

--- a/tests/PHPStan/Analyser/nsrt/throw-points/illegal-array-offset-php7.php
+++ b/tests/PHPStan/Analyser/nsrt/throw-points/illegal-array-offset-php7.php
@@ -1,0 +1,43 @@
+<?php // lint < 8.0
+
+namespace ThrowPoints\IllegalArrayOffset;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+
+// Before PHP 8.0 an illegal (array/object) offset does not throw TypeError, so a
+// non-throwing offset expression introduces no throw point and $foo is always assigned.
+
+function () {
+	try {
+		$foo[doesntThrow()] = 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[$foo[doesntThrow()]] = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[doesntThrow()] .= 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[][doesntThrow()];
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/throw-points/illegal-array-offset-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/throw-points/illegal-array-offset-php8.php
@@ -1,0 +1,44 @@
+<?php // lint >= 8.0
+
+namespace ThrowPoints\IllegalArrayOffset;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+
+// doesntThrow() never throws by itself, but on PHP 8.0+ its mixed return value used
+// as an array/string offset may be an array or an object, which throws TypeError.
+// That TypeError is the only throw point here, so $foo may be left unassigned.
+
+function () {
+	try {
+		$foo[doesntThrow()] = 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		[$foo[doesntThrow()]] = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[doesntThrow()] .= 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		[][doesntThrow()];
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Levels/data/arrayOffsetAccess-4.json
+++ b/tests/PHPStan/Levels/data/arrayOffsetAccess-4.json
@@ -15,26 +15,6 @@
         "ignorable": true
     },
     {
-        "message": "Expression \"$a[$objectOrInt]\" on a separate line does not do anything.",
-        "line": 19,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$a[$objectOrNull]\" on a separate line does not do anything.",
-        "line": 20,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$a[$explicitlyMixed]\" on a separate line does not do anything.",
-        "line": 21,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$a[$implicitlyMixed]\" on a separate line does not do anything.",
-        "line": 22,
-        "ignorable": true
-    },
-    {
         "message": "Expression \"$arrayOrObject[42]\" on a separate line does not do anything.",
         "line": 24,
         "ignorable": true
@@ -47,26 +27,6 @@
     {
         "message": "Expression \"$arrayOrObject[$intOrNull]\" on a separate line does not do anything.",
         "line": 27,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$arrayOrObject[$objectOrInt]\" on a separate line does not do anything.",
-        "line": 28,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$arrayOrObject[$objectOrNull]\" on a separate line does not do anything.",
-        "line": 29,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$arrayOrObject[$explicitlyMixed]\" on a separate line does not do anything.",
-        "line": 30,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$arrayOrObject[$implicitlyMixed]\" on a separate line does not do anything.",
-        "line": 31,
         "ignorable": true
     },
     {
@@ -85,26 +45,6 @@
         "ignorable": true
     },
     {
-        "message": "Expression \"$explicitlyMixed[$objectOrInt]\" on a separate line does not do anything.",
-        "line": 37,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$explicitlyMixed[$objectOrNull]\" on a separate line does not do anything.",
-        "line": 38,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$explicitlyMixed[$explicitlyMixed]\" on a separate line does not do anything.",
-        "line": 39,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$explicitlyMixed[$implicitlyMixed]\" on a separate line does not do anything.",
-        "line": 40,
-        "ignorable": true
-    },
-    {
         "message": "Expression \"$implicitlyMixed[42]\" on a separate line does not do anything.",
         "line": 42,
         "ignorable": true
@@ -117,26 +57,6 @@
     {
         "message": "Expression \"$implicitlyMixed[$intOrNull]\" on a separate line does not do anything.",
         "line": 45,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$implicitlyMixed[$objectOrInt]\" on a separate line does not do anything.",
-        "line": 46,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$implicitlyMixed[$objectOrNull]\" on a separate line does not do anything.",
-        "line": 47,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$implicitlyMixed[$explicitlyMixed]\" on a separate line does not do anything.",
-        "line": 48,
-        "ignorable": true
-    },
-    {
-        "message": "Expression \"$implicitlyMixed[$implicitlyMixed]\" on a separate line does not do anything.",
-        "line": 49,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -705,6 +705,33 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug6970(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6970.php'], [
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				96,
+			],
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				109,
+			],
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				147,
+			],
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				198,
+			],
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				286,
+			],
+		]);
+	}
+
 	#[RequiresPhp('>= 8.3.0')]
 	public function testPr5105(): void
 	{

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6970.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6970.php
@@ -1,0 +1,334 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace Bug6970;
+
+use ArrayAccess;
+use Generator;
+use TypeError;
+use UnexpectedValueException;
+use function count;
+
+/**
+ * @template K
+ * @template T
+ * @template L
+ * @template U
+ *
+ * @param iterable<K, T> $stream
+ * @param callable(T, K): Generator<L, U> $fn
+ *
+ * @return Generator<L, U>
+ */
+function scollect(iterable $stream, callable $fn): Generator
+{
+	foreach ($stream as $key => $value) {
+		yield from $fn($value, $key);
+	}
+}
+
+/**
+ * @param mixed[] $array
+ *
+ * @return mixed[]
+ */
+function collectWithKeys(array $array, callable $fn): array
+{
+	$stream = scollect($array, $fn);
+
+	$values = [];
+	$counter = 0;
+
+	foreach ($stream as $key => $value) {
+		try {
+			$values[$key] = $value;
+		} catch (TypeError) {
+			throw new UnexpectedValueException('The key yielded in the callable is not compatible with the type "array-key".');
+		}
+
+		++$counter;
+	}
+
+	if ($counter !== count($values)) {
+		throw new UnexpectedValueException(
+			'Data loss occurred because of duplicated keys. Use `collect()` if you do not care about ' .
+			'the yielded keys, or use `scollect()` if you need to support duplicated keys (as arrays cannot).',
+		);
+	}
+
+	return $values;
+}
+
+class MoreCases
+{
+
+	/**
+	 * @param mixed[] $array
+	 * @param mixed $key
+	 */
+	public function writeMixedKey(array $array, $key): void
+	{
+		try {
+			$array[$key] = 1;
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 */
+	public function writeObjectKey(array $array, \stdClass $key): void
+	{
+		try {
+			$array[$key] = 1;
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 */
+	public function writeIntKey(array $array, int $key): void
+	{
+		try {
+			$array[$key] = 1;
+		} catch (TypeError) { // error: Dead catch - TypeError is never thrown in the try block.
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param mixed $value
+	 */
+	public function append(array $array, $value): void
+	{
+		try {
+			$array[] = $value;
+		} catch (TypeError) { // error: Dead catch - TypeError is never thrown in the try block.
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param mixed $key
+	 */
+	public function assignOpMixedKey(array $array, $key): void
+	{
+		try {
+			$array[$key] .= 'x';
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param mixed $key
+	 */
+	public function readMixedKey(array $array, $key): void
+	{
+		try {
+			$x = $array[$key];
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 */
+	public function readIntKey(array $array, int $key): void
+	{
+		try {
+			$x = $array[$key];
+		} catch (TypeError) { // error: Dead catch - TypeError is never thrown in the try block.
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param mixed $key
+	 */
+	public function readCoalesceMixedKey(array $array, $key): void
+	{
+		try {
+			$x = $array[$key] ?? null;
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param mixed $key
+	 */
+	public function issetMixedKey(array $array, $key): void
+	{
+		try {
+			$x = isset($array[$key]);
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param mixed $key
+	 */
+	public function unsetMixedKey(array $array, $key): void
+	{
+		try {
+			unset($array[$key]);
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 */
+	public function unsetIntKey(array $array, int $key): void
+	{
+		try {
+			unset($array[$key]);
+		} catch (TypeError) { // error: Dead catch - TypeError is never thrown in the try block.
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed $key
+	 */
+	public function stringOffsetWriteMixedKey(string $s, $key): void
+	{
+		try {
+			$s[$key] = 'x';
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed $key
+	 */
+	public function stringOffsetReadMixedKey(string $s, $key): void
+	{
+		try {
+			$x = $s[$key];
+		} catch (TypeError) { // not dead
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param int|mixed[] $key
+	 */
+	public function writeArrayOrIntKey(array $array, $key): void
+	{
+		try {
+			$array[$key] = 1;
+		} catch (TypeError) { // not dead - key may be an array
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[] $array
+	 * @param int|\stdClass $key
+	 */
+	public function writeObjectOrIntKey(array $array, $key): void
+	{
+		try {
+			$array[$key] = 1;
+		} catch (TypeError) { // not dead - key may be an object
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[]|int $arrayOrInt
+	 * @param mixed $key
+	 */
+	public function readArrayOrIntVar($arrayOrInt, $key): void
+	{
+		try {
+			$x = $arrayOrInt[$key];
+		} catch (TypeError) { // not dead - reading an array offset with an illegal key throws
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param string|int $stringOrInt
+	 * @param mixed $key
+	 */
+	public function readStringOrIntVar($stringOrInt, $key): void
+	{
+		try {
+			$x = $stringOrInt[$key];
+		} catch (TypeError) { // not dead - reading a string offset with an illegal key throws
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed $key
+	 */
+	public function writeConcreteArrayAccessKey(ConcreteArrayAccess $container, $key): void
+	{
+		try {
+			$container[$key] = 1;
+		} catch (TypeError) { // error: dead - ArrayAccess offsetSet() handles the offset, so no TypeError from the illegal offset
+			echo 'caught';
+		}
+	}
+
+	/**
+	 * @param mixed[]|ConcreteArrayAccess $container
+	 * @param mixed $key
+	 */
+	public function writeMaybeArrayAccessKey($container, $key): void
+	{
+		try {
+			$container[$key] = 1;
+		} catch (TypeError) { // not dead - container may be a plain array, whose illegal offset throws
+			echo 'caught';
+		}
+	}
+
+}
+
+/**
+ * @implements ArrayAccess<mixed, mixed>
+ */
+final class ConcreteArrayAccess implements ArrayAccess
+{
+
+	public function offsetExists($offset): bool
+	{
+		return true;
+	}
+
+	public function offsetGet($offset): mixed
+	{
+		return null;
+	}
+
+	/**
+	 * @throws \RuntimeException
+	 */
+	public function offsetSet($offset, $value): void
+	{
+		throw new \RuntimeException();
+	}
+
+	public function offsetUnset($offset): void
+	{
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6970

## Root cause

Since PHP 8.0, using an array or an object as an array (or string) offset throws `TypeError` instead of emitting an "Illegal offset type" warning ([Reclassifying engine warnings RFC](https://wiki.php.net/rfc/engine_warnings) — the "Illegal offset type" / "Illegal offset type in isset or empty" / "Illegal offset type in unset" diagnostics). PHPStan did not model this anywhere: `AssignHandler::processAssignVar()` (ArrayDimFetch branch) only collected throw points from evaluating the root variable, the dimension expressions, the assigned expression, and a synthetic `offsetSet()` call for `ArrayAccess` containers. Nothing represented the engine's own `TypeError` for an illegal key, so `CatchWithUnthrownExceptionRule` reported `Dead catch - TypeError is never thrown in the try block` on code that can genuinely throw — while `InvalidKeyInArrayDimFetchRule` was simultaneously warning about `Possibly invalid array key type mixed` for the same expression.

The same gap existed for reads (`$arr[$key]`, including under `??`, `isset()`, `empty()`), for `unset($arr[$key])` and for string offset access — it is one coherent hole (the engine throws from the same offset-legality check in all of these), so this PR covers all of them together rather than splitting.

## The fix

- New `PhpVersion::throwsTypeErrorForIllegalOffsets()` (`>= 80000`) gates everything: on PHP 7.x these operations only raised a warning, so the dead-catch report was *correct* there and must stay.
- New `IllegalOffsetTypeHelper::mayOffsetThrowTypeError()`: an offset may throw only if `array|object` is not definitively ruled out for it — float, bool and null keys are coerced with at most a deprecation, resource keys with a warning, so those never throw.
- **Write side** (`AssignHandler`, ArrayDimFetch branch): after evaluating the dimensions, add an `InternalThrowPoint::createExplicit(..., TypeError, ...)` for every collected offset that may be illegal. Skipped when the offset expression is `null` (`$arr[] =` never throws for the offset) and when the container is definitely `ArrayAccess` (the write goes through `offsetSet()`, whose throw points are already modelled by the existing synthetic call — including built-ins like `ArrayIterator` which throw from inside `offsetSet()`). Compound assignments (`$arr[$key] .= …`) flow through the same branch and are covered automatically, as are string offset writes (`$str[$key] = 'x'`) and null-container auto-vivification (`$null[$key] = 1` vivifies to array first, then throws).
- **Read side** (`ArrayDimFetchHandler::processExpr()`): same throw point when the container may be an array or a string and the offset may be illegal. Reads on `null`/other scalars only emit a warning and evaluate to `null` (verified below), so containers that are definitely neither array nor string are skipped. Reads under `??`, `isset()` and `empty()` are covered automatically because those handlers process the inner `ArrayDimFetch` through the same code path — and PHP does throw there (null coalescing suppresses undefined-key notices, *not* illegal-offset `TypeError`s).
- **`unset($arr[$key])`** is covered automatically as well: the `Unset_` statement handling processes the `ArrayDimFetch` through `ArrayDimFetchHandler`.

This mirrors the fix for the identical bug shape with typed property assignment: phpstan/phpstan#9146, fixed in #4981 (commit 88b41d43c), which added `InternalThrowPoint::createExplicit($scope, new ObjectType(TypeError::class), $assignedExpr, false)` in the PropertyFetch branch of the same method. The new test is modeled on `testBug9146`.

## Runtime semantics verification (`php -r`, PHP 8.4.22 and 8.5.7)

| operation | result |
|---|---|
| `$array[$object] = 'x'` / `$array[[1]] = 'x'` | `TypeError` |
| `$array[true] = 'x'` / `$array[1.5] = 'x'` / `$array[null] = 'x'` | no throw (coerced) |
| `$array[$resource] = 'x'` | no throw (warning, cast to int) |
| `$x = $array[$object]` | `TypeError` |
| `$array[$object] ?? 'default'` | `TypeError` |
| `isset($array[$object])` / `empty($array[$object])` | `TypeError` ("in isset or empty") |
| `unset($array[$object])` | `TypeError` ("Cannot unset offset") |
| `$string[$object] = 'x'` / `$x = $string[$object]` | `TypeError` |
| `$null[$object] = 1` / `$false[$object] = 1` | `TypeError` (after auto-vivification) |
| `$x = $null[$object]` / `$x = $int[$object]` | no throw (warning, `null`) |
| `isset($null[$object])` / `$undefined[$object] ?? 'd'` | no throw (`false` / `'d'`) |
| `$int[$object] = 1` | `Error` "Cannot use a scalar value as an array" (not `TypeError`) |
| `$arrayIterator[$object] = 1` / `unset($arrayIterator[$object])` | `TypeError` from inside `offsetSet()`/`offsetUnset()` (covered by the existing synthetic method call modelling) |

On PHP 7.4 all of the array-offset cases above emit `Warning: Illegal offset type` (or the isset/unset variants) instead of throwing — hence the version gate. The boundary is PHP 8.0.0 per the [engine warnings RFC](https://wiki.php.net/rfc/engine_warnings) and the [PHP 8.0 UPGRADING notes](https://github.com/php/php-src/blob/PHP-8.0/UPGRADING).

## Test expectation updates

Four existing `assertVariableCertainty` expectations relied on the previously unmodeled throw and change from `Yes` to `Maybe` — each is the correct consequence of the new throw points, because the helper `doesntThrow()` returns `mixed` (an array or object key would throw at runtime):

- `tests/PHPStan/Analyser/nsrt/throw-points/assign.php`: `$foo[doesntThrow()] = 0;` and `[$foo[doesntThrow()]] = 1;`
- `tests/PHPStan/Analyser/nsrt/throw-points/assign-op.php`: `$foo[doesntThrow()] .= 0;`
- `tests/PHPStan/Analyser/nsrt/throw-points/array-dim-fetch.php`: `[][doesntThrow()];` (read side)

New regression test `testBug6970` contains the original issue reproducer plus minimal cases for each context (write, compound assign, read, `??`, `isset`, `unset`, string offset read/write), with `int`-keyed and `$arr[] =` counterparts asserting the dead catch is still reported when the offset is provably legal.

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Fable 5.
