### PR TITLE
Store the result cache in a framed serialize() format instead of a var_export'd PHP file

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -180,6 +180,22 @@ jobs:
               echo "$OUTPUT"
               ../bashunit -a contains 'Result cache restored.' "$OUTPUT"
           - script: |
+              cd e2e/result-cache-stale-objects
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan -vvv")
+              echo "$OUTPUT"
+              # Renaming a property inside the cache file is what a cache written by a PHPStan whose
+              # classes have changed since looks like: the payload does not carry the property the class
+              # now declares, so reconstructing the object leaves it uninitialized and reading it throws.
+              php rename-property.php
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan -vvv")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'could not be read back' "$OUTPUT"
+              ../bashunit -a contains 'Result cache is saved.' "$OUTPUT"
+              # The cache written in its place is usable again.
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan -vvv")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored.' "$OUTPUT"
+          - script: |
               cd e2e/bug-14514
               composer install
               ../../bin/phpstan analyze bug-14515.php

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -162,6 +162,24 @@ jobs:
               ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
               ../bashunit -a not_contains 'metadata do not match' "$OUTPUT"
           - script: |
+              cd e2e/result-cache-truncated
+              ../../bin/phpstan -vvv
+              # Cut inside the first section's payload: the cache is damaged, not merely stale, so
+              # it has to be discarded rather than read as far as it goes.
+              php truncate.php
+              OUTPUT=$(../../bin/phpstan -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'an error occurred while loading the cache file' "$OUTPUT"
+              ../bashunit -a contains 'Result cache is saved.' "$OUTPUT"
+              # And once more inside a section that is read lazily, which is a different code path.
+              php truncate-lazy.php
+              OUTPUT=$(../../bin/phpstan -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'is truncated at entry' "$OUTPUT"
+              OUTPUT=$(../../bin/phpstan -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored.' "$OUTPUT"
+          - script: |
               cd e2e/bug-14514
               composer install
               ../../bin/phpstan analyze bug-14515.php

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ e2e/bashunit
 /e2e/result-cache-atomic-save/tmp
 /e2e/result-cache-moved-tmpdir/tmp-a
 /e2e/result-cache-moved-tmpdir/tmp-b
+/e2e/result-cache-truncated/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ e2e/bashunit
 /e2e/result-cache-atomic-save/tmp
 /e2e/result-cache-moved-tmpdir/tmp-a
 /e2e/result-cache-moved-tmpdir/tmp-b
+/e2e/result-cache-stale-objects/tmp
 /e2e/result-cache-truncated/tmp

--- a/e2e/result-cache-stale-objects/phpstan.neon
+++ b/e2e/result-cache-stale-objects/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: 8
+	tmpDir: tmp
+	paths:
+		- src

--- a/e2e/result-cache-stale-objects/rename-property.php
+++ b/e2e/result-cache-stale-objects/rename-property.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+// A cache written by a PHPStan whose classes have changed since cannot be reconstructed: the payload
+// does not carry the property the class now declares, so the object comes back with it uninitialized
+// and reading it throws. Renaming one inside the cache file is that shape without needing two
+// PHPStan versions installed, and keeping the byte length identical leaves the rest of the payload
+// valid - the frame headers count bytes.
+$file = __DIR__ . '/tmp/resultCache.php';
+$contents = file_get_contents($file);
+if ($contents === false) {
+	throw new RuntimeException('No result cache at ' . $file);
+}
+
+// Error::$message, read by transformPaths() while the cached errors are absolutized.
+$property = "\0PHPStan\\Analyser\\Error\0message";
+if (substr_count($contents, $property) !== 1) {
+	throw new RuntimeException('Expected exactly one cached Error carrying that property.');
+}
+
+$renamed = substr($property, 0, -strlen('message')) . 'messagf';
+if (strlen($renamed) !== strlen($property)) {
+	throw new RuntimeException('The replacement has to keep the byte length.');
+}
+
+file_put_contents($file, str_replace($property, $renamed, $contents));

--- a/e2e/result-cache-stale-objects/src/Foo.php
+++ b/e2e/result-cache-stale-objects/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace ResultCacheE2EStaleObjects;
+
+class Foo
+{
+
+	public function doFoo(): int
+	{
+		return 'not an int';
+	}
+
+}

--- a/e2e/result-cache-stale-objects/tmp/.gitignore
+++ b/e2e/result-cache-stale-objects/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/e2e/result-cache-truncated/phpstan.neon
+++ b/e2e/result-cache-truncated/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: 8
+	tmpDir: tmp
+	paths:
+		- src

--- a/e2e/result-cache-truncated/src/Bar.php
+++ b/e2e/result-cache-truncated/src/Bar.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace TestResultCacheTruncated;
+
+class Bar
+{
+
+	public function doBar(): string
+	{
+		return 'bar';
+	}
+
+}

--- a/e2e/result-cache-truncated/src/Foo.php
+++ b/e2e/result-cache-truncated/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace TestResultCacheTruncated;
+
+class Foo
+{
+
+	public function doFoo(Bar $bar): string
+	{
+		return $bar->doBar();
+	}
+
+}

--- a/e2e/result-cache-truncated/truncate-lazy.php
+++ b/e2e/result-cache-truncated/truncate-lazy.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+// The same shape as truncate.php, but cutting far enough in to land inside one of the sections
+// restore() reads lazily. Those are walked rather than decoded when the cache is opened, and
+// fseek() past the end of a file succeeds, so only comparing the position with the file size
+// catches this - otherwise the section would be handed out as a callback pointing past the end.
+$file = __DIR__ . '/tmp/resultCache.php';
+$contents = file_get_contents($file);
+if ($contents === false) {
+	throw new RuntimeException('No result cache at ' . $file);
+}
+
+file_put_contents($file, substr($contents, 0, (int) (strlen($contents) * 0.9)));

--- a/e2e/result-cache-truncated/truncate.php
+++ b/e2e/result-cache-truncated/truncate.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+// A cache file that is this format but incomplete: a CI cache artifact that was archived or
+// restored half way, a disk that filled up under something else, a copy that was interrupted.
+// Cutting inside the first section's payload is the shape that would otherwise be read as a
+// half-populated cache rather than a damaged one.
+$file = __DIR__ . '/tmp/resultCache.php';
+$contents = file_get_contents($file);
+if ($contents === false) {
+	throw new RuntimeException('No result cache at ' . $file);
+}
+
+file_put_contents($file, substr($contents, 0, 200));

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -30,6 +30,7 @@ use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\ShouldNotHappenException;
 use ReflectionClass;
 use ReflectionException;
+use RuntimeException;
 use Throwable;
 use function array_diff;
 use function array_fill_keys;
@@ -45,7 +46,12 @@ use function count;
 use function error_get_last;
 use function explode;
 use function fclose;
+use function fgets;
 use function fopen;
+use function fread;
+use function fseek;
+use function fstat;
+use function ftell;
 use function fwrite;
 use function get_loaded_extensions;
 use function getmypid;
@@ -58,15 +64,20 @@ use function is_file;
 use function ksort;
 use function microtime;
 use function rename;
+use function rtrim;
+use function serialize;
 use function sort;
 use function sprintf;
+use function str_ends_with;
 use function str_starts_with;
+use function strlen;
 use function substr;
 use function time;
 use function uniqid;
 use function unlink;
-use function var_export;
+use function unserialize;
 use const PHP_VERSION_ID;
+use const SEEK_CUR;
 
 /**
  * @phpstan-import-type LinesToIgnore from FileAnalyserResult
@@ -109,6 +120,22 @@ final class ResultCacheManager
 	 * anything about the analysis. They stay in the fully invalidating executedFilesHashes entry.
 	 */
 	private const PARTIALLY_INVALIDATING_META_KEYS = ['composerLocks', 'composerInstalled', 'scannedFiles'];
+
+	/**
+	 * The cache file is serialize() output, but an older PHPStan reading it would
+	 * include it as PHP and echo the whole multi-megabyte content to stdout as
+	 * inline text before discarding it. This prefix makes such an include return
+	 * null immediately (the text after ?> is never reached), so a downgrade
+	 * degrades to a silent full analysis instead.
+	 */
+	private const SERIALIZED_FILE_PREFIX = '<?php return; ?>';
+
+	/**
+	 * Sections restore() hands back as callbacks instead of arrays, so a run that never asks for them
+	 * never pays for decoding them. Each is a whole array frame in the file, so the reader only has to
+	 * remember where it starts and walk past its entries.
+	 */
+	private const LAZY_SECTIONS = ['errors', 'locallyIgnoredErrors', 'collectedData', 'exportedNodes'];
 
 	/** @var array<string, string> */
 	private array $fileHashes = [];
@@ -274,7 +301,12 @@ final class ResultCacheManager
 		}
 
 		try {
-			$data = require $cacheFilePath;
+			// The cache used to be a var_export'd PHP file loaded via include. Including a
+			// multi-megabyte PHP source retains its compiled op_arrays and interned strings
+			// for the process lifetime; unserialize() produces only the values. A cache file
+			// in the old PHP format fails to unserialize and is discarded below like any
+			// other corrupted file, so no cache version bump is needed for the transition.
+			$data = $this->readCacheFile($cacheFilePath);
 		} catch (Throwable $e) {
 			@unlink($cacheFilePath);
 
@@ -1448,9 +1480,11 @@ final class ResultCacheManager
 		$pid = getmypid();
 		$temporaryFile = sprintf('%s.%s.tmp', $file, $pid === false ? uniqid() : $pid);
 
-		// streamed to the file section by section - building the whole
-		// var_export()ed contents in memory at once would take up roughly
-		// twice the size of the resulting file in the main process
+		// Written frame by frame, and the array sections entry by entry, so the peak cost of saving is
+		// one entry rather than the whole cache. Serializing the payload in one call would hold the
+		// entire cache in memory twice over - on one project that is 53 MB serialized, 39 MB of it
+		// exportedNodes alone - which is the same trap the var_export writer this replaces avoided by
+		// streaming.
 		$handle = @fopen($temporaryFile, 'w');
 		if ($handle === false) {
 			$error = error_get_last();
@@ -1461,38 +1495,18 @@ final class ResultCacheManager
 		$renamed = false;
 
 		try {
-			$this->writeToHandle($handle, $file, "<?php declare(strict_types = 1);
-
-return [
-	'lastFullAnalysisTime' => " . var_export($lastFullAnalysisTime, true) . ",
-	'meta' => " . var_export($meta, true) . ",
-	'projectExtensionFiles' => " . var_export($projectExtensionFiles, true) . ",
-	'errorsCallback' => static function (): array { return ");
-			$this->streamArrayVarExportToHandle($handle, $file, $errors);
-			$this->writeToHandle($handle, $file, "; },
-	'locallyIgnoredErrorsCallback' => static function (): array { return ");
-			$this->streamArrayVarExportToHandle($handle, $file, $locallyIgnoredErrors);
-			$this->writeToHandle($handle, $file, "; },
-	'linesToIgnore' => ");
-			$this->streamArrayVarExportToHandle($handle, $file, $linesToIgnore);
-			$this->writeToHandle($handle, $file, ",
-	'unmatchedLineIgnores' => ");
-			$this->streamArrayVarExportToHandle($handle, $file, $unmatchedLineIgnores);
-			$this->writeToHandle($handle, $file, ",
-	'collectedDataCallback' => static function (): array { return ");
-			$this->streamArrayVarExportToHandle($handle, $file, $collectedData);
-			$this->writeToHandle($handle, $file, "; },
-	'dependencies' => ");
-			$this->streamArrayVarExportToHandle($handle, $file, $invertedDependencies);
-			$this->writeToHandle($handle, $file, ",
-	'packageDependencies' => ");
-			$this->streamArrayVarExportToHandle($handle, $file, $packageDependencies);
-			$this->writeToHandle($handle, $file, ",
-	'exportedNodesCallback' => static function (): array { return ");
-			$this->streamArrayVarExportToHandle($handle, $file, $exportedNodes);
-			$this->writeToHandle($handle, $file, '; },
-];
-');
+			$this->writeToHandle($handle, $file, self::SERIALIZED_FILE_PREFIX . "\n");
+			$this->writeValueFrame($handle, $file, 'lastFullAnalysisTime', $lastFullAnalysisTime);
+			$this->writeValueFrame($handle, $file, 'meta', $meta);
+			$this->writeValueFrame($handle, $file, 'projectExtensionFiles', $projectExtensionFiles);
+			$this->writeArrayFrame($handle, $file, 'errors', $errors);
+			$this->writeArrayFrame($handle, $file, 'locallyIgnoredErrors', $locallyIgnoredErrors);
+			$this->writeArrayFrame($handle, $file, 'linesToIgnore', $linesToIgnore);
+			$this->writeArrayFrame($handle, $file, 'unmatchedLineIgnores', $unmatchedLineIgnores);
+			$this->writeArrayFrame($handle, $file, 'collectedData', $collectedData);
+			$this->writeArrayFrame($handle, $file, 'dependencies', $invertedDependencies);
+			$this->writeArrayFrame($handle, $file, 'packageDependencies', $packageDependencies);
+			$this->writeArrayFrame($handle, $file, 'exportedNodes', $exportedNodes);
 			fclose($handle);
 			$closed = true;
 
@@ -1525,30 +1539,227 @@ return [
 	}
 
 	/**
-	 * Streams the var_export() representation of an array to the file entry
-	 * by entry, producing output byte-identical to var_export($values, true).
+	 * A single value, as `name length\n` followed by that many bytes.
 	 *
-	 * var_export() builds the whole export in memory even when told to print it,
-	 * so exporting a big section in one call would take up as much memory
-	 * as the resulting file section itself.
+	 * @param resource $handle
+	 */
+	private function writeValueFrame($handle, string $file, string $name, mixed $value): void
+	{
+		$blob = serialize($value);
+		$this->writeToHandle($handle, $file, $name . ' ' . strlen($blob) . "\n");
+		$this->writeToHandle($handle, $file, $blob);
+	}
+
+	/**
+	 * An array, as `name* count\n` followed by one length-prefixed frame per entry.
 	 *
-	 * Each entry is exported wrapped in a single-entry array whose "array (\n"
-	 * prefix and "\n)" suffix are stripped, yielding the same bytes (including
-	 * indentation) the entry would get inside the full export. Indenting the lines
-	 * of a standalone value export would corrupt multi-line string contents instead.
+	 * Each entry is serialized as a single-element array so its key travels with it, which keeps string
+	 * and integer keys distinct without a second frame for the key.
 	 *
 	 * @param resource $handle
 	 * @param array<mixed> $values
 	 */
-	private function streamArrayVarExportToHandle($handle, string $file, array $values): void
+	private function writeArrayFrame($handle, string $file, string $name, array $values): void
 	{
-		$this->writeToHandle($handle, $file, 'array (');
+		$this->writeToHandle($handle, $file, $name . '* ' . count($values) . "\n");
 		foreach ($values as $key => $value) {
-			$entry = var_export([$key => $value], true);
-			$this->writeToHandle($handle, $file, "\n" . substr($entry, 8, -2));
+			$blob = serialize([$key => $value]);
+			$this->writeToHandle($handle, $file, strlen($blob) . "\n");
+			$this->writeToHandle($handle, $file, $blob);
+		}
+	}
+
+	/**
+	 * Read a framed cache file back, one frame at a time.
+	 *
+	 * Returns null for anything that is not this format, which is how a cache written by an older
+	 * PHPStan is detected: the caller discards it and analyses everything, exactly as it does for a
+	 * corrupted file.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function readCacheFile(string $cacheFilePath): ?array
+	{
+		$handle = @fopen($cacheFilePath, 'r');
+		if ($handle === false) {
+			return null;
 		}
 
-		$this->writeToHandle($handle, $file, "\n)");
+		$stat = fstat($handle);
+		$fileSize = $stat === false ? 0 : $stat['size'];
+		$closeHandle = true;
+
+		try {
+			if (rtrim((string) fgets($handle), "\n") !== self::SERIALIZED_FILE_PREFIX) {
+				return null;
+			}
+
+			$data = [];
+			$lazy = array_fill_keys(self::LAZY_SECTIONS, false);
+			while (($header = fgets($handle)) !== false) {
+				$header = rtrim($header, "\n");
+				if ($header === '') {
+					continue;
+				}
+
+				$parts = explode(' ', $header, 2);
+				if (count($parts) !== 2) {
+					throw new RuntimeException(sprintf('Malformed frame header "%s".', $header));
+				}
+
+				[$name, $size] = $parts;
+				if (!str_ends_with($name, '*')) {
+					$data[$name] = $this->readFrame($handle, (int) $size);
+
+					continue;
+				}
+
+				$name = substr($name, 0, -1);
+				$count = (int) $size;
+				if (!array_key_exists($name, $lazy)) {
+					$data[$name] = $this->readEntryFrames($handle, $count);
+
+					continue;
+				}
+
+				// The entries are walked rather than decoded: that validates the framing of the whole
+				// file up front, so a damaged cache is still discarded by restore() instead of failing
+				// later inside the callback, and leaves the payloads to be unserialized on demand.
+				$offset = ftell($handle);
+				if ($offset === false) {
+					throw new RuntimeException(sprintf('Cannot tell the position of section "%s".', $name));
+				}
+
+				$this->skipEntryFrames($handle, $count, $fileSize, $name);
+				$lazy[$name] = true;
+				$data[$name . 'Callback'] = fn (): array => $this->readEntryFramesAt($handle, $offset, $count, $name);
+			}
+
+			foreach ($lazy as $name => $seen) {
+				if ($seen) {
+					continue;
+				}
+
+				$data[$name . 'Callback'] = static fn (): array => [];
+			}
+
+			$closeHandle = false;
+
+			return $data;
+		} finally {
+			if ($closeHandle) {
+				fclose($handle);
+			}
+		}
+	}
+
+	/**
+	 * Walks past an array frame's entries without unserializing them, checking as it goes that the
+	 * file really holds them.
+	 *
+	 * @param resource $handle
+	 */
+	private function skipEntryFrames($handle, int $count, int $fileSize, string $name): void
+	{
+		for ($i = 0; $i < $count; $i++) {
+			$length = fgets($handle);
+			if ($length === false) {
+				throw new RuntimeException(sprintf('Section "%s" ended after %d of %d entries.', $name, $i, $count));
+			}
+
+			$length = (int) rtrim($length, "\n");
+			if ($length <= 0) {
+				throw new RuntimeException(sprintf('Frame length %d is not positive.', $length));
+			}
+
+			// fseek() past the end of a file succeeds, so the position is what catches a section the
+			// file does not actually hold.
+			if (fseek($handle, $length, SEEK_CUR) !== 0) {
+				throw new RuntimeException(sprintf('Cannot skip entry %d of section "%s".', $i, $name));
+			}
+
+			$position = ftell($handle);
+			if ($position === false || $position > $fileSize) {
+				throw new RuntimeException(sprintf('Section "%s" is truncated at entry %d of %d.', $name, $i, $count));
+			}
+		}
+	}
+
+	/**
+	 * @param resource $handle
+	 * @return array<mixed>
+	 */
+	private function readEntryFramesAt($handle, int $offset, int $count, string $name): array
+	{
+		if (fseek($handle, $offset) !== 0) {
+			throw new RuntimeException(sprintf('Cannot seek to section "%s".', $name));
+		}
+
+		return $this->readEntryFrames($handle, $count);
+	}
+
+	/**
+	 * @param resource $handle
+	 * @return array<mixed>
+	 */
+	private function readEntryFrames($handle, int $count): array
+	{
+		$entries = [];
+		for ($i = 0; $i < $count; $i++) {
+			$length = fgets($handle);
+			if ($length === false) {
+				throw new RuntimeException(sprintf('Cache file ended after %d of %d entries.', $i, $count));
+			}
+
+			$entry = $this->readFrame($handle, (int) rtrim($length, "\n"));
+			if (!is_array($entry)) {
+				throw new RuntimeException('An entry frame did not contain an array.');
+			}
+
+			foreach ($entry as $key => $value) {
+				$entries[$key] = $value;
+			}
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * A frame's payload, or an exception when the file does not hold one.
+	 *
+	 * Every failure here means a cache file that is this format but damaged: a CI cache artifact
+	 * archived or restored half way, an interrupted copy, a disk that filled up. restore() turns
+	 * the exception into a discarded cache and a full analysis, the same way it handles the parse
+	 * error an incomplete var_export'd file used to produce. Returning a value instead would
+	 * hand a half-read cache to the caller, where the missing pieces surface as type errors far
+	 * from the cause.
+	 *
+	 * false is treated as failure because unserialize() reports failure that way and no value in
+	 * the cache is a bare false: the sections are arrays and lastFullAnalysisTime is an int.
+	 *
+	 * @param resource $handle
+	 */
+	private function readFrame($handle, int $length): mixed
+	{
+		if ($length <= 0) {
+			throw new RuntimeException(sprintf('Frame length %d is not positive.', $length));
+		}
+
+		$blob = fread($handle, $length);
+		if ($blob === false || strlen($blob) !== $length) {
+			throw new RuntimeException(sprintf(
+				'Expected a %d byte frame, read %d bytes.',
+				$length,
+				$blob === false ? 0 : strlen($blob),
+			));
+		}
+
+		$value = @unserialize($blob);
+		if ($value === false) {
+			throw new RuntimeException(sprintf('A %d byte frame could not be unserialized.', $length));
+		}
+
+		return $value;
 	}
 
 	/**

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -134,6 +134,12 @@ final class ResultCacheManager
 	 * Sections restore() hands back as callbacks instead of arrays, so a run that never asks for them
 	 * never pays for decoding them. Each is a whole array frame in the file, so the reader only has to
 	 * remember where it starts and walk past its entries.
+	 *
+	 * Nothing closure-shaped is written: a frame holds the plain serialized payload
+	 * (`a:1:{s:9:"file.php";a:1:{i:0;O:22:"PHPStan\Analyser\Error"...`), and readCacheFile() builds
+	 * the callback in PHP around the open handle and that offset, which is only the shape restore()
+	 * expects. The var_export format writes a real `static function (): array` into the file instead,
+	 * and PHP still compiles the array literal inside it.
 	 */
 	private const LAZY_SECTIONS = ['errors', 'locallyIgnoredErrors', 'collectedData', 'exportedNodes'];
 
@@ -593,12 +599,31 @@ final class ResultCacheManager
 		$filesToAnalyse = [];
 		$invertedDependenciesToReturn = [];
 		$invertedUsedTraitDependenciesToReturn = [];
-		$errors = $data['errorsCallback']();
-		$locallyIgnoredErrors = $data['locallyIgnoredErrorsCallback']();
 		$linesToIgnore = $data['linesToIgnore'];
 		$unmatchedLineIgnores = $data['unmatchedLineIgnores'];
-		$collectedData = $data['collectedDataCallback']();
-		$exportedNodes = $data['exportedNodesCallback']();
+
+		try {
+			// The cached objects are reconstructed here, and a cache written by a PHPStan whose classes
+			// have since changed can fail at it: a property the payload does not carry stays
+			// uninitialized, and reading it throws. The cacheVersion and phpstanVersion in the metadata
+			// keep a released version away from another release's objects, but a source checkout keeps
+			// one phpstanVersion across every edit of these classes, so this is reachable there. A cache
+			// that cannot be reconstructed is discarded like any other unusable one.
+			$errors = $data['errorsCallback']();
+			$locallyIgnoredErrors = $data['locallyIgnoredErrorsCallback']();
+			$collectedData = $data['collectedDataCallback']();
+			$exportedNodes = $data['exportedNodesCallback']();
+		} catch (Throwable $e) {
+			@unlink($cacheFilePath);
+
+			return $this->fullAnalysis(
+				sprintf('Result cache not used because the cached results could not be read back: %s', $e->getMessage()),
+				$allAnalysedFiles,
+				$meta,
+				$currentFileHashes,
+				$output,
+			);
+		}
 		$filteredErrors = [];
 		$filteredLocallyIgnoredErrors = [];
 		$filteredLinesToIgnore = [];


### PR DESCRIPTION
## What

The result cache is a `var_export`'d PHP file hydrated with `include`. Including a multi-megabyte PHP source retains its compiled op_arrays and interned strings, and where OPCache is on it also occupies shared memory. This writes the file as framed `serialize()` payloads instead.

Format: `<?php return; ?>` on the first line, then `name length` or `name* count` headers, each followed by length-prefixed serialized payloads. Written frame by frame, and the array sections entry by entry, because serializing a section in one call holds it in memory twice over - `exportedNodes` alone is 39 MB on the larger project below. The read side is framed for the same reason.

`errors`, `locallyIgnoredErrors`, `collectedData` and `exportedNodes` are the sections `restore()` hands back as callbacks. The `var_export` format defers them by writing one closure per section, which still leaves PHP compiling the array literal inside it. Here each section is a single frame, so the reader remembers where it starts, walks past its entries without unserializing them, and decodes on demand.

## What loading the cache costs

Isolated, same 5400 entries, both formats read with OPCache enabled:

| | var_export | framed |
| --- | --- | --- |
| open the cache | 0.39s | 0.01s |
| heap after opening | 325.0 MB | 14.0 MB |
| heap with all four lazy sections materialised | 325.0 MB | 124.0 MB |
| OPCache shared memory | 39.9 MB, one 41,739,216 byte script entry | none |

Default `opcache.memory_consumption` is 128 MB, so on this project the cache file alone claims a third of the buffer, leaving that much less for PHPStan's own code; a project three times the size does not fit in it at all.

## End to end

Warm peak of the main process, interleaved A/B, every figure repeated across rounds:

| project | base | this change | |
| --- | --- | --- | --- |
| 4524 files, level 5 | 357.7 MB | 140.0 MB | **-61%** |
| 2485 files, level 5 | 220.4 MB | 96.0 MB | **-56%** |

Cold main-process peak on the first: 120 MB against 92 MB, worker peak flat (334.1 against 336.1 MB). Cold and warm wall are unchanged or slightly better.

One exception worth naming: analysing this repository with its own `phpstan.neon.dist` (bleeding edge, strict rules, collectors) the warm peak goes the other way, 339.05 to 346.52 MB. There the peak is set by collector processing rather than by the restore, and I have not chased the remaining 7 MB.

The file on disk is bigger: +11.9% at 2485 files, +34.7% at 4524.

## Truncated caches

The separable half of this is now phpstan/phpstan-src#6349, which renames the cache into place so a killed run stops leaving a partial file at the path the next run reads, in either format.

The guard here stays, because a format that *can* be read halfway has to refuse to: every frame violation throws and `restore()` discards the file, which is what the `var_export` format got for free from a `ParseError`. Two e2e cases cover it, one cutting inside a lazily-read section - `fseek()` past the end of a file succeeds, so that one is only caught by comparing the position with the file size.

## Transition

No cache version bump is needed. A cache in the old PHP format fails to unserialize and is discarded like any other unreadable file.
