### PR TITLE
Faster DuplicateFunctionDeclarationRule

### DIFF
--- a/src/Rules/Functions/DuplicateFunctionDeclarationRule.php
+++ b/src/Rules/Functions/DuplicateFunctionDeclarationRule.php
@@ -44,7 +44,6 @@ final class DuplicateFunctionDeclarationRule implements Rule
 			$this->functionMap = [];
 
 			$allFunctions = $this->reflector->reflectAllFunctions();
-			$filteredFunctions = [];
 			foreach ($allFunctions as $reflectionFunction) {
 				$reflectionFunctionName = $reflectionFunction->getName();
 				if (!isset($this->functionMap[$reflectionFunctionName])) {

--- a/src/Rules/Functions/DuplicateFunctionDeclarationRule.php
+++ b/src/Rules/Functions/DuplicateFunctionDeclarationRule.php
@@ -23,6 +23,9 @@ use function sprintf;
 final class DuplicateFunctionDeclarationRule implements Rule
 {
 
+	/** @var array<non-empty-string, list<ReflectionFunction>>|null */
+	private ?array $functionMap = null;
+
 	public function __construct(private Reflector $reflector, private RelativePathHelper $relativePathHelper)
 	{
 	}
@@ -35,25 +38,31 @@ final class DuplicateFunctionDeclarationRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$thisFunction = $node->getFunctionReflection();
-		$allFunctions = $this->reflector->reflectAllFunctions();
-		$filteredFunctions = [];
-		foreach ($allFunctions as $reflectionFunction) {
-			if ($reflectionFunction->getName() !== $thisFunction->getName()) {
-				continue;
-			}
+		$functionName = $thisFunction->getName();
 
-			$filteredFunctions[] = $reflectionFunction;
+		if ($this->functionMap === null) {
+			$this->functionMap = [];
+
+			$allFunctions = $this->reflector->reflectAllFunctions();
+			$filteredFunctions = [];
+			foreach ($allFunctions as $reflectionFunction) {
+				$reflectionFunctionName = $reflectionFunction->getName();
+				if (!isset($this->functionMap[$reflectionFunctionName])) {
+					$this->functionMap[$reflectionFunctionName] = [];
+				}
+				$this->functionMap[$reflectionFunctionName][] = $reflectionFunction;
+			}
 		}
 
-		if (count($filteredFunctions) < 2) {
+		if (!isset($this->functionMap[$functionName]) || count($this->functionMap[$functionName]) < 2) {
 			return [];
 		}
 
 		return [
 			RuleErrorBuilder::message(sprintf(
 				"Function %s declared multiple times:\n%s",
-				$thisFunction->getName(),
-				implode("\n", array_map(fn (ReflectionFunction $function) => sprintf('- %s:%d', $this->relativePathHelper->getRelativePath($function->getFileName() ?? 'unknown'), $function->getStartLine()), $filteredFunctions)),
+				$functionName,
+				implode("\n", array_map(fn (ReflectionFunction $function) => sprintf('- %s:%d', $this->relativePathHelper->getRelativePath($function->getFileName() ?? 'unknown'), $function->getStartLine()), $this->functionMap[$functionName])),
 			))->identifier('function.duplicate')->build(),
 		];
 	}

--- a/src/Rules/Functions/DuplicateFunctionDeclarationRule.php
+++ b/src/Rules/Functions/DuplicateFunctionDeclarationRule.php
@@ -40,6 +40,8 @@ final class DuplicateFunctionDeclarationRule implements Rule
 		$thisFunction = $node->getFunctionReflection();
 		$functionName = $thisFunction->getName();
 
+		// this rule runs at the very end of the analysis,
+		// so all function already have been discovered at this point.
 		if ($this->functionMap === null) {
 			$this->functionMap = [];
 


### PR DESCRIPTION
similar to https://github.com/phpstan/phpstan-src/pull/6038

the improvement is rather small because phpstan-src contains only few global functions.
in codebases with more functions it should safe even more. we also do this for consistency with `DuplicateClassDeclarationRule`

----

before the PR:
```
➜  phpstan-src git:(2.2.x) hyperfine 'php -d memory_limit=450M bin/phpstan analyze -v --debug src/Testing' -i
Benchmark 1: php -d memory_limit=450M bin/phpstan analyze -v --debug src/Testing
  Time (mean ± σ):      3.221 s ±  0.016 s    [User: 2.844 s, System: 0.372 s]
  Range (min … max):    3.201 s …  3.254 s    10 runs
```

after the PR:
```
➜  phpstan-src git:(funcs) hyperfine 'php -d memory_limit=450M bin/phpstan analyze -v --debug src/Testing' -i
Benchmark 1: php -d memory_limit=450M bin/phpstan analyze -v --debug src/Testing
  Time (mean ± σ):      3.202 s ±  0.007 s    [User: 2.837 s, System: 0.361 s]
  Range (min … max):    3.195 s …  3.218 s    10 runs
 ```

---

inspired by https://github.com/phpstan/phpstan-src/commit/11aebc1e24d63cc168442332b167cf60dae02f20 which also memoizes `allConstants`. this method has not a single caller in one of the phpstan/* repos, therefore we don't tackle it
