### PR TITLE
Resolve forward_static_call() with the caller's late static binding

### DIFF
--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -4,12 +4,14 @@ namespace PHPStan\Analyser;
 
 use PhpParser\Node as PhpParserNode;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Node\Expr\TypeExpr;
@@ -19,16 +21,19 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use function array_is_list;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
 use function count;
+use function explode;
 use function is_string;
 use function key;
 use function ksort;
 use function max;
 use function sprintf;
+use function str_contains;
 
 /**
  * @api
@@ -191,6 +196,91 @@ final class ArgumentsNormalizer
 			$passThruArgs,
 			self::attributesWithoutPrintedForm($callUserFuncArrayCall),
 		), $acceptsNamedArguments];
+	}
+
+	/**
+	 * @return array{ParametersAcceptor, FuncCall|StaticCall, TrinaryLogic}|null
+	 */
+	public static function reorderForwardStaticCallArguments(
+		FuncCall $forwardStaticCallCall,
+		Scope $scope,
+	): ?array
+	{
+		$result = self::reorderCallUserFuncArguments($forwardStaticCallCall, $scope);
+		if ($result === null) {
+			return null;
+		}
+
+		[$parametersAcceptor, $innerFuncCall, $acceptsNamedArguments] = $result;
+
+		return [
+			$parametersAcceptor,
+			self::createForwardingStaticCall($innerFuncCall, $scope) ?? $innerFuncCall,
+			$acceptsNamedArguments,
+		];
+	}
+
+	/**
+	 * @return array{ParametersAcceptor, FuncCall|StaticCall, TrinaryLogic}|null
+	 */
+	public static function reorderForwardStaticCallArrayArguments(
+		FuncCall $forwardStaticCallArrayCall,
+		Scope $scope,
+	): ?array
+	{
+		$result = self::reorderCallUserFuncArrayArguments($forwardStaticCallArrayCall, $scope);
+		if ($result === null) {
+			return null;
+		}
+
+		[$parametersAcceptor, $innerFuncCall, $acceptsNamedArguments] = $result;
+
+		return [
+			$parametersAcceptor,
+			self::createForwardingStaticCall($innerFuncCall, $scope) ?? $innerFuncCall,
+			$acceptsNamedArguments,
+		];
+	}
+
+	/**
+	 * Turns a normalized callable invocation into a static call marked as a forwarding call
+	 * (a call that forwards the caller's late static binding, like self:: and parent:: do),
+	 * when the callable names a class and a method. Returns null for other callables.
+	 */
+	private static function createForwardingStaticCall(FuncCall $funcCall, Scope $scope): ?StaticCall
+	{
+		$callableExpr = $funcCall->name;
+		if (!$callableExpr instanceof Expr) {
+			return null;
+		}
+
+		$callableType = $scope->getType($callableExpr);
+
+		$className = null;
+		$methodName = null;
+		$constantArrays = $callableType->getConstantArrays();
+		$constantStrings = $callableType->getConstantStrings();
+		if (count($constantArrays) === 1) {
+			$classStrings = $constantArrays[0]->getOffsetValueType(new ConstantIntegerType(0))->getConstantStrings();
+			$methodStrings = $constantArrays[0]->getOffsetValueType(new ConstantIntegerType(1))->getConstantStrings();
+			if (count($classStrings) === 1 && count($methodStrings) === 1) {
+				$className = $classStrings[0]->getValue();
+				$methodName = $methodStrings[0]->getValue();
+			}
+		} elseif (count($constantStrings) === 1 && str_contains($constantStrings[0]->getValue(), '::')) {
+			[$className, $methodName] = explode('::', $constantStrings[0]->getValue(), 2);
+		}
+
+		if ($className === null || $className === '' || $methodName === null || $methodName === '') {
+			return null;
+		}
+
+		return new StaticCall(
+			new FullyQualified($className),
+			new Identifier($methodName),
+			$funcCall->getArgs(),
+			$funcCall->getAttributes(),
+		);
 	}
 
 	public static function reorderFuncArguments(

--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -275,9 +275,11 @@ final class ArgumentsNormalizer
 			return null;
 		}
 
+		// The original call's position attributes are propagated to the name nodes too,
+		// so rule errors about the synthesized call point at the original call site.
 		return new StaticCall(
-			new FullyQualified($className),
-			new Identifier($methodName),
+			new FullyQualified($className, $funcCall->getAttributes()),
+			new Identifier($methodName, $funcCall->getAttributes()),
 			$funcCall->getArgs(),
 			$funcCall->getAttributes(),
 		);

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -9,7 +9,9 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
@@ -20,6 +22,7 @@ use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\EarlyTerminatingCallHelper;
+use PHPStan\Analyser\ExprHandler\Helper\MethodCallReturnTypeHelper;
 use PHPStan\Analyser\ExprHandler\Helper\OutputBufferHelper;
 use PHPStan\Analyser\ExprHandler\Helper\VoidToNullTypeTransformer;
 use PHPStan\Analyser\GatheringNodeCallback;
@@ -102,6 +105,7 @@ final class FuncCallHandler implements ExprHandler
 		#[AutowiredExtensions(of: DynamicFunctionThrowTypeExtension::class)]
 		private ExtensionsCollection $dynamicFunctionThrowTypeExtensions,
 		private DynamicReturnTypeExtensionRegistry $dynamicReturnTypeExtensionRegistry,
+		private MethodCallReturnTypeHelper $methodCallReturnTypeHelper,
 		#[AutowiredParameter(ref: '%exceptions.implicitThrows%')]
 		private bool $implicitThrows,
 		#[AutowiredParameter]
@@ -906,6 +910,24 @@ final class FuncCallHandler implements ExprHandler
 			}
 		}
 
+		if ($functionReflection->getName() === 'forward_static_call') {
+			$result = ArgumentsNormalizer::reorderForwardStaticCallArguments($expr, $scope);
+			if ($result !== null) {
+				[, $innerCall] = $result;
+
+				return $this->resolveForwardStaticCallType($scope, $innerCall);
+			}
+		}
+
+		if ($functionReflection->getName() === 'forward_static_call_array') {
+			$result = ArgumentsNormalizer::reorderForwardStaticCallArrayArguments($expr, $scope);
+			if ($result !== null) {
+				[, $innerCall] = $result;
+
+				return $this->resolveForwardStaticCallType($scope, $innerCall);
+			}
+		}
+
 		$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
 			$expr->getArgs(),
@@ -945,6 +967,41 @@ final class FuncCallHandler implements ExprHandler
 		}
 
 		return VoidToNullTypeTransformer::transform($parametersAcceptor->getReturnType(), $expr);
+	}
+
+	/**
+	 * forward_static_call() is a forwarding call: it keeps the caller's late static binding
+	 * (like self:: and parent:: do). The named class is therefore resolved without resetting
+	 * static:: to it — resolveTypeByName() already yields the caller-bound ancestor type when
+	 * the named class is an ancestor, and a plain object type otherwise, matching the runtime
+	 * behavior of only forwarding within the caller's own ancestry.
+	 *
+	 * The synthesized static call is resolved here directly instead of through
+	 * MutatingScope::getType(), because it would be indistinguishable from a real,
+	 * non-forwarding static call on the same class in the scope's expression-type cache.
+	 */
+	private function resolveForwardStaticCallType(MutatingScope $scope, FuncCall|StaticCall $innerCall): Type
+	{
+		if (
+			$innerCall instanceof StaticCall
+			&& $innerCall->class instanceof Name
+			&& $innerCall->name instanceof Identifier
+		) {
+			$callType = $this->methodCallReturnTypeHelper->methodCallReturnType(
+				$scope,
+				$scope->resolveTypeByName($innerCall->class),
+				$innerCall->name->toString(),
+				$innerCall,
+			);
+			if ($callType !== null) {
+				return $callType;
+			}
+
+			return new ErrorType();
+		}
+
+		// Closures and other callables have their own lexical scope; resolve them as-is.
+		return $scope->getType($innerCall);
 	}
 
 	public function specifyTypes(TypeSpecifier $typeSpecifier, Scope $scope, Expr $expr, TypeSpecifierContext $context): SpecifiedTypes

--- a/src/Rules/Functions/CallUserFuncRule.php
+++ b/src/Rules/Functions/CallUserFuncRule.php
@@ -62,6 +62,16 @@ final class CallUserFuncRule implements Rule
 				$node,
 				$scope,
 			);
+		} elseif ($functionName === 'forward_static_call') {
+			$result = ArgumentsNormalizer::reorderForwardStaticCallArguments(
+				$node,
+				$scope,
+			);
+		} elseif ($functionName === 'forward_static_call_array') {
+			$result = ArgumentsNormalizer::reorderForwardStaticCallArrayArguments(
+				$node,
+				$scope,
+			);
 		} else {
 			return [];
 		}

--- a/tests/PHPStan/Analyser/nsrt/forward-static-call-multi-level.php
+++ b/tests/PHPStan/Analyser/nsrt/forward-static-call-multi-level.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace ForwardStaticCallMultiLevel;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Multi-level hierarchy: Root -> Middle -> Leaf (final).
+ * Each class has its own which() implementation with a distinct return type, so the
+ * assertions below can tell exactly which implementation the call is resolved against.
+ */
+class Root
+{
+
+	/** @return 'Root' */
+	public static function which(): string
+	{
+		return 'Root';
+	}
+
+	/** @return static */
+	public static function create(): static
+	{
+		return new static(); // @phpstan-ignore new.static
+	}
+
+}
+
+class Middle extends Root
+{
+
+	/** @return 'Middle' */
+	public static function which(): string // @phpstan-ignore method.childReturnType
+	{
+		return 'Middle';
+	}
+
+	/** @return static */
+	public static function make(): static
+	{
+		return new static(); // @phpstan-ignore new.static
+	}
+
+	public static function test(): void
+	{
+		// Naming an ancestor calls the *named* class's implementation (runtime returns
+		// 'Root' even though Middle and Leaf override which()), while the late static
+		// binding is forwarded.
+		assertType("'Root'", forward_static_call([Root::class, 'which']));
+		assertType("'Root'", forward_static_call('ForwardStaticCallMultiLevel\Root::which'));
+
+		// The forwarded binding is the caller's static: at runtime Middle::test() gives
+		// Middle and Leaf::test() gives Leaf, both covered by static(Middle).
+		assertType('static(ForwardStaticCallMultiLevel\Middle)', forward_static_call([Root::class, 'create']));
+		assertType('static(ForwardStaticCallMultiLevel\Middle)', forward_static_call('ForwardStaticCallMultiLevel\Root::create'));
+
+		// self::class names this very class; its own implementation is called.
+		assertType("'Middle'", forward_static_call([self::class, 'which']));
+		assertType('static(ForwardStaticCallMultiLevel\Middle)', forward_static_call([self::class, 'make']));
+
+		// Naming a descendant: at runtime the binding is forwarded only when the caller's
+		// runtime static is a subclass of the named class (Leaf::test() gives Leaf,
+		// Middle::test() gives Leaf too because the binding resets to the named class),
+		// so the named class's object type covers both outcomes.
+		assertType('ForwardStaticCallMultiLevel\Leaf', forward_static_call([Leaf::class, 'create']));
+	}
+
+	public function instanceContext(): void
+	{
+		// An instance method also has an active class scope to forward
+		// (at runtime the binding is the object's class).
+		assertType('static(ForwardStaticCallMultiLevel\Middle)', forward_static_call([Root::class, 'create']));
+	}
+
+}
+
+final class Leaf extends Middle
+{
+
+	/** @return 'Leaf' */
+	public static function which(): string // @phpstan-ignore method.childReturnType
+	{
+		return 'Leaf';
+	}
+
+	public static function test(): void
+	{
+		// Called from the final class, naming the two-levels-up ancestor: still the named
+		// class's implementation (runtime returns 'Root', not this class's override), and
+		// the forwarded binding collapses to the final class itself.
+		assertType("'Root'", forward_static_call([Root::class, 'which']));
+		assertType('ForwardStaticCallMultiLevel\Leaf', forward_static_call([Root::class, 'create']));
+
+		// A method defined only in the intermediate class forwards the same way.
+		assertType('ForwardStaticCallMultiLevel\Leaf', forward_static_call([Middle::class, 'make']));
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/forward-static-call.php
+++ b/tests/PHPStan/Analyser/nsrt/forward-static-call.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace ForwardStaticCall;
+
+use function PHPStan\Testing\assertType;
+
+class Base
+{
+
+	/** @return static */
+	public static function create(): static
+	{
+		return new static(); // @phpstan-ignore new.static
+	}
+
+	public static function name(): string
+	{
+		return static::class;
+	}
+
+}
+
+class Caller extends Base
+{
+
+	public static function test(): void
+	{
+		// forward_static_call() forwards the caller's late static binding when the
+		// named class is an ancestor (or self), unlike call_user_func().
+		assertType('static(ForwardStaticCall\Caller)', forward_static_call([Base::class, 'create']));
+		assertType('static(ForwardStaticCall\Caller)', forward_static_call('ForwardStaticCall\Base::create'));
+		assertType('static(ForwardStaticCall\Caller)', forward_static_call_array([Base::class, 'create'], []));
+		assertType('string', forward_static_call([Base::class, 'name']));
+
+		assertType('static(ForwardStaticCall\Caller)', forward_static_call([self::class, 'create']));
+
+		// call_user_func() is a non-forwarding call: static:: is reset to the named class.
+		assertType('ForwardStaticCall\Base', call_user_func([Base::class, 'create']));
+
+		// A class outside the caller's ancestry does not receive the forwarded binding.
+		assertType('ForwardStaticCall\Other', forward_static_call([Other::class, 'create']));
+
+		// Closures have their own lexical scope; just resolve the callable's return type.
+		assertType('1', forward_static_call(static fn (): int => 1));
+	}
+
+}
+
+class Other
+{
+
+	/** @return static */
+	public static function create(): static
+	{
+		return new static(); // @phpstan-ignore new.static
+	}
+
+}
+
+function outsideClass(): void {
+	// Runtime would throw (no class scope is active), but the type is still resolvable.
+	assertType('ForwardStaticCall\Base', forward_static_call([Base::class, 'create']));
+}

--- a/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
@@ -45,6 +45,32 @@ class CallUserFuncRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testForwardStaticCall(): void
+	{
+		$this->analyse([__DIR__ . '/data/forward-static-call.php'], [
+			[
+				'Callable passed to forward_static_call() invoked with 0 parameters, 1 required.',
+				21,
+			],
+			[
+				'Parameter #1 $name of callable passed to forward_static_call() expects string, int given.',
+				22,
+			],
+			[
+				'Callable passed to forward_static_call() invoked with 0 parameters, 1 required.',
+				23,
+			],
+			[
+				'Callable passed to forward_static_call_array() invoked with 0 parameters, 1 required.',
+				25,
+			],
+			[
+				'Parameter #1 $name of callable passed to forward_static_call_array() expects string, int given.',
+				26,
+			],
+		]);
+	}
+
 	#[RequiresPhp('>= 8.0.0')]
 	public function testRule(): void
 	{

--- a/tests/PHPStan/Rules/Functions/data/forward-static-call.php
+++ b/tests/PHPStan/Rules/Functions/data/forward-static-call.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace ForwardStaticCallRule;
+
+class Base
+{
+
+	public static function greet(string $name): string
+	{
+		return 'hi ' . $name;
+	}
+
+}
+
+class Caller extends Base
+{
+
+	public static function doFoo(): void
+	{
+		forward_static_call([Base::class, 'greet'], 'John');
+		forward_static_call([Base::class, 'greet']);
+		forward_static_call([Base::class, 'greet'], 42);
+		forward_static_call('ForwardStaticCallRule\Base::greet');
+		forward_static_call_array([Base::class, 'greet'], ['John']);
+		forward_static_call_array([Base::class, 'greet'], []);
+		forward_static_call_array([Base::class, 'greet'], [42]);
+	}
+
+}


### PR DESCRIPTION
Closes phpstan/phpstan#14958

`forward_static_call()` / `forward_static_call_array()` are *forwarding* calls: they propagate the caller's late static binding, unlike `call_user_func()` which resets it to the named class. Both previously fell through to the function map and returned `mixed`, and their arguments were not checked against the callable.

### Type inference

The callable is normalized into an inner call the same way `call_user_func()` does. When it names a class and a method (`[Base::class, 'create']`, `'Base::create'`), the synthesized static call is resolved on `Scope::resolveTypeByName()`'s result *without* the static-type reset that `StaticCallHandler` applies to explicit class names — so the named class yields the caller-bound ancestor type when it is an ancestor and a plain object type otherwise, matching the runtime rule that the binding is only forwarded within the caller's own ancestry (verified on PHP 8.5, including descendant and unrelated classes). Other callables (closures, …) resolve as before.

```php
class Base {
    /** @return static */
    public static function create(): static { /* … */ }
}
class Caller extends Base {
    public static function test(): void {
        forward_static_call([Base::class, 'create']);  // static(Caller), was mixed
        call_user_func([Base::class, 'create']);       // Base (unchanged)
    }
}
```

The multi-level-hierarchy semantics are covered by tests in a separate commit: naming an ancestor calls the named class's implementation (overrides below do not re-dispatch) while the binding is forwarded, the binding collapses in a final class, instance methods forward as well, and generics resolve through the passed arguments.

One implementation note: the synthesized static call is resolved directly instead of through `MutatingScope::getType()`, because its printed form would collide with a real, non-forwarding static call on the same class in the expression-type cache.

### Rule

`CallUserFuncRule` is extended to `forward_static_call*`, reusing the same normalization, so missing or mismatched arguments of the forwarded callable are reported like for `call_user_func()`. (A callable that is not callable at all — including a nonexistent method — was already reported by the generic parameter check.) The synthesized call's name nodes carry the original call's position attributes so the errors point at the call site.
