### PR TITLE
Return early from ClassReflection::getMethod() cache

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -579,6 +579,10 @@ final class ClassReflection
 			$key = sprintf('%s-%s', $key, $scope->getClassReflection()->getCacheKey());
 		}
 
+		if (isset($this->methods[$key])) {
+			return $this->methods[$key];
+		}
+
 		$phpClassReflectionExtension = $this->classReflectionExtensionRegistryProvider->getRegistry()->getPhpClassReflectionExtension();
 		if ($phpClassReflectionExtension->hasMethod($this, $methodName)) {
 			$method = $phpClassReflectionExtension->getMethod($this, $methodName);

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -737,28 +737,30 @@ final class ClassReflection
 			$key = sprintf('%s-%s', $key, $scope->getClassReflection()->getCacheKey());
 		}
 
+		if (array_key_exists($key, $this->properties)) {
+			return $this->properties[$key];
+		}
+
 		$phpClassReflectionExtension = $this->classReflectionExtensionRegistryProvider->getRegistry()->getPhpClassReflectionExtension();
-		if (!isset($this->properties[$key])) {
-			if ($phpClassReflectionExtension->hasProperty($this, $propertyName)) {
-				$property = $this->classReflectionExtensionRegistryProvider->getRegistry()->getPhpClassReflectionExtension()->getProperty($this, $propertyName, $scope);
+		if ($phpClassReflectionExtension->hasProperty($this, $propertyName)) {
+			$property = $this->classReflectionExtensionRegistryProvider->getRegistry()->getPhpClassReflectionExtension()->getProperty($this, $propertyName, $scope);
+			if ($scope->canReadProperty($property)) {
+				return $this->properties[$key] = $property;
+			}
+			$this->properties[$key] = $property;
+		}
+
+		if ($this->allowsDynamicProperties()) {
+			foreach ($this->classReflectionExtensionRegistryProvider->getRegistry()->getPropertiesClassReflectionExtensions() as $extension) {
+				if (!$extension->hasProperty($this, $propertyName)) {
+					continue;
+				}
+
+				$property = $this->wrapExtendedProperty($propertyName, $extension->getProperty($this, $propertyName));
 				if ($scope->canReadProperty($property)) {
 					return $this->properties[$key] = $property;
 				}
 				$this->properties[$key] = $property;
-			}
-
-			if ($this->allowsDynamicProperties()) {
-				foreach ($this->classReflectionExtensionRegistryProvider->getRegistry()->getPropertiesClassReflectionExtensions() as $extension) {
-					if (!$extension->hasProperty($this, $propertyName)) {
-						continue;
-					}
-
-					$property = $this->wrapExtendedProperty($propertyName, $extension->getProperty($this, $propertyName));
-					if ($scope->canReadProperty($property)) {
-						return $this->properties[$key] = $property;
-					}
-					$this->properties[$key] = $property;
-				}
 			}
 		}
 

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -579,7 +579,7 @@ final class ClassReflection
 			$key = sprintf('%s-%s', $key, $scope->getClassReflection()->getCacheKey());
 		}
 
-		if (isset($this->methods[$key])) {
+		if (array_key_exists($key, $this->methods)) {
 			return $this->methods[$key];
 		}
 


### PR DESCRIPTION
The method wrote resolved reflections into $this->methods but never read them back, so every repeated call re-ran the whole extension dispatch (native hasMethod lookup, canCallMethod, wrapping). The result is deterministic per cache key - the key already includes the asking scope's class - so the early return preserves behaviour.

this is one of the fixes from [fable performance branch](https://github.com/phpstan/phpstan-src/tree/worktree-spx-perf-hunt), but I was not able to verify it improves performance in my benchmarks.

in the end I think it is a bugfix, to make the caching work.

[review with whitespaces ignored](https://github.com/phpstan/phpstan-src/pull/6043/files?w=1)