### PR TITLE
Replace `NodeFinder` with direct recursion in `shouldInvalidateExpression()`

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3186,30 +3186,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			return false;
 		}
 
-		$nodeFinder = new NodeFinder();
-		$expressionToInvalidateClass = get_class($exprToInvalidate);
-		$found = $nodeFinder->findFirst([$expr], function (Node $node) use ($expressionToInvalidateClass, $exprStringToInvalidate): bool {
-			if (
-				$exprStringToInvalidate === '$this'
-				&& $node instanceof Name
-				&& (
-					in_array($node->toLowerString(), ['self', 'static', 'parent'], true)
-					|| ($this->getClassReflection() !== null && $this->getClassReflection()->is($this->resolveName($node)))
-				)
-			) {
-				return true;
-			}
-
-			if (!$node instanceof $expressionToInvalidateClass) {
-				return false;
-			}
-
-			$nodeString = $this->getNodeKey($node);
-
-			return $nodeString === $exprStringToInvalidate;
-		});
-
-		if ($found === null) {
+		if (!$this->containsExpressionToInvalidate($expr, get_class($exprToInvalidate), $exprStringToInvalidate)) {
 			return false;
 		}
 
@@ -3230,6 +3207,55 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		return true;
+	}
+
+	/**
+	 * Depth-first pre-order search for the invalidated expression, replacing a
+	 * NodeFinder::findFirst() call - this runs for every (stored expression,
+	 * invalidated expression) pair whose keys pass the substring pre-filter,
+	 * so the traverser/visitor machinery overhead was significant.
+	 *
+	 * @param class-string<Expr> $expressionToInvalidateClass
+	 */
+	private function containsExpressionToInvalidate(Node $node, string $expressionToInvalidateClass, string $exprStringToInvalidate): bool
+	{
+		if (
+			$exprStringToInvalidate === '$this'
+			&& $node instanceof Name
+			&& (
+				in_array($node->toLowerString(), ['self', 'static', 'parent'], true)
+				|| ($this->getClassReflection() !== null && $this->getClassReflection()->is($this->resolveName($node)))
+			)
+		) {
+			return true;
+		}
+
+		if (
+			$node instanceof $expressionToInvalidateClass
+			&& $this->getNodeKey($node) === $exprStringToInvalidate
+		) {
+			return true;
+		}
+
+		foreach ($node->getSubNodeNames() as $subNodeName) {
+			$subNode = $node->$subNodeName;
+			if ($subNode instanceof Node) {
+				if ($this->containsExpressionToInvalidate($subNode, $expressionToInvalidateClass, $exprStringToInvalidate)) {
+					return true;
+				}
+			} elseif (is_array($subNode)) {
+				foreach ($subNode as $subNodeItem) {
+					if (
+						$subNodeItem instanceof Node
+						&& $this->containsExpressionToInvalidate($subNodeItem, $expressionToInvalidateClass, $exprStringToInvalidate)
+					) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 
 	private function isPrivatePropertyOfDifferentClass(Expr $expr, ClassReflection $invalidatingClass): bool


### PR DESCRIPTION
The findFirst() call allocated a NodeTraverser + FirstFindingVisitor and paid the full visitor protocol (~4 calls per visited node) for every (stored expression, invalidated expression) pair that passes the substring pre-filter - about 2M visited nodes per analysed slice. A hand-rolled pre-order search with identical match semantics does one method call per node.

taken from https://github.com/phpstan/phpstan-src/commit/517cde72368205ad331a30e96449099dedebaba4

before this PR:

```
➜  phpstan-src git:(2.2.x) ✗ php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
21.57s user 1.66s system 314% cpu 7.379 total
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
21.34s user 1.61s system 320% cpu 7.150 total
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
21.51s user 1.50s system 318% cpu 7.233 total
```

after this PR:
```
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
20.45s user 1.57s system 327% cpu 6.714 total
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
20.46s user 1.58s system 327% cpu 6.722 total
➜  phpstan-src git:(2.2.x) php bin/phpstan clear-result-cache -q && time php -d memory_limit=450M bin/phpstan analyze src/Analyser -q
20.52s user 1.54s system 324% cpu 6.797 total
```