### PR TITLE
Drop the container reference in LazyClassReflectionExtensionRegistryProvider after building the registry

### DIFF
--- a/src/DependencyInjection/Reflection/LazyClassReflectionExtensionRegistryProvider.php
+++ b/src/DependencyInjection/Reflection/LazyClassReflectionExtensionRegistryProvider.php
@@ -15,6 +15,7 @@ use PHPStan\Reflection\Php\Soap\SoapClientMethodsClassReflectionExtension;
 use PHPStan\Reflection\Php\UniversalObjectCratesClassReflectionExtension;
 use PHPStan\Reflection\RequireExtension\RequireExtendsMethodsClassReflectionExtension;
 use PHPStan\Reflection\RequireExtension\RequireExtendsPropertiesClassReflectionExtension;
+use PHPStan\ShouldNotHappenException;
 use function array_merge;
 
 #[AutowiredService(as: ClassReflectionExtensionRegistryProvider::class)]
@@ -23,29 +24,39 @@ final class LazyClassReflectionExtensionRegistryProvider implements ClassReflect
 
 	private ?ClassReflectionExtensionRegistry $registry = null;
 
-	public function __construct(private Container $container)
+	public function __construct(private ?Container $container)
 	{
 	}
 
 	public function getRegistry(): ClassReflectionExtensionRegistry
 	{
 		if ($this->registry === null) {
-			$annotationsMethodsClassReflectionExtension = $this->container->getByType(AnnotationsMethodsClassReflectionExtension::class);
-			$annotationsPropertiesClassReflectionExtension = $this->container->getByType(AnnotationsPropertiesClassReflectionExtension::class);
+			$container = $this->container;
+			if ($container === null) {
+				throw new ShouldNotHappenException();
+			}
 
-			$mixinMethodsClassReflectionExtension = $this->container->getByType(MixinMethodsClassReflectionExtension::class);
-			$mixinPropertiesClassReflectionExtension = $this->container->getByType(MixinPropertiesClassReflectionExtension::class);
-			$soapClientMethodsClassReflectionExtension = $this->container->getByType(SoapClientMethodsClassReflectionExtension::class);
-			$universalObjectCratesClassReflectionExtension = $this->container->getByType(UniversalObjectCratesClassReflectionExtension::class);
+			$annotationsMethodsClassReflectionExtension = $container->getByType(AnnotationsMethodsClassReflectionExtension::class);
+			$annotationsPropertiesClassReflectionExtension = $container->getByType(AnnotationsPropertiesClassReflectionExtension::class);
+
+			$mixinMethodsClassReflectionExtension = $container->getByType(MixinMethodsClassReflectionExtension::class);
+			$mixinPropertiesClassReflectionExtension = $container->getByType(MixinPropertiesClassReflectionExtension::class);
+			$soapClientMethodsClassReflectionExtension = $container->getByType(SoapClientMethodsClassReflectionExtension::class);
+			$universalObjectCratesClassReflectionExtension = $container->getByType(UniversalObjectCratesClassReflectionExtension::class);
 
 			$this->registry = new ClassReflectionExtensionRegistry(
-				array_merge($this->container->getServicesByTag(BrokerFactory::PROPERTIES_CLASS_REFLECTION_EXTENSION_TAG), [$annotationsPropertiesClassReflectionExtension, $mixinPropertiesClassReflectionExtension, $universalObjectCratesClassReflectionExtension]),
-				array_merge($this->container->getServicesByTag(BrokerFactory::METHODS_CLASS_REFLECTION_EXTENSION_TAG), [$annotationsMethodsClassReflectionExtension, $mixinMethodsClassReflectionExtension, $soapClientMethodsClassReflectionExtension]),
-				$this->container->getServicesByTag(BrokerFactory::ALLOWED_SUB_TYPES_CLASS_REFLECTION_EXTENSION_TAG),
-				$this->container->getByType(RequireExtendsPropertiesClassReflectionExtension::class),
-				$this->container->getByType(RequireExtendsMethodsClassReflectionExtension::class),
-				$this->container->getByType(PhpClassReflectionExtension::class),
+				array_merge($container->getServicesByTag(BrokerFactory::PROPERTIES_CLASS_REFLECTION_EXTENSION_TAG), [$annotationsPropertiesClassReflectionExtension, $mixinPropertiesClassReflectionExtension, $universalObjectCratesClassReflectionExtension]),
+				array_merge($container->getServicesByTag(BrokerFactory::METHODS_CLASS_REFLECTION_EXTENSION_TAG), [$annotationsMethodsClassReflectionExtension, $mixinMethodsClassReflectionExtension, $soapClientMethodsClassReflectionExtension]),
+				$container->getServicesByTag(BrokerFactory::ALLOWED_SUB_TYPES_CLASS_REFLECTION_EXTENSION_TAG),
+				$container->getByType(RequireExtendsPropertiesClassReflectionExtension::class),
+				$container->getByType(RequireExtendsMethodsClassReflectionExtension::class),
+				$container->getByType(PhpClassReflectionExtension::class),
 			);
+
+			// Every ClassReflection instance holds this provider; keeping the container
+			// reference here would make each of them a transitive handle on the entire DI
+			// container. After the registry is built the container is no longer needed.
+			$this->container = null;
 		}
 
 		return $this->registry;


### PR DESCRIPTION
Every `ClassReflection` instance holds `ClassReflectionExtensionRegistryProvider` as a constructor dependency (`ClassReflection.php`), and the lazy provider kept its `Container` reference for the whole process — making every `ClassReflection` (and transitively every `ObjectType` that ever lazily resolved its class, every `ResolvedPhpDocBlock` tag type, every cached signature) a handle on the **entire DI container**.

The reference is only needed once, to build the registry on first use. This PR nulls it out afterwards.

Found while instrumenting memory retention on a large project (ShipMonk backend): retention-path tracing repeatedly showed `... → ObjectType::$classReflection → ClassReflection::$classReflectionExtensionRegistryProvider → LazyClassReflectionExtensionRegistryProvider::$container → Container::$instances[] → everything`, which (a) means a single stale reflection can keep a whole dead container alive (e.g. the stub validator's derived container, #5984), and (b) defeats any future eviction strategy for class reflections. After this change the instrumentation confirms no reference chain from `ClassReflection` to the container remains.

No behavioral change; `ClassReflectionTest`, `ClassTemplateTypeRuleTest`, `StubValidatorIntegrationTest` pass, phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrTvR9j1mW2NNNC8RkuTsF
