### PR TITLE
Check class constant access through constant class-name strings and class-string unions

### DIFF
--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -12,6 +12,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Internal\SprintfHelper;
+use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\ClassNameCheck;
@@ -28,6 +29,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 use function array_merge;
+use function count;
 use function in_array;
 use function sprintf;
 use function strtolower;
@@ -198,9 +200,28 @@ final class ClassConstantRule implements Rule
 				return $messages;
 			}
 		} else {
+			$exprToCheck = NullsafeOperatorHelper::getNullsafeShortcircuitedExprRespectingScope($scope, $class);
+			if (strtolower($constantName) !== 'class') {
+				$exprType = $scope->getType($exprToCheck);
+				if ($exprType->isClassString()->yes() && !$exprType->hasConstant($constantName)->yes()) {
+					// A constant class-name string or a class-string type describes the
+					// object it names, so route the check through that object type. This
+					// makes constant-string / class-string unions behave exactly like
+					// object unions with regard to rule levels (member filtering when
+					// checkUnionTypes is off, whole-union check when it is on).
+					// The ::class pseudo-constant is excluded above because
+					// $string::class is a runtime TypeError, handled below as a string.
+					$objectType = $exprType->getClassStringObjectType();
+					if (count($objectType->getObjectClassNames()) === 0) {
+						// plain class-string resolves to ObjectWithoutClassType, keep silent
+						return $messages;
+					}
+					$exprToCheck = new TypeExpr($objectType);
+				}
+			}
 			$classTypeResult = $this->ruleLevelHelper->findTypeToCheck(
 				$scope,
-				NullsafeOperatorHelper::getNullsafeShortcircuitedExprRespectingScope($scope, $class),
+				$exprToCheck,
 				sprintf('Access to constant %s on an unknown class %%s.', SprintfHelper::escapeFormatString($constantName)),
 				static fn (Type $type): bool => $type->canAccessConstants()->yes() && $type->hasConstant($constantName)->yes(),
 			);

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -21,6 +21,8 @@ class ClassConstantRuleTest extends RuleTestCase
 
 	private int $phpVersion;
 
+	private bool $checkUnionTypes = true;
+
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
@@ -31,7 +33,7 @@ class ClassConstantRuleTest extends RuleTestCase
 				$reflectionProvider,
 				checkNullables: true,
 				checkThisOnly: false,
-				checkUnionTypes: true,
+				checkUnionTypes: $this->checkUnionTypes,
 				checkExplicitMixed: true,
 				checkImplicitMixed: true,
 				checkBenevolentUnionTypes: false,
@@ -563,6 +565,67 @@ class ClassConstantRuleTest extends RuleTestCase
 			[
 				'Class constant name for object must be a string, but mixed was given.',
 				39,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
+	public function testClassConstantAccessOnStringUnions(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/data/class-constant-string-unions.php'], [
+			[
+				'Access to undefined constant ClassConstantStringUnions\Baz::BAR.',
+				39,
+			],
+			[
+				'Access to undefined constant ClassConstantStringUnions\Baz|ClassConstantStringUnions\Foo::BAR.',
+				45,
+			],
+			[
+				'Access to undefined constant ClassConstantStringUnions\Baz|ClassConstantStringUnions\Foo::BAR.',
+				57,
+			],
+			[
+				'Access to undefined constant ClassConstantStringUnions\Baz|ClassConstantStringUnions\Foo::BAR.',
+				65,
+			],
+			[
+				'Access to undefined constant ClassConstantStringUnions\Baz::BAR.',
+				73,
+			],
+			[
+				'Accessing ::class constant on a dynamic string is not supported in PHP.',
+				87,
+			],
+			[
+				'Accessing ::class constant on a dynamic string is not supported in PHP.',
+				95,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
+	public function testClassConstantAccessOnStringUnionsWithoutCheckUnionTypes(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->checkUnionTypes = false;
+		$this->analyse([__DIR__ . '/data/class-constant-string-unions.php'], [
+			[
+				'Access to undefined constant ClassConstantStringUnions\Baz::BAR.',
+				39,
+			],
+			[
+				'Access to undefined constant ClassConstantStringUnions\Baz::BAR.',
+				73,
+			],
+			[
+				'Accessing ::class constant on a dynamic string is not supported in PHP.',
+				87,
+			],
+			[
+				'Accessing ::class constant on a dynamic string is not supported in PHP.',
+				95,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/data/class-constant-string-unions.php
+++ b/tests/PHPStan/Rules/Classes/data/class-constant-string-unions.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace ClassConstantStringUnions;
+
+class Foo
+{
+
+	const BAR = 1;
+
+}
+
+class Bar
+{
+
+	const BAR = 2;
+
+}
+
+class Baz
+{
+
+}
+
+enum SomeEnum: string
+{
+
+	case A = 'a';
+
+	const K = 1;
+
+}
+
+class Runner
+{
+
+	public function singleConstantString(): void
+	{
+		$class = Baz::class;
+		echo $class::BAR;
+	}
+
+	public function unionOfConstantStrings(bool $flag): void
+	{
+		$class = $flag ? Foo::class : Baz::class;
+		echo $class::BAR;
+	}
+
+	public function unionOfConstantStringsAllValid(bool $flag): void
+	{
+		$class = $flag ? Foo::class : Bar::class;
+		echo $class::BAR;
+	}
+
+	public function getClassUnion(Foo|Baz $object): void
+	{
+		$class = get_class($object);
+		echo $class::BAR;
+	}
+
+	/**
+	 * @param class-string<Foo>|class-string<Baz> $class
+	 */
+	public function genericClassStringUnion(string $class): void
+	{
+		echo $class::BAR;
+	}
+
+	/**
+	 * @param class-string<Baz> $class
+	 */
+	public function singleGenericClassString(string $class): void
+	{
+		echo $class::BAR;
+	}
+
+	/**
+	 * @param class-string $class
+	 */
+	public function plainClassString(string $class): void
+	{
+		echo $class::BAR;
+	}
+
+	public function classPseudoConstantOnConstantStringUnion(bool $flag): void
+	{
+		$class = $flag ? Foo::class : Baz::class;
+		echo $class::class;
+	}
+
+	/**
+	 * @param class-string<Foo> $class
+	 */
+	public function classPseudoConstantOnGenericClassString(string $class): void
+	{
+		echo $class::class;
+	}
+
+	public function enumCaseAccessThroughConstantString(): void
+	{
+		$class = SomeEnum::class;
+		echo $class::A->value;
+	}
+
+	/**
+	 * @param class-string<SomeEnum> $class
+	 */
+	public function enumCaseAccessThroughGenericClassString(string $class): void
+	{
+		echo $class::A->value;
+	}
+
+}


### PR DESCRIPTION
Follow-up to phpstan/phpstan-src#5976 (same root-cause family). `ClassConstantRule` had a legacy string bail-out that predates `Type::isClassString()` / `Type::getClassStringObjectType()`: for a `$classString::CONST` fetch where the class expression is a constant class-name string, a `class-string<T>`, or a union thereof, the rule silently returned once `$classType->isString()->yes()`, so a missing constant on one or all members went unreported.

## Fix

Mirrors the `TypeExpr` routing from #5976, adapted to class constants. Before calling `RuleLevelHelper::findTypeToCheck()`, a class-string-typed class expression is converted via `isClassString()->yes()` + `getClassStringObjectType()` and wrapped in `new TypeExpr($objectType)`. This makes constant-string / class-string unions behave exactly like object-typed unions with respect to rule levels — per-member filtering when `checkUnionTypes` is off, whole-union check when it is on.

- Plain `class-string` (resolving to `ObjectWithoutClassType`, i.e. `getObjectClassNames()` empty) stays silent, as in #5976.
- The conversion is guarded by `!$exprType->hasConstant($constantName)->yes()`, matching the template's `hasMethod` guard (cheap insurance so a class-string already known to carry the constant is not needlessly rerouted).

## `::class` handling

The `class` pseudo-constant is deliberately excluded from the conversion (`strtolower($constantName) !== 'class'`). `$string::class` is a runtime `TypeError` (`Cannot use "::class" on string`), unlike `$object::class`, and the rule already reports this as `classConstant.dynamicString`. Rerouting a class-string through its object type would suppress that error, so the pseudo-constant is left on the existing string code path. Pinning tests cover `$constantStringUnion::class` and `class-string<Foo>::class`, both of which keep emitting `classConstant.dynamicString`.

## Tests

New data file `class-constant-string-unions.php` mirrors #5976's matrix: single constant string, constant-string union with one member missing the constant, `get_class()` union, single `class-string<C>`, `class-string` union, plain `class-string` (silent), the two `::class` pinning cases, and enum-case access through both a constant string and a `class-string<Enum>`. Wired into `ClassConstantRuleTest` with `checkUnionTypes` on and off to pin level semantics, using the same flag-combination approach as the template.

If the maintainer prefers the alternative approach discussed in #5976's review, this PR will be reworked to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Fable 5.