### PR TITLE
Fix 'path ... does not exist' false-positive for expr containing DIRECTORY_SEPARATOR

### DIFF
--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -90,8 +90,7 @@ final class FileHelper
 			$path = $originalPath;
 		}
 
-		$path = str_replace(['\\', '//', '///', '////'], '/', $path);
-
+		$path = $this->normalizeSeparator($path);
 		$pathRoot = str_starts_with($path, '/') ? $directorySeparator : '';
 		$pathParts = explode('/', trim($path, '/'));
 
@@ -111,6 +110,11 @@ final class FileHelper
 		}
 
 		return self::$normalizedPathsCache[$originalPath][$directorySeparator] = ($scheme !== null ? $scheme . '://' : '') . $pathRoot . implode($directorySeparator, $normalizedPathParts);
+	}
+
+	public function normalizeSeparator(string $path): string
+	{
+		return str_replace(['\\', '//', '///', '////'], '/', $path);
 	}
 
 }

--- a/src/Rules/Keywords/RequireFileExistsRule.php
+++ b/src/Rules/Keywords/RequireFileExistsRule.php
@@ -52,6 +52,7 @@ final class RequireFileExistsRule implements Rule
 		private ExprPrinter $exprPrinter,
 		#[AutowiredParameter(ref: '%featureToggles.magicDirInInclude%')]
 		private bool $checkMagicDirInInclude,
+		private FileHelper $fileHelper,
 	)
 	{
 	}
@@ -188,10 +189,16 @@ final class RequireFileExistsRule implements Rule
 		$rightPaths = $this->resolveFilePaths($expr->right, $scope, $magicDirFallback);
 		foreach ($this->resolveFilePaths($expr->left, $scope, $magicDirFallback) as $left) {
 			foreach ($rightPaths as $rightPath) {
-				$paths[] = new ConstantStringType($left->getValue() . $rightPath->getValue());
+				$normalizedPath = $this->fileHelper->normalizeSeparator($left->getValue() . $rightPath->getValue());
+				$paths[$normalizedPath] = $normalizedPath;
 			}
 		}
-		return $paths;
+
+		$list = [];
+		foreach ($paths as $path) {
+			$list[] = new ConstantStringType($path);
+		}
+		return $list;
 	}
 
 	private function isInFileExists(Include_ $node, Scope $scope): bool

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleNoConstantPathTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleNoConstantPathTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Keywords;
 
+use PHPStan\File\FileHelper;
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -20,6 +21,7 @@ class RequireFileExistsRuleNoConstantPathTest extends RuleTestCase
 			$this->currentWorkingDirectory,
 			self::getContainer()->getByType(ExprPrinter::class),
 			true,
+			self::getContainer()->getByType(FileHelper::class),
 		);
 	}
 
@@ -41,6 +43,14 @@ class RequireFileExistsRuleNoConstantPathTest extends RuleTestCase
 			[
 				'Path in require_once() __DIR__ . "{$path}/{$file}" is not a file or it does not exist.',
 				12,
+			],
+			[
+				'Path in require_once() __DIR__ . DIRECTORY_SEPARATOR . $path . \'/\' . $file is not a file or it does not exist.',
+				14,
+			],
+			[
+				'Path in require_once() "../bug-12203-sure-does-not-exist.php" is not a file or it does not exist.',
+				15,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Keywords;
 
+use PHPStan\File\FileHelper;
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -25,6 +26,7 @@ class RequireFileExistsRuleTest extends RuleTestCase
 			$this->currentWorkingDirectory,
 			self::getContainer()->getByType(ExprPrinter::class),
 			true,
+			self::getContainer()->getByType(FileHelper::class),
 		);
 	}
 
@@ -144,6 +146,14 @@ class RequireFileExistsRuleTest extends RuleTestCase
 			[
 				'Path in require_once() __DIR__ . "{$path}/{$file}" is not a file or it does not exist.',
 				12,
+			],
+			[
+				'Path in require_once() __DIR__ . DIRECTORY_SEPARATOR . $path . \'/\' . $file is not a file or it does not exist.',
+				14,
+			],
+			[
+				'Path in require_once() "../bug-12203-sure-does-not-exist.php" is not a file or it does not exist.',
+				15,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Keywords/data/bug-12203.php
+++ b/tests/PHPStan/Rules/Keywords/data/bug-12203.php
@@ -10,3 +10,6 @@ $file = 'bug-12203-sure-does-not-exist.php';
 require_once __DIR__ . '/'. $path .'/'. $file;
 
 require_once __DIR__ . "$path/$file";
+
+require_once __DIR__ . DIRECTORY_SEPARATOR. $path .'/'. $file;
+require_once '..'. \DIRECTORY_SEPARATOR .'bug-12203-sure-does-not-exist.php';

--- a/tests/PHPStan/Rules/Keywords/data/require-file-simple-case.php
+++ b/tests/PHPStan/Rules/Keywords/data/require-file-simple-case.php
@@ -12,3 +12,5 @@ include $fileThatDoesNotExist;
 include_once $fileThatDoesNotExist;
 require $fileThatDoesNotExist;
 require_once $fileThatDoesNotExist;
+
+$fileThatExists = __DIR__ . \DIRECTORY_SEPARATOR . 'include-me-to-prove-you-work.txt';


### PR DESCRIPTION
root problem was that `DIRECTORY_SEPARATOR` was resolved into `'\\'|’/'` which made it duplicate errors when paths later on where build with both variants. this also lead to the 'crazy' result of seeing windows-style path separators in errors on linux based systems and vice-versa.

closes https://github.com/phpstan/phpstan/issues/14944
closes https://github.com/phpstan/phpstan-src/pull/6027