### PR TITLE
Narrow array_all()/array_any() through the array_filter() machinery

### DIFF
--- a/src/Type/Php/ArrayAllAnyNarrowingHelper.php
+++ b/src/Type/Php/ArrayAllAnyNarrowingHelper.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PHPStan\Analyser\MutatingScope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function count;
+use function in_array;
+
+/**
+ * Builds the narrowed array type for `array_all` (truthy) and `array_any`
+ * (falsey): every element is required to satisfy (array_all) or fail
+ * (array_any) the predicate, so element value/key types are refined
+ * accordingly.
+ *
+ * When narrowing rejects a general element, the member becomes `array{}`
+ * (an empty array still makes `array_all` true / `array_any` false) rather than
+ * `never` - the caller's scope intersection turns a genuinely non-empty array
+ * into `never` on its own.
+ */
+#[AutowiredService]
+final class ArrayAllAnyNarrowingHelper
+{
+
+	public function __construct(
+		private ArrayPredicateCallbackResolver $predicateCallbackResolver,
+	)
+	{
+	}
+
+	/**
+	 * @param bool $truthy true narrows elements by the predicate being truthy
+	 *                     (array_all), false by the predicate being falsey
+	 *                     (array_any).
+	 */
+	public function narrowArrayType(MutatingScope $scope, Type $arrayType, ArrayCallbackPredicate $predicate, bool $truthy): ?Type
+	{
+		if ($predicate->getExpr() === null) {
+			return null;
+		}
+
+		$arrays = $arrayType->getArrays();
+		if (count($arrays) === 0) {
+			return null;
+		}
+
+		$results = [];
+		foreach ($arrays as $array) {
+			$constantArrays = $array->getConstantArrays();
+			if (count($constantArrays) > 0) {
+				foreach ($constantArrays as $constantArray) {
+					$results[] = $this->narrowConstantArray($scope, $constantArray, $predicate, $truthy);
+				}
+				continue;
+			}
+
+			[$newKey, $newValue, $rejected] = $this->narrowElement($scope, $array->getIterableKeyType(), $array->getIterableValueType(), $predicate, $truthy);
+			if ($rejected) {
+				$results[] = new ConstantArrayType([], []);
+				continue;
+			}
+
+			$results[] = new ArrayType($newKey, $newValue);
+		}
+
+		return TypeCombinator::union(...$results);
+	}
+
+	private function narrowConstantArray(MutatingScope $scope, ConstantArrayType $constantArray, ArrayCallbackPredicate $predicate, bool $truthy): Type
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		$optionalKeys = $constantArray->getOptionalKeys();
+
+		foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+			$itemType = $constantArray->getValueTypes()[$i];
+			$optional = in_array($i, $optionalKeys, true);
+
+			[, $newValue, $rejected] = $this->narrowElement($scope, $keyType, $itemType, $predicate, $truthy);
+			if ($rejected) {
+				if ($optional) {
+					// The predicate rejects this element, so satisfying the
+					// whole array requires the optional offset to be absent.
+					continue;
+				}
+
+				// A required offset that cannot satisfy the predicate makes
+				// the whole shape impossible.
+				return new NeverType();
+			}
+
+			$builder->setOffsetValueType($keyType, $newValue, $optional);
+		}
+
+		if ($constantArray->isUnsealed()->yes()) {
+			$unsealedTypes = $constantArray->getUnsealedTypes();
+			if ($unsealedTypes !== null) {
+				[$newKey, $newValue, $rejected] = $this->narrowElement($scope, $unsealedTypes[0], $unsealedTypes[1], $predicate, $truthy);
+				if (!$rejected) {
+					$builder->makeUnsealed($newKey, $newValue);
+				}
+			}
+		}
+
+		return $builder->getArray();
+	}
+
+	/**
+	 * @return array{Type, Type, bool} the narrowed key and value, plus whether
+	 *                                 the element cannot satisfy the predicate.
+	 */
+	private function narrowElement(MutatingScope $scope, Type $keyType, Type $itemType, ArrayCallbackPredicate $predicate, bool $truthy): array
+	{
+		[$scope, $itemVarName, $keyVarName] = $this->predicateCallbackResolver->assignPredicateVariables($scope, $predicate, $itemType, $keyType);
+
+		$expr = $predicate->getExpr();
+		if ($expr === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		$booleanResult = $scope->getType($expr)->toBoolean();
+		$impossible = $truthy ? $booleanResult->isFalse()->yes() : $booleanResult->isTrue()->yes();
+		if ($impossible) {
+			return [new NeverType(), new NeverType(), true];
+		}
+
+		$narrowedScope = $truthy ? $scope->filterByTruthyValue($expr) : $scope->filterByFalseyValue($expr);
+		$newKey = $keyVarName !== null ? $narrowedScope->getVariableType($keyVarName) : $keyType;
+		$newValue = $itemVarName !== null ? $narrowedScope->getVariableType($itemVarName) : $itemType;
+
+		$rejected = $newKey instanceof NeverType || $newValue instanceof NeverType;
+
+		return [$newKey, $newValue, $rejected];
+	}
+
+}

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use function array_find;
+use function count;
+use function is_string;
+use function strtolower;
+
+#[AutowiredService]
+final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	private TypeSpecifier $typeSpecifier;
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
+	{
+		return strtolower($functionReflection->getName()) === 'array_all'
+			&& !$context->null();
+	}
+
+	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
+	{
+		$args = $node->getArgs();
+		if (!$context->truthy() || count($args) < 2) {
+			return new SpecifiedTypes();
+		}
+
+		$array = $args[0]->value;
+		$callable = $args[1]->value;
+		if ($callable instanceof Expr\ArrowFunction) {
+			$callableExpr = $callable->expr;
+		} elseif (
+			$callable instanceof Expr\Closure &&
+			count($callable->stmts) === 1 &&
+			$callable->stmts[0] instanceof Stmt\Return_ &&
+			isset($callable->stmts[0]->expr)
+		) {
+			$callableExpr = $callable->stmts[0]->expr;
+		} else {
+			return new SpecifiedTypes();
+		}
+
+		$callableParams = $callable->params;
+		$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callableExpr, $context)->getSureTypes();
+
+		if (
+			isset($callableParams[0]) &&
+			$callableParams[0]->var instanceof Variable &&
+			is_string($callableParams[0]->var->name)
+		) {
+			$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[0]->var->name);
+		}
+
+		if (
+			isset($callableParams[1]) &&
+			$callableParams[1]->var instanceof Variable &&
+			is_string($callableParams[1]->var->name)
+		) {
+			$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[1]->var->name);
+		}
+
+		if (isset($keyType) || isset($valueType)) {
+			return $this->typeSpecifier->create(
+				$array,
+				new ArrayType($keyType ?? new MixedType(), $valueType ?? new MixedType()),
+				$context,
+				$scope,
+			);
+		}
+
+		return new SpecifiedTypes();
+	}
+
+	/**
+	 * @param array<string, list{Expr, Type}> $specifiedTypes
+	 */
+	private function fetchTypeByVariable(array $specifiedTypes, string $variableName): ?Type
+	{
+		$specifiedTypeOfKey = array_find(
+			$specifiedTypes,
+			static fn ($specifiedType) => $specifiedType[0] instanceof Expr\Variable && $specifiedType[0]->name === $variableName,
+		);
+
+		if (isset($specifiedTypeOfKey)) {
+			return $specifiedTypeOfKey[1];
+		}
+
+		return null;
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+}

--- a/src/Type/Php/ArrayAnyFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAnyFunctionTypeSpecifyingExtension.php
@@ -20,13 +20,14 @@ use function count;
 use function strtolower;
 
 /**
- * array_all($array, $callback):
- * - true  => every element satisfies the predicate (an empty array qualifies),
- *            so element value/key types are narrowed by the predicate.
- * - false => at least one element fails, so the array is non-empty.
+ * array_any($array, $callback):
+ * - true  => at least one element satisfies the predicate, so the array is
+ *            non-empty (holds even when the callback cannot be analysed).
+ * - false => no element satisfies the predicate (an empty array qualifies), so
+ *            element value/key types are narrowed by the predicate being falsey.
  */
 #[AutowiredService]
-final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+final class ArrayAnyFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
 	private TypeSpecifier $typeSpecifier;
@@ -40,7 +41,7 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
 	{
-		return strtolower($functionReflection->getName()) === 'array_all'
+		return strtolower($functionReflection->getName()) === 'array_any'
 			&& !$context->null();
 	}
 
@@ -60,26 +61,27 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		}
 
 		if ($context->false()) {
-			// At least one element fails the predicate: the array is non-empty.
-			$nonEmptyType = $arrayType->isArray()->yes()
-				? new NonEmptyArrayType()
-				: TypeCombinator::intersect(new ArrayType(new MixedType(), new MixedType()), new NonEmptyArrayType());
+			// No element satisfies the predicate: narrow value/key types by the
+			// predicate being falsey.
+			$predicates = $this->predicateCallbackResolver->resolve($scope, $callbackArg, ArrayCallbackParameterMapping::valueAndKey());
+			if ($predicates === null || count($predicates) !== 1) {
+				return new SpecifiedTypes();
+			}
 
-			return $this->typeSpecifier->create($arrayArg, $nonEmptyType, TypeSpecifierContext::createTruthy(), $scope);
+			$narrowedType = $this->narrowingHelper->narrowArrayType($scope, $arrayType, $predicates[0], false);
+			if ($narrowedType === null) {
+				return new SpecifiedTypes();
+			}
+
+			return $this->typeSpecifier->create($arrayArg, $narrowedType, TypeSpecifierContext::createTruthy(), $scope);
 		}
 
-		// Every element satisfies the predicate: narrow value/key types.
-		$predicates = $this->predicateCallbackResolver->resolve($scope, $callbackArg, ArrayCallbackParameterMapping::valueAndKey());
-		if ($predicates === null || count($predicates) !== 1) {
-			return new SpecifiedTypes();
-		}
+		// At least one element satisfies the predicate: the array is non-empty.
+		$nonEmptyType = $arrayType->isArray()->yes()
+			? new NonEmptyArrayType()
+			: TypeCombinator::intersect(new ArrayType(new MixedType(), new MixedType()), new NonEmptyArrayType());
 
-		$narrowedType = $this->narrowingHelper->narrowArrayType($scope, $arrayType, $predicates[0], true);
-		if ($narrowedType === null) {
-			return new SpecifiedTypes();
-		}
-
-		return $this->typeSpecifier->create($arrayArg, $narrowedType, TypeSpecifierContext::createTruthy(), $scope);
+		return $this->typeSpecifier->create($arrayArg, $nonEmptyType, TypeSpecifierContext::createTruthy(), $scope);
 	}
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/src/Type/Php/ArrayCallbackParameterMapping.php
+++ b/src/Type/Php/ArrayCallbackParameterMapping.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+/**
+ * Describes which positional parameters of an array callback receive the
+ * element value and the element key. `array_filter` varies this by its flag
+ * argument (USE_ITEM / USE_KEY / USE_BOTH), while `array_all` / `array_any`
+ * always pass value first and key second.
+ */
+final class ArrayCallbackParameterMapping
+{
+
+	private function __construct(
+		private ?int $itemPosition,
+		private ?int $keyPosition,
+	)
+	{
+	}
+
+	public static function item(): self
+	{
+		return new self(0, null);
+	}
+
+	public static function key(): self
+	{
+		return new self(null, 0);
+	}
+
+	public static function valueAndKey(): self
+	{
+		return new self(0, 1);
+	}
+
+	public function getItemPosition(): ?int
+	{
+		return $this->itemPosition;
+	}
+
+	public function getKeyPosition(): ?int
+	{
+		return $this->keyPosition;
+	}
+
+}

--- a/src/Type/Php/ArrayCallbackPredicate.php
+++ b/src/Type/Php/ArrayCallbackPredicate.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
+
+/**
+ * A single normalized form of an array callback: the variables that stand for
+ * the element value and key, and the predicate expression evaluated against
+ * them. A constant-string callable that resolves to a union of names produces
+ * several predicates.
+ *
+ * A null `$expr` marks a callable that cannot be turned into a predicate at all
+ * (e.g. an empty or invalid function name) - consumers decide whether that
+ * means "error" (array_filter) or "no narrowing" (array_all / array_any).
+ */
+final class ArrayCallbackPredicate
+{
+
+	public function __construct(
+		private ?Variable $itemVar,
+		private ?Variable $keyVar,
+		private ?Expr $expr,
+	)
+	{
+	}
+
+	public function getItemVar(): ?Variable
+	{
+		return $this->itemVar;
+	}
+
+	public function getKeyVar(): ?Variable
+	{
+		return $this->keyVar;
+	}
+
+	public function getExpr(): ?Expr
+	{
+		return $this->expr;
+	}
+
+}

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
@@ -84,11 +84,13 @@ final class ArrayFilterFunctionReturnTypeHelper
 			throw new ShouldNotHappenException();
 		}
 
-		$mapping = match ($mode) {
-			self::USE_ITEM => ArrayCallbackParameterMapping::item(),
-			self::USE_KEY => ArrayCallbackParameterMapping::key(),
-			self::USE_BOTH => ArrayCallbackParameterMapping::valueAndKey(),
-		};
+		if ($mode === self::USE_ITEM) {
+			$mapping = ArrayCallbackParameterMapping::item();
+		} elseif ($mode === self::USE_KEY) {
+			$mapping = ArrayCallbackParameterMapping::key();
+		} else {
+			$mapping = ArrayCallbackParameterMapping::valueAndKey();
+		}
 
 		$predicates = $this->predicateCallbackResolver->resolve($scope, $callbackArg, $mapping);
 		if ($predicates === null) {

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
@@ -2,24 +2,14 @@
 
 namespace PHPStan\Type\Php;
 
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Expr\Error;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
-use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\TrinaryLogic;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -35,9 +25,7 @@ use PHPStan\Type\TypeUtils;
 use function array_map;
 use function count;
 use function in_array;
-use function is_string;
 use function sprintf;
-use function substr;
 
 #[AutowiredService]
 final class ArrayFilterFunctionReturnTypeHelper
@@ -50,6 +38,7 @@ final class ArrayFilterFunctionReturnTypeHelper
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
 		private PhpVersion $phpVersion,
+		private ArrayPredicateCallbackResolver $predicateCallbackResolver,
 	)
 	{
 	}
@@ -91,62 +80,32 @@ final class ArrayFilterFunctionReturnTypeHelper
 			return new ArrayType($keyType, $itemType);
 		}
 
-		if ($callbackArg instanceof Closure && count($callbackArg->stmts) === 1 && count($callbackArg->params) > 0) {
-			$statement = $callbackArg->stmts[0];
-			if ($statement instanceof Return_ && $statement->expr !== null) {
-				if ($mode === self::USE_ITEM) {
-					$keyVar = null;
-					$itemVar = $callbackArg->params[0]->var;
-				} elseif ($mode === self::USE_KEY) {
-					$keyVar = $callbackArg->params[0]->var;
-					$itemVar = null;
-				} elseif ($mode === self::USE_BOTH) {
-					$keyVar = $callbackArg->params[1]->var ?? null;
-					$itemVar = $callbackArg->params[0]->var;
-				}
-				return $this->filterByTruthyValue($scope, $itemVar, $arrayArgType, $keyVar, $statement->expr);
-			}
-		} elseif ($callbackArg instanceof ArrowFunction && count($callbackArg->params) > 0) {
-			if ($mode === self::USE_ITEM) {
-				$keyVar = null;
-				$itemVar = $callbackArg->params[0]->var;
-			} elseif ($mode === self::USE_KEY) {
-				$keyVar = $callbackArg->params[0]->var;
-				$itemVar = null;
-			} elseif ($mode === self::USE_BOTH) {
-				$keyVar = $callbackArg->params[1]->var ?? null;
-				$itemVar = $callbackArg->params[0]->var;
-			}
-			return $this->filterByTruthyValue($scope, $itemVar, $arrayArgType, $keyVar, $callbackArg->expr);
-		} elseif (
-			($callbackArg instanceof FuncCall || $callbackArg instanceof MethodCall || $callbackArg instanceof StaticCall)
-			&& $callbackArg->isFirstClassCallable()
-		) {
-			[$args, $itemVar, $keyVar] = $this->createDummyArgs($mode);
-			$expr = clone $callbackArg;
-			$expr->args = $args;
-			return $this->filterByTruthyValue($scope, $itemVar, $arrayArgType, $keyVar, $expr);
-		} else {
-			$constantStrings = $scope->getType($callbackArg)->getConstantStrings();
-			if (count($constantStrings) > 0) {
-				$results = [];
-				[$args, $itemVar, $keyVar] = $this->createDummyArgs($mode);
-
-				foreach ($constantStrings as $constantString) {
-					$funcName = self::createFunctionName($constantString->getValue());
-					if ($funcName === null) {
-						$results[] = new ErrorType();
-						continue;
-					}
-
-					$expr = new FuncCall($funcName, $args);
-					$results[] = $this->filterByTruthyValue($scope, $itemVar, $arrayArgType, $keyVar, $expr);
-				}
-				return TypeCombinator::union(...$results);
-			}
+		if (!$scope instanceof MutatingScope) {
+			throw new ShouldNotHappenException();
 		}
 
-		return new ArrayType($keyType, $itemType);
+		$mapping = match ($mode) {
+			self::USE_ITEM => ArrayCallbackParameterMapping::item(),
+			self::USE_KEY => ArrayCallbackParameterMapping::key(),
+			self::USE_BOTH => ArrayCallbackParameterMapping::valueAndKey(),
+		};
+
+		$predicates = $this->predicateCallbackResolver->resolve($scope, $callbackArg, $mapping);
+		if ($predicates === null) {
+			return new ArrayType($keyType, $itemType);
+		}
+
+		$results = [];
+		foreach ($predicates as $predicate) {
+			if ($predicate->getExpr() === null) {
+				$results[] = new ErrorType();
+				continue;
+			}
+
+			$results[] = $this->filterByTruthyValue($scope, $predicate, $arrayArgType);
+		}
+
+		return TypeCombinator::union(...$results);
 	}
 
 	private function removeFalsey(Type $type): Type
@@ -154,12 +113,8 @@ final class ArrayFilterFunctionReturnTypeHelper
 		return $type->filterArrayRemovingFalsey();
 	}
 
-	private function filterByTruthyValue(Scope $scope, Error|Variable|null $itemVar, Type $arrayType, Error|Variable|null $keyVar, Expr $expr): Type
+	private function filterByTruthyValue(MutatingScope $scope, ArrayCallbackPredicate $predicate, Type $arrayType): Type
 	{
-		if (!$scope instanceof MutatingScope) {
-			throw new ShouldNotHappenException();
-		}
-
 		$constantArrays = $arrayType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$results = [];
@@ -168,7 +123,7 @@ final class ArrayFilterFunctionReturnTypeHelper
 				$optionalKeys = $constantArray->getOptionalKeys();
 				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
 					$itemType = $constantArray->getValueTypes()[$i];
-					[$newKeyType, $newItemType, $optional] = $this->processKeyAndItemType($scope, $keyType, $itemType, $itemVar, $keyVar, $expr);
+					[$newKeyType, $newItemType, $optional] = $this->processKeyAndItemType($scope, $keyType, $itemType, $predicate);
 					$optional = $optional || in_array($i, $optionalKeys, true);
 					if ($newKeyType instanceof NeverType || $newItemType instanceof NeverType) {
 						continue;
@@ -184,7 +139,7 @@ final class ArrayFilterFunctionReturnTypeHelper
 				if ($constantArray->isUnsealed()->yes()) {
 					$unsealedTypes = $constantArray->getUnsealedTypes();
 					if ($unsealedTypes !== null) {
-						[$newKey, $newValue] = $this->processKeyAndItemType($scope, $unsealedTypes[0], $unsealedTypes[1], $itemVar, $keyVar, $expr);
+						[$newKey, $newValue] = $this->processKeyAndItemType($scope, $unsealedTypes[0], $unsealedTypes[1], $predicate);
 						// Drop the unsealed slot when the predicate
 						// rejects every possible extra (key or value
 						// narrows to `Never`).
@@ -200,7 +155,7 @@ final class ArrayFilterFunctionReturnTypeHelper
 			return TypeCombinator::union(...$results);
 		}
 
-		[$newKeyType, $newItemType] = $this->processKeyAndItemType($scope, $arrayType->getIterableKeyType(), $arrayType->getIterableValueType(), $itemVar, $keyVar, $expr);
+		[$newKeyType, $newItemType] = $this->processKeyAndItemType($scope, $arrayType->getIterableKeyType(), $arrayType->getIterableValueType(), $predicate);
 
 		if ($newItemType instanceof NeverType || $newKeyType instanceof NeverType) {
 			return new ConstantArrayType([], []);
@@ -212,24 +167,13 @@ final class ArrayFilterFunctionReturnTypeHelper
 	/**
 	 * @return array{Type, Type, bool}
 	 */
-	private function processKeyAndItemType(MutatingScope $scope, Type $keyType, Type $itemType, Error|Variable|null $itemVar, Error|Variable|null $keyVar, Expr $expr): array
+	private function processKeyAndItemType(MutatingScope $scope, Type $keyType, Type $itemType, ArrayCallbackPredicate $predicate): array
 	{
-		$itemVarName = null;
-		if ($itemVar !== null) {
-			if (!$itemVar instanceof Variable || !is_string($itemVar->name)) {
-				throw new ShouldNotHappenException();
-			}
-			$itemVarName = $itemVar->name;
-			$scope = $scope->assignVariable($itemVarName, $itemType, new MixedType(), TrinaryLogic::createYes());
-		}
+		[$scope, $itemVarName, $keyVarName] = $this->predicateCallbackResolver->assignPredicateVariables($scope, $predicate, $itemType, $keyType);
 
-		$keyVarName = null;
-		if ($keyVar !== null) {
-			if (!$keyVar instanceof Variable || !is_string($keyVar->name)) {
-				throw new ShouldNotHappenException();
-			}
-			$keyVarName = $keyVar->name;
-			$scope = $scope->assignVariable($keyVarName, $keyType, new MixedType(), TrinaryLogic::createYes());
+		$expr = $predicate->getExpr();
+		if ($expr === null) {
+			throw new ShouldNotHappenException();
 		}
 
 		$booleanResult = $scope->getType($expr)->toBoolean();
@@ -254,47 +198,6 @@ final class ArrayFilterFunctionReturnTypeHelper
 			$itemVarName !== null ? $truthyScope->getVariableType($itemVarName) : $itemType,
 			$optional,
 		];
-	}
-
-	private static function createFunctionName(string $funcName): ?Name
-	{
-		if ($funcName === '') {
-			return null;
-		}
-
-		if ($funcName[0] === '\\') {
-			$funcName = substr($funcName, 1);
-
-			if ($funcName === '') {
-				return null;
-			}
-
-			return new Name\FullyQualified($funcName);
-		}
-
-		return new Name($funcName);
-	}
-
-	/**
-	 * @param self::USE_* $mode
-	 * @return array{list<Arg>, ?Variable, ?Variable}
-	 */
-	private function createDummyArgs(int $mode): array
-	{
-		if ($mode === self::USE_ITEM) {
-			$itemVar = new Variable('item');
-			$keyVar = null;
-			$args = [new Arg($itemVar)];
-		} elseif ($mode === self::USE_KEY) {
-			$itemVar = null;
-			$keyVar = new Variable('key');
-			$args = [new Arg($keyVar)];
-		} elseif ($mode === self::USE_BOTH) {
-			$itemVar = new Variable('item');
-			$keyVar = new Variable('key');
-			$args = [new Arg($itemVar), new Arg($keyVar)];
-		}
-		return [$args, $itemVar, $keyVar];
 	}
 
 	/**

--- a/src/Type/Php/ArrayPredicateCallbackResolver.php
+++ b/src/Type/Php/ArrayPredicateCallbackResolver.php
@@ -1,0 +1,220 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\MutatingScope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use function array_values;
+use function count;
+use function is_string;
+use function ksort;
+use function substr;
+
+/**
+ * Normalizes an array callback (arrow function, single-return closure,
+ * first-class callable or constant-string callable) into a list of
+ * {@see ArrayCallbackPredicate}, and assigns the element value/key types into a
+ * scope so the predicate can be evaluated against them. Shared by
+ * `array_filter` and the `array_all` / `array_any` type-specifying extensions.
+ */
+#[AutowiredService]
+final class ArrayPredicateCallbackResolver
+{
+
+	/**
+	 * Returns the normalized predicates, or null when the callback form cannot
+	 * be analysed (a variable holding a closure, a by-ref/variadic parameter, a
+	 * dynamic name, etc.).
+	 *
+	 * @return list<ArrayCallbackPredicate>|null
+	 */
+	public function resolve(MutatingScope $scope, Expr $callbackArg, ArrayCallbackParameterMapping $mapping): ?array
+	{
+		if ($callbackArg instanceof ArrowFunction) {
+			$predicate = $this->fromParams($callbackArg->params, $mapping, $callbackArg->expr);
+			return $predicate === null ? null : [$predicate];
+		}
+
+		if (
+			$callbackArg instanceof Closure
+			&& count($callbackArg->stmts) === 1
+			&& $callbackArg->stmts[0] instanceof Return_
+			&& $callbackArg->stmts[0]->expr !== null
+		) {
+			$predicate = $this->fromParams($callbackArg->params, $mapping, $callbackArg->stmts[0]->expr);
+			return $predicate === null ? null : [$predicate];
+		}
+
+		if (
+			($callbackArg instanceof FuncCall || $callbackArg instanceof MethodCall || $callbackArg instanceof StaticCall)
+			&& $callbackArg->isFirstClassCallable()
+		) {
+			[$args, $itemVar, $keyVar] = $this->createDummyArgs($mapping);
+			$expr = clone $callbackArg;
+			$expr->args = $args;
+
+			return [new ArrayCallbackPredicate($itemVar, $keyVar, $expr)];
+		}
+
+		$constantStrings = $scope->getType($callbackArg)->getConstantStrings();
+		if (count($constantStrings) > 0) {
+			[$args, $itemVar, $keyVar] = $this->createDummyArgs($mapping);
+
+			$predicates = [];
+			foreach ($constantStrings as $constantString) {
+				$funcName = self::createFunctionName($constantString->getValue());
+				if ($funcName === null) {
+					$predicates[] = new ArrayCallbackPredicate($itemVar, $keyVar, null);
+					continue;
+				}
+
+				$predicates[] = new ArrayCallbackPredicate($itemVar, $keyVar, new FuncCall($funcName, $args));
+			}
+
+			return $predicates;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Assigns the element value/key types onto the scope for the predicate's
+	 * variables, returning the new scope along with the variable names that were
+	 * assigned (null when the callback does not receive that value or key).
+	 *
+	 * @return array{MutatingScope, ?string, ?string}
+	 */
+	public function assignPredicateVariables(MutatingScope $scope, ArrayCallbackPredicate $predicate, Type $itemType, Type $keyType): array
+	{
+		$itemVarName = null;
+		$itemVar = $predicate->getItemVar();
+		if ($itemVar !== null) {
+			if (!is_string($itemVar->name)) {
+				throw new ShouldNotHappenException();
+			}
+			$itemVarName = $itemVar->name;
+			$scope = $scope->assignVariable($itemVarName, $itemType, new MixedType(), TrinaryLogic::createYes());
+		}
+
+		$keyVarName = null;
+		$keyVar = $predicate->getKeyVar();
+		if ($keyVar !== null) {
+			if (!is_string($keyVar->name)) {
+				throw new ShouldNotHappenException();
+			}
+			$keyVarName = $keyVar->name;
+			$scope = $scope->assignVariable($keyVarName, $keyType, new MixedType(), TrinaryLogic::createYes());
+		}
+
+		return [$scope, $itemVarName, $keyVarName];
+	}
+
+	/**
+	 * @param Param[] $params
+	 */
+	private function fromParams(array $params, ArrayCallbackParameterMapping $mapping, Expr $expr): ?ArrayCallbackPredicate
+	{
+		if (count($params) === 0) {
+			return null;
+		}
+
+		$itemVar = null;
+		if ($mapping->getItemPosition() !== null) {
+			$var = $this->paramVariable($params, $mapping->getItemPosition());
+			if ($var === false) {
+				return null;
+			}
+			$itemVar = $var;
+		}
+
+		$keyVar = null;
+		if ($mapping->getKeyPosition() !== null) {
+			$var = $this->paramVariable($params, $mapping->getKeyPosition());
+			if ($var === false) {
+				return null;
+			}
+			$keyVar = $var;
+		}
+
+		return new ArrayCallbackPredicate($itemVar, $keyVar, $expr);
+	}
+
+	/**
+	 * Returns the variable at the given parameter position, null when the
+	 * callback declares no such parameter, or false when the parameter cannot be
+	 * used for narrowing (by-ref, variadic or non-variable/dynamic name).
+	 *
+	 * @param Param[] $params
+	 */
+	private function paramVariable(array $params, int $position): Variable|false|null
+	{
+		if (!isset($params[$position])) {
+			return null;
+		}
+
+		$param = $params[$position];
+		if ($param->byRef || $param->variadic || !$param->var instanceof Variable || !is_string($param->var->name)) {
+			return false;
+		}
+
+		return $param->var;
+	}
+
+	/**
+	 * @return array{list<Arg>, ?Variable, ?Variable}
+	 */
+	private function createDummyArgs(ArrayCallbackParameterMapping $mapping): array
+	{
+		$itemPosition = $mapping->getItemPosition();
+		$keyPosition = $mapping->getKeyPosition();
+
+		$itemVar = $itemPosition !== null ? new Variable('item') : null;
+		$keyVar = $keyPosition !== null ? new Variable('key') : null;
+
+		$args = [];
+		if ($itemVar !== null) {
+			$args[$itemPosition] = new Arg($itemVar);
+		}
+		if ($keyVar !== null) {
+			$args[$keyPosition] = new Arg($keyVar);
+		}
+		ksort($args);
+
+		return [array_values($args), $itemVar, $keyVar];
+	}
+
+	private static function createFunctionName(string $funcName): ?Name
+	{
+		if ($funcName === '') {
+			return null;
+		}
+
+		if ($funcName[0] === '\\') {
+			$funcName = substr($funcName, 1);
+
+			if ($funcName === '') {
+				return null;
+			}
+
+			return new Name\FullyQualified($funcName);
+		}
+
+		return new Name($funcName);
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -16,7 +16,7 @@ class Foo {
 		if (array_all($array, fn ($value) => is_int($value))) {
 			assertType("array<int>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -28,9 +28,9 @@ class Foo {
 		if (array_all($array, fn ($value, $key) => is_string($key))) {
 			assertType("array<string, mixed>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
-		assertType("array", $array);
+		assertType("array<mixed>", $array);
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Foo {
 		if (array_all($array, fn ($value, $key) => is_string($key) && is_int($value))) {
 			assertType("array<string, int>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -52,7 +52,7 @@ class Foo {
 		if (array_all($array, fn ($value) => is_string($value) && is_numeric($value))) {
 			assertType("array<numeric-string>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -64,7 +64,7 @@ class Foo {
 		if (array_all($array, fn ($value) => is_bool($value) || is_float($value))) {
 			assertType("array<bool|float>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -74,9 +74,10 @@ class Foo {
 	 */
 	public function test6($array) {
 		if (array_all($array, fn ($value) => is_float(1))) {
-			assertType("array<mixed>", $array);
+			// the predicate can never be true, so array_all only holds for the empty array
+			assertType("array{}", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -88,7 +89,7 @@ class Foo {
 		if (array_all($array, fn ($value) => $value instanceof DateTime)) {
 			assertType("array<DateTime>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -100,7 +101,7 @@ class Foo {
 		if (array_all($array, fn ($value) => $value instanceof DateTime || $value instanceof DateTimeImmutable)) {
 			assertType("array<DateTime|DateTimeImmutable>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -112,7 +113,7 @@ class Foo {
 		if (array_all($array, fn ($value, $key) => is_int($key))) {
 			assertType("list<mixed>", $array);
 		} else {
-			assertType("list<mixed>", $array);
+			assertType("non-empty-list<mixed>", $array);
 		}
 		assertType("list<mixed>", $array);
 	}
@@ -126,7 +127,7 @@ class Foo {
 		} else {
 			assertType("non-empty-array<mixed>", $array);
 		}
-		assertType("non-empty-array", $array);
+		assertType("non-empty-array<mixed>", $array);
 	}
 
 	/**
@@ -136,7 +137,7 @@ class Foo {
 		if (array_all($array, function ($value) {return is_int($value);})) {
 			assertType("array<int>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -148,7 +149,7 @@ class Foo {
 		if (array_all($array, function ($value) {$value = 1; return is_int($value);})) {
 			assertType("array<mixed>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -160,7 +161,7 @@ class Foo {
 		if (array_all($array, function ($value, $key) {return is_int($value) && is_string($key);})) {
 			assertType("array<string, int>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -172,7 +173,7 @@ class Foo {
 		if (array_all($array, function ($value, $key) {return;})) {
 			assertType("array<mixed>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
@@ -184,8 +185,133 @@ class Foo {
 		if (array_all($array, fn ($value) => is_int($value)) === true) {
 			assertType("array<int>", $array);
 		} else {
-			assertType("array<mixed>", $array);
+			assertType("non-empty-array<mixed>", $array);
 		}
 		assertType("array<mixed>", $array);
 	}
+
+	/**
+	 * A negated predicate narrows via sureNotTypes - the previous
+	 * implementation could not express this.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testNegatedIsNull($array) {
+		if (array_all($array, fn ($value) => !is_null($value))) {
+			assertType("array<mixed~null>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function testNotIdenticalNull($array) {
+		if (array_all($array, fn ($value) => $value !== null)) {
+			assertType("array<mixed~null>", $array);
+		}
+	}
+
+	/**
+	 * Bare truthiness of the value.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testBareTruthiness($array) {
+		if (array_all($array, fn ($value) => $value)) {
+			assertType("array<mixed~(0|0.0|''|'0'|array{}|false|null)>", $array);
+		}
+	}
+
+	/**
+	 * A possibly-empty list stays sound: the empty list makes array_all true,
+	 * so the narrowed type is array{}, not never.
+	 *
+	 * @param list<mixed> $array
+	 */
+	public function testListStringKey($array) {
+		if (array_all($array, fn ($value, $key) => is_string($key))) {
+			assertType("array{}", $array);
+		} else {
+			assertType("non-empty-list<mixed>", $array);
+		}
+	}
+
+	/**
+	 * First-class callable with a two-parameter predicate.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testFirstClassCallable($array) {
+		if (array_all($array, self::isIntValue(...))) {
+			assertType("array<int>", $array);
+		}
+	}
+
+	/**
+	 * Constant-string callable naming a two-parameter user function.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testStringCallable($array) {
+		if (array_all($array, '\ArrayAll\isIntValue')) {
+			assertType("array<int>", $array);
+		}
+	}
+
+	/**
+	 * @phpstan-assert-if-true int $value
+	 */
+	public static function isIntValue(mixed $value, int|string $key): bool {
+		return is_int($value);
+	}
+
+	/**
+	 * A predicate using @phpstan-assert-if-true through a static method call.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testAssertIfTrue($array) {
+		if (array_all($array, fn ($value) => self::isDateTime($value))) {
+			assertType("array<DateTime>", $array);
+		}
+	}
+
+	/**
+	 * @phpstan-assert-if-true DateTime $value
+	 */
+	public static function isDateTime(mixed $value): bool {
+		return $value instanceof DateTime;
+	}
+
+	/**
+	 * Array shapes are narrowed per offset: the required int offsets stay, the
+	 * optional string offset that cannot be int is dropped.
+	 *
+	 * @param array{a: int, b?: string, c: int} $array
+	 */
+	public function testShape($array) {
+		if (array_all($array, fn ($value) => is_int($value))) {
+			assertType("array{a: int, c: int}", $array);
+		}
+	}
+
+	/**
+	 * A by-ref callback parameter disables narrowing (the callback may rewrite
+	 * elements).
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testByRefParameter($array) {
+		if (array_all($array, function (&$value) { return is_int($value); })) {
+			assertType("array<mixed>", $array);
+		}
+	}
+
+}
+
+/**
+ * @phpstan-assert-if-true int $value
+ */
+function isIntValue(mixed $value, int|string $key): bool {
+	return is_int($value);
 }

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -1,0 +1,191 @@
+<?php // lint >= 8.4
+
+namespace ArrayAll;
+
+use DateTime;
+use DateTimeImmutable;
+
+use function PHPStan\Testing\assertType;
+
+class Foo {
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test1($array) {
+		if (array_all($array, fn ($value) => is_int($value))) {
+			assertType("array<int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test2($array) {
+		if (array_all($array, fn ($value, $key) => is_string($key))) {
+			assertType("array<string, mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test3($array) {
+		if (array_all($array, fn ($value, $key) => is_string($key) && is_int($value))) {
+			assertType("array<string, int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test4($array) {
+		if (array_all($array, fn ($value) => is_string($value) && is_numeric($value))) {
+			assertType("array<numeric-string>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test5($array) {
+		if (array_all($array, fn ($value) => is_bool($value) || is_float($value))) {
+			assertType("array<bool|float>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test6($array) {
+		if (array_all($array, fn ($value) => is_float(1))) {
+			assertType("array<mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test7($array) {
+		if (array_all($array, fn ($value) => $value instanceof DateTime)) {
+			assertType("array<DateTime>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test8($array) {
+		if (array_all($array, fn ($value) => $value instanceof DateTime || $value instanceof DateTimeImmutable)) {
+			assertType("array<DateTime|DateTimeImmutable>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param list<mixed> $array
+	 */
+	public function test9($array) {
+		if (array_all($array, fn ($value, $key) => is_int($key))) {
+			assertType("list<mixed>", $array);
+		} else {
+			assertType("list<mixed>", $array);
+		}
+		assertType("list<mixed>", $array);
+	}
+
+	/**
+	 * @param non-empty-array<mixed> $array
+	 */
+	public function test10($array) {
+		if (array_all($array, fn ($value, $key) => is_int($key))) {
+			assertType("non-empty-array<int, mixed>", $array);
+		} else {
+			assertType("non-empty-array<mixed>", $array);
+		}
+		assertType("non-empty-array", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test11($array) {
+		if (array_all($array, function ($value) {return is_int($value);})) {
+			assertType("array<int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test12($array) {
+		if (array_all($array, function ($value) {$value = 1; return is_int($value);})) {
+			assertType("array<mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test13($array) {
+		if (array_all($array, function ($value, $key) {return is_int($value) && is_string($key);})) {
+			assertType("array<string, int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test14($array) {
+		if (array_all($array, function ($value, $key) {return;})) {
+			assertType("array<mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test15($array) {
+		if (array_all($array, fn ($value) => is_int($value)) === true) {
+			assertType("array<int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -307,6 +307,23 @@ class Foo {
 		}
 	}
 
+	/**
+	 * Strict `=== false` comparison. The else branch is the truthy result of
+	 * array_all(), so elements are narrowed there; it exercises the falsey-but-
+	 * not-false type-specifier context, which a plain `if (array_all(...))` does
+	 * not reach.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testStrictFalseComparison($array) {
+		if (array_all($array, fn ($value) => is_int($value)) === false) {
+			assertType("non-empty-array<mixed>", $array);
+		} else {
+			assertType("array<int>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/array-any.php
+++ b/tests/PHPStan/Analyser/nsrt/array-any.php
@@ -1,0 +1,150 @@
+<?php // lint >= 8.4
+
+namespace ArrayAny;
+
+use DateTime;
+
+use function PHPStan\Testing\assertType;
+
+class Foo {
+
+	/**
+	 * array_any true means at least one element matches (so the array is
+	 * non-empty); false means no element matches, narrowing every element by
+	 * the predicate being falsey.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function test1($array) {
+		if (array_any($array, fn ($value) => $value === null)) {
+			assertType("non-empty-array<mixed>", $array);
+		} else {
+			assertType("array<mixed~null>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test2($array) {
+		if (array_any($array, fn ($value) => is_int($value))) {
+			assertType("non-empty-array<mixed>", $array);
+		} else {
+			assertType("array<mixed~int>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * The dual of `!is_null` for array_all: `!array_any(... === null)` narrows
+	 * away null.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testNegated($array) {
+		if (!array_any($array, fn ($value) => $value === null)) {
+			assertType("array<mixed~null>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function testKey($array) {
+		if (array_any($array, fn ($value, $key) => is_string($key))) {
+			assertType("non-empty-array<mixed>", $array);
+		} else {
+			assertType("array<int, mixed>", $array);
+		}
+	}
+
+	/**
+	 * @param list<mixed> $array
+	 */
+	public function testList($array) {
+		if (array_any($array, fn ($value, $key) => is_string($key))) {
+			assertType("non-empty-list<mixed>", $array);
+		} else {
+			assertType("list<mixed>", $array);
+		}
+	}
+
+	/**
+	 * @param non-empty-array<mixed> $array
+	 */
+	public function testNonEmpty($array) {
+		if (array_any($array, fn ($value) => is_int($value))) {
+			assertType("non-empty-array<mixed>", $array);
+		} else {
+			assertType("non-empty-array<mixed~int>", $array);
+		}
+	}
+
+	/**
+	 * First-class callable predicate, narrowing on the falsey side.
+	 *
+	 * @param array<int|string> $array
+	 */
+	public function testFirstClassCallable($array) {
+		if (!array_any($array, self::isIntValue(...))) {
+			assertType("array<string>", $array);
+		}
+	}
+
+	/**
+	 * Constant-string callable predicate, narrowing on the falsey side.
+	 *
+	 * @param array<int|string> $array
+	 */
+	public function testStringCallable($array) {
+		if (!array_any($array, '\ArrayAny\isIntValue')) {
+			assertType("array<string>", $array);
+		}
+	}
+
+	/**
+	 * @phpstan-assert-if-true int $value
+	 */
+	public static function isIntValue(mixed $value, int|string $key): bool {
+		return is_int($value);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function testAssertIfTrue($array) {
+		if (!array_any($array, fn ($value) => $value instanceof DateTime)) {
+			assertType("array<mixed~DateTime>", $array);
+		}
+	}
+
+	/**
+	 * Optional offsets that would match are dropped; required offsets that
+	 * cannot fail make the whole shape impossible.
+	 *
+	 * @param array{a?: int, b: string} $array
+	 */
+	public function testShapeOptionalDropped($array) {
+		if (!array_any($array, fn ($value) => is_int($value))) {
+			assertType("array{b: string}", $array);
+		}
+	}
+
+	/**
+	 * @param array{a: int, b: string} $array
+	 */
+	public function testShapeRequiredImpossible($array) {
+		if (!array_any($array, fn ($value) => is_int($value))) {
+			assertType("*NEVER*", $array);
+		}
+	}
+
+}
+
+/**
+ * @phpstan-assert-if-true int $value
+ */
+function isIntValue(mixed $value, int|string $key): bool {
+	return is_int($value);
+}

--- a/tests/PHPStan/Analyser/nsrt/array-any.php
+++ b/tests/PHPStan/Analyser/nsrt/array-any.php
@@ -140,6 +140,22 @@ class Foo {
 		}
 	}
 
+	/**
+	 * Strict `=== false` comparison. The else branch is the truthy result of
+	 * array_any() (at least one match, so the array is non-empty); it exercises
+	 * the falsey-but-not-false type-specifier context.
+	 *
+	 * @param array<mixed> $array
+	 */
+	public function testStrictFalseComparison($array) {
+		if (array_any($array, fn ($value) => $value === null) === false) {
+			assertType("array<mixed~null>", $array);
+		} else {
+			assertType("non-empty-array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
 }
 
 /**

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -295,6 +295,23 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7898.php'], []);
 	}
 
+	public function testArrayAllNonEmptyList(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/array-all-non-empty-list.php'], [
+			[
+				'Call to function array_all() with non-empty-list<mixed> and Closure(mixed, mixed): false will always evaluate to false.',
+				13,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+			[
+				'Call to function is_string() with int<0, max> will always evaluate to false.',
+				13,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+		]);
+	}
+
 	#[RequiresPhp('>= 8.1.0')]
 	public function testStructExists(): void
 	{

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -301,12 +301,7 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/array-all-non-empty-list.php'], [
 			[
 				'Call to function array_all() with non-empty-list<mixed> and Closure(mixed, mixed): false will always evaluate to false.',
-				13,
-				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
-			],
-			[
-				'Call to function is_string() with int<0, max> will always evaluate to false.',
-				13,
+				20,
 				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/data/array-all-non-empty-list.php
+++ b/tests/PHPStan/Rules/Comparison/data/array-all-non-empty-list.php
@@ -1,0 +1,18 @@
+<?php // lint >= 8.4
+
+namespace ArrayAllNonEmptyList;
+
+class Foo
+{
+
+	/**
+	 * @param non-empty-list<mixed> $array
+	 */
+	public function doFoo(array $array): void
+	{
+		if (array_all($array, fn ($value, $key) => is_string($key))) {
+			echo 'never';
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/array-all-non-empty-list.php
+++ b/tests/PHPStan/Rules/Comparison/data/array-all-non-empty-list.php
@@ -6,11 +6,18 @@ class Foo
 {
 
 	/**
+	 * A predicate that can never hold makes array_all() on a non-empty array
+	 * impossible: every element would have to satisfy it, but the array is
+	 * guaranteed to have at least one element. A literal-false predicate keeps
+	 * the reported closure type stable across PHP versions (a predicate like
+	 * is_string($key) is inferred as false on newer PHP but bool on the
+	 * downgraded builds).
+	 *
 	 * @param non-empty-list<mixed> $array
 	 */
 	public function doFoo(array $array): void
 	{
-		if (array_all($array, fn ($value, $key) => is_string($key))) {
+		if (array_all($array, fn ($value, $key) => false)) {
 			echo 'never';
 		}
 	}


### PR DESCRIPTION
This adds type narrowing for `array_all()`/`array_any()` on top of the callback-handling machinery already used by `array_filter()`.

`array_all($arr, $cb) === true` narrows element value/key types by the predicate being truthy (an empty array still satisfies it); `=== false` implies the array is non-empty. `array_any()` is the dual: `=== true` implies non-empty, `=== false` narrows elements by the predicate being falsey.

Callback normalization (arrow functions, single-return closures, first-class callables, constant-string callables) and per-element scope narrowing are extracted into shared services also used by `ArrayFilterFunctionReturnTypeHelper`, so negated predicates, bare truthiness and custom `@phpstan-assert-if-true` predicates all narrow uniformly, and constant array shapes are narrowed per offset.

This also fixes an unsound narrowing to `never`: an empty array still makes `array_all()` true, so a rejected element narrows the array to `array{}` rather than `never`, letting the scope's own type intersection decide whether that is actually impossible for a known non-empty input.

By-ref and variadic callback parameters no longer narrow, since the callback may rewrite the elements before the predicate is evaluated.

Partially resolves https://github.com/phpstan/phpstan/issues/12939.

The first commit is a straight rebase/squash of the original work by @uekann in #5134, kept separate so the second commit's diff against it is easy to review. The second commit is the rewrite described above.