### PR TITLE
Disable zend.assertions as suggested by PHPParser

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 
 	gc_disable();
 	if (ini_get('zend.assertions') !== '-1') {
-		ini_set('zend.assertions', 0);
+		ini_set('zend.assertions', '0');
 	}
 
 	define('__PHPSTAN_RUNNING__', true);

--- a/bin/phpstan
+++ b/bin/phpstan
@@ -17,6 +17,9 @@ use Symfony\Component\Console\Helper\ProgressBar;
 	ini_set('display_errors', 'stderr');
 
 	gc_disable();
+	if (ini_get('zend.assertions') !== '-1') {
+		ini_set('zend.assertions', 0);
+	}
 
 	define('__PHPSTAN_RUNNING__', true);
 


### PR DESCRIPTION
[nikic/PHP-Parser Performance.markdown](https://github.com/nikic/PHP-Parser/blob/044a6a392ff8ad0d61f14370a5fbbd0a0107152f/doc/component/Performance.markdown) suggests to use `zend.assertions=0` at runtime.

at best the php.ini of the php binary beeing used would define `zend.assertions=-1`, but thats neither the default php ships with in development nor is it likely people will adjust this setting in a environment in which PHPStan is running

quoting the php.ini:
```
; Switch whether to compile assertions at all (to have no overhead at run-time)
; -1: Do not compile at all
;  0: Jump over assertion at run-time
;  1: Execute assertions
; Changing from or to a negative value is only possible in php.ini!
; (For turning assertions on and off at run-time, toggle zend.assertions between the values 1 and 0)
; Default Value: 1
; Development Value: 1
; Production Value: -1
; https://php.net/zend.assertions
;zend.assertions = -1
```

so with this PR we disable zend-asserts at runtime in case they are not disabled entirely by the used php.ini setting already.

testing on https://github.com/TomasVotruba/php-parser-speed-comparison-2026 suggests this has some small benefit
