### PR TITLE
Restore process-wide statics from the main container after stub validation

### DIFF
--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -8,11 +8,10 @@ use PHPStan\Analyser\InternalError;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\DependencyInjection\ContainerFactory;
 use PHPStan\DependencyInjection\DerivativeContainerFactory;
-use PHPStan\Reflection\PhpVersionStaticAccessor;
-use PHPStan\Reflection\ReflectionProviderStaticAccessor;
 use PHPStan\Rules\DirectRegistry as DirectRuleRegistry;
-use PHPStan\Type\ObjectType;
 use Throwable;
 use function array_fill_keys;
 use function count;
@@ -26,6 +25,7 @@ final class StubValidator
 
 	public function __construct(
 		private DerivativeContainerFactory $derivativeContainerFactory,
+		private Container $mainContainer,
 		private StubFilesProvider $stubFilesProvider,
 	)
 	{
@@ -40,9 +40,6 @@ final class StubValidator
 		if (count($stubFiles) === 0) {
 			return [];
 		}
-
-		$originalReflectionProvider = ReflectionProviderStaticAccessor::getInstance();
-		$originalPhpVersion = PhpVersionStaticAccessor::getInstance();
 
 		try {
 			$container = $this->derivativeContainerFactory->create([
@@ -93,9 +90,15 @@ final class StubValidator
 				}
 			}
 		} finally {
-			ReflectionProviderStaticAccessor::registerInstance($originalReflectionProvider);
-			PhpVersionStaticAccessor::registerInstance($originalPhpVersion);
-			ObjectType::resetCaches();
+			// Creating the derived container above re-ran ContainerFactory::postInitializeContainer(),
+			// pointing all process-wide statics (ReflectionProviderStaticAccessor,
+			// BetterReflection::populate() with the source locator/reflector/stubber, bleeding-edge
+			// toggles, ...) at the derived container. Re-initialize them from the main container —
+			// previously only the two accessors were restored, so the BetterReflection statics kept
+			// the whole derived container alive for the rest of the process, and reflections created
+			// through them afterwards (e.g. adapter-internal lookups during result finalization)
+			// were built by the derived container's reflector.
+			ContainerFactory::postInitializeContainer($this->mainContainer);
 		}
 
 		return $errors;


### PR DESCRIPTION
## Problem

`StubValidator::validate()` creates a derived DI container; its creation re-runs `ContainerFactory::postInitializeContainer()`, pointing **all** process-wide statics at the derived container — the two accessors, the `BetterReflection::populate()` statics (source locator, reflector, php parser, source stubber, printer) and the bleeding-edge toggles.

The `finally` block restored only `ReflectionProviderStaticAccessor` and `PhpVersionStaticAccessor`. The `BetterReflection` statics kept pointing at the derived container's reflection stack after validation:

- the **whole derived container stayed alive** for the rest of the process (reflections capture their reflector; the reflector's source-locator factory back-references the container that created it) — a process-lifetime leak;
- **adapter-internal lookups after stub validation** (Roave adapters construct `new BetterReflection()` internally — e.g. attribute instantiation during result finalization) were served by the derived container's reflector, populating the wrong container's caches.

Found while instrumenting memory retention on a large project (ShipMonk backend, 25k files, 14 `stubFiles`): retention-path tracing showed the derived container pinned via `static:PHPStan\BetterReflection\BetterReflection::$sharedSourceLocator` long after validation ended.

## Fix

Re-run `ContainerFactory::postInitializeContainer($this->mainContainer)` in the `finally`. It already memoizes by container object id, so this is exactly its intended use — and it restores every static consistently, including the toggles the previous code missed. `ObjectType::resetCaches()` is part of it, so the manual call is gone too.

## Measured

On the instrumented large project the leaked derived container measured ~4.6 MB retained per process at 115-file scale — real but modest there; the correctness aspect (post-validation reflections built by the wrong reflector) is the stronger motivation.

Tests: `StubValidatorIntegrationTest`, `DefaultStubFilesProviderTest`, `TraitStubFilesTest`, `AssertStubTest`, `AnalyseCommandTest`, `AnalyseApplicationIntegrationTest` pass; phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrTvR9j1mW2NNNC8RkuTsF
