### PR TITLE
Replace PhpClassReflectionExtension::evictPrivateSymbols() with a shared LRU over the member caches

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -127,6 +127,7 @@ parameters:
 		resolvedPhpDocBlockCacheCountMax: 2048
 		nameScopeMapMemoryCacheCountMax: 512
 		phpStormStubsNodesCountMax: 128
+		memberCacheKeysMax: 2048
 	reportUnmatchedIgnoredErrors: true
 	reportIgnoresWithoutComments: false
 	typeAliases: []

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -150,7 +150,8 @@ parametersSchema:
 		nodesByStringCountMax: int(),
 		resolvedPhpDocBlockCacheCountMax: int(),
 		nameScopeMapMemoryCacheCountMax: int(),
-		phpStormStubsNodesCountMax: int()
+		phpStormStubsNodesCountMax: int(),
+		memberCacheKeysMax: int()
 	])
 	reportUnmatchedIgnoredErrors: bool()
 	reportIgnoresWithoutComments: bool()

--- a/conf/services.neon
+++ b/conf/services.neon
@@ -59,6 +59,7 @@ services:
 		arguments:
 			parser: @defaultAnalysisParser
 			inferPrivatePropertyTypeFromConstructor: %inferPrivatePropertyTypeFromConstructor%
+			memberCacheKeysMax: %cache.memberCacheKeysMax%
 
 	-
 		class: PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -716,7 +716,9 @@ final class ClassReflection
 
 			unset($this->methods[$name]);
 		}
-		$this->classReflectionExtensionRegistryProvider->getRegistry()->getPhpClassReflectionExtension()->evictPrivateSymbols($this->getCacheKey());
+		// PhpClassReflectionExtension's member caches are governed by their own LRU
+		// (see PhpClassReflectionExtension::touchMemberCacheKey()) instead of per-class
+		// private-symbol eviction.
 	}
 
 	/** @deprecated Use getInstanceProperty or getStaticProperty */

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -74,8 +74,6 @@ use function strtolower;
 final class PhpClassReflectionExtension
 {
 
-	private const MEMBER_CACHE_KEYS_MAX = 2048;
-
 	/** @var array<string, true> shared LRU over the member cache keys below; first entry = least recently used */
 	private array $memberCacheOrder = [];
 
@@ -114,6 +112,7 @@ final class PhpClassReflectionExtension
 		private ParameterAllowedConstantsMapProvider $allowedConstantsMapProvider,
 		private bool $inferPrivatePropertyTypeFromConstructor,
 		private PhpVersion $phpVersion,
+		private int $memberCacheKeysMax,
 	)
 	{
 	}
@@ -121,7 +120,7 @@ final class PhpClassReflectionExtension
 	/**
 	 * Moves the cache key to the most-recently-used position of the shared LRU governing
 	 * all four member caches; evicts the least recently used key's entries from all of
-	 * them once the limit is reached.
+	 * them once the limit is reached. A limit of 0 means unlimited.
 	 *
 	 * Replaces the former evictPrivateSymbols(): instead of dropping only private members
 	 * of the just-analysed class (public/protected members accumulated for the whole
@@ -137,7 +136,7 @@ final class PhpClassReflectionExtension
 		}
 
 		$this->memberCacheOrder[$cacheKey] = true;
-		if (count($this->memberCacheOrder) <= self::MEMBER_CACHE_KEYS_MAX) {
+		if ($this->memberCacheKeysMax === 0 || count($this->memberCacheOrder) <= $this->memberCacheKeysMax) {
 			return;
 		}
 

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -60,6 +60,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypehintHelper;
 use PHPStan\Type\UnionType;
 use function array_key_exists;
+use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_slice;
@@ -72,6 +73,11 @@ use function strtolower;
 
 final class PhpClassReflectionExtension
 {
+
+	private const MEMBER_CACHE_KEYS_MAX = 2048;
+
+	/** @var array<string, true> shared LRU over the member cache keys below; first entry = least recently used */
+	private array $memberCacheOrder = [];
 
 	/** @var PhpPropertyReflection[][] */
 	private array $propertiesIncludingAnnotations = [];
@@ -112,52 +118,37 @@ final class PhpClassReflectionExtension
 	{
 	}
 
-	public function evictPrivateSymbols(string $classCacheKey): void
+	/**
+	 * Moves the cache key to the most-recently-used position of the shared LRU governing
+	 * all four member caches; evicts the least recently used key's entries from all of
+	 * them once the limit is reached.
+	 *
+	 * Replaces the former evictPrivateSymbols(): instead of dropping only private members
+	 * of the just-analysed class (public/protected members accumulated for the whole
+	 * process, measured at hundreds of MB on large codebases), classes not used recently
+	 * are evicted wholesale — misses are pure recomputation.
+	 */
+	private function touchMemberCacheKey(string $cacheKey): void
 	{
-		foreach ($this->propertiesIncludingAnnotations as $key => $properties) {
-			if ($key !== $classCacheKey) {
-				continue;
-			}
-			foreach ($properties as $name => $property) {
-				if (!$property->isPrivate()) {
-					continue;
-				}
-				unset($this->propertiesIncludingAnnotations[$key][$name]);
-			}
+		if (isset($this->memberCacheOrder[$cacheKey])) {
+			unset($this->memberCacheOrder[$cacheKey]);
+			$this->memberCacheOrder[$cacheKey] = true;
+			return;
 		}
-		foreach ($this->nativeProperties as $key => $properties) {
-			if ($key !== $classCacheKey) {
-				continue;
-			}
-			foreach ($properties as $name => $property) {
-				if (!$property->isPrivate()) {
-					continue;
-				}
-				unset($this->nativeProperties[$key][$name]);
-			}
+
+		$this->memberCacheOrder[$cacheKey] = true;
+		if (count($this->memberCacheOrder) <= self::MEMBER_CACHE_KEYS_MAX) {
+			return;
 		}
-		foreach ($this->methodsIncludingAnnotations as $key => $methods) {
-			if ($key !== $classCacheKey) {
-				continue;
-			}
-			foreach ($methods as $name => $method) {
-				if (!$method->isPrivate()) {
-					continue;
-				}
-				unset($this->methodsIncludingAnnotations[$key][$name]);
-			}
-		}
-		foreach ($this->nativeMethods as $key => $methods) {
-			if ($key !== $classCacheKey) {
-				continue;
-			}
-			foreach ($methods as $name => $method) {
-				if (!$method->isPrivate()) {
-					continue;
-				}
-				unset($this->nativeMethods[$key][$name]);
-			}
-		}
+
+		$evictKey = array_key_first($this->memberCacheOrder);
+		unset(
+			$this->memberCacheOrder[$evictKey],
+			$this->methodsIncludingAnnotations[$evictKey],
+			$this->nativeMethods[$evictKey],
+			$this->propertiesIncludingAnnotations[$evictKey],
+			$this->nativeProperties[$evictKey],
+		);
 	}
 
 	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
@@ -171,6 +162,7 @@ final class PhpClassReflectionExtension
 		if ($scope->isInClass()) {
 			$cacheKey = sprintf('%s-%s', $cacheKey, $scope->getClassReflection()->getCacheKey());
 		}
+		$this->touchMemberCacheKey($cacheKey);
 		if (!isset($this->propertiesIncludingAnnotations[$cacheKey][$propertyName])) {
 			$this->propertiesIncludingAnnotations[$cacheKey][$propertyName] = $this->createProperty($classReflection, $propertyName, $scope, true);
 		}
@@ -180,6 +172,7 @@ final class PhpClassReflectionExtension
 
 	public function getNativeProperty(ClassReflection $classReflection, string $propertyName): PhpPropertyReflection
 	{
+		$this->touchMemberCacheKey($classReflection->getCacheKey());
 		if (!isset($this->nativeProperties[$classReflection->getCacheKey()][$propertyName])) {
 			$property = $this->createProperty($classReflection, $propertyName, new OutOfClassScope(), false);
 			$this->nativeProperties[$classReflection->getCacheKey()][$propertyName] = $property;
@@ -535,6 +528,7 @@ final class PhpClassReflectionExtension
 
 	public function getMethod(ClassReflection $classReflection, string $methodName): ExtendedMethodReflection
 	{
+		$this->touchMemberCacheKey($classReflection->getCacheKey());
 		if (isset($this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$methodName])) {
 			return $this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$methodName];
 		}
@@ -558,6 +552,7 @@ final class PhpClassReflectionExtension
 
 	public function getNativeMethod(ClassReflection $classReflection, string $methodName): ExtendedMethodReflection
 	{
+		$this->touchMemberCacheKey($classReflection->getCacheKey());
 		if (isset($this->nativeMethods[$classReflection->getCacheKey()][$methodName])) {
 			return $this->nativeMethods[$classReflection->getCacheKey()][$methodName];
 		}


### PR DESCRIPTION
## Problem

`PhpClassReflectionExtension`'s four member caches (`methodsIncludingAnnotations`, `nativeMethods`, `propertiesIncludingAnnotations`, `nativeProperties`) are unbounded except for `evictPrivateSymbols()`, which drops only **private** members of the just-analysed class. Public/protected member reflections accumulate for the whole process.

Instrumented on a large project (ShipMonk backend), these caches were the **single largest analysis-growth bucket: 334 MB of a 675 MB per-process growth** at 2,358 analysed files (3,710 + 6,258 + 2,501 + 2,073 first-level keys; each entry a full `PhpMethodReflection`/`PhpPropertyReflection` graph).

The private-only eviction also silently misses the composite `class-scope` cache keys used by `getProperty()` — it compares keys with `!==` against the plain class cache key, so scoped private property entries were never evicted.

## Change

One insertion-ordered LRU over the first-level cache keys, shared by all four maps:

- every cache access moves the key to the most-recently-used position,
- inserting beyond 2048 keys evicts the least recently used key's entries from all four maps at once,
- `evictPrivateSymbols()` (and its per-class full-map scan after every analysed class, plus the delegation from `ClassReflection::evictPrivateSymbols()`) is removed.

Misses are pure recomputation, so eviction cannot change results.

## Measured (2,358-file project, single process)

- error output **byte-identical** (776 errors), across three independent runs
- no measurable time cost (99 s → 99 s; LRU bookkeeping is one `unset`+set per access, and the old eviction's full map scan per analysed class is gone)
- member-cache keys at end of run: 14,542 → 3,608
- end-of-run memory: −32 MB on this project — honest caveat: much of the evicted graphs' weight survives via other holders of the same `ClassReflection`s (`MemoizingReflectionProvider`, `DependencyResolver::$classDependencies`, rule state), so the standalone win is bounded. The value is replacing an incomplete, quadratic-ish eviction with a general bounded cache — a prerequisite for the eviction to cascade once the sibling holders are bounded too.

The 2048 cap could be promoted to a `cache.*` parameter like `nameScopeMapMemoryCacheCountMax` if desired.

Tests: `ClassReflectionTest`, `TypesAssignedToPropertiesRuleTest`, `CallMethodsRuleTest` pass; phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrTvR9j1mW2NNNC8RkuTsF
