### PR TITLE
Negating the smallest integer results in a float

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -2623,7 +2623,9 @@ final class InitializerExprTypeResolver
 					/** @var int|float $newValue */
 					$newValue = -$scalarValue;
 					if (!is_int($newValue)) {
-						return $type;
+						// Negating the smallest integer overflows into a float.
+						$newTypes[] = new ConstantFloatType($newValue);
+						continue;
 					}
 					$newTypes[] = new ConstantIntegerType($newValue);
 				} elseif (is_float($scalarValue)) {

--- a/src/Type/Constant/ConstantIntegerType.php
+++ b/src/Type/Constant/ConstantIntegerType.php
@@ -18,6 +18,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 use function abs;
 use function sprintf;
+use const PHP_INT_MIN;
 
 /** @api */
 class ConstantIntegerType extends IntegerType implements ConstantScalarType
@@ -85,6 +86,11 @@ class ConstantIntegerType extends IntegerType implements ConstantScalarType
 
 	public function toAbsoluteNumber(): Type
 	{
+		if ($this->value === PHP_INT_MIN) {
+			// The absolute value of the smallest integer is not representable as an int.
+			return new ConstantFloatType(-(float) $this->value);
+		}
+
 		return new self(abs($this->value));
 	}
 

--- a/src/Type/Constant/ConstantIntegerType.php
+++ b/src/Type/Constant/ConstantIntegerType.php
@@ -88,6 +88,8 @@ class ConstantIntegerType extends IntegerType implements ConstantScalarType
 	{
 		if ($this->value === PHP_INT_MIN) {
 			// The absolute value of the smallest integer is not representable as an int.
+			// Checking is_int(abs($this->value)) instead is dead code to PHPStan itself,
+			// which infers abs(int) as int<0, max>.
 			return new ConstantFloatType(-(float) $this->value);
 		}
 

--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -13,6 +13,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryDecimalIntegerStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use function array_filter;
 use function array_map;
@@ -485,13 +486,22 @@ class IntegerRangeType extends IntegerType implements CompoundType
 			return $this;
 		}
 
-		if ($this->max === null || $this->max >= 0) {
-			$inversedMin = $this->min !== null ? $this->min * -1 : null;
+		if ($this->max === PHP_INT_MIN) {
+			// Nothing is smaller than the smallest integer, so this range holds a single value
+			// whose absolute value is not representable as an int.
+			return new ConstantFloatType(-(float) PHP_INT_MIN);
+		}
 
+		// Negating the smallest integer overflows, so its absolute value is treated as unbounded,
+		// the same way an unbounded lower bound is. This keeps abs(int<min, 0>) and
+		// abs(int<-9223372036854775808, 0>) in agreement.
+		$inversedMin = $this->min !== null && $this->min !== PHP_INT_MIN ? -$this->min : null;
+
+		if ($this->max === null || $this->max >= 0) {
 			return self::fromInterval(0, $inversedMin !== null && $this->max !== null ? max($inversedMin, $this->max) : null);
 		}
 
-		return self::fromInterval($this->max * -1, $this->min !== null ? $this->min * -1 : null);
+		return self::fromInterval(-$this->max, $inversedMin);
 	}
 
 	public function toString(): Type

--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -13,7 +13,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryDecimalIntegerStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use function array_filter;
 use function array_map;
@@ -56,7 +55,21 @@ class IntegerRangeType extends IntegerType implements CompoundType
 			return new IntegerType();
 		}
 
-		return (new self($min, $max))->shift($shift);
+		$range = (new self($min, $max))->shift($shift);
+		if (!$range instanceof self) {
+			return $range;
+		}
+
+		// Nothing is smaller than the smallest integer, and nothing is bigger than the biggest one,
+		// so an unbounded side that reaches either one holds a single value.
+		if ($range->min === null && $range->max === PHP_INT_MIN) {
+			return new ConstantIntegerType(PHP_INT_MIN);
+		}
+		if ($range->min === PHP_INT_MAX && $range->max === null) {
+			return new ConstantIntegerType(PHP_INT_MAX);
+		}
+
+		return $range;
 	}
 
 	protected static function isDisjoint(?int $minA, ?int $maxA, ?int $minB, ?int $maxB, bool $touchingIsDisjoint = true): bool
@@ -484,12 +497,6 @@ class IntegerRangeType extends IntegerType implements CompoundType
 	{
 		if ($this->min !== null && $this->min >= 0) {
 			return $this;
-		}
-
-		if ($this->max === PHP_INT_MIN) {
-			// Nothing is smaller than the smallest integer, so this range holds a single value
-			// whose absolute value is not representable as an int.
-			return new ConstantFloatType(-(float) PHP_INT_MIN);
 		}
 
 		// Negating the smallest integer overflows, so its absolute value is treated as unbounded,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -113,6 +113,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_INT_SIZE === 8) {
 			yield __DIR__ . '/data/predefined-constants-64bit.php';
 			yield __DIR__ . '/data/abs-64bit.php';
+			yield __DIR__ . '/data/unary-minus-64bit.php';
 		} else {
 			yield __DIR__ . '/data/predefined-constants-32bit.php';
 		}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -112,6 +112,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		if (PHP_INT_SIZE === 8) {
 			yield __DIR__ . '/data/predefined-constants-64bit.php';
+			yield __DIR__ . '/data/abs-64bit.php';
 		} else {
 			yield __DIR__ . '/data/predefined-constants-32bit.php';
 		}

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -863,7 +863,8 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$n' => 'mixed~int<' . (PHP_INT_MIN + 1) . ', max>',
 				],
 				[
-					'$n' => 'mixed~(0.0|bool|int<min, ' . PHP_INT_MIN . '>|null)',
+					// int<min, PHP_INT_MIN> holds a single value
+					'$n' => 'mixed~(' . PHP_INT_MIN . '|0.0|bool|null)',
 				],
 			],
 			[
@@ -875,7 +876,8 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$n' => 'mixed~(0.0|int<min, ' . (PHP_INT_MAX - 1) . '>|false|null)',
 				],
 				[
-					'$n' => 'mixed~(int<' . PHP_INT_MAX . ', max>|true)',
+					// int<PHP_INT_MAX, max> holds a single value
+					'$n' => 'mixed~(' . PHP_INT_MAX . '|true)',
 				],
 			],
 			[

--- a/tests/PHPStan/Analyser/data/abs-64bit.php
+++ b/tests/PHPStan/Analyser/data/abs-64bit.php
@@ -8,6 +8,10 @@ use function PHPStan\Testing\assertType;
 assertType('9.223372036854776E+18', abs(-9223372036854775807 - 1));
 assertType('2147483648|9.223372036854776E+18', abs(PHP_INT_MIN));
 
+// One step away from the overflow, so still an integer.
+assertType('9223372036854775807', abs(-9223372036854775807));
+assertType('2147483647|9223372036854775807', abs(-PHP_INT_MAX));
+
 function integerRanges(int $int): void
 {
 	/** @var int<-9223372036854775808, 0> $int */

--- a/tests/PHPStan/Analyser/data/abs-64bit.php
+++ b/tests/PHPStan/Analyser/data/abs-64bit.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Abs64bit;
+
+use function PHPStan\Testing\assertType;
+
+// abs() of the smallest integer overflows and returns a float.
+assertType('9.223372036854776E+18', abs(-9223372036854775807 - 1));
+assertType('2147483648|9.223372036854776E+18', abs(PHP_INT_MIN));
+
+function integerRanges(int $int): void
+{
+	/** @var int<-9223372036854775808, 0> $int */
+	assertType('int<0, max>', abs($int));
+
+	/** @var int<-9223372036854775808, -1> $int */
+	assertType('int<1, max>', abs($int));
+
+	/** @var int<-9223372036854775808, 9223372036854775807> $int */
+	assertType('int<0, max>', abs($int));
+
+	// The only value in this range is the smallest integer.
+	/** @var int<min, -9223372036854775808> $int */
+	assertType('9.223372036854776E+18', abs($int));
+}

--- a/tests/PHPStan/Analyser/data/abs-64bit.php
+++ b/tests/PHPStan/Analyser/data/abs-64bit.php
@@ -23,7 +23,12 @@ function integerRanges(int $int): void
 	/** @var int<-9223372036854775808, 9223372036854775807> $int */
 	assertType('int<0, max>', abs($int));
 
-	// The only value in this range is the smallest integer.
+	// IntegerRangeType::fromInterval() collapses these to a single value.
 	/** @var int<min, -9223372036854775808> $int */
+	assertType('-9223372036854775808', $int);
 	assertType('9.223372036854776E+18', abs($int));
+
+	/** @var int<9223372036854775807, max> $int */
+	assertType('9223372036854775807', $int);
+	assertType('9223372036854775807', abs($int));
 }

--- a/tests/PHPStan/Analyser/data/unary-minus-64bit.php
+++ b/tests/PHPStan/Analyser/data/unary-minus-64bit.php
@@ -8,6 +8,9 @@ use function PHPStan\Testing\assertType;
 assertType('9.223372036854776E+18', -(-9223372036854775807 - 1));
 assertType('2147483648|9.223372036854776E+18', -PHP_INT_MIN);
 
+// Negating the largest integer stays an integer.
+assertType('-9223372036854775807|-2147483647', -PHP_INT_MAX);
+
 $min = -9223372036854775807 - 1;
 assertType('9.223372036854776E+18', -$min);
 
@@ -27,4 +30,15 @@ function constantUnion(int $int): void
 {
 	/** @var -1|-2 $int */
 	assertType('1|2', -$int);
+
+	/** @var 9223372036854775807|25 $int */
+	assertType('-9223372036854775807|-25', -$int);
+}
+
+// The union has one member that overflows and one that does not.
+function partiallyOverflowingUnion(bool $bool): void
+{
+	$int = $bool ? -9223372036854775807 - 1 : 25;
+	assertType('-9223372036854775808|25', $int);
+	assertType('-25|9.223372036854776E+18', -$int);
 }

--- a/tests/PHPStan/Analyser/data/unary-minus-64bit.php
+++ b/tests/PHPStan/Analyser/data/unary-minus-64bit.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace UnaryMinus64bit;
+
+use function PHPStan\Testing\assertType;
+
+// Negating the smallest integer overflows and produces a float.
+assertType('9.223372036854776E+18', -(-9223372036854775807 - 1));
+assertType('2147483648|9.223372036854776E+18', -PHP_INT_MIN);
+
+$min = -9223372036854775807 - 1;
+assertType('9.223372036854776E+18', -$min);
+
+assertType('9223372036854775807', -(-9223372036854775807));
+assertType('-9223372036854775807', -9223372036854775807);
+
+function integerRanges(int $int): void
+{
+	/** @var int<min, -1> $int */
+	assertType('int<1, max>', -$int);
+
+	/** @var int<-9223372036854775808, -1> $int */
+	assertType('int<1, max>', -$int);
+}
+
+function constantUnion(int $int): void
+{
+	/** @var -1|-2 $int */
+	assertType('1|2', -$int);
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/14946
Closes https://github.com/phpstan/phpstan/issues/14947

This started as two PRs, #6028 for the crash and #6029 for the wrong type. They were logically independent, but they conflicted in `NodeScopeResolverTest` and reviewing them apart turned out to be more work than reviewing them together. Merged here; #6029 is closed.

Negating the smallest integer overflows into a float, because `9223372036854775808` is not representable as an `int`:

```php
var_dump(-PHP_INT_MIN);    // float(9.2233720368548E+18)
var_dump(abs(PHP_INT_MIN)); // float(9.2233720368548E+18)
```

Three places got this wrong.

## 1. `abs(PHP_INT_MIN)` was an internal error

`ConstantIntegerType::toAbsoluteNumber()` did `new self(abs($this->value))`, which is a `TypeError` for the smallest integer. It now returns the float, matching what PHPStan already infers for the equivalent literal `abs(-9223372036854775808)`.

`IntegerRangeType::toAbsoluteNumber()` crashed the same way through `$this->min * -1` and `$this->max * -1`.

## 2. `-PHP_INT_MIN` was inferred as `PHP_INT_MIN`

`InitializerExprTypeResolver::getUnaryMinusTypeFromType()` noticed the overflow and then bailed out to the **un-negated** type:

```php
$newValue = -$scalarValue;
if (!is_int($newValue)) {
    return $type;   // the original type, negation not applied
}
```

It now produces a `ConstantFloatType` for that member and keeps negating the rest of the union. The union case is where the old code did the most damage:

```php
$int = $bool ? -9223372036854775807 - 1 : 25;
\PHPStan\dumpType(-$int);   // was: -9223372036854775808|25   now: -25|9.223372036854776E+18
```

It threw away the members it had already negated. Integer ranges were fine, since `getUnaryMinusType()` routes them through `* -1`, which handles the overflow.

## 3. `fromInterval()` did not collapse degenerate ranges

Suggested by @VincentLanglet. Nothing is smaller than `PHP_INT_MIN` and nothing is bigger than `PHP_INT_MAX`, so these hold a single value:

```php
\PHPStan\dumpType($a);  // int<min, -9223372036854775808>  ->  -9223372036854775808
\PHPStan\dumpType($b);  // int<9223372036854775807, max>   ->  9223372036854775807
```

`IntegerRangeType::fromInterval()` now returns a `ConstantIntegerType` for both, so `toAbsoluteNumber()` no longer needs its own special case for `max === PHP_INT_MIN`.

`min === PHP_INT_MIN` on a range that holds more than one value still needs a guard, because negating that bound overflows. `fromInterval()` could normalize it to `null`, since `int<-9223372036854775808, 0>` and `int<min, 0>` denote the same values, but that changes how those types describe themselves and is a bigger change than this bugfix.

## Behaviour for integer ranges

`abs(int)` is already `int<0, max>` and `abs(int<min, 0>)` is already `int<0, max>`, so a lower bound of `PHP_INT_MIN` is treated the same as an unbounded one rather than introducing a float into the union:

| type | `abs()` |
| --- | --- |
| `int` | `int<0, max>` (unchanged) |
| `int<min, 0>` | `int<0, max>` (unchanged) |
| `int<-9223372036854775808, 0>` | `int<0, max>` (was: internal error) |
| `int<min, -1>` | `int<1, max>` (unchanged) |
| `int<-9223372036854775808, -1>` | `int<1, max>` (was: internal error) |

Making those precise (`int<0, max>|9.223372036854776E+18`) would also change `abs(int)`, so I left it out.

## Tests

Expected values depend on the host's integer width, so the asserts live in `tests/PHPStan/Analyser/data/{abs,unary-minus}-64bit.php`, yielded from `NodeScopeResolverTest` under `PHP_INT_SIZE === 8` next to `predefined-constants-64bit.php`.
