### PR TITLE
Narrow `explode()` result for limit 0, 1, and -1

### DIFF
--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -90,9 +90,12 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 		}
 
 		$limitType = isset($args[2]) ? $scope->getType($args[2]->value) : null;
+		$delimiterGuaranteedPresent = $this->isDelimiterGuaranteedPresent($args, $scope);
 
-		if (
-			$this->isDelimiterGuaranteedPresent($args, $scope)
+		if ($this->isSingleElementLimit($limitType)) {
+			$returnType = $this->createSingleElementSplitType($stringType->toString());
+		} elseif (
+			$delimiterGuaranteedPresent
 			&& ($limitType === null || IntegerRangeType::fromInterval(2, null)->isSuperTypeOf($limitType)->yes())
 		) {
 			$returnType = $this->createGuaranteedSplitType($returnValueType, $limitType);
@@ -102,6 +105,7 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 			if (
 				$limitType === null
 				|| IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($limitType)->yes()
+				|| ($delimiterGuaranteedPresent && $this->isMinusOneLimit($limitType))
 			) {
 				$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
 			}
@@ -138,6 +142,31 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 		}
 
 		return false;
+	}
+
+	/**
+	 * A limit of 0 or 1 returns the whole string as the only element, without
+	 * splitting on the delimiter.
+	 */
+	private function isSingleElementLimit(?Type $limitType): bool
+	{
+		return $limitType !== null
+			&& IntegerRangeType::fromInterval(0, 1)->isSuperTypeOf($limitType)->yes();
+	}
+
+	private function isMinusOneLimit(?Type $limitType): bool
+	{
+		return $limitType !== null
+			&& (new ConstantIntegerType(-1))->isSuperTypeOf($limitType)->yes();
+	}
+
+	/** The whole string, unsplit, as the only element. */
+	private function createSingleElementSplitType(Type $valueType): Type
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		$builder->setOffsetValueType(new ConstantIntegerType(0), $valueType);
+
+		return $builder->getArray();
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/bug-14651.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14651.php
@@ -86,10 +86,10 @@ function notGuaranteed(string $s): void
 		assertType('non-falsy-string', $s);
 		// different delimiter than the proven substring
 		assertType('non-empty-list<string>', explode(",", $s, 2));
-		// limit 1 always yields a single element
-		assertType('non-empty-list<string>', explode("\n", $s, 1));
-		// negative limit may drop the guaranteed parts
-		assertType('list<string>', explode("\n", $s, -1));
+		// limit 1 returns the whole string as the only element
+		assertType('array{non-falsy-string}', explode("\n", $s, 1));
+		// limit -1 drops only the last of the guaranteed parts, so one remains
+		assertType('non-empty-list<string>', explode("\n", $s, -1));
 	} else {
 		assertType('string', $s);
 	}
@@ -142,16 +142,19 @@ function zeroAndNegativeLimit(string $s): void
 {
 	if (str_contains($s, "\n")) {
 		assertType('non-falsy-string', $s);
-		// limit 0 is treated as 1, so a single non-empty element
-		assertType('non-empty-list<string>', explode("\n", $s, 0));
-		// a negative limit drops trailing components and may empty the result
-		assertType('list<string>', explode("\n", $s, -1));
+		// limit 0 is treated as 1, so the whole string is the only element
+		assertType('array{non-falsy-string}', explode("\n", $s, 0));
+		// limit -1 drops the last component, but a guaranteed part remains
+		assertType('non-empty-list<string>', explode("\n", $s, -1));
+		// limit -2 or beyond may drop every guaranteed part
 		assertType('list<string>', explode("\n", $s, -2));
 	} else {
 		assertType('string', $s);
 	}
 
 	assertType('string', $s);
+	// without a guard, limit -1 may drop the only component and empty the result
+	assertType('list<string>', explode("\n", $s, -1));
 }
 
 function largeConstantLimit(string $s): void
@@ -165,4 +168,38 @@ function largeConstantLimit(string $s): void
 	}
 
 	assertType('string', $s);
+}
+
+function singleElementLimit(string $s): void
+{
+	// limit 0 or 1 returns the whole string as the only element, even without a guard
+	assertType('array{string}', explode("\n", $s, 0));
+	assertType('array{string}', explode("\n", $s, 1));
+
+	if (str_contains($s, "\n")) {
+		assertType('non-falsy-string', $s);
+		// the single element keeps the refined haystack type
+		assertType('array{non-falsy-string}', explode("\n", $s, 0));
+		assertType('array{non-falsy-string}', explode("\n", $s, 1));
+		// the limit governs even when the delimiter differs from the proven one
+		assertType('array{non-falsy-string}', explode(",", $s, 1));
+	}
+}
+
+/**
+ * @param int<0, 1> $zeroOrOne
+ * @param int<-1, -1> $minusOne
+ * @param int<0, 2> $wider
+ */
+function singleElementRangeLimit(string $s, int $zeroOrOne, int $minusOne, int $wider): void
+{
+	// a range fully within {0, 1} still yields a single element
+	assertType('array{string}', explode("\n", $s, $zeroOrOne));
+	// a wider range no longer guarantees a single element
+	assertType('non-empty-list<string>', explode("\n", $s, $wider));
+
+	if (str_contains($s, "\n")) {
+		// limit -1 keeps at least one of the guaranteed parts
+		assertType('non-empty-list<string>', explode("\n", $s, $minusOne));
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-3961-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3961-php8.php
@@ -12,8 +12,8 @@ class Foo
 		assertType('non-empty-list<string>', explode('.', $v));
 		assertType('*NEVER*', explode('', $v));
 		assertType('list<string>', explode('.', $v, -2));
-		assertType('non-empty-list<string>', explode('.', $v, 0));
-		assertType('non-empty-list<string>', explode('.', $v, 1));
+		assertType('array{string}', explode('.', $v, 0));
+		assertType('array{string}', explode('.', $v, 1));
 		assertType('non-empty-list<string>', explode($d, $v));
 		assertType('non-empty-list<string>', explode($m, $v));
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-3961.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3961.php
@@ -12,8 +12,8 @@ class Foo
 		assertType('non-empty-list<string>', explode('.', $v));
 		assertType('false', explode('', $v));
 		assertType('list<string>', explode('.', $v, -2));
-		assertType('non-empty-list<string>', explode('.', $v, 0));
-		assertType('non-empty-list<string>', explode('.', $v, 1));
+		assertType('array{string}', explode('.', $v, 0));
+		assertType('array{string}', explode('.', $v, 1));
 		assertType('non-empty-list<string>|false', explode($d, $v));
 		assertType('(non-empty-list<string>|false)', explode($m, $v));
 	}


### PR DESCRIPTION
Follow-up to #5959, refining `explode()`'s return type for small limits, per the [`explode()` manual](https://www.php.net/manual/en/function.explode.php):

- Limit `0` or `1` returns the whole string unsplit (a limit of `0` is treated as `1`), so the result is the single-element shape `array{string}` instead of `non-empty-list<string>`. This holds regardless of whether the delimiter is present.
- Limit `-1` with a delimiter proven present drops only the last of the (at least two) parts, leaving at least one, so `non-empty-list<string>` instead of `list<string>`. Limit `-2` and beyond can still empty the result and stay `list<string>`.
