### PR TITLE
Memoize `ExprHandler` dispatch in `MutatingScope::resolveType()`

### DIFF
--- a/src/Analyser/ExprHandlerRegistry.php
+++ b/src/Analyser/ExprHandlerRegistry.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\DependencyInjection\Container;
 use function get_class;
+use function spl_object_id;
 
 /**
  * Resolves which ExprHandler handles a given Expr, memoizing the result by
@@ -16,17 +17,13 @@ use function get_class;
 final class ExprHandlerRegistry
 {
 
-	/** @var array<non-empty-string, ExprHandler<Expr>|false> */
-	private array $exprHandlersByClass = [];
-
-	public function __construct(private Container $container)
-	{
-	}
+	/** @var array<int, array<non-empty-string, ExprHandler<Expr>|false>> */
+	private static array $exprHandlersByClass = [];
 
 	/**
 	 * @return ExprHandler<Expr>|null
 	 */
-	public function resolve(Expr $expr): ?ExprHandler
+	public static function resolve(Expr $expr, Container $container): ?ExprHandler
 	{
 		$cacheKey = get_class($expr);
 		if ($expr instanceof Expr\CallLike) {
@@ -36,14 +33,16 @@ final class ExprHandlerRegistry
 			}
 		}
 
-		$cached = $this->exprHandlersByClass[$cacheKey] ?? null;
+		$containerId = spl_object_id($container);
+		self::$exprHandlersByClass[$containerId] ??= [];
+		$cached = self::$exprHandlersByClass[$containerId][$cacheKey] ?? null;
 		if ($cached !== null) {
 			return $cached === false ? null : $cached;
 		}
 
 		$matchedHandler = null;
 		/** @var ExprHandler<Expr> $exprHandler */
-		foreach ($this->container->getServicesByTag(ExprHandler::EXTENSION_TAG) as $exprHandler) {
+		foreach ($container->getServicesByTag(ExprHandler::EXTENSION_TAG) as $exprHandler) {
 			if (!$exprHandler->supports($expr)) {
 				continue;
 			}
@@ -52,7 +51,7 @@ final class ExprHandlerRegistry
 			break;
 		}
 
-		$this->exprHandlersByClass[$cacheKey] = $matchedHandler ?? false;
+		self::$exprHandlersByClass[$containerId][$cacheKey] = $matchedHandler ?? false;
 
 		return $matchedHandler;
 	}

--- a/src/Analyser/ExprHandlerRegistry.php
+++ b/src/Analyser/ExprHandlerRegistry.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node\Expr;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\DependencyInjection\Container;
+use function get_class;
+
+/**
+ * Resolves which ExprHandler handles a given Expr, memoizing the result by
+ * Expr class so dispatch does not re-scan every tagged handler (a linear
+ * supports() sweep) on each call.
+ *
+ * Call-likes (Expr\CallLike) are never memoized: their handlers select on
+ * isFirstClassCallable(), which the Expr class alone does not determine. Every
+ * other handler's supports() is a pure instanceof check, so the class fully
+ * determines it.
+ */
+#[AutowiredService]
+final class ExprHandlerRegistry
+{
+
+	/** @var array<class-string<Expr>, ExprHandler<Expr>|false> */
+	private array $exprHandlersByClass = [];
+
+	public function __construct(private Container $container)
+	{
+	}
+
+	/**
+	 * @return ExprHandler<Expr>|null
+	 */
+	public function resolve(Expr $expr): ?ExprHandler
+	{
+		if (!$expr instanceof Expr\CallLike) {
+			$cached = $this->exprHandlersByClass[get_class($expr)] ?? null;
+			if ($cached !== null) {
+				return $cached === false ? null : $cached;
+			}
+		}
+
+		$matchedHandler = null;
+		/** @var ExprHandler<Expr> $exprHandler */
+		foreach ($this->container->getServicesByTag(ExprHandler::EXTENSION_TAG) as $exprHandler) {
+			if (!$exprHandler->supports($expr)) {
+				continue;
+			}
+
+			$matchedHandler = $exprHandler;
+			break;
+		}
+
+		if (!$expr instanceof Expr\CallLike) {
+			$this->exprHandlersByClass[get_class($expr)] = $matchedHandler ?? false;
+		}
+
+		return $matchedHandler;
+	}
+
+}

--- a/src/Analyser/ExprHandlerRegistry.php
+++ b/src/Analyser/ExprHandlerRegistry.php
@@ -5,7 +5,6 @@ namespace PHPStan\Analyser;
 use PhpParser\Node\Expr;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\DependencyInjection\Container;
-use WeakMap;
 use function get_class;
 use function spl_object_id;
 
@@ -18,8 +17,8 @@ use function spl_object_id;
 final class ExprHandlerRegistry
 {
 
-	/** @var WeakMap<Container, array<non-empty-string, ExprHandler<Expr>|false>>|null */
-	private static ?WeakMap $exprHandlersByClass = null;
+	/** @var array<int, array<non-empty-string, ExprHandler<Expr>|false>> */
+	private static array $exprHandlersByClass = [];
 
 	/**
 	 * @return ExprHandler<Expr>|null
@@ -34,9 +33,9 @@ final class ExprHandlerRegistry
 			}
 		}
 
-		self::$exprHandlersByClass ??= new WeakMap();
-		self::$exprHandlersByClass[$container] ??= [];
-		$cached = self::$exprHandlersByClass[$container][$cacheKey] ?? null;
+		$containerId = spl_object_id($container);
+		self::$exprHandlersByClass[$containerId] ??= [];
+		$cached = self::$exprHandlersByClass[$containerId][$cacheKey] ?? null;
 		if ($cached !== null) {
 			return $cached === false ? null : $cached;
 		}
@@ -52,7 +51,7 @@ final class ExprHandlerRegistry
 			break;
 		}
 
-		self::$exprHandlersByClass[$container][$cacheKey] = $matchedHandler ?? false;
+		self::$exprHandlersByClass[$containerId][$cacheKey] = $matchedHandler ?? false;
 
 		return $matchedHandler;
 	}

--- a/src/Analyser/ExprHandlerRegistry.php
+++ b/src/Analyser/ExprHandlerRegistry.php
@@ -31,6 +31,9 @@ final class ExprHandlerRegistry
 		$cacheKey = get_class($expr);
 		if ($expr instanceof Expr\CallLike) {
 			$cacheKey .= '|' . $expr->isFirstClassCallable();
+			if ($expr instanceof Expr\New_) {
+				$cacheKey .= '|' . get_class($expr->class);
+			}
 		}
 
 		$cached = $this->exprHandlersByClass[$cacheKey] ?? null;

--- a/src/Analyser/ExprHandlerRegistry.php
+++ b/src/Analyser/ExprHandlerRegistry.php
@@ -11,17 +11,12 @@ use function get_class;
  * Resolves which ExprHandler handles a given Expr, memoizing the result by
  * Expr class so dispatch does not re-scan every tagged handler (a linear
  * supports() sweep) on each call.
- *
- * Call-likes (Expr\CallLike) are never memoized: their handlers select on
- * isFirstClassCallable(), which the Expr class alone does not determine. Every
- * other handler's supports() is a pure instanceof check, so the class fully
- * determines it.
  */
 #[AutowiredService]
 final class ExprHandlerRegistry
 {
 
-	/** @var array<class-string<Expr>, ExprHandler<Expr>|false> */
+	/** @var array<non-empty-string, ExprHandler<Expr>|false> */
 	private array $exprHandlersByClass = [];
 
 	public function __construct(private Container $container)
@@ -33,11 +28,14 @@ final class ExprHandlerRegistry
 	 */
 	public function resolve(Expr $expr): ?ExprHandler
 	{
-		if (!$expr instanceof Expr\CallLike) {
-			$cached = $this->exprHandlersByClass[get_class($expr)] ?? null;
-			if ($cached !== null) {
-				return $cached === false ? null : $cached;
-			}
+		$cacheKey = get_class($expr);
+		if ($expr instanceof Expr\CallLike) {
+			$cacheKey .= '|' . $expr->isFirstClassCallable();
+		}
+
+		$cached = $this->exprHandlersByClass[$cacheKey] ?? null;
+		if ($cached !== null) {
+			return $cached === false ? null : $cached;
 		}
 
 		$matchedHandler = null;
@@ -51,9 +49,7 @@ final class ExprHandlerRegistry
 			break;
 		}
 
-		if (!$expr instanceof Expr\CallLike) {
-			$this->exprHandlersByClass[get_class($expr)] = $matchedHandler ?? false;
-		}
+		$this->exprHandlersByClass[$cacheKey] = $matchedHandler ?? false;
 
 		return $matchedHandler;
 	}

--- a/src/Analyser/ExprHandlerRegistry.php
+++ b/src/Analyser/ExprHandlerRegistry.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser;
 use PhpParser\Node\Expr;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\DependencyInjection\Container;
+use WeakMap;
 use function get_class;
 use function spl_object_id;
 
@@ -17,8 +18,8 @@ use function spl_object_id;
 final class ExprHandlerRegistry
 {
 
-	/** @var array<int, array<non-empty-string, ExprHandler<Expr>|false>> */
-	private static array $exprHandlersByClass = [];
+	/** @var WeakMap<Container, array<non-empty-string, ExprHandler<Expr>|false>>|null */
+	private static ?WeakMap $exprHandlersByClass = null;
 
 	/**
 	 * @return ExprHandler<Expr>|null
@@ -33,9 +34,9 @@ final class ExprHandlerRegistry
 			}
 		}
 
-		$containerId = spl_object_id($container);
-		self::$exprHandlersByClass[$containerId] ??= [];
-		$cached = self::$exprHandlersByClass[$containerId][$cacheKey] ?? null;
+		self::$exprHandlersByClass ??= new WeakMap();
+		self::$exprHandlersByClass[$container] ??= [];
+		$cached = self::$exprHandlersByClass[$container][$cacheKey] ?? null;
 		if ($cached !== null) {
 			return $cached === false ? null : $cached;
 		}
@@ -51,7 +52,7 @@ final class ExprHandlerRegistry
 			break;
 		}
 
-		self::$exprHandlersByClass[$containerId][$cacheKey] = $matchedHandler ?? false;
+		self::$exprHandlersByClass[$container][$cacheKey] = $matchedHandler ?? false;
 
 		return $matchedHandler;
 	}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1059,12 +1059,8 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			return $this->expressionTypes[$exprString]->getType();
 		}
 
-		/** @var ExprHandler<Expr> $exprHandler */
-		foreach ($this->container->getServicesByTag(ExprHandler::EXTENSION_TAG) as $exprHandler) {
-			if (!$exprHandler->supports($node)) {
-				continue;
-			}
-
+		$exprHandler = $this->container->getByType(ExprHandlerRegistry::class)->resolve($node);
+		if ($exprHandler !== null) {
 			return $exprHandler->resolveType($this, $node);
 		}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1059,7 +1059,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			return $this->expressionTypes[$exprString]->getType();
 		}
 
-		$exprHandler = $this->container->getByType(ExprHandlerRegistry::class)->resolve($node);
+		$exprHandler = ExprHandlerRegistry::resolve($node, $this->container);
 		if ($exprHandler !== null) {
 			return $exprHandler->resolveType($this, $node);
 		}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -198,18 +198,7 @@ class NodeScopeResolver
 	/** @var array<string, true> filePath(string) => bool(true) */
 	private array $analysedFiles = [];
 
-	/**
-	 * Memoizes which ExprHandler handles each Expr class so processExprNode() does not
-	 * re-scan every tagged handler on each call. Keyed by Expr class-string; false means
-	 * no handler matched (default handling).
-	 *
-	 * Call-likes (Expr\CallLike) are never memoized: their handlers select on
-	 * isFirstClassCallable(), which the Expr class alone does not determine. Every other
-	 * handler's supports() is a pure instanceof check, so the class fully determines it.
-	 *
-	 * @var array<class-string<Expr>, ExprHandler<Expr>|false>
-	 */
-	private array $exprHandlersByClass = [];
+	private ?ExprHandlerRegistry $exprHandlerRegistry = null;
 
 	/** @var array<string, true> */
 	private array $earlyTerminatingMethodNames;
@@ -2833,31 +2822,7 @@ class NodeScopeResolver
 	 */
 	private function resolveExprHandler(Expr $expr): ?ExprHandler
 	{
-		// Call-likes are excluded from the cache: their handlers select on
-		// isFirstClassCallable(), so the Expr class does not uniquely determine the handler.
-		if (!$expr instanceof Expr\CallLike) {
-			$cached = $this->exprHandlersByClass[get_class($expr)] ?? null;
-			if ($cached !== null) {
-				return $cached === false ? null : $cached;
-			}
-		}
-
-		$matchedHandler = null;
-		/** @var ExprHandler<Expr> $exprHandler */
-		foreach ($this->container->getServicesByTag(ExprHandler::EXTENSION_TAG) as $exprHandler) {
-			if (!$exprHandler->supports($expr)) {
-				continue;
-			}
-
-			$matchedHandler = $exprHandler;
-			break;
-		}
-
-		if (!$expr instanceof Expr\CallLike) {
-			$this->exprHandlersByClass[get_class($expr)] = $matchedHandler ?? false;
-		}
-
-		return $matchedHandler;
+		return ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
 	}
 
 	/**

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2793,7 +2793,7 @@ class NodeScopeResolver
 
 		$this->callNodeCallbackWithExpression($nodeCallback, $expr, $scope, $storage, $context);
 
-		$exprHandler = $this->resolveExprHandler($expr);
+		$exprHandler = ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
 		if ($exprHandler !== null) {
 			return $exprHandler->processExpr($this, $stmt, $expr, $scope, $storage, $nodeCallback, $context);
 		}
@@ -2812,16 +2812,6 @@ class NodeScopeResolver
 			truthyScopeCallback: static fn (): MutatingScope => $scope->filterByTruthyValue($expr),
 			falseyScopeCallback: static fn (): MutatingScope => $scope->filterByFalseyValue($expr),
 		);
-	}
-
-	/**
-	 * Resolves the ExprHandler for the given expression, memoizing the result by Expr class.
-	 *
-	 * @return ExprHandler<Expr>|null
-	 */
-	private function resolveExprHandler(Expr $expr): ?ExprHandler
-	{
-		return ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
 	}
 
 	/**

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -197,8 +197,6 @@ class NodeScopeResolver
 	/** @var array<string, true> filePath(string) => bool(true) */
 	private array $analysedFiles = [];
 
-	private ?ExprHandlerRegistry $exprHandlerRegistry = null;
-
 	/** @var array<string, true> */
 	private array $earlyTerminatingMethodNames;
 
@@ -2793,7 +2791,7 @@ class NodeScopeResolver
 
 		$this->callNodeCallbackWithExpression($nodeCallback, $expr, $scope, $storage, $context);
 
-		$exprHandler = ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
+		$exprHandler = ExprHandlerRegistry::resolve($expr, $this->container);
 		if ($exprHandler !== null) {
 			return $exprHandler->processExpr($this, $stmt, $expr, $scope, $storage, $nodeCallback, $context);
 		}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -175,7 +175,6 @@ use function array_merge;
 use function array_slice;
 use function array_values;
 use function count;
-use function get_class;
 use function in_array;
 use function is_array;
 use function is_int;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -60,19 +60,7 @@ final class TypeSpecifier
 	/** @var StaticMethodTypeSpecifyingExtension[][]|null */
 	private ?array $staticMethodTypeSpecifyingExtensionsByClass = null;
 
-	/**
-	 * Memoizes which ExprHandler handles each Expr class so specifyTypesInCondition()
-	 * does not re-scan every tagged handler (a linear supports() sweep) on each call.
-	 * This matters for deep boolean chains, where specifyTypesInCondition() runs once per arm.
-	 * Keyed by Expr class-string; false means no handler matched (default narrowing).
-	 *
-	 * Call-likes (Expr\CallLike) are never memoized: their handlers select on
-	 * isFirstClassCallable(), which the Expr class alone does not determine. Every other
-	 * handler's supports() is a pure instanceof check, so the class fully determines it.
-	 *
-	 * @var array<class-string<Expr>, ExprHandler<Expr>|false>
-	 */
-	private array $exprHandlersByClass = [];
+	private ?ExprHandlerRegistry $exprHandlerRegistry = null;
 
 	/**
 	 * @param FunctionTypeSpecifyingExtension[] $functionTypeSpecifyingExtensions
@@ -119,31 +107,7 @@ final class TypeSpecifier
 	 */
 	private function resolveExprHandler(Expr $expr): ?ExprHandler
 	{
-		// Call-likes are excluded from the cache: their handlers select on
-		// isFirstClassCallable(), so the Expr class does not uniquely determine the handler.
-		if (!$expr instanceof Expr\CallLike) {
-			$cached = $this->exprHandlersByClass[get_class($expr)] ?? null;
-			if ($cached !== null) {
-				return $cached === false ? null : $cached;
-			}
-		}
-
-		$matchedHandler = null;
-		/** @var ExprHandler<Expr> $exprHandler */
-		foreach ($this->container->getServicesByTag(ExprHandler::EXTENSION_TAG) as $exprHandler) {
-			if (!$exprHandler->supports($expr)) {
-				continue;
-			}
-
-			$matchedHandler = $exprHandler;
-			break;
-		}
-
-		if (!$expr instanceof Expr\CallLike) {
-			$this->exprHandlersByClass[get_class($expr)] = $matchedHandler ?? false;
-		}
-
-		return $matchedHandler;
+		return ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
 	}
 
 	/** @internal */

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -44,7 +44,6 @@ use function array_last;
 use function array_map;
 use function array_merge;
 use function count;
-use function get_class;
 use function in_array;
 use function strtolower;
 use function substr;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -59,8 +59,6 @@ final class TypeSpecifier
 	/** @var StaticMethodTypeSpecifyingExtension[][]|null */
 	private ?array $staticMethodTypeSpecifyingExtensionsByClass = null;
 
-	private ?ExprHandlerRegistry $exprHandlerRegistry = null;
-
 	/**
 	 * @param FunctionTypeSpecifyingExtension[] $functionTypeSpecifyingExtensions
 	 * @param MethodTypeSpecifyingExtension[] $methodTypeSpecifyingExtensions
@@ -91,7 +89,7 @@ final class TypeSpecifier
 			return (new SpecifiedTypes([], []))->setRootExpr($expr);
 		}
 
-		$exprHandler = ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
+		$exprHandler = ExprHandlerRegistry::resolve($expr, $this->container);
 		if ($exprHandler !== null) {
 			return $exprHandler->specifyTypes($this, $scope, $expr, $context);
 		}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -91,22 +91,12 @@ final class TypeSpecifier
 			return (new SpecifiedTypes([], []))->setRootExpr($expr);
 		}
 
-		$exprHandler = $this->resolveExprHandler($expr);
+		$exprHandler = ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
 		if ($exprHandler !== null) {
 			return $exprHandler->specifyTypes($this, $scope, $expr, $context);
 		}
 
 		return $this->specifyDefaultTypes($scope, $expr, $context);
-	}
-
-	/**
-	 * Resolves the ExprHandler for the given expression, memoizing the result by Expr class.
-	 *
-	 * @return ExprHandler<Expr>|null
-	 */
-	private function resolveExprHandler(Expr $expr): ?ExprHandler
-	{
-		return ($this->exprHandlerRegistry ??= $this->container->getByType(ExprHandlerRegistry::class))->resolve($expr);
 	}
 
 	/** @internal */


### PR DESCRIPTION
resolveType() re-scanned every tagged handler with a linear supports() sweep on each call - 2.3M supports() calls for 56K dispatches measured on a small self-analysis slice. NodeScopeResolver and TypeSpecifier already memoized this dispatch by Expr class in private copies; extract the memo into a shared ExprHandlerRegistry and use it in all three places.

before this PR:
```
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
php -d memory_limit=450M bin/phpstan analyze src/Analyser -q  
22.66s user 1.52s system 320% cpu 7.554 total
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
php -d memory_limit=450M bin/phpstan analyze src/Analyser -q  
22.62s user 1.53s system 318% cpu 7.573 total
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
php -d memory_limit=450M bin/phpstan analyze src/Analyser -q  
22.63s user 1.49s system 319% cpu 7.548 total
```

after this PR:
```
➜  phpstan-src git:(reg) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
php -d memory_limit=450M bin/phpstan analyze src/Analyser -q  
21.85s user 1.48s system 322% cpu 7.227 total
➜  phpstan-src git:(reg) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
php -d memory_limit=450M bin/phpstan analyze src/Analyser -q  
21.87s user 1.50s system 322% cpu 7.237 total
➜  phpstan-src git:(reg) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
php -d memory_limit=450M bin/phpstan analyze src/Analyser -q  
21.83s user 1.45s system 321% cpu 7.236 total
```