### PR TITLE
LRU-cap resolved local type aliases in UsefulTypeAliasResolver

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -128,6 +128,7 @@ parameters:
 		nameScopeMapMemoryCacheCountMax: 512
 		phpStormStubsNodesCountMax: 128
 		memberCacheKeysMax: 2048
+		resolvedLocalTypeAliasesCountMax: 2048
 	reportUnmatchedIgnoredErrors: true
 	reportIgnoresWithoutComments: false
 	typeAliases: []

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -151,7 +151,8 @@ parametersSchema:
 		resolvedPhpDocBlockCacheCountMax: int(),
 		nameScopeMapMemoryCacheCountMax: int(),
 		phpStormStubsNodesCountMax: int(),
-		memberCacheKeysMax: int()
+		memberCacheKeysMax: int(),
+		resolvedLocalTypeAliasesCountMax: int()
 	])
 	reportUnmatchedIgnoredErrors: bool()
 	reportIgnoresWithoutComments: bool()

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -137,6 +137,7 @@ abstract class PHPStanTestCase extends TestCase
 			$container->getByType(TypeStringResolver::class),
 			$container->getByType(TypeNodeResolver::class),
 			$reflectionProvider,
+			0,
 		);
 	}
 

--- a/src/Type/UsefulTypeAliasResolver.php
+++ b/src/Type/UsefulTypeAliasResolver.php
@@ -10,16 +10,20 @@ use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use function array_key_exists;
+use function array_key_first;
+use function count;
 use function sprintf;
 
 #[AutowiredService(as: TypeAliasResolver::class)]
 final class UsefulTypeAliasResolver implements TypeAliasResolver
 {
 
+	private const RESOLVED_LOCAL_TYPE_ALIASES_MAX = 2048;
+
 	/** @var array<string, Type> */
 	private array $resolvedGlobalTypeAliases = [];
 
-	/** @var array<string, Type> */
+	/** @var array<string, Type> LRU; first entry = least recently used */
 	private array $resolvedLocalTypeAliases = [];
 
 	/** @var array<string, true> */
@@ -81,7 +85,11 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 		$aliasNameInClassScope = $className . '::' . $aliasName;
 
 		if (array_key_exists($aliasNameInClassScope, $this->resolvedLocalTypeAliases)) {
-			return $this->resolvedLocalTypeAliases[$aliasNameInClassScope];
+			// LRU: move to the most-recently-used position
+			$resolvedAliasType = $this->resolvedLocalTypeAliases[$aliasNameInClassScope];
+			unset($this->resolvedLocalTypeAliases[$aliasNameInClassScope]);
+
+			return $this->resolvedLocalTypeAliases[$aliasNameInClassScope] = $resolvedAliasType;
 		}
 
 		// prevent infinite recursion
@@ -120,6 +128,11 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 		}
 
 		$this->resolvedLocalTypeAliases[$aliasNameInClassScope] = $resolvedAliasType;
+		if (count($this->resolvedLocalTypeAliases) > self::RESOLVED_LOCAL_TYPE_ALIASES_MAX) {
+			// resolved alias types transitively pin ClassReflections and their whole
+			// reflection trees — evict the least recently used
+			unset($this->resolvedLocalTypeAliases[array_key_first($this->resolvedLocalTypeAliases)]);
+		}
 		unset($this->inProcess[$aliasNameInClassScope]);
 
 		return $resolvedAliasType;

--- a/src/Type/UsefulTypeAliasResolver.php
+++ b/src/Type/UsefulTypeAliasResolver.php
@@ -18,8 +18,6 @@ use function sprintf;
 final class UsefulTypeAliasResolver implements TypeAliasResolver
 {
 
-	private const RESOLVED_LOCAL_TYPE_ALIASES_MAX = 2048;
-
 	/** @var array<string, Type> */
 	private array $resolvedGlobalTypeAliases = [];
 
@@ -41,6 +39,8 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 		private TypeStringResolver $typeStringResolver,
 		private TypeNodeResolver $typeNodeResolver,
 		private ReflectionProvider $reflectionProvider,
+		#[AutowiredParameter(ref: '%cache.resolvedLocalTypeAliasesCountMax%')]
+		private int $resolvedLocalTypeAliasesCountMax,
 	)
 	{
 	}
@@ -128,7 +128,7 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 		}
 
 		$this->resolvedLocalTypeAliases[$aliasNameInClassScope] = $resolvedAliasType;
-		if (count($this->resolvedLocalTypeAliases) > self::RESOLVED_LOCAL_TYPE_ALIASES_MAX) {
+		if ($this->resolvedLocalTypeAliasesCountMax !== 0 && count($this->resolvedLocalTypeAliases) > $this->resolvedLocalTypeAliasesCountMax) {
 			// resolved alias types transitively pin ClassReflections and their whole
 			// reflection trees — evict the least recently used
 			unset($this->resolvedLocalTypeAliases[array_key_first($this->resolvedLocalTypeAliases)]);


### PR DESCRIPTION
## Problem

`UsefulTypeAliasResolver::$resolvedLocalTypeAliases` caches every resolved `@phpstan-type` local alias forever, keyed by `Class::alias`. Resolved alias **Types transitively pin `ClassReflection`s** (`ObjectType::$classReflection`, `EnumCaseObjectType::$classReflection`, …) and through them whole BetterReflection trees.

Retention-path instrumentation on the ShipMonk backend named this cache as the single largest *type-level* pin of the reflection universe — a sampled path:

```
ReflectionNamedType ← ReflectionEnum ← ClassReflection
  ← EnumCaseObjectType::$classReflection ← UnionType
  ← UsefulTypeAliasResolver::$resolvedLocalTypeAliases[]
```

Types are stronger pins than reflections themselves: bounding this one cache freed more memory than bounding any reflection-side cache in the same experiment series.

## Change

Cap `$resolvedLocalTypeAliases` at 2048 entries with LRU eviction (move-to-end on hit, evict-first on insert). Evicted aliases are re-resolved on demand — pure recomputation. Global aliases are untouched (bounded by config).

## Measured (2,358-file project, single process)

- **−34 MB end-of-run memory** (largest single win in the prototype series that reached −76 MB / −8% total together with #5986/#5988)
- error output **byte-identical** (89/776 errors on two configs; the project uses local aliases heavily)
- no measurable time cost: interleaved A/B capped vs uncapped, 100 s vs 95 s (within environmental noise)

The 2048 cap could be promoted to a `cache.*` parameter if desired.

Tests: `LocalTypeAliasesRuleTest` + type-alias NSRT assertions pass; phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrTvR9j1mW2NNNC8RkuTsF


## Configurability + default (added)

The cap is now a `cache.*` parameter (**`cache.resolvedLocalTypeAliasesCountMax`**, default **2048**, `0` disables eviction), following the `phpStormStubsNodesCountMax` pattern.

The default comes from a cap sweep on the 2,358-file project (all LRU caps set to the sweep value, single process, error output identical — 776 — at every point):

| cap | elapsed | end usage |
|--:|--:|--:|
| 512 | 101 s | 936.5 MB |
| 1024 | 93 s | 912.5 MB |
| **2048** | **88 s** | **880.5 MB** |
| 4096 | 84 s | 894.5 MB |
| 8192 | 92 s | 930.6 MB |
| unlimited | 98 s | 930.5 MB |

The curve is **U-shaped**: too-small caps are actively harmful — evicted entries are recreated as fresh object graphs while the old copies are still pinned by sibling caches, so duplicates accumulate (this also explains why very small caps regressed memory on large projects before). Too-large caps converge to unbounded retention. Elapsed time shows no trend across the whole range — the knob trades memory only, so 2048 is chosen purely on the memory optimum.
