### PR TITLE
Fix actionlint error

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -437,7 +437,7 @@ jobs:
         shell: bash
         run: |
           MAPPED_PHP=$(jq -r '[.[] | select(.vendored != true) | .php] | join(" ")' turbo-ext/shadowed-classes.json)
-          SHA=$(git log -1 --format=%H -- turbo-ext/src $MAPPED_PHP | cut -c1-7)
+          SHA=$(git log -1 --format=%H -- turbo-ext/src "$MAPPED_PHP" | cut -c1-7)
           echo "extension version: $SHA"
           echo "PHPSTANTURBO_VERSION=$SHA" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
```
SHA=$(git log -1 --format=%H -- turbo-ext/src $MAPPED_PHP | cut -c1-7)
                                              ^-- [SC2086](https://www.shellcheck.net/wiki/SC2086) (info): Double quote to prevent globbing and word splitting.
```