### PR TITLE
Account for subclasses in get_parent_class() of a $this/static value

### DIFF
--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -12,6 +12,9 @@ use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
@@ -65,7 +68,24 @@ final class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicF
 
 		$classNames = $argType->getObjectClassNames();
 		if (count($classNames) > 0) {
-			return TypeCombinator::union(...array_map(fn (string $classNames): Type => $this->findParentClassNameType($classNames), $classNames));
+			// A `$this`/`static` value can be an instance of a subclass through late static
+			// binding. For a non-final class the parent class is then not pinned to the declared
+			// parent: a direct child's parent is the class itself, a deeper descendant's parent is
+			// some subclass. So the result also includes `class-string<Class>`.
+			$isLateStaticBound = $argType instanceof StaticType;
+
+			return TypeCombinator::union(...array_map(function (string $className) use ($isLateStaticBound): Type {
+				$parentType = $this->findParentClassNameType($className);
+				if (!$isLateStaticBound || !$this->reflectionProvider->hasClass($className)) {
+					return $parentType;
+				}
+
+				if ($this->reflectionProvider->getClass($className)->isFinal()) {
+					return $parentType;
+				}
+
+				return TypeCombinator::union($parentType, new GenericClassStringType(new ObjectType($className)));
+			}, $classNames));
 		}
 
 		return null;

--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -76,6 +76,12 @@ final class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicF
 			}
 		}
 
+		// Inside a trait a late-static-bound value cannot be resolved to a concrete parent,
+		// same as `$this` above.
+		if ($scope->isInTrait() && $valueType instanceof StaticType) {
+			return null;
+		}
+
 		$classNames = $valueType->getObjectClassNames();
 		if (count($classNames) > 0) {
 			// A `$this`/`static` value can be an instance of a subclass through late static

--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -74,18 +74,22 @@ final class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicF
 			// some subclass. So the result also includes `class-string<Class>`.
 			$isLateStaticBound = $argType instanceof StaticType;
 
-			return TypeCombinator::union(...array_map(function (string $className) use ($isLateStaticBound): Type {
-				$parentType = $this->findParentClassNameType($className);
-				if (!$isLateStaticBound || !$this->reflectionProvider->hasClass($className)) {
-					return $parentType;
+			$types = [];
+			foreach ($classNames as $className) {
+				$types[] = $this->findParentClassNameType($className);
+
+				if (
+					!$isLateStaticBound
+					|| !$this->reflectionProvider->hasClass($className)
+					|| $this->reflectionProvider->getClass($className)->isFinal()
+				) {
+					continue;
 				}
 
-				if ($this->reflectionProvider->getClass($className)->isFinal()) {
-					return $parentType;
-				}
+				$types[] = new GenericClassStringType(new ObjectType($className));
+			}
 
-				return TypeCombinator::union($parentType, new GenericClassStringType(new ObjectType($className)));
-			}, $classNames));
+			return TypeCombinator::union(...$types);
 		}
 
 		return null;

--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -66,13 +66,23 @@ final class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicF
 			return TypeCombinator::union(...array_map(fn (ConstantStringType $stringType): Type => $this->findParentClassNameType($stringType->getValue()), $constantStrings));
 		}
 
-		$classNames = $argType->getObjectClassNames();
+		// A `static::class` string refers to the same late-static-bound type as `$this`/`static`,
+		// so unwrap it and reuse the object handling below.
+		$valueType = $argType;
+		if ($argType->isClassString()->yes()) {
+			$classStringObjectType = $argType->getClassStringObjectType();
+			if ($classStringObjectType instanceof StaticType) {
+				$valueType = $classStringObjectType;
+			}
+		}
+
+		$classNames = $valueType->getObjectClassNames();
 		if (count($classNames) > 0) {
 			// A `$this`/`static` value can be an instance of a subclass through late static
 			// binding. For a non-final class the parent class is then not pinned to the declared
 			// parent: a direct child's parent is the class itself, a deeper descendant's parent is
 			// some subclass. So the result also includes `class-string<Class>`.
-			$isLateStaticBound = $argType instanceof StaticType;
+			$isLateStaticBound = $valueType instanceof StaticType;
 
 			$types = [];
 			foreach ($classNames as $className) {

--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -67,13 +67,12 @@ final class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicF
 		}
 
 		// A `static::class` string refers to the same late-static-bound type as `$this`/`static`,
-		// so unwrap it and reuse the object handling below.
+		// so unwrap it and reuse the object handling below. Non-class-string types resolve to
+		// an ErrorType here, so they are left alone.
 		$valueType = $argType;
-		if ($argType->isClassString()->yes()) {
-			$classStringObjectType = $argType->getClassStringObjectType();
-			if ($classStringObjectType instanceof StaticType) {
-				$valueType = $classStringObjectType;
-			}
+		$classStringObjectType = $argType->getClassStringObjectType();
+		if ($classStringObjectType instanceof StaticType) {
+			$valueType = $classStringObjectType;
 		}
 
 		// Inside a trait a late-static-bound value cannot be resolved to a concrete parent,

--- a/tests/PHPStan/Analyser/nsrt/bug-14951.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14951.php
@@ -13,6 +13,11 @@ class A
 		// may return A::class (for a direct child) — not just false.
 		assertType('class-string<Bug14951\A>|false', get_parent_class($this));
 
+		// The sibling functions already model late static binding, so they do not have the
+		// same problem: they keep the subclass possibility instead of pinning to this class.
+		assertType('class-string<static(Bug14951\A)>', get_called_class());
+		assertType('class-string<$this(Bug14951\A)>', get_class($this));
+
 		return get_parent_class($this) === self::class;
 	}
 
@@ -35,6 +40,8 @@ final class FinalNoParent
 	{
 		// Final class cannot be subclassed, so the parent is exactly false.
 		assertType('false', get_parent_class($this));
+		// ... and get_called_class() is pinned to the final class.
+		assertType("'Bug14951\\\\FinalNoParent'", get_called_class());
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-14951.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14951.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14951;
+
+use function PHPStan\Testing\assertType;
+
+class A
+{
+
+	public function isDirectChildOfA(): bool
+	{
+		// $this can be an instance of a subclass, so get_parent_class($this)
+		// may return A::class (for a direct child) — not just false.
+		assertType('class-string<Bug14951\A>|false', get_parent_class($this));
+
+		return get_parent_class($this) === self::class;
+	}
+
+}
+
+class B extends A
+{
+
+	public function parentOfThis(): void
+	{
+		assertType('\'Bug14951\\\\A\'|class-string<Bug14951\B>', get_parent_class($this));
+	}
+
+}
+
+final class FinalNoParent
+{
+
+	public function parentOfThis(): void
+	{
+		// Final class cannot be subclassed, so the parent is exactly false.
+		assertType('false', get_parent_class($this));
+	}
+
+}
+
+final class FinalWithParent extends A
+{
+
+	public function parentOfThis(): void
+	{
+		assertType("'Bug14951\\\\A'", get_parent_class($this));
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-14951.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14951.php
@@ -22,6 +22,9 @@ class A
 		// value, so it keeps the exact parent — no subclass widening.
 		assertType('false', get_parent_class(self::class));
 
+		// static::class is late static bound just like $this, so it is widened the same way.
+		assertType('class-string<Bug14951\A>|false', get_parent_class(static::class));
+
 		return get_parent_class($this) === self::class;
 	}
 
@@ -35,6 +38,8 @@ class B extends A
 		assertType('\'Bug14951\\\\A\'|class-string<Bug14951\B>', get_parent_class($this));
 		// self::class is the exact class B, so its parent is exactly A.
 		assertType("'Bug14951\\\\A'", get_parent_class(self::class));
+		// static::class is late static bound, matching get_parent_class($this).
+		assertType('\'Bug14951\\\\A\'|class-string<Bug14951\B>', get_parent_class(static::class));
 	}
 
 }
@@ -46,6 +51,7 @@ final class FinalNoParent
 	{
 		// Final class cannot be subclassed, so the parent is exactly false.
 		assertType('false', get_parent_class($this));
+		assertType('false', get_parent_class(static::class));
 		// ... and get_called_class() is pinned to the final class.
 		assertType("'Bug14951\\\\FinalNoParent'", get_called_class());
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-14951.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14951.php
@@ -64,6 +64,32 @@ final class FinalWithParent extends A
 	public function parentOfThis(): void
 	{
 		assertType("'Bug14951\\\\A'", get_parent_class($this));
+		assertType("'Bug14951\\\\A'", get_parent_class(static::class));
+	}
+
+}
+
+/** @final */
+class PhpDocFinalNoParent
+{
+
+	public function parentOfThis(): void
+	{
+		// A @final class cannot be subclassed either, so there is no subclass widening.
+		assertType('false', get_parent_class($this));
+		assertType('false', get_parent_class(static::class));
+	}
+
+}
+
+/** @final */
+class PhpDocFinalWithParent extends A
+{
+
+	public function parentOfThis(): void
+	{
+		assertType("'Bug14951\\\\A'", get_parent_class($this));
+		assertType("'Bug14951\\\\A'", get_parent_class(static::class));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-14951.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14951.php
@@ -18,6 +18,10 @@ class A
 		assertType('class-string<static(Bug14951\A)>', get_called_class());
 		assertType('class-string<$this(Bug14951\A)>', get_class($this));
 
+		// A class-string argument (e.g. self::class) names an exact class, not a runtime
+		// value, so it keeps the exact parent — no subclass widening.
+		assertType('false', get_parent_class(self::class));
+
 		return get_parent_class($this) === self::class;
 	}
 
@@ -29,6 +33,8 @@ class B extends A
 	public function parentOfThis(): void
 	{
 		assertType('\'Bug14951\\\\A\'|class-string<Bug14951\B>', get_parent_class($this));
+		// self::class is the exact class B, so its parent is exactly A.
+		assertType("'Bug14951\\\\A'", get_parent_class(self::class));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/get-parent-class.php
+++ b/tests/PHPStan/Analyser/nsrt/get-parent-class.php
@@ -10,7 +10,7 @@ class Foo
 	public function doFoo()
 	{
 		assertType('false', get_parent_class());
-		assertType('false', get_parent_class($this));
+		assertType('class-string<ParentClass\Foo>|false', get_parent_class($this));
 		assertType('class-string<$this(ParentClass\Foo)>', get_class($this));
 		assertType('\'ParentClass\\\\Foo\'', get_class());
 	}
@@ -25,7 +25,7 @@ class Bar extends Foo
 	public function doBar()
 	{
 		assertType('\'ParentClass\\\\Foo\'', get_parent_class());
-		assertType('\'ParentClass\\\\Foo\'', get_parent_class($this));
+		assertType('\'ParentClass\\\\Foo\'|class-string<ParentClass\Bar>', get_parent_class($this));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/get-parent-class.php
+++ b/tests/PHPStan/Analyser/nsrt/get-parent-class.php
@@ -45,12 +45,10 @@ trait FooTrait
 
 	public function doBaz()
 	{
-		// Inside a trait the using class is unknown, so $this defers to the general type.
+		// Inside a trait a late-static-bound argument is not resolved to a concrete parent.
 		assertType('class-string|false', get_parent_class());
 		assertType('class-string|false', get_parent_class($this));
-		// self::class / static::class resolve against the using class (Bar).
-		assertType('\'ParentClass\\\\Foo\'', get_parent_class(self::class));
-		assertType('\'ParentClass\\\\Foo\'|class-string<ParentClass\Bar>', get_parent_class(static::class));
+		assertType('class-string|false', get_parent_class(static::class));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/get-parent-class.php
+++ b/tests/PHPStan/Analyser/nsrt/get-parent-class.php
@@ -49,6 +49,12 @@ trait FooTrait
 		assertType('class-string|false', get_parent_class());
 		assertType('class-string|false', get_parent_class($this));
 		assertType('class-string|false', get_parent_class(static::class));
+
+		// self::class is not late static bound - it is the using class, so it is already a
+		// constant class-string here, indistinguishable from writing Bar::class.
+		assertType('\'ParentClass\\\\Bar\'', self::class);
+		assertType('\'ParentClass\\\\Foo\'', get_parent_class(self::class));
+		assertType('\'ParentClass\\\\Foo\'', get_parent_class(Bar::class));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/get-parent-class.php
+++ b/tests/PHPStan/Analyser/nsrt/get-parent-class.php
@@ -45,8 +45,12 @@ trait FooTrait
 
 	public function doBaz()
 	{
+		// Inside a trait the using class is unknown, so $this defers to the general type.
 		assertType('class-string|false', get_parent_class());
 		assertType('class-string|false', get_parent_class($this));
+		// self::class / static::class resolve against the using class (Bar).
+		assertType('\'ParentClass\\\\Foo\'', get_parent_class(self::class));
+		assertType('\'ParentClass\\\\Foo\'|class-string<ParentClass\Bar>', get_parent_class(static::class));
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -347,6 +347,11 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-2835.php'], []);
 	}
 
+	public function testBug14951(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14951.php'], []);
+	}
+
 	public function testBug1860(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-1860.php'], [

--- a/tests/PHPStan/Rules/Comparison/data/bug-14951.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-14951.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14951StrictComparison;
+
+class A
+{
+
+	public function isDirectChildOfA(): bool
+	{
+		// $this can be an instance of a subclass, so get_parent_class($this)
+		// can equal self::class for a direct child — this comparison is not always false.
+		return get_parent_class($this) === self::class;
+	}
+
+}
+
+class B extends A
+{
+}
+
+class C extends B
+{
+}


### PR DESCRIPTION
Closes phpstan/phpstan#14951

`get_parent_class($this)` inside a non-final class returned the declared parent (or `false` when there was none), treating `$this` as exactly the current class.

Through late static binding, `$this` can be an instance of a subclass, so for a direct child the parent is the class itself, and for a deeper descendant it is a subclass. The return type now also includes `class-string<Class>` in that case — which removes a false-positive `identical.alwaysFalse` on `get_parent_class($this) === self::class` (the reported bug).

Final classes and non-`$this`/`static` arguments (typed parameters, `new X()`) keep the exact parent type, so `get_parent_class($typedParam)` and `get_parent_class(new B())` are unchanged.

### Behaviour

Inside a non-final class `A` (no parent), with `class B extends A`:

- `get_parent_class($this)` in `A` → `class-string<A>|false` (was `false`).
- `get_parent_class($this)` in `B` → `'A'|class-string<B>` (was `'A'`).
- `get_parent_class($this)` in a `final` class → unchanged (exact parent / `false`).
- `get_parent_class($typedParam)`, `get_parent_class(new B())`, `get_parent_class(SomeClass::class)` → unchanged.

The two updated assertions in `get-parent-class.php` reflect this corrected behaviour.

### Note

While checking whether phpstan/phpstan#14951 would interfere with the `self`/`parent`/`static` scope and member-visibility work in #4081 (`Closure::bind()`), it turned out the two are independent and this one could be fixed on its own — so it is submitted here as a separate PR.
