### PR TITLE
fix: don't try to load non-existent files

### DIFF
--- a/src/Cache/FileCacheStorage.php
+++ b/src/Cache/FileCacheStorage.php
@@ -17,6 +17,7 @@ use function array_keys;
 use function closedir;
 use function dirname;
 use function error_get_last;
+use function file_exists;
 use function hash;
 use function is_dir;
 use function is_file;
@@ -50,6 +51,9 @@ final class FileCacheStorage implements CacheStorage
 		[,, $filePath] = $this->getFilePaths($key);
 
 		return (static function ($variableKey, $filePath) {
+			if (! file_exists($filePath)) {
+				return null;
+			}
 			$cacheItem = @include $filePath;
 			if (!$cacheItem instanceof CacheItem) {
 				return null;


### PR DESCRIPTION
Hello!

We're getting [failures on Larastan](https://github.com/larastan/larastan/actions/runs/29059934565/job/86259357412) because this is trying to include a file that doesn't exist---from Claude:

```
The @ is supposed to silently suppress the missing-file warning. But the error chain in your CI is:
@include (file missing) 
  → PHPUnit 13's ErrorHandler->__invoke()
    → forwardToPreviousErrorHandler()
      → Laravel's HandleExceptions->handleError()
        → FATAL
PHPUnit 13's error handler intercepts the warning before @ suppression takes effect, then forwards it to Laravel's HandleExceptions, which throws.
```

The fix is to simply return early if the file doesn't exist

Thanks!