### PR TITLE
Distribute Windows and ZTS builds of the turbo extension

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -496,9 +496,15 @@ jobs:
 
   turbo-run:
     name: "Run with Turbo Extension"
-    needs: "turbo-compile"
+    needs:
+      - turbo-compile
+      - turbo-compile-windows
     runs-on: ${{ matrix.setup.operating-system }}
     timeout-minutes: 60
+
+    defaults:
+      run:
+        shell: bash
 
     strategy:
       fail-fast: false
@@ -506,6 +512,12 @@ jobs:
         setup:
           - operating-system: "ubuntu-latest"
             artifact: "phpstan_turbo-linux-gnu-x86_64-php8.5"
+          # windows-latest only runs the DLL, it cannot build it: the DLL is
+          # linked with the 14.4x toolset on windows-2022, and the loader's
+          # linker-generation gate is one-directional (module <= core), so the
+          # vs17-built official PHP loads it fine.
+          - operating-system: "windows-latest"
+            artifact: "phpstan_turbo-windows-x86_64-php8.5"
         script: ["make tests", "make phpstan"]
 
     steps:
@@ -532,8 +544,23 @@ jobs:
           path: "turbo-ext"
 
       - name: "Install extension"
+        # The ini line needs a native path and the redirection a POSIX one,
+        # hence the cygpath round-trip on Windows; setup-php's Linux ini is
+        # root-owned, hence the sudo fallback.
         run: |
-          sudo bash -c "echo 'extension=$GITHUB_WORKSPACE/turbo-ext/phpstan_turbo.so' >> $(php -r 'echo php_ini_loaded_file();')"
+          FILE="$(find turbo-ext -maxdepth 1 \( -name phpstan_turbo.so -o -name php_phpstan_turbo.dll \) | head -1)"
+          [ -n "$FILE" ]
+          EXT="$PWD/$FILE"
+          INI="$(php -r 'echo php_ini_loaded_file();')"
+          if command -v cygpath > /dev/null; then
+            EXT="$(cygpath -w "$EXT")"
+            INI="$(cygpath -u "$INI")"
+          fi
+          if [ -w "$INI" ]; then
+            echo "extension=$EXT" >> "$INI"
+          else
+            sudo bash -c "echo 'extension=$EXT' >> '$INI'"
+          fi
           php -m | grep phpstan_turbo
 
       - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
@@ -557,7 +584,13 @@ jobs:
         # stays under.
         env:
           PHPSTAN_MEMORY_LIMIT: ${{ matrix.setup.operating-system == 'macos-latest' && '1G' || '450M' }}
-        run: ${{ matrix.script }}
+        # The Windows runner image ships GNU make only inside its MSYS2
+        # install, which is not on PATH.
+        run: |
+          if ! command -v make > /dev/null && [ -e /c/msys64/usr/bin/make.exe ]; then
+            export PATH="$PATH:/c/msys64/usr/bin"
+          fi
+          ${{ matrix.script }}
 
   integration-tests:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -344,15 +344,19 @@ jobs:
       - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
         if: matrix.target.family == 'macos'
 
-      - name: "Install Composer dependencies (containers)"
+      - name: "Install Composer dependencies (pinned composer)"
         if: matrix.target.family != 'macos'
         # checksum-pinned composer, run under the matrix PHP so platform
         # requirements are validated against the interpreter the tests below
-        # run on
+        # run on. COMPOSER_HOME is isolated: on the runner (ZTS) legs,
+        # setup-php seeds ~/.composer/auth.json with the workflow's GitHub
+        # token, which this pinned composer rejects at startup ("github oauth
+        # token contains invalid characters") — everything here comes from
+        # packagist dists, no auth needed.
         run: |
           curl -fsSLo composer.phar "https://getcomposer.org/download/$COMPOSER_VERSION/composer.phar"
           echo "$COMPOSER_PHAR_SHA256  composer.phar" | sha256sum -c -
-          php composer.phar install --no-interaction --no-progress
+          COMPOSER_HOME="$(mktemp -d)" php composer.phar install --no-interaction --no-progress
           rm composer.phar
 
       - name: "Smoke test (differential: native vs PHP implementations)"

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -539,7 +539,7 @@ jobs:
     needs:
       - turbo-compile
       - turbo-compile-windows
-    runs-on: ${{ matrix.setup.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
     timeout-minutes: 60
 
     defaults:
@@ -548,16 +548,14 @@ jobs:
 
     strategy:
       fail-fast: false
+      # windows-latest only runs the DLL, it cannot build it: the DLL is
+      # linked with the 14.4x toolset on windows-2022, and the loader's
+      # linker-generation gate is one-directional (module <= core), so the
+      # vs17-built official PHP loads it fine.
       matrix:
-        setup:
-          - operating-system: "ubuntu-latest"
-            artifact: "phpstan_turbo-linux-gnu-x86_64-php8.5"
-          # windows-latest only runs the DLL, it cannot build it: the DLL is
-          # linked with the 14.4x toolset on windows-2022, and the loader's
-          # linker-generation gate is one-directional (module <= core), so the
-          # vs17-built official PHP loads it fine.
-          - operating-system: "windows-latest"
-            artifact: "phpstan_turbo-windows-x86_64-php8.5"
+        operating-system: ["ubuntu-latest", "windows-latest"]
+        php-version: ["8.4", "8.5"]
+        ts: ["nts", "zts"]
         script: ["make tests", "make phpstan"]
 
     steps:
@@ -573,14 +571,16 @@ jobs:
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2.37.2
+        env:
+          phpts: "${{ matrix.ts == 'zts' && 'ts' || 'nts' }}"
         with:
           coverage: "none"
-          php-version: "8.5"
+          php-version: "${{ matrix.php-version }}"
 
       - name: "Download extension artifact"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: "${{ matrix.setup.artifact }}"
+          name: "phpstan_turbo-${{ matrix.operating-system == 'windows-latest' && 'windows-x86_64' || 'linux-gnu-x86_64' }}-php${{ matrix.php-version }}${{ matrix.ts == 'zts' && '-zts' || '' }}"
           path: "turbo-ext"
 
       - name: "Install extension"
@@ -618,12 +618,11 @@ jobs:
           '
 
       - name: "Run"
-        # The memo's per-worker footprint grows with files-per-worker; macOS
-        # runners have few cores, so each of their few workers analyses enough
-        # files to tip the default 450M limit that a many-worker Linux runner
-        # stays under.
+        # The memo's per-worker footprint grows with files-per-worker; a
+        # future few-core leg (macOS runners) needs 1G where these many-worker
+        # runners stay under the default 450M.
         env:
-          PHPSTAN_MEMORY_LIMIT: ${{ matrix.setup.operating-system == 'macos-latest' && '1G' || '450M' }}
+          PHPSTAN_MEMORY_LIMIT: "450M"
         # The Windows runner image ships GNU make only inside its MSYS2
         # install, which is not on PATH.
         run: |

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -347,9 +347,115 @@ jobs:
           path: "turbo-ext/phpstan_turbo.so"
           if-no-files-found: "error"
 
+  turbo-compile-windows:
+    name: "Compile Turbo Extension (Windows)"
+    # windows-latest and windows-2025 serve the VS2026 image, whose 14.5x
+    # toolset links DLLs the official php.net binaries (built with vs17,
+    # toolset 14.4x) refuse to load — PHP's loader rejects modules linked
+    # with a newer toolset generation than the core. The windows-2022 image
+    # is the one that ships VS2022.
+    runs-on: "windows-2022"
+    timeout-minutes: 40
+
+    env:
+      # php/php-sdk-binary-tools — the toolchain every PHP Windows build
+      # uses (ships bison and the unix tools phpize/configure expect).
+      PHP_SDK_COMMIT: "c73faaf1cce914e2fc04da5587132f8f425996af" # php-sdk-2.7.1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["8.4", "8.5"]
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # full history: the extension version is baked from git log over
+          # the watched paths
+          fetch-depth: 0
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2.37.2
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: "Compute the extension version and download the build tools"
+        shell: bash
+        run: |
+          MAPPED_PHP=$(jq -r '[.[] | select(.vendored != true) | .php] | join(" ")' turbo-ext/shadowed-classes.json)
+          SHA=$(git log -1 --format=%H -- turbo-ext/src $MAPPED_PHP | cut -c1-7)
+          echo "extension version: $SHA"
+          echo "PHPSTANTURBO_VERSION=$SHA" >> "$GITHUB_ENV"
+
+          FULL=$(php -r 'echo PHP_VERSION;')
+          PACK="php-devel-pack-$FULL-nts-Win32-vs17-x64.zip"
+          echo "devel pack: $PACK"
+          curl -fsSLo devel-pack.zip "https://windows.php.net/downloads/releases/$PACK" \
+            || curl -fsSLo devel-pack.zip "https://windows.php.net/downloads/releases/archives/$PACK"
+          unzip -q devel-pack.zip -d /c/php-devel
+
+          git clone -q https://github.com/php/php-sdk-binary-tools.git /c/php-sdk
+          git -C /c/php-sdk checkout -q "$PHP_SDK_COMMIT"
+
+      - name: "Set up MSVC environment"
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: x64
+
+      - name: "Build the extension"
+        shell: cmd
+        working-directory: turbo-ext
+        run: |
+          for /d %%d in (C:\php-devel\php-*-devel-*) do set DEVEL=%%d
+          set PATH=%DEVEL%;C:\php-sdk\bin;C:\php-sdk\msys2\usr\bin;%PATH%
+          call phpize.bat
+          if errorlevel 1 exit /b 1
+          call configure.bat --enable-phpstan-turbo
+          if errorlevel 1 exit /b 1
+          nmake
+
+      - name: "Verify the built extension reports the expected version"
+        shell: bash
+        run: |
+          DLL=$(find turbo-ext -name "php_phpstan_turbo.dll" | head -1)
+          [ -n "$DLL" ]
+          TURBO_DLL=$(cygpath -w "$PWD/$DLL")
+          echo "TURBO_DLL=$TURBO_DLL" >> "$GITHUB_ENV"
+          echo "DLL_PATH=$DLL" >> "$GITHUB_ENV"
+          REPORTED="$(php -d extension="$TURBO_DLL" -r 'echo phpversion("phpstan_turbo");')"
+          EXPECTED="$(sed -n "s/.*EXPECTED_EXTENSION_VERSION = '\([^']*\)'.*/\1/p" src/Turbo/TurboExtensionEnabler.php)"
+          echo "built extension reports: $REPORTED, enabler expects: $EXPECTED"
+          [ "$REPORTED" = "$EXPECTED" ]
+
+      - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
+
+      - name: "Smoke test (differential: native vs PHP implementations)"
+        shell: bash
+        run: php -d extension="$TURBO_DLL" turbo-ext/tests/smoke.php
+
+      - name: "Signature parity (reflect native classes against the PHP twins)"
+        shell: bash
+        run: php -d extension="$TURBO_DLL" turbo-ext/tests/signature-parity.php
+
+      - name: "Parser corpus (differential: native vs PHP ASTs must be byte-identical)"
+        shell: bash
+        run: php -d extension="$TURBO_DLL" -d memory_limit=4G turbo-ext/tests/parser-corpus.php
+
+      - name: "Upload extension artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "phpstan_turbo-windows-x86_64-php${{ matrix.php-version }}"
+          path: "${{ env.DLL_PATH }}"
+          if-no-files-found: "error"
+
   turbo-artifact:
     name: "Aggregate Turbo Extension Artifact"
-    needs: "turbo-compile"
+    needs:
+      - turbo-compile
+      - turbo-compile-windows
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
 
@@ -375,7 +481,9 @@ jobs:
             name="${dir#turbo-artifacts/phpstan_turbo-}"
             target="${name%-php*}"
             minor="${name##*-php}"
-            install -D -m 644 "$dir/phpstan_turbo.so" "turbo-ext-dist/$target/phpstan_turbo-$minor.so"
+            for file in "$dir"/*; do
+              install -D -m 644 "$file" "turbo-ext-dist/$target/phpstan_turbo-$minor.${file##*.}"
+            done
           done
           find turbo-ext-dist -type f | sort
 
@@ -632,6 +740,7 @@ jobs:
       - compiler-tests
       - turbo-version
       - turbo-compile
+      - turbo-compile-windows
     runs-on: "ubuntu-latest"
     timeout-minutes: 60
     steps:
@@ -756,9 +865,12 @@ jobs:
         env:
           TURBO_VERSION: ${{ steps.turbo-difference.outputs.version }}
         run: |
-          for target in linux-gnu-x86_64 linux-gnu-arm64 linux-musl-x86_64; do
-            for v in 8.4 8.5; do
-              install -D -m 644 "turbo-artifacts/phpstan_turbo-$target-php$v/phpstan_turbo.so" "phpstan-dist/turbo-ext/$target/phpstan_turbo-$v.so"
+          for dir in turbo-artifacts/phpstan_turbo-*; do
+            name="${dir#turbo-artifacts/phpstan_turbo-}"
+            target="${name%-php*}"
+            minor="${name##*-php}"
+            for file in "$dir"/*; do
+              install -D -m 644 "$file" "phpstan-dist/turbo-ext/$target/phpstan_turbo-$minor.${file##*.}"
             done
           done
           echo "$TURBO_VERSION" > phpstan-dist/turbo-ext/.version

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -208,7 +208,11 @@ jobs:
     # (RHEL 9, Ubuntu 22.04+, Debian 12+), alpine:3.24 builds the musl
     # variant. There is no linux-musl-arm64 leg: JavaScript-based actions
     # cannot run in Alpine containers on arm64 runners (the runner only
-    # ships an x64 musl Node).
+    # ships an x64 musl Node). The ZTS legs (for hosts with a thread-safe
+    # PHP, like PMMP's bundled build) run directly on ubuntu-22.04 runners —
+    # same glibc floor — because no distro packages ZTS PHP (neither
+    # ppa:ondrej/php nor Alpine); setup-php provides thread-safe builds.
+    # No musl ZTS for the same packaging reason.
     container: ${{ matrix.target.container }}
     timeout-minutes: 30
 
@@ -235,6 +239,16 @@ jobs:
             container: "alpine:3.24"
             family: "musl"
             artifact: "phpstan_turbo"
+          - name: "linux-gnu-x86_64"
+            runs-on: "ubuntu-22.04"
+            family: "zts"
+            artifact: "phpstan_turbo"
+            suffix: "-zts"
+          - name: "linux-gnu-arm64"
+            runs-on: "ubuntu-22.04-arm"
+            family: "zts"
+            artifact: "phpstan_turbo"
+            suffix: "-zts"
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -292,6 +306,21 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
+      - name: "Install PHP (ZTS runner)"
+        if: matrix.target.family == 'zts'
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2.37.2
+        env:
+          phpts: "ts"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      # Guards against setup-php silently falling back to an NTS build,
+      # which would ship an NTS binary under the -zts name.
+      - name: "Verify the interpreter is thread-safe"
+        if: matrix.target.family == 'zts'
+        run: "php -r 'exit((bool) PHP_ZTS ? 0 : 1);'"
+
       - name: "Compile phpstan_turbo with strict warnings"
         working-directory: "turbo-ext"
         # Exemptions, each caused by third-party macro expansions, not our code:
@@ -343,7 +372,7 @@ jobs:
       - name: "Upload extension artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "${{ matrix.target.artifact }}-${{ matrix.target.name }}-php${{ matrix.php-version }}"
+          name: "${{ matrix.target.artifact }}-${{ matrix.target.name }}-php${{ matrix.php-version }}${{ matrix.target.suffix }}"
           path: "turbo-ext/phpstan_turbo.so"
           if-no-files-found: "error"
 
@@ -366,6 +395,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.4", "8.5"]
+        ts: ["nts", "zts"]
 
     steps:
       - name: "Checkout"
@@ -378,6 +408,8 @@ jobs:
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2.37.2
+        env:
+          phpts: "${{ matrix.ts == 'zts' && 'ts' || 'nts' }}"
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
@@ -391,7 +423,9 @@ jobs:
           echo "PHPSTANTURBO_VERSION=$SHA" >> "$GITHUB_ENV"
 
           FULL=$(php -r 'echo PHP_VERSION;')
-          PACK="php-devel-pack-$FULL-nts-Win32-vs17-x64.zip"
+          # thread-safe devel packs carry no infix, NTS ones carry -nts
+          INFIX=$([ "${{ matrix.ts }}" = "zts" ] && echo "" || echo "-nts")
+          PACK="php-devel-pack-$FULL$INFIX-Win32-vs17-x64.zip"
           echo "devel pack: $PACK"
           curl -fsSLo devel-pack.zip "https://windows.php.net/downloads/releases/$PACK" \
             || curl -fsSLo devel-pack.zip "https://windows.php.net/downloads/releases/archives/$PACK"
@@ -429,6 +463,11 @@ jobs:
           EXPECTED="$(sed -n "s/.*EXPECTED_EXTENSION_VERSION = '\([^']*\)'.*/\1/p" src/Turbo/TurboExtensionEnabler.php)"
           echo "built extension reports: $REPORTED, enabler expects: $EXPECTED"
           [ "$REPORTED" = "$EXPECTED" ]
+          # the loader rejects a ts-mismatched DLL, so php loading it above
+          # proves the DLL matches the interpreter; assert the interpreter
+          # itself so both sides cannot silently be NTS on the zts leg
+          WANT_ZTS=$([ "${{ matrix.ts }}" = "zts" ] && echo 1 || echo 0)
+          [ "$(php -r 'echo (int) ((bool) PHP_ZTS);')" = "$WANT_ZTS" ]
 
       - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
 
@@ -447,7 +486,7 @@ jobs:
       - name: "Upload extension artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "phpstan_turbo-windows-x86_64-php${{ matrix.php-version }}"
+          name: "phpstan_turbo-windows-x86_64-php${{ matrix.php-version }}${{ matrix.ts == 'zts' && '-zts' || '' }}"
           path: "${{ env.DLL_PATH }}"
           if-no-files-found: "error"
 
@@ -472,8 +511,9 @@ jobs:
           path: "turbo-artifacts"
 
       - name: "Arrange the distribution layout"
-        # phpstan_turbo-<target>-php<minor> → <target>/phpstan_turbo-<minor>.so,
-        # derived from the artifact names so new targets need no change here.
+        # phpstan_turbo-<target>-php<minor>[-zts] →
+        # <target>/phpstan_turbo-<minor>[-zts].<so|dll>, derived from the
+        # artifact names so new targets need no change here.
         # The integration/extension/other test workflows in phpstan/phpstan
         # download this artifact next to the phar under test.
         run: |

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -56,7 +56,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '3dce41a';
+	public const EXPECTED_EXTENSION_VERSION = 'b0cb6fd';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -56,7 +56,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '5876433';
+	public const EXPECTED_EXTENSION_VERSION = '3dce41a';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/src/Turbo/TurboExtensionSelector.php
+++ b/src/Turbo/TurboExtensionSelector.php
@@ -21,8 +21,9 @@ use const PHP_ZTS;
  * so worker processes can load it via `-d extension=`.
  *
  * The binaries are committed to the phpstan/phpstan repository next to
- * phpstan.phar (turbo-ext/<platform>/phpstan_turbo-<minor>.so) by the
- * phar.yml commit job, so they only exist for phar-based installations —
+ * phpstan.phar (turbo-ext/<platform>/phpstan_turbo-<minor>.so, .dll on
+ * Windows) by the phar.yml commit job, so they only exist for phar-based
+ * installations —
  * a source checkout loads its locally built extension through php.ini
  * instead. Only NTS non-debug builds are shipped. Workers run the regular
  * entrypoint, so TurboExtensionEnabler still gates activation on the
@@ -54,7 +55,14 @@ final class TurboExtensionSelector
 			return null;
 		}
 
-		$file = sprintf('%s/turbo-ext/%s/phpstan_turbo-%d.%d.so', dirname($pharPath), $platform, PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
+		$file = sprintf(
+			'%s/turbo-ext/%s/phpstan_turbo-%d.%d.%s',
+			dirname($pharPath),
+			$platform,
+			PHP_MAJOR_VERSION,
+			PHP_MINOR_VERSION,
+			PHP_OS_FAMILY === 'Windows' ? 'dll' : 'so',
+		);
 		if (!is_file($file)) {
 			return null;
 		}
@@ -67,6 +75,9 @@ final class TurboExtensionSelector
 		if ($osFamily === 'Darwin') {
 			// one universal binary covers x86_64 and arm64
 			return 'macos';
+		}
+		if ($osFamily === 'Windows') {
+			return $machine === 'AMD64' || $machine === 'x86_64' ? 'windows-x86_64' : null;
 		}
 		if ($osFamily !== 'Linux') {
 			return null;

--- a/src/Turbo/TurboExtensionSelector.php
+++ b/src/Turbo/TurboExtensionSelector.php
@@ -25,7 +25,9 @@ use const PHP_ZTS;
  * Windows) by the phar.yml commit job, so they only exist for phar-based
  * installations —
  * a source checkout loads its locally built extension through php.ini
- * instead. Only NTS non-debug builds are shipped. Workers run the regular
+ * instead. Only non-debug builds are shipped; ZTS variants (-zts filename
+ * suffix) exist for linux-gnu and Windows so hosts with a thread-safe PHP
+ * (like PMMP's bundled build) are covered too. Workers run the regular
  * entrypoint, so TurboExtensionEnabler still gates activation on the
  * expected extension version.
  */
@@ -41,7 +43,7 @@ final class TurboExtensionSelector
 		if (getenv('PHPSTAN_TURBO') === '0') {
 			return null;
 		}
-		if ((bool) PHP_ZTS || (bool) PHP_DEBUG) {
+		if ((bool) PHP_DEBUG) {
 			return null;
 		}
 
@@ -56,11 +58,12 @@ final class TurboExtensionSelector
 		}
 
 		$file = sprintf(
-			'%s/turbo-ext/%s/phpstan_turbo-%d.%d.%s',
+			'%s/turbo-ext/%s/phpstan_turbo-%d.%d%s.%s',
 			dirname($pharPath),
 			$platform,
 			PHP_MAJOR_VERSION,
 			PHP_MINOR_VERSION,
+			(bool) PHP_ZTS ? '-zts' : '',
 			PHP_OS_FAMILY === 'Windows' ? 'dll' : 'so',
 		);
 		if (!is_file($file)) {

--- a/tests/PHPStan/Turbo/TurboExtensionSelectorTest.php
+++ b/tests/PHPStan/Turbo/TurboExtensionSelectorTest.php
@@ -22,7 +22,9 @@ final class TurboExtensionSelectorTest extends PHPStanTestCase
 		yield ['Linux', 'aarch64', true, 'linux-musl-arm64'];
 		yield ['Linux', 'riscv64', false, null];
 		yield ['Linux', 'i686', true, null];
-		yield ['Windows', 'AMD64', false, null];
+		yield ['Windows', 'AMD64', false, 'windows-x86_64'];
+		yield ['Windows', 'x86', false, null];
+		yield ['Windows', 'ARM64', false, null];
 		yield ['BSD', 'x86_64', false, null];
 		yield ['Unknown', 'x86_64', false, null];
 	}

--- a/turbo-ext/CLAUDE.md
+++ b/turbo-ext/CLAUDE.md
@@ -112,7 +112,11 @@ Output identity: `--error-format=raw` runs in both modes must diff empty.
   never plain `zend_hash_find` on user-derived keys.
 - Private userland methods are callable from C via `ce->function_table`
   lookup + `zend_call_known_function` — no visibility check applies.
-- Globals are plain statics (NTS-only build); keep new state in `pt_globals`.
+- Globals are plain statics; keep new state in `pt_globals`. This holds in
+  ZTS builds too — PHPStan's CLI processes are single-threaded (parallelism
+  is worker processes, not threads) — but only EG()/CG() access is truly
+  thread-aware (via the TSRMLS cache in `main.cpp`), so never introduce
+  actual multi-threaded use.
 - Fibers can suspend from internal frames — native code may be re-entered.
 - Cloned scopes must reset per-instance memo properties to constructor
   defaults, and native factories must instantiate the `…Impl` stub classes.

--- a/turbo-ext/Makefile
+++ b/turbo-ext/Makefile
@@ -11,7 +11,11 @@ CXX ?= c++
 # CI overrides with stricter settings, e.g. WARN_FLAGS="-Wall -Wextra -Werror"
 # (the Zend engine headers are exempted via the pragma guard in src/support.h)
 WARN_FLAGS ?= -Wall
+# ZEND_ENABLE_STATIC_TSRMLS_CACHE: on ZTS builds EG()/CG() go through the
+# per-thread cache main.cpp defines instead of a ts_resource lookup per
+# access; a no-op on NTS builds.
 CXXFLAGS := $(WARN_FLAGS) -O2 -std=c++17 -fPIC \
+	-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 \
 	`$(PHP_CONFIG) --includes`
 
 # The extension version is the short SHA of the last commit touching

--- a/turbo-ext/README.md
+++ b/turbo-ext/README.md
@@ -166,6 +166,20 @@ make          # builds phpstan_turbo.so
 The only requirements are a C++17 compiler and `php-config` on PATH (or
 passed as `make PHP_CONFIG=...`).
 
+On Windows the extension builds through the standard PHP extension pipeline
+(`config.w32`): with a PHP devel pack, [php-sdk-binary-tools] and a VS2022
+x64 developer prompt, run `phpize && configure --enable-phpstan-turbo &&
+nmake` inside `turbo-ext/`. The toolset generation matters for distribution:
+PHP's module loader rejects DLLs linked with a newer MSVC generation than
+the PHP core, and the official php.net binaries are built with VS2022
+(toolset 14.4x) — so CI builds on `windows-2022`, not `windows-latest`
+(whose VS2026 image links with 14.5x). Set the `PHPSTANTURBO_VERSION`
+environment variable before `configure` to bake the version (the Makefile
+computes it from git automatically; `config.w32` reads it from the
+environment).
+
+[php-sdk-binary-tools]: https://github.com/php/php-sdk-binary-tools
+
 ## Enabling
 
 Add to `php.ini` (recommended — parallel worker processes inherit it):

--- a/turbo-ext/README.md
+++ b/turbo-ext/README.md
@@ -164,7 +164,10 @@ make          # builds phpstan_turbo.so
 ```
 
 The only requirements are a C++17 compiler and `php-config` on PATH (or
-passed as `make PHP_CONFIG=...`).
+passed as `make PHP_CONFIG=...`). Both NTS and ZTS interpreters are
+supported — the build inherits thread-safety from the `php-config` it is
+pointed at (ZTS hosts like PMMP's bundled PHP get a matching build; PHPStan
+itself only ever runs the native code single-threaded).
 
 On Windows the extension builds through the standard PHP extension pipeline
 (`config.w32`): with a PHP devel pack, [php-sdk-binary-tools] and a VS2022

--- a/turbo-ext/config.w32
+++ b/turbo-ext/config.w32
@@ -13,9 +13,11 @@ if (PHP_PHPSTAN_TURBO != "no") {
 
 	// /EHsc: the C++ standard library assumes unwinding; /bigobj: the
 	// generated parser action files exceed the default section limit.
+	// ZEND_ENABLE_STATIC_TSRMLS_CACHE: ZTS builds resolve EG()/CG() through
+	// the per-thread cache main.cpp defines (a no-op on NTS builds).
 	// The version is passed as a bare token (main.cpp stringizes it) —
 	// quote characters do not survive the configure-to-nmake pipeline.
-	var flags = "/std:c++17 /EHsc /bigobj /DPHPSTANTURBO_VERSION_RAW=" + version;
+	var flags = "/std:c++17 /EHsc /bigobj /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /DPHPSTANTURBO_VERSION_RAW=" + version;
 
 	// backslash-separated paths: confutils' ADD_SOURCES derives the object
 	// directory by splitting on backslashes only — with forward slashes the

--- a/turbo-ext/config.w32
+++ b/turbo-ext/config.w32
@@ -1,0 +1,30 @@
+// phpstan_turbo — Windows build (php-devel-pack: phpize && configure && nmake).
+// The extension version is baked from the PHPSTANTURBO_VERSION environment
+// variable at configure time (the CI workflow computes it the same way the
+// Makefile does); it defaults to "dev", which the enabler rejects.
+
+ARG_ENABLE("phpstan-turbo", "phpstan turbo extension", "no");
+
+if (PHP_PHPSTAN_TURBO != "no") {
+	var version = WScript.CreateObject("WScript.Shell").Environment("PROCESS")("PHPSTANTURBO_VERSION");
+	if (!version || version == "") {
+		version = "dev";
+	}
+
+	// /EHsc: the C++ standard library assumes unwinding; /bigobj: the
+	// generated parser action files exceed the default section limit.
+	// The version is passed as a bare token (main.cpp stringizes it) —
+	// quote characters do not survive the configure-to-nmake pipeline.
+	var flags = "/std:c++17 /EHsc /bigobj /DPHPSTANTURBO_VERSION_RAW=" + version;
+
+	// backslash-separated paths: confutils' ADD_SOURCES derives the object
+	// directory by splitting on backslashes only — with forward slashes the
+	// objects compile flat while the link list expects the subpath
+	EXTENSION("phpstan_turbo",
+		"src\\main.cpp src\\support.cpp src\\CombinationsHelper.cpp src\\ConditionalExpressionHolder.cpp src\\ExpressionTypeHolder.cpp src\\NodeScanner.cpp src\\NodeTraverser.cpp src\\ScopeOps.cpp src\\TrinaryLogic.cpp src\\TypeCombinatorCache.cpp",
+		true,
+		flags);
+	ADD_SOURCES(configure_module_dirname + "/src/parser",
+		"ParserRunner.cpp ParserRunnerActions1.cpp ParserRunnerActions2.cpp ParserRunnerActions3.cpp ParserRunnerHelpers.cpp",
+		"phpstan_turbo");
+}

--- a/turbo-ext/src/main.cpp
+++ b/turbo-ext/src/main.cpp
@@ -51,6 +51,10 @@ static void ZEND_FASTCALL runtimeConfigure(INTERNAL_FUNCTION_PARAMETERS)
 
 static PHP_MINIT_FUNCTION(phpstan_turbo)
 {
+#ifdef ZTS
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
+
 	reg::Class runtime("PHPStanTurbo\\Runtime");
 	runtime.method("configure", reg::PublicStatic, 1, { reg::arrayArg("classMap") }, runtimeConfigure);
 	runtime.register_();
@@ -70,6 +74,10 @@ static PHP_MINIT_FUNCTION(phpstan_turbo)
 
 static PHP_RINIT_FUNCTION(phpstan_turbo)
 {
+#ifdef ZTS
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
+
 	pt_support_rinit();
 	pt_node_traverser_rinit();
 	pt_scope_ops_rinit();
@@ -89,6 +97,16 @@ static PHP_RSHUTDOWN_FUNCTION(phpstan_turbo)
 }
 
 extern "C" {
+
+/* ZTS builds resolve EG()/CG() through this per-thread cache (the build
+ * defines ZEND_ENABLE_STATIC_TSRMLS_CACHE; php.h declares the extern in
+ * every translation unit). The extension's own state stays in plain statics
+ * regardless: PHPStan's CLI processes are single-threaded — parallelism is
+ * worker processes, not threads — so a ZTS build (for hosts like PMMP's
+ * bundled PHP) never runs our code from two threads at once. */
+#ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE()
+#endif
 
 zend_module_entry phpstan_turbo_module_entry = {
 	STANDARD_MODULE_HEADER,

--- a/turbo-ext/src/main.cpp
+++ b/turbo-ext/src/main.cpp
@@ -11,8 +11,16 @@
 #include "support.h"
 #include "reg.h"
 
-/* Baked by the Makefile from git (short SHA of the last commit touching the
- * watched set); "dev" outside a git checkout, which the enabler rejects. */
+/* Baked from git (short SHA of the last commit touching the watched set);
+ * "dev" outside a git checkout, which the enabler rejects. The Makefile
+ * passes the quoted string directly; config.w32 passes the bare token as
+ * PHPSTANTURBO_VERSION_RAW — quote characters do not survive the Windows
+ * configure-to-nmake pipeline — and it is stringized here. */
+#ifdef PHPSTANTURBO_VERSION_RAW
+#define PT_VERSION_STR2(x) #x
+#define PT_VERSION_STR(x) PT_VERSION_STR2(x)
+#define PHPSTANTURBO_VERSION PT_VERSION_STR(PHPSTANTURBO_VERSION_RAW)
+#endif
 #ifndef PHPSTANTURBO_VERSION
 #define PHPSTANTURBO_VERSION "dev"
 #endif
@@ -20,8 +28,10 @@
 /* PHPStanTurbo\Runtime::configure() — cold-path configuration entry point.
  * TurboExtensionEnabler passes a map of class names (::class constants, so
  * they stay correct under the scoped phar) that the native code resolves
- * lazily at run time. */
-static void runtimeConfigure(INTERNAL_FUNCTION_PARAMETERS)
+ * lazily at run time. ZEND_FASTCALL matches zif_handler's calling
+ * convention — on MSVC x64 that is __vectorcall, and a named function
+ * defaults to __cdecl (the reg.h lambdas convert implicitly). */
+static void ZEND_FASTCALL runtimeConfigure(INTERNAL_FUNCTION_PARAMETERS)
 {
 	HashTable *map;
 	ZEND_PARSE_PARAMETERS_START(1, 1)

--- a/turbo-ext/tests/signature-parity.php
+++ b/turbo-ext/tests/signature-parity.php
@@ -73,7 +73,8 @@ foreach ($manifest as $twinClass => $entry) {
 
 	// the manifest must point at the file the class actually lives in
 	// (bin/side-by-side.php parses that file's source as the PHP side)
-	$actualFile = substr(realpath($twin->getFileName()), strlen(realpath($root)) + 1);
+	// normalized to forward slashes: the manifest stores portable paths
+	$actualFile = str_replace(DIRECTORY_SEPARATOR, '/', substr(realpath($twin->getFileName()), strlen(realpath($root)) + 1));
 	if ($actualFile !== $entry['php']) {
 		$problems[] = sprintf('lives in %s, but the manifest says %s — regenerate with bin/side-by-side.php --update-manifest', $actualFile, $entry['php']);
 	}


### PR DESCRIPTION
Extends the turbo extension distribution matrix from 3 Linux NTS targets to Windows and thread-safe builds:

- **Windows build** (`config.w32` + phar.yml job): built on `windows-2022` — the official php.net binaries are built with VS2022's 14.4x toolset and PHP's loader rejects modules linked with a newer toolset generation (windows-latest/windows-2025 both serve the VS2026 image). The full differential battery (smoke, signature parity, parser corpus) runs against the built DLL for every matrix leg.
- **ZTS builds** for linux-gnu x86_64/arm64 and Windows, with a `-zts` filename suffix. Motivating case: hosts bundling a thread-safe PHP, like PMMP. Natively this only needs the standard TSRMLS cache (`ZEND_ENABLE_STATIC_TSRMLS_CACHE` + define/update in `main.cpp`); the extension's own state stays in plain statics since PHPStan's CLI processes are single-threaded. The ZTS CI legs run on `ubuntu-22.04` runners (same glibc 2.34 floor as the container legs) with setup-php's thread-safe builds, because no distro packages ZTS PHP — which is also why there is no musl ZTS variant. Both ZTS legs assert `PHP_ZTS` so a silent NTS fallback cannot ship a mislabeled binary.
- **`TurboExtensionSelector`** now maps Windows/AMD64 to `windows-x86_64` with a `.dll` suffix and picks the `-zts` variant on thread-safe interpreters instead of bailing.
- **`turbo-run`** covers the full runnable matrix: {ubuntu-latest, windows-latest} × PHP {8.4, 8.5} × {nts, zts} × {make tests, make phpstan}, all steps under `shell: bash`. Running (not building) on windows-latest is fine — the loader's linker-generation gate is one-directional, so the 14.4x-linked DLL loads into the vs17-built official PHP.

Dist layout becomes `turbo-ext/<platform>/phpstan_turbo-<minor>[-zts].{so,dll}`; the artifact-name-driven staging loops needed no per-target changes.

First CI run has to prove three assumptions: setup-php's ZTS builds ship phpize/php-config, the TS devel-pack naming (no `-nts-` infix), and the MSYS2 make fallback on windows-latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j6ePxd1BobZkr8YVLnNet