### PR TITLE
Reuse FileExcluder instances in `IgnoredError::shouldIgnore()`

### DIFF
--- a/src/Analyser/Ignore/IgnoredError.php
+++ b/src/Analyser/Ignore/IgnoredError.php
@@ -21,6 +21,16 @@ final class IgnoredError
 {
 
 	/**
+	 * FileExcluder construction stats the filesystem (is_file/is_dir), and
+	 * shouldIgnore() runs once per (error, ignore entry with a path) pair, so
+	 * reuse excluders for the same path. Keyed by working directory + path
+	 * because path normalization depends on the working directory.
+	 *
+	 * @var array<string, FileExcluder>
+	 */
+	private static array $fileExcluders = [];
+
+	/**
 	 * @param ExpandedIgnoredErrorData|string $ignoredError
 	 */
 	public static function getIgnoredErrorLabel(array|string $ignoredError): string
@@ -116,7 +126,7 @@ final class IgnoredError
 		}
 
 		if ($path !== null) {
-			$fileExcluder = new FileExcluder($fileHelper, [$path]);
+			$fileExcluder = self::$fileExcluders[$fileHelper->getWorkingDirectory() . "\0" . $path] ??= new FileExcluder($fileHelper, [$path]);
 			$isExcluded = $fileExcluder->isExcludedFromAnalysing($error->getFilePath());
 			if (!$isExcluded && $error->getTraitFilePath() !== null) {
 				return $fileExcluder->isExcludedFromAnalysing($error->getTraitFilePath());


### PR DESCRIPTION
A fresh FileExcluder was constructed for every (error, ignore entry with a path) pair - each construction normalizes the path, runs a preg_match and stats the filesystem via is_file/is_dir. With a large baseline this ran tens of thousands of times per run. Memoize the excluder per working directory + path.

picked from https://github.com/phpstan/phpstan-src/commits/worktree-spx-perf-hunt/