### PR TITLE
Faster DuplicateClassDeclarationRule

### DIFF
--- a/src/Rules/Classes/DuplicateClassDeclarationRule.php
+++ b/src/Rules/Classes/DuplicateClassDeclarationRule.php
@@ -24,6 +24,7 @@ use function strtolower;
 #[ValidatesStubFiles]
 final class DuplicateClassDeclarationRule implements Rule
 {
+	private ?array $classMap = null;
 
 	public function __construct(private Reflector $reflector, private RelativePathHelper $relativePathHelper)
 	{
@@ -38,21 +39,25 @@ final class DuplicateClassDeclarationRule implements Rule
 	{
 		$thisClass = $node->getClassReflection();
 		$className = $thisClass->getName();
-		$allClasses = $this->reflector->reflectAllClasses();
-		$filteredClasses = [];
-		foreach ($allClasses as $reflectionClass) {
-			if ($reflectionClass->getName() !== $className) {
-				continue;
-			}
 
-			$filteredClasses[] = $reflectionClass;
+		if ($this->classMap === null) {
+			$this->classMap = [];
+
+			$allClasses = $this->reflector->reflectAllClasses();
+			foreach ($allClasses as $reflectionClass) {
+				$reflectionClassName = $reflectionClass->getName();
+				if (!isset($this->classMap[$reflectionClassName])) {
+					$this->classMap[$reflectionClassName] = [];
+				}
+				$this->classMap[$reflectionClassName][] = $reflectionClass;
+			}
 		}
 
-		if (count($filteredClasses) < 2) {
+		if (!isset($this->classMap[$className]) || count($this->classMap[$className]) < 2) {
 			return [];
 		}
 
-		$filteredClasses = array_filter($filteredClasses, static fn (ReflectionClass $class) => $class->getStartLine() !== $thisClass->getNativeReflection()->getStartLine());
+		$filteredClasses = array_filter($this->classMap[$className], static fn (ReflectionClass $class) => $class->getStartLine() !== $thisClass->getNativeReflection()->getStartLine());
 
 		$identifierType = strtolower($thisClass->getClassTypeDescription());
 

--- a/src/Rules/Classes/DuplicateClassDeclarationRule.php
+++ b/src/Rules/Classes/DuplicateClassDeclarationRule.php
@@ -9,6 +9,7 @@ use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\DependencyInjection\ValidatesStubFiles;
 use PHPStan\File\RelativePathHelper;
 use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function array_filter;
@@ -24,6 +25,8 @@ use function strtolower;
 #[ValidatesStubFiles]
 final class DuplicateClassDeclarationRule implements Rule
 {
+
+	/** @var array<class-string|trait-string, list<ReflectionClass>>|null */
 	private ?array $classMap = null;
 
 	public function __construct(private Reflector $reflector, private RelativePathHelper $relativePathHelper)
@@ -40,6 +43,8 @@ final class DuplicateClassDeclarationRule implements Rule
 		$thisClass = $node->getClassReflection();
 		$className = $thisClass->getName();
 
+		// this rule runs at the very end of the analysis,
+		// so all classes already have been discovered at this point.
 		if ($this->classMap === null) {
 			$this->classMap = [];
 

--- a/src/Rules/Classes/DuplicateClassDeclarationRule.php
+++ b/src/Rules/Classes/DuplicateClassDeclarationRule.php
@@ -9,7 +9,6 @@ use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\DependencyInjection\ValidatesStubFiles;
 use PHPStan\File\RelativePathHelper;
 use PHPStan\Node\InClassNode;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function array_filter;


### PR DESCRIPTION
inspired by https://github.com/phpstan/phpstan-src/commit/11aebc1e24d63cc168442332b167cf60dae02f20

since DuplicateClassDeclarationRule is the only caller of `MemoizingReflector::reflectAllClasses`, lets optimize the rule for its very specific use-case instead of memoizing only parts of the costs in `MemoizingReflector`.

`DuplicateFunctionDeclarationRule` will be optimized in a separate PR.

----

before this PR:
```
➜  phpstan-src git:(class) hyperfine 'php -d memory_limit=450M bin/phpstan analyze -v --debug src/Analyser/Ignore' -i
Benchmark 1: php -d memory_limit=450M bin/phpstan analyze -v --debug src/Analyser/Ignore
  Time (mean ± σ):      2.547 s ±  0.019 s    [User: 2.204 s, System: 0.338 s]
  Range (min … max):    2.522 s …  2.583 s    10 runs
```

after this PR:
```
➜  phpstan-src git:(class) ✗ hyperfine 'php -d memory_limit=450M bin/phpstan analyze -v --debug src/Analyser/Ignore' -i
Benchmark 1: php -d memory_limit=450M bin/phpstan analyze -v --debug src/Analyser/Ignore
  Time (mean ± σ):      2.392 s ±  0.014 s    [User: 2.082 s, System: 0.304 s]
  Range (min … max):    2.376 s …  2.416 s    10 runs
```