### PR TITLE
Negating the smallest integer results in a float

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -2623,7 +2623,9 @@ final class InitializerExprTypeResolver
 					/** @var int|float $newValue */
 					$newValue = -$scalarValue;
 					if (!is_int($newValue)) {
-						return $type;
+						// Negating the smallest integer overflows into a float.
+						$newTypes[] = new ConstantFloatType($newValue);
+						continue;
 					}
 					$newTypes[] = new ConstantIntegerType($newValue);
 				} elseif (is_float($scalarValue)) {

--- a/src/Type/Constant/ConstantIntegerType.php
+++ b/src/Type/Constant/ConstantIntegerType.php
@@ -18,6 +18,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 use function abs;
 use function sprintf;
+use const PHP_INT_MIN;
 
 /** @api */
 class ConstantIntegerType extends IntegerType implements ConstantScalarType
@@ -85,6 +86,11 @@ class ConstantIntegerType extends IntegerType implements ConstantScalarType
 
 	public function toAbsoluteNumber(): Type
 	{
+		if ($this->value === PHP_INT_MIN) {
+			// The absolute value of the smallest integer is not representable as an int.
+			return new ConstantFloatType(-(float) $this->value);
+		}
+
 		return new self(abs($this->value));
 	}
 

--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -13,6 +13,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryDecimalIntegerStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use function array_filter;
 use function array_map;
@@ -485,13 +486,22 @@ class IntegerRangeType extends IntegerType implements CompoundType
 			return $this;
 		}
 
-		if ($this->max === null || $this->max >= 0) {
-			$inversedMin = $this->min !== null ? $this->min * -1 : null;
+		if ($this->max === PHP_INT_MIN) {
+			// Nothing is smaller than the smallest integer, so this range holds a single value
+			// whose absolute value is not representable as an int.
+			return new ConstantFloatType(-(float) PHP_INT_MIN);
+		}
 
+		// Negating the smallest integer overflows, so its absolute value is treated as unbounded,
+		// the same way an unbounded lower bound is. This keeps abs(int<min, 0>) and
+		// abs(int<-9223372036854775808, 0>) in agreement.
+		$inversedMin = $this->min !== null && $this->min !== PHP_INT_MIN ? -$this->min : null;
+
+		if ($this->max === null || $this->max >= 0) {
 			return self::fromInterval(0, $inversedMin !== null && $this->max !== null ? max($inversedMin, $this->max) : null);
 		}
 
-		return self::fromInterval($this->max * -1, $this->min !== null ? $this->min * -1 : null);
+		return self::fromInterval(-$this->max, $inversedMin);
 	}
 
 	public function toString(): Type

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -113,6 +113,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_INT_SIZE === 8) {
 			yield __DIR__ . '/data/predefined-constants-64bit.php';
 			yield __DIR__ . '/data/abs-64bit.php';
+			yield __DIR__ . '/data/unary-minus-64bit.php';
 		} else {
 			yield __DIR__ . '/data/predefined-constants-32bit.php';
 		}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -112,6 +112,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		if (PHP_INT_SIZE === 8) {
 			yield __DIR__ . '/data/predefined-constants-64bit.php';
+			yield __DIR__ . '/data/abs-64bit.php';
 		} else {
 			yield __DIR__ . '/data/predefined-constants-32bit.php';
 		}

--- a/tests/PHPStan/Analyser/data/abs-64bit.php
+++ b/tests/PHPStan/Analyser/data/abs-64bit.php
@@ -8,6 +8,10 @@ use function PHPStan\Testing\assertType;
 assertType('9.223372036854776E+18', abs(-9223372036854775807 - 1));
 assertType('2147483648|9.223372036854776E+18', abs(PHP_INT_MIN));
 
+// One step away from the overflow, so still an integer.
+assertType('9223372036854775807', abs(-9223372036854775807));
+assertType('2147483647|9223372036854775807', abs(-PHP_INT_MAX));
+
 function integerRanges(int $int): void
 {
 	/** @var int<-9223372036854775808, 0> $int */

--- a/tests/PHPStan/Analyser/data/abs-64bit.php
+++ b/tests/PHPStan/Analyser/data/abs-64bit.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Abs64bit;
+
+use function PHPStan\Testing\assertType;
+
+// abs() of the smallest integer overflows and returns a float.
+assertType('9.223372036854776E+18', abs(-9223372036854775807 - 1));
+assertType('2147483648|9.223372036854776E+18', abs(PHP_INT_MIN));
+
+function integerRanges(int $int): void
+{
+	/** @var int<-9223372036854775808, 0> $int */
+	assertType('int<0, max>', abs($int));
+
+	/** @var int<-9223372036854775808, -1> $int */
+	assertType('int<1, max>', abs($int));
+
+	/** @var int<-9223372036854775808, 9223372036854775807> $int */
+	assertType('int<0, max>', abs($int));
+
+	// The only value in this range is the smallest integer.
+	/** @var int<min, -9223372036854775808> $int */
+	assertType('9.223372036854776E+18', abs($int));
+}

--- a/tests/PHPStan/Analyser/data/unary-minus-64bit.php
+++ b/tests/PHPStan/Analyser/data/unary-minus-64bit.php
@@ -8,6 +8,9 @@ use function PHPStan\Testing\assertType;
 assertType('9.223372036854776E+18', -(-9223372036854775807 - 1));
 assertType('2147483648|9.223372036854776E+18', -PHP_INT_MIN);
 
+// Negating the largest integer stays an integer.
+assertType('-9223372036854775807|-2147483647', -PHP_INT_MAX);
+
 $min = -9223372036854775807 - 1;
 assertType('9.223372036854776E+18', -$min);
 
@@ -27,4 +30,15 @@ function constantUnion(int $int): void
 {
 	/** @var -1|-2 $int */
 	assertType('1|2', -$int);
+
+	/** @var 9223372036854775807|25 $int */
+	assertType('-9223372036854775807|-25', -$int);
+}
+
+// The union has one member that overflows and one that does not.
+function partiallyOverflowingUnion(bool $bool): void
+{
+	$int = $bool ? -9223372036854775807 - 1 : 25;
+	assertType('-9223372036854775808|25', $int);
+	assertType('-25|9.223372036854776E+18', -$int);
 }

--- a/tests/PHPStan/Analyser/data/unary-minus-64bit.php
+++ b/tests/PHPStan/Analyser/data/unary-minus-64bit.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace UnaryMinus64bit;
+
+use function PHPStan\Testing\assertType;
+
+// Negating the smallest integer overflows and produces a float.
+assertType('9.223372036854776E+18', -(-9223372036854775807 - 1));
+assertType('2147483648|9.223372036854776E+18', -PHP_INT_MIN);
+
+$min = -9223372036854775807 - 1;
+assertType('9.223372036854776E+18', -$min);
+
+assertType('9223372036854775807', -(-9223372036854775807));
+assertType('-9223372036854775807', -9223372036854775807);
+
+function integerRanges(int $int): void
+{
+	/** @var int<min, -1> $int */
+	assertType('int<1, max>', -$int);
+
+	/** @var int<-9223372036854775808, -1> $int */
+	assertType('int<1, max>', -$int);
+}
+
+function constantUnion(int $int): void
+{
+	/** @var -1|-2 $int */
+	assertType('1|2', -$int);
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/14947

Negating the smallest integer overflows into a float, because `9223372036854775808` is not representable as an `int`:

```php
var_dump(-PHP_INT_MIN); // float(9.2233720368548E+18)
```

`getUnaryMinusTypeFromType()` detected the overflow but returned the **un-negated** type, so `-PHP_INT_MIN` came out as `PHP_INT_MIN`. It now produces a `ConstantFloatType` for that value and keeps negating the remaining constants of the union.

| expression | before | after | PHP |
| --- | --- | --- | --- |
| `-(-9223372036854775807 - 1)` | `-9223372036854775808` | `9.223372036854776E+18` | `float(9.2233720368548E+18)` |
| `-PHP_INT_MIN` | `-9223372036854775808\|-2147483648` | `2147483648\|9.223372036854776E+18` | same |

The new result matches what the multiplication path already inferred for `PHP_INT_MIN * -1`, which is where `getUnaryMinusType()` routes integer ranges — so `-int<min, -1>` was already correct and stays `int<1, max>`. Only the constant-integer path changed. The test file covers the range and constant-union cases too, to pin that down.

Expected values depend on the host's integer width, so the asserts live in `tests/PHPStan/Analyser/data/unary-minus-64bit.php`, yielded from `NodeScopeResolverTest` under `PHP_INT_SIZE === 8` next to `predefined-constants-64bit.php`.

### Related

Same root cause as #6028 (`abs(PHP_INT_MIN)` crashing with an internal error), but that one is a `TypeError` in `toAbsoluteNumber()` while this one is silently wrong. The two PRs are independent and touch different files.
