### PR TITLE
Infer array_reduce() callback parameter types from the initial and array arguments

### DIFF
--- a/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
+++ b/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
@@ -21,16 +21,19 @@ use PHPStan\Node\ExecutionEndNode;
 use PHPStan\Node\InvalidateExprNode;
 use PHPStan\Node\PropertyAssignNode;
 use PHPStan\Parser\ArrayMapArgVisitor;
+use PHPStan\Parser\ArrayReduceArgVisitor;
 use PHPStan\Parser\ImmediatelyInvokedClosureVisitor;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
 use PHPStan\Reflection\Callables\SimpleThrowPoint;
 use PHPStan\Reflection\ExtendedParameterReflection;
 use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\PassedByReference;
 use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ClosureType;
+use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
@@ -38,6 +41,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NonAcceptingNeverType;
 use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VoidType;
 use function array_key_exists;
@@ -100,7 +104,9 @@ final class ClosureTypeResolver
 		$callableParameters = null;
 		$nativeCallableParameters = null;
 		$arrayMapArgs = $expr->getAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME);
+		$arrayReduceArgs = $expr->getAttribute(ArrayReduceArgVisitor::ATTRIBUTE_NAME);
 		$immediatelyInvokedArgs = $expr->getAttribute(ImmediatelyInvokedClosureVisitor::ARGS_ATTRIBUTE_NAME);
+		$arrayReducePass = null;
 		if ($arrayMapArgs !== null) {
 			$callableParameters = [];
 			$nativeCallableParameters = [];
@@ -108,59 +114,75 @@ final class ClosureTypeResolver
 				$callableParameters[] = new DummyParameter('item', $scope->getType($funcCallArg->value)->getIterableValueType(), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 				$nativeCallableParameters[] = new DummyParameter('item', $scope->getNativeType($funcCallArg->value)->getIterableValueType(), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 			}
+		} elseif ($arrayReduceArgs !== null) {
+			[$reduceArrayArg, $reduceInitialArg] = $arrayReduceArgs;
+			$reduceInitialType = $reduceInitialArg !== null ? $scope->getType($reduceInitialArg->value) : new NullType();
+			$callableParameters = [
+				new DummyParameter('carry', $reduceInitialType, optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+				new DummyParameter('item', $scope->getType($reduceArrayArg->value)->getIterableValueType(), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+			];
+			$nativeCallableParameters = [
+				new DummyParameter('carry', new MixedType(), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+				new DummyParameter('item', $scope->getNativeType($reduceArrayArg->value)->getIterableValueType(), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+			];
+			$arrayReducePass = 1;
 		} elseif ($immediatelyInvokedArgs !== null) {
 			foreach ($immediatelyInvokedArgs as $immediatelyInvokedArg) {
 				$callableParameters[] = new DummyParameter('item', $scope->getType($immediatelyInvokedArg->value), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 				$nativeCallableParameters[] = new DummyParameter('item', $scope->getNativeType($immediatelyInvokedArg->value), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 			}
 		} else {
-			$inFunctionCallsStackCount = count($scope->inFunctionCallsStack);
-			if ($inFunctionCallsStackCount > 0) {
-				[, $inParameter] = $scope->inFunctionCallsStack[$inFunctionCallsStackCount - 1];
-				if ($inParameter !== null) {
-					$callableParameters = $this->nodeScopeResolver->createCallableParameters($scope, $expr, null, $inParameter->getType());
-					$nativeType = $inParameter instanceof ExtendedParameterReflection ? $inParameter->getNativeType() : $inParameter->getType();
-					$nativeCallableParameters = $this->nodeScopeResolver->createNativeCallableParameters($scope, $expr, null, $nativeType);
-				}
-			}
+			[$callableParameters, $nativeCallableParameters] = $this->getCallableParametersFromCallStack($scope, $expr);
 		}
 
 		if ($expr instanceof ArrowFunction) {
-			$arrowScope = $scope->enterArrowFunctionWithoutReflection($expr, $callableParameters, $nativeCallableParameters);
+			while (true) {
+				$arrowScope = $scope->enterArrowFunctionWithoutReflection($expr, $callableParameters, $nativeCallableParameters);
 
-			if ($expr->expr instanceof Yield_ || $expr->expr instanceof YieldFrom) {
-				$yieldNode = $expr->expr;
+				if ($expr->expr instanceof Yield_ || $expr->expr instanceof YieldFrom) {
+					$yieldNode = $expr->expr;
 
-				if ($yieldNode instanceof Yield_) {
-					if ($yieldNode->key === null) {
-						$keyType = new IntegerType();
+					if ($yieldNode instanceof Yield_) {
+						if ($yieldNode->key === null) {
+							$keyType = new IntegerType();
+						} else {
+							$keyType = $arrowScope->getType($yieldNode->key);
+						}
+
+						if ($yieldNode->value === null) {
+							$valueType = new NullType();
+						} else {
+							$valueType = $arrowScope->getType($yieldNode->value);
+						}
 					} else {
-						$keyType = $arrowScope->getType($yieldNode->key);
+						$yieldFromType = $arrowScope->getType($yieldNode->expr);
+						$keyType = $arrowScope->getIterableKeyType($yieldFromType);
+						$valueType = $arrowScope->getIterableValueType($yieldFromType);
 					}
 
-					if ($yieldNode->value === null) {
-						$valueType = new NullType();
-					} else {
-						$valueType = $arrowScope->getType($yieldNode->value);
-					}
+					$returnType = new GenericObjectType(Generator::class, [
+						$keyType,
+						$valueType,
+						new MixedType(),
+						new VoidType(),
+					]);
 				} else {
-					$yieldFromType = $arrowScope->getType($yieldNode->expr);
-					$keyType = $arrowScope->getIterableKeyType($yieldFromType);
-					$valueType = $arrowScope->getIterableValueType($yieldFromType);
+					$returnType = $arrowScope->getKeepVoidType($expr->expr);
+					if ($expr->returnType !== null) {
+						$nativeReturnType = $scope->getFunctionType($expr->returnType, false, false);
+						$returnType = MutatingScope::intersectButNotNever($nativeReturnType, $returnType);
+					}
 				}
 
-				$returnType = new GenericObjectType(Generator::class, [
-					$keyType,
-					$valueType,
-					new MixedType(),
-					new VoidType(),
-				]);
-			} else {
-				$returnType = $arrowScope->getKeepVoidType($expr->expr);
-				if ($expr->returnType !== null) {
-					$nativeReturnType = $scope->getFunctionType($expr->returnType, false, false);
-					$returnType = MutatingScope::intersectButNotNever($nativeReturnType, $returnType);
+				if ($arrayReducePass !== null && $callableParameters !== null) {
+					$nextPassParameters = $this->getNextArrayReducePassParameters($scope, $expr, $arrayReducePass, $callableParameters, $nativeCallableParameters, $returnType);
+					if ($nextPassParameters !== null) {
+						[$callableParameters, $nativeCallableParameters, $arrayReducePass] = $nextPassParameters;
+						continue;
+					}
 				}
+
+				break;
 			}
 
 			$arrowFunctionImpurePoints = [];
@@ -239,145 +261,157 @@ final class ClosureTypeResolver
 				);
 			}
 
-			self::$resolveClosureTypeDepth++;
+			while (true) {
+				self::$resolveClosureTypeDepth++;
 
-			$closureScope = $scope->enterAnonymousFunctionWithoutReflection($expr, $callableParameters, $nativeCallableParameters);
-			$closureReturnStatements = [];
-			$closureYieldStatements = [];
-			$onlyNeverExecutionEnds = null;
-			$closureImpurePoints = [];
-			$invalidateExpressions = [];
+				$closureScope = $scope->enterAnonymousFunctionWithoutReflection($expr, $callableParameters, $nativeCallableParameters);
+				$closureReturnStatements = [];
+				$closureYieldStatements = [];
+				$onlyNeverExecutionEnds = null;
+				$closureImpurePoints = [];
+				$invalidateExpressions = [];
 
-			try {
-				$closureStatementResult = $this->nodeScopeResolver->processStmtNodes($expr, $expr->stmts, $closureScope, static function (Node $node, Scope $scope) use ($closureScope, &$closureReturnStatements, &$closureYieldStatements, &$onlyNeverExecutionEnds, &$closureImpurePoints, &$invalidateExpressions): void {
-					if ($scope->getAnonymousFunctionReflection() !== $closureScope->getAnonymousFunctionReflection()) {
-						return;
-					}
+				try {
+					$closureStatementResult = $this->nodeScopeResolver->processStmtNodes($expr, $expr->stmts, $closureScope, static function (Node $node, Scope $scope) use ($closureScope, &$closureReturnStatements, &$closureYieldStatements, &$onlyNeverExecutionEnds, &$closureImpurePoints, &$invalidateExpressions): void {
+						if ($scope->getAnonymousFunctionReflection() !== $closureScope->getAnonymousFunctionReflection()) {
+							return;
+						}
 
-					if ($node instanceof InvalidateExprNode) {
-						$invalidateExpressions[] = $node;
-						return;
-					}
+						if ($node instanceof InvalidateExprNode) {
+							$invalidateExpressions[] = $node;
+							return;
+						}
 
-					if ($node instanceof PropertyAssignNode) {
-						$closureImpurePoints[] = new ImpurePoint(
-							$scope,
-							$node,
-							'propertyAssign',
-							'property assignment',
-							true,
-						);
-						$invalidateExpressions[] = new InvalidateExprNode($node->getPropertyFetch());
-						return;
-					}
+						if ($node instanceof PropertyAssignNode) {
+							$closureImpurePoints[] = new ImpurePoint(
+								$scope,
+								$node,
+								'propertyAssign',
+								'property assignment',
+								true,
+							);
+							$invalidateExpressions[] = new InvalidateExprNode($node->getPropertyFetch());
+							return;
+						}
 
-					if ($node instanceof ExecutionEndNode) {
-						if ($node->getStatementResult()->isAlwaysTerminating()) {
-							foreach ($node->getStatementResult()->getExitPoints() as $exitPoint) {
-								if ($exitPoint->getStatement() instanceof Node\Stmt\Return_) {
-									$onlyNeverExecutionEnds = false;
-									continue;
+						if ($node instanceof ExecutionEndNode) {
+							if ($node->getStatementResult()->isAlwaysTerminating()) {
+								foreach ($node->getStatementResult()->getExitPoints() as $exitPoint) {
+									if ($exitPoint->getStatement() instanceof Node\Stmt\Return_) {
+										$onlyNeverExecutionEnds = false;
+										continue;
+									}
+
+									if ($onlyNeverExecutionEnds === null) {
+										$onlyNeverExecutionEnds = true;
+									}
+
+									break;
 								}
 
-								if ($onlyNeverExecutionEnds === null) {
-									$onlyNeverExecutionEnds = true;
+								if (count($node->getStatementResult()->getExitPoints()) === 0) {
+									if ($onlyNeverExecutionEnds === null) {
+										$onlyNeverExecutionEnds = true;
+									}
 								}
-
-								break;
+							} else {
+								$onlyNeverExecutionEnds = false;
 							}
 
-							if (count($node->getStatementResult()->getExitPoints()) === 0) {
-								if ($onlyNeverExecutionEnds === null) {
-									$onlyNeverExecutionEnds = true;
-								}
-							}
-						} else {
-							$onlyNeverExecutionEnds = false;
+							return;
 						}
 
-						return;
-					}
-
-					if ($node instanceof Node\Stmt\Return_) {
-						$closureReturnStatements[] = [$node, $scope];
-					}
-
-					if (!$node instanceof Yield_ && !$node instanceof YieldFrom) {
-						return;
-					}
-
-					$closureYieldStatements[] = [$node, $scope];
-				}, StatementContext::createTopLevel());
-			} finally {
-				self::$resolveClosureTypeDepth--;
-			}
-
-			$throwPoints = $closureStatementResult->getThrowPoints();
-			$impurePoints = array_merge($closureImpurePoints, $closureStatementResult->getImpurePoints());
-
-			$returnTypes = [];
-			$hasNull = false;
-			foreach ($closureReturnStatements as [$returnNode, $returnScope]) {
-				if ($returnNode->expr === null) {
-					$hasNull = true;
-					continue;
-				}
-
-				$returnTypes[] = $returnScope->toMutatingScope()->getType($returnNode->expr);
-			}
-
-			if (count($returnTypes) === 0) {
-				if ($onlyNeverExecutionEnds === true && !$hasNull) {
-					$returnType = new NonAcceptingNeverType();
-				} else {
-					$returnType = new VoidType();
-				}
-			} else {
-				if ($onlyNeverExecutionEnds === true) {
-					$returnTypes[] = new NonAcceptingNeverType();
-				}
-				if ($hasNull) {
-					$returnTypes[] = new NullType();
-				}
-				$returnType = TypeCombinator::union(...$returnTypes);
-			}
-
-			if (count($closureYieldStatements) > 0) {
-				$keyTypes = [];
-				$valueTypes = [];
-				foreach ($closureYieldStatements as [$yieldNode, $yieldScope]) {
-					if ($yieldNode instanceof Yield_) {
-						if ($yieldNode->key === null) {
-							$keyTypes[] = new IntegerType();
-						} else {
-							$keyTypes[] = $yieldScope->toMutatingScope()->getType($yieldNode->key);
+						if ($node instanceof Node\Stmt\Return_) {
+							$closureReturnStatements[] = [$node, $scope];
 						}
 
-						if ($yieldNode->value === null) {
-							$valueTypes[] = new NullType();
-						} else {
-							$valueTypes[] = $yieldScope->toMutatingScope()->getType($yieldNode->value);
+						if (!$node instanceof Yield_ && !$node instanceof YieldFrom) {
+							return;
 						}
 
+						$closureYieldStatements[] = [$node, $scope];
+					}, StatementContext::createTopLevel());
+				} finally {
+					self::$resolveClosureTypeDepth--;
+				}
+
+				$throwPoints = $closureStatementResult->getThrowPoints();
+				$impurePoints = array_merge($closureImpurePoints, $closureStatementResult->getImpurePoints());
+
+				$returnTypes = [];
+				$hasNull = false;
+				foreach ($closureReturnStatements as [$returnNode, $returnScope]) {
+					if ($returnNode->expr === null) {
+						$hasNull = true;
 						continue;
 					}
 
-					$yieldFromType = $yieldScope->toMutatingScope()->getType($yieldNode->expr);
-					$keyTypes[] = $yieldScope->toMutatingScope()->getIterableKeyType($yieldFromType);
-					$valueTypes[] = $yieldScope->toMutatingScope()->getIterableValueType($yieldFromType);
+					$returnTypes[] = $returnScope->toMutatingScope()->getType($returnNode->expr);
 				}
 
-				$returnType = new GenericObjectType(Generator::class, [
-					TypeCombinator::union(...$keyTypes),
-					TypeCombinator::union(...$valueTypes),
-					new MixedType(),
-					$returnType,
-				]);
-			} else {
-				if ($expr->returnType !== null) {
-					$nativeReturnType = $scope->getFunctionType($expr->returnType, false, false);
-					$returnType = MutatingScope::intersectButNotNever($nativeReturnType, $returnType);
+				if (count($returnTypes) === 0) {
+					if ($onlyNeverExecutionEnds === true && !$hasNull) {
+						$returnType = new NonAcceptingNeverType();
+					} else {
+						$returnType = new VoidType();
+					}
+				} else {
+					if ($onlyNeverExecutionEnds === true) {
+						$returnTypes[] = new NonAcceptingNeverType();
+					}
+					if ($hasNull) {
+						$returnTypes[] = new NullType();
+					}
+					$returnType = TypeCombinator::union(...$returnTypes);
 				}
+
+				if (count($closureYieldStatements) > 0) {
+					$keyTypes = [];
+					$valueTypes = [];
+					foreach ($closureYieldStatements as [$yieldNode, $yieldScope]) {
+						if ($yieldNode instanceof Yield_) {
+							if ($yieldNode->key === null) {
+								$keyTypes[] = new IntegerType();
+							} else {
+								$keyTypes[] = $yieldScope->toMutatingScope()->getType($yieldNode->key);
+							}
+
+							if ($yieldNode->value === null) {
+								$valueTypes[] = new NullType();
+							} else {
+								$valueTypes[] = $yieldScope->toMutatingScope()->getType($yieldNode->value);
+							}
+
+							continue;
+						}
+
+						$yieldFromType = $yieldScope->toMutatingScope()->getType($yieldNode->expr);
+						$keyTypes[] = $yieldScope->toMutatingScope()->getIterableKeyType($yieldFromType);
+						$valueTypes[] = $yieldScope->toMutatingScope()->getIterableValueType($yieldFromType);
+					}
+
+					$returnType = new GenericObjectType(Generator::class, [
+						TypeCombinator::union(...$keyTypes),
+						TypeCombinator::union(...$valueTypes),
+						new MixedType(),
+						$returnType,
+					]);
+				} else {
+					if ($expr->returnType !== null) {
+						$nativeReturnType = $scope->getFunctionType($expr->returnType, false, false);
+						$returnType = MutatingScope::intersectButNotNever($nativeReturnType, $returnType);
+					}
+				}
+
+				if ($arrayReducePass !== null && $callableParameters !== null) {
+					$nextPassParameters = $this->getNextArrayReducePassParameters($scope, $expr, $arrayReducePass, $callableParameters, $nativeCallableParameters, $returnType);
+					if ($nextPassParameters !== null) {
+						[$callableParameters, $nativeCallableParameters, $arrayReducePass] = $nextPassParameters;
+						continue;
+					}
+				}
+
+				break;
 			}
 
 			$usedVariables = [];
@@ -457,6 +491,88 @@ final class ClosureTypeResolver
 			mustUseReturnValue: $mustUseReturnValue,
 			isStatic: TrinaryLogic::createFromBoolean($expr->static),
 		);
+	}
+
+	/**
+	 * @return array{ParameterReflection[]|null, ParameterReflection[]|null}
+	 */
+	private function getCallableParametersFromCallStack(
+		MutatingScope $scope,
+		Node\Expr\Closure|ArrowFunction $expr,
+	): array
+	{
+		$callableParameters = null;
+		$nativeCallableParameters = null;
+		$inFunctionCallsStackCount = count($scope->inFunctionCallsStack);
+		if ($inFunctionCallsStackCount > 0) {
+			[, $inParameter] = $scope->inFunctionCallsStack[$inFunctionCallsStackCount - 1];
+			if ($inParameter !== null) {
+				$callableParameters = $this->nodeScopeResolver->createCallableParameters($scope, $expr, null, $inParameter->getType());
+				$nativeType = $inParameter instanceof ExtendedParameterReflection ? $inParameter->getNativeType() : $inParameter->getType();
+				$nativeCallableParameters = $this->nodeScopeResolver->createNativeCallableParameters($scope, $expr, null, $nativeType);
+			}
+		}
+
+		return [$callableParameters, $nativeCallableParameters];
+	}
+
+	/**
+	 * Decides whether the body of an array_reduce() callback needs to be analysed again.
+	 *
+	 * The first pass types $carry as the initial argument. When the callback's return
+	 * type escapes it, the carry type is widened and verified in a second pass. When
+	 * even the widened type is not a fixed point, the callback is analysed once more
+	 * with the parameter types it would have without this inference.
+	 *
+	 * @param ParameterReflection[] $callableParameters
+	 * @param ParameterReflection[]|null $nativeCallableParameters
+	 * @return array{ParameterReflection[]|null, ParameterReflection[]|null, int}|null parameters and pass number for the next pass, or null when no more passes are needed
+	 */
+	private function getNextArrayReducePassParameters(
+		MutatingScope $scope,
+		Node\Expr\Closure|ArrowFunction $expr,
+		int $pass,
+		array $callableParameters,
+		?array $nativeCallableParameters,
+		Type $returnType,
+	): ?array
+	{
+		if ($pass >= 3 || !isset($callableParameters[0])) {
+			return null;
+		}
+
+		$carryType = $callableParameters[0]->getType();
+		if ($carryType->isSuperTypeOf($returnType)->yes()) {
+			return null;
+		}
+
+		if ($pass === 1) {
+			$callableParameters[0] = new DummyParameter('carry', self::widenArrayReduceCarryType($carryType, $returnType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
+
+			return [$callableParameters, $nativeCallableParameters, 2];
+		}
+
+		// the widened carry type is not a fixed point - fall back to the naive behaviour
+		[$callableParameters, $nativeCallableParameters] = $this->getCallableParametersFromCallStack($scope, $expr);
+
+		return [$callableParameters, $nativeCallableParameters, 3];
+	}
+
+	/** Widens while preserving constant array shapes so that the second pass can converge. */
+	private static function widenArrayReduceCarryType(Type $initialType, Type $returnType): Type
+	{
+		$union = TypeCombinator::union($initialType, $returnType);
+		$constantArrays = $union->getConstantArrays();
+		if (count($constantArrays) > 0) {
+			$generalized = [];
+			foreach ($constantArrays as $constantArray) {
+				$generalized[] = $constantArray->generalizeValues();
+			}
+
+			return TypeCombinator::union(...$generalized);
+		}
+
+		return $union->generalize(GeneralizePrecision::lessSpecific());
 	}
 
 }

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -40,6 +40,7 @@ use PHPStan\Node\IssetExpr;
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Node\VirtualNode;
 use PHPStan\Parser\ArrayMapArgVisitor;
+use PHPStan\Parser\ArrayReduceArgVisitor;
 use PHPStan\Parser\Parser;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Php\PhpVersionFactory;
@@ -979,11 +980,14 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		$attributes = $node->getAttributes();
 		if (
 			$node instanceof Node\FunctionLike
-			&& (($attributes[ArrayMapArgVisitor::ATTRIBUTE_NAME] ?? null) !== null)
+			&& (
+				(($attributes[ArrayMapArgVisitor::ATTRIBUTE_NAME] ?? null) !== null)
+				|| (($attributes[ArrayReduceArgVisitor::ATTRIBUTE_NAME] ?? null) !== null)
+			)
 			&& (($attributes['startFilePos'] ?? null) !== null)
 		) {
 			$key .= '/*' . $attributes['startFilePos'];
-			foreach ($attributes[ArrayMapArgVisitor::ATTRIBUTE_NAME] as $arg) {
+			foreach ($attributes[ArrayMapArgVisitor::ATTRIBUTE_NAME] ?? [] as $arg) {
 				$key .= ':' . $this->exprPrinter->printExpr($arg->value);
 			}
 			$key .= '*/';

--- a/src/Parser/ArrayReduceArgVisitor.php
+++ b/src/Parser/ArrayReduceArgVisitor.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parser;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\DependencyInjection\AutowiredService;
+
+#[AutowiredService]
+final class ArrayReduceArgVisitor extends NodeVisitorAbstract
+{
+
+	public const ATTRIBUTE_NAME = 'arrayReduceArgs';
+
+	#[Override]
+	public function enterNode(Node $node): ?Node
+	{
+		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name && !$node->isFirstClassCallable()) {
+			$functionName = $node->name->toLowerString();
+			if ($functionName === 'array_reduce') {
+				$arrayArg = null;
+				$callbackArg = null;
+				$initialArg = null;
+				foreach ($node->getArgs() as $i => $arg) {
+					if ($arg->unpack) {
+						return null;
+					}
+					$name = $arg->name !== null ? $arg->name->toString() : null;
+					if ($name === 'array' || ($name === null && $i === 0)) {
+						$arrayArg = $arg;
+					} elseif ($name === 'callback' || ($name === null && $i === 1)) {
+						$callbackArg = $arg;
+					} elseif ($name === 'initial' || ($name === null && $i === 2)) {
+						$initialArg = $arg;
+					}
+				}
+				if ($arrayArg !== null && $callbackArg !== null) {
+					$callbackArg->value->setAttribute(self::ATTRIBUTE_NAME, [$arrayArg, $initialArg]);
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -11,6 +11,7 @@ use PHPStan\Node\Expr\ParameterVariableOriginalValueExpr;
 use PHPStan\Parser\ArrayFilterArgVisitor;
 use PHPStan\Parser\ArrayFindArgVisitor;
 use PHPStan\Parser\ArrayMapArgVisitor;
+use PHPStan\Parser\ArrayReduceArgVisitor;
 use PHPStan\Parser\ArrayWalkArgVisitor;
 use PHPStan\Parser\ClosureBindArgVisitor;
 use PHPStan\Parser\ClosureBindToVarVisitor;
@@ -130,6 +131,41 @@ final class ParametersAcceptorSelector
 					$parameters[0] = self::overrideParameterType($parameters[0], $callableType, $nativeCallableType);
 					$parametersAcceptors = [self::overrideAcceptorParameters($acceptor, $parameters)];
 				}
+			}
+
+			foreach ($args as $arg) {
+				$arrayReduceArgs = $arg->value->getAttribute(ArrayReduceArgVisitor::ATTRIBUTE_NAME);
+				if ($arrayReduceArgs === null) {
+					continue;
+				}
+				if (!$arg->value instanceof Node\Expr\Closure && !$arg->value instanceof Node\Expr\ArrowFunction) {
+					break;
+				}
+
+				$acceptor = $parametersAcceptors[0];
+				$parameters = $acceptor->getParameters();
+				if (!isset($parameters[1]) || !$parameters[1]->getType()->isCallable()->yes()) {
+					// the acceptor belongs to the callback itself, not to array_reduce()
+					break;
+				}
+
+				$callbackParameterAcceptors = $parameters[1]->getType()->getCallableParametersAcceptors($scope);
+				$callbackAcceptors = $scope->getType($arg->value)->getCallableParametersAcceptors($scope);
+				if (count($callbackParameterAcceptors) !== 1 || count($callbackAcceptors) !== 1) {
+					break;
+				}
+
+				[$arrayArg, $initialArg] = $arrayReduceArgs;
+				$initialType = $initialArg !== null ? $scope->getType($initialArg->value) : new NullType();
+				$carryType = TypeCombinator::union($initialType, $callbackAcceptors[0]->getReturnType());
+				$itemType = $scope->getIterableValueType($scope->getType($arrayArg->value));
+				$callableType = new CallableType([
+					new DummyParameter('carry', $carryType, optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+					new DummyParameter('item', $itemType, optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+				], $callbackParameterAcceptors[0]->getReturnType(), false);
+				$parameters[1] = self::overrideParameterType($parameters[1], $callableType, $callableType);
+				$parametersAcceptors = [self::overrideAcceptorParameters($acceptor, $parameters)];
+				break;
 			}
 
 			if (count($args) >= 3 && (bool) $args[0]->getAttribute(CurlSetOptArgVisitor::ATTRIBUTE_NAME)) {

--- a/tests/PHPStan/Analyser/nsrt/bug-7280.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7280.php
@@ -1,0 +1,116 @@
+<?php // lint >= 8.1
+
+namespace Bug7280;
+
+use function PHPStan\Testing\assertType;
+
+function namedArguments(): void
+{
+	$result = array_reduce(
+		['test1', 'test2'],
+		static function (array $carry, string $value): array{
+			assertType('array{starts: array{}, ends: array{}}|array{starts: non-empty-list<string>, ends: non-empty-list<string>}', $carry);
+			$carry['starts'][] = $value;
+			$carry['ends'][] = $value;
+
+			return $carry;
+		},
+		initial: ['starts' => [], 'ends' => []],
+	);
+	assertType('array{starts: non-empty-list<string>, ends: non-empty-list<string>}', $result);
+}
+
+function positionalArguments(): void
+{
+	$result = array_reduce(
+		['test1', 'test2'],
+		static function (array $carry, string $value): array{
+			assertType('array{starts: array{}, ends: array{}}|array{starts: non-empty-list<string>, ends: non-empty-list<string>}', $carry);
+			$carry['starts'][] = $value;
+			$carry['ends'][] = $value;
+
+			return $carry;
+		},
+		['starts' => [], 'ends' => []],
+	);
+	assertType('array{starts: non-empty-list<string>, ends: non-empty-list<string>}', $result);
+}
+
+function reducer(?int $carry, int $item): int
+{
+	return ($carry ?? 0) + $item;
+}
+
+/**
+ * @param list<int> $integers
+ */
+function firstClassCallable(array $integers): void
+{
+	$result = array_reduce($integers, reducer(...), 0);
+	assertType('int', $result);
+}
+
+/**
+ * @param int[] $integers
+ */
+function nonConvergingCallback(array $integers): void
+{
+	// the carry type never reaches a fixed point here - the naive behaviour is kept
+	$result = array_reduce($integers, function ($carry, $value) {
+		assertType('array{}|array{x: mixed}', $carry);
+
+		return ['x' => $carry];
+	}, []);
+	assertType('array{}|array{x: mixed}', $result);
+
+	$result2 = array_reduce($integers, fn ($carry, $value) => ['x' => $carry], []);
+	assertType('array{}|array{x: mixed}', $result2);
+}
+
+/**
+ * @param array<string> $strings
+ */
+function arrowFunction(array $strings): void
+{
+	$result = array_reduce($strings, fn (int $carry, string $value): int => $carry + strlen($value), 0);
+	assertType('int', $result);
+}
+
+/**
+ * @param int[] $integers
+ */
+function intSum(array $integers): void
+{
+	$sum = array_reduce($integers, function ($carry, $n) {
+		assertType('int', $carry);
+
+		return $carry + $n;
+	}, 0);
+	assertType('int', $sum);
+}
+
+/**
+ * @param array<string> $strings
+ */
+function stringConcat(array $strings): void
+{
+	$concatenated = array_reduce($strings, function (string $carry, string $string): string {
+		assertType('string', $carry);
+
+		return $carry . $string;
+	}, '');
+	assertType('string', $concatenated);
+}
+
+/**
+ * @param array<string> $strings
+ */
+function withoutInitial(array $strings): void
+{
+	$concatenated = array_reduce($strings, function ($carry, string $string) {
+		assertType('string|null', $carry);
+
+		return ($carry ?? '') . $string;
+	});
+	assertType('string|null', $concatenated);
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -11,7 +11,6 @@ use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
-use function getenv;
 use function sprintf;
 use const PHP_VERSION_ID;
 
@@ -643,12 +642,12 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				5,
 			],
 			[
-				sprintf('Parameter #2 $callback of function array_reduce expects callable(%1$s|null, 1|2|3): (%1$s|null), Closure(string, int): non-falsy-string given.', getenv('PHPSTAN_FNSR') !== '0' && PHP_VERSION_ID >= 80100 ? 'non-falsy-string' : 'non-empty-string'),
+				'Parameter #2 $callback of function array_reduce expects callable(non-falsy-string|null, 1|2|3): (non-falsy-string|null), Closure(string, int): non-falsy-string given.',
 				13,
 				'Type string of parameter #1 $foo of passed callable needs to be same or wider than parameter type string|null of accepting callable.',
 			],
 			[
-				sprintf('Parameter #2 $callback of function array_reduce expects callable(%1$s|null, 1|2|3): (%1$s|null), Closure(string, int): non-falsy-string given.', getenv('PHPSTAN_FNSR') !== '0' && PHP_VERSION_ID >= 80100 ? 'non-falsy-string' : 'non-empty-string'),
+				'Parameter #2 $callback of function array_reduce expects callable(non-falsy-string|null, 1|2|3): (non-falsy-string|null), Closure(string, int): non-falsy-string given.',
 				22,
 				'Type string of parameter #1 $foo of passed callable needs to be same or wider than parameter type string|null of accepting callable.',
 			],
@@ -663,12 +662,12 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				5,
 			],
 			[
-				sprintf('Parameter #2 $callback of function array_reduce expects callable(%1$s|null, 1|2|3): (%1$s|null), Closure(string, int): non-falsy-string given.', getenv('PHPSTAN_FNSR') !== '0' && PHP_VERSION_ID >= 80100 ? 'non-falsy-string' : 'non-empty-string'),
+				'Parameter #2 $callback of function array_reduce expects callable(non-falsy-string|null, 1|2|3): (non-falsy-string|null), Closure(string, int): non-falsy-string given.',
 				11,
 				'Type string of parameter #1 $foo of passed callable needs to be same or wider than parameter type string|null of accepting callable.',
 			],
 			[
-				sprintf('Parameter #2 $callback of function array_reduce expects callable(%1$s|null, 1|2|3): (%1$s|null), Closure(string, int): non-falsy-string given.', getenv('PHPSTAN_FNSR') !== '0' && PHP_VERSION_ID >= 80100 ? 'non-falsy-string' : 'non-empty-string'),
+				'Parameter #2 $callback of function array_reduce expects callable(non-falsy-string|null, 1|2|3): (non-falsy-string|null), Closure(string, int): non-falsy-string given.',
 				18,
 				'Type string of parameter #1 $foo of passed callable needs to be same or wider than parameter type string|null of accepting callable.',
 			],


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7280

## Description

Inside an `array_reduce()` callback, `$carry` was typed from the naive closure analysis (`non-empty-array` in the linked issue) instead of from the `$initial` argument, and the call's result type was correspondingly imprecise.

## Root cause

`array_reduce()`'s callback parameter type is recursive — `stubs/arrayFunctions.stub` types it `callable(TReturn, TIn): TReturn` — and PHPStan has no fixed-point machinery to resolve it:

- `ParametersAcceptorSelector::selectFromArgs()` types the closure argument naively via `ClosureTypeResolver::getClosureType()`, using only the declared parameter hints.
- `GenericParametersAcceptorResolver` then unions that polluted return type into `TReturn`, which `NodeScopeResolver` propagates into the callback body.
- `ArrayReduceFunctionReturnTypeExtension` reads the same garbage-in closure type for the call's result.

Unlike `array_map()`, there was no visitor connecting the callback to the other arguments of the call (`ArrayMapArgVisitor` is how `array_map()` callbacks get precise parameter types).

## Design

A new `ArrayReduceArgVisitor` attaches the array and initial arguments (positional or named — the issue's own reproducer uses `initial:`) to the callback expression, skipping first-class-callable `array_reduce(...)` and argument unpacking.

`ClosureTypeResolver::getClosureType()` then resolves the callback with a bounded fixed-point iteration, for both closures and arrow functions:

1. **Pass 1** analyses the body with `$carry` = type of `$initial` and `$item` = the array's iterable value type. If the resulting return type is a subtype of the carry type, the carry type is a fixed point and we are done.
2. Otherwise the carry type is **widened**: `union(initial, return)`, generalized shape-preservingly (`ConstantArrayType::generalizeValues()` when all union members are constant arrays, `generalize(GeneralizePrecision::lessSpecific())` otherwise), and **pass 2** re-analyses the body with the widened carry `W`.
3. The result is **verified**: only if `f(W) ⊆ W` is the widened type accepted. If even the widened type is not a fixed point (e.g. a nesting callback like `fn ($carry, $v) => ['x' => $carry]`, whose result grows without bound), the callback is analysed once more with the parameter types it would have had without this feature — i.e. **the current behaviour is kept verbatim**, instead of claiming an unsound shape.

`ParametersAcceptorSelector::selectFromArgs()` (mirroring its `array_map()` branch) overrides the callback parameter of `array_reduce()` to `callable(union(initial, callbackReturn), itemType): TReturn`, keeping the declared return type so existing rule messages don't change. This is what rules and the callback body see, so `$carry` inside the body becomes the union of the initial type and the callback's (fixed-point) return type. `MutatingScope::getNodeKey()` includes the new attribute in the expression cache key for the same reason `arrayMapArgs` is included — cached closure types must not leak between contexts.

`ArrayReduceFunctionReturnTypeExtension` is unchanged; it now simply reads a precise callback type.

For the issue's reproducer this infers:

```php
$carry  // array{starts: array{}, ends: array{}}|array{starts: non-empty-list<string>, ends: non-empty-list<string>}
$result // array{starts: non-empty-list<string>, ends: non-empty-list<string>}
```

## Prior art

#5168 attempted this with a `FunctionParameterClosureTypeExtension` and was closed unmerged after review: typing `$carry` as the initial type is only correct for the first iteration, and unioning with the *declared* return type destroyed precision. This PR answers that soundness objection differently: the carry type is `initial ∪ callbackReturn` (exactly the union the reviewers asked for), the callback return comes from a verified fixed point rather than from declared hints, and when no fixed point is reached the implementation falls back to today's behaviour entirely. The extension-only route also could not fix the *result* type, because the return type extension reads the naive closure type, which never consults parameter-closure-type extensions.

## Performance

`array_reduce()` callback bodies are now analysed up to two times inside `getClosureType()` (a third pass happens only for the rare non-converging callbacks, to restore the naive behaviour). Non-`array_reduce` paths through `ClosureTypeResolver` are untouched.

## Ecosystem note

Every `array_reduce()` user's carry/result types become more precise, so downstream projects may see new findings (e.g. the result of a summing reduce is now `int` instead of a benevolent `(array|float|int)`).

Existing expectations survive unchanged: the six `array_reduce` return types in `tests/PHPStan/Analyser/nsrt/array-functions.php`, the six `CallToFunctionParametersRule` messages (identical carry/item types), and `tests/PHPStan/Rules/Operators/data/bug-7280-comment.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Fable 5.
