### PR TITLE
fix: resolve static/self/parent relative to @param-closure-this bound class

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2020,7 +2020,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$expressionTypes,
 			$nativeExpressionTypes,
 			$this->conditionalExpressions,
-			$this->inClosureBindScopeClasses,
+			$restoreThisScope->inClosureBindScopeClasses,
 			$this->anonymousFunctionReflection,
 			$this->inFirstLevelStatement,
 			[],
@@ -2057,6 +2057,31 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	public function isInClosureBind(): bool
 	{
 		return $this->inClosureBindScopeClasses !== [];
+	}
+
+	/**
+	 * @param list<non-empty-string> $scopeClasses
+	 */
+	public function withClosureBindScopeClasses(array $scopeClasses): self
+	{
+		return $this->scopeFactory->create(
+			$this->context,
+			$this->isDeclareStrictTypes(),
+			$this->getFunction(),
+			$this->getNamespace(),
+			$this->expressionTypes,
+			$this->nativeExpressionTypes,
+			$this->conditionalExpressions,
+			$scopeClasses,
+			$this->anonymousFunctionReflection,
+			$this->isInFirstLevelStatement(),
+			$this->currentlyAssignedExpressions,
+			$this->currentlyAllowedUndefinedExpressions,
+			$this->inFunctionCallsStack,
+			$this->afterExtractCall,
+			$this->parentScope,
+			$this->nativeTypesPromoted,
+		);
 	}
 
 	/**
@@ -2397,6 +2422,23 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				false,
 			)), new AccessoryArrayListType()]);
 		}
+		if (
+			$type instanceof Name
+			&& $this->inClosureBindScopeClasses !== []
+			&& $this->inClosureBindScopeClasses !== ['static']
+			&& in_array($type->toLowerString(), ['static', 'self', 'parent'], true)
+			&& $this->reflectionProvider->hasClass($this->inClosureBindScopeClasses[0])
+		) {
+			return $this->initializerExprTypeResolver->getFunctionType(
+				$type,
+				$isNullable,
+				false,
+				InitializerExprContext::fromClassReflection(
+					$this->reflectionProvider->getClass($this->inClosureBindScopeClasses[0]),
+				),
+			);
+		}
+
 		return $this->initializerExprTypeResolver->getFunctionType($type, $isNullable, false, InitializerExprContext::fromScope($this));
 	}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3656,7 +3656,8 @@ class NodeScopeResolver
 					$closureThisType = $this->resolveClosureThisType($callLike, $calleeReflection, $parameter, $scopeToPass);
 					if ($closureThisType !== null) {
 						$restoreThisScope = $scopeToPass;
-						$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes());
+						$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes())
+							->withClosureBindScopeClasses($closureThisType->getObjectClassNames());
 					}
 				}
 
@@ -3722,7 +3723,8 @@ class NodeScopeResolver
 				) {
 					$closureThisType = $this->resolveClosureThisType($callLike, $calleeReflection, $parameter, $scopeToPass);
 					if ($closureThisType !== null) {
-						$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes());
+						$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes())
+							->withClosureBindScopeClasses($closureThisType->getObjectClassNames());
 					}
 				}
 

--- a/tests/PHPStan/Analyser/nsrt/param-closure-this.php
+++ b/tests/PHPStan/Analyser/nsrt/param-closure-this.php
@@ -316,3 +316,75 @@ class ImplicitInheritanceMoreComplicated extends Foo
 	}
 
 }
+
+class FooParent
+{
+
+}
+
+class FooChild extends FooParent
+{
+
+	private string $secret = 'secret';
+
+}
+
+class StaticReturnClosureThis
+{
+
+	/**
+	 * @param-closure-this FooChild $cb
+	 */
+	public function withFooChild(callable $cb): void
+	{
+
+	}
+
+	/**
+	 * @param-closure-this Foo $cb
+	 */
+	public function withFoo(callable $cb): void
+	{
+
+	}
+
+}
+
+class TestStaticResolutionInParamClosureThis
+{
+
+	public function testStaticReturnType(StaticReturnClosureThis $o): void
+	{
+		$o->withFoo(function (): static {
+			assertType('ParamClosureThis\Foo', $this);
+			return $this;
+		});
+
+		$o->withFoo(fn (): static => $this);
+	}
+
+	public function testSelfReturnType(StaticReturnClosureThis $o): void
+	{
+		$o->withFooChild(function (): self {
+			assertType('ParamClosureThis\FooChild', $this);
+			return $this;
+		});
+	}
+
+	public function testParentReturnType(StaticReturnClosureThis $o): void
+	{
+		$o->withFooChild(function (): parent {
+			assertType('ParamClosureThis\FooChild', $this);
+			return $this;
+		});
+	}
+
+	public function testNullableStaticReturnType(StaticReturnClosureThis $o): void
+	{
+		$o->withFoo(function (): ?static {
+			assertType('ParamClosureThis\Foo', $this);
+			return rand() ? $this : null;
+		});
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3394,6 +3394,15 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug11010(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-11010.php'], []);
+	}
+
 	public function testPureCallable(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/bug-11010.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-11010.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug11010;
+
+class HelloWorld
+{
+	protected function sayHello(): void
+	{
+		echo 'Hello';
+	}
+
+	/**
+	 * @param-closure-this self $cb
+	 */
+	public static function cb(\Closure $cb): void
+	{
+		$cb = $cb->bindTo(new self, self::class);
+		if ($cb) {
+			$cb();
+		}
+	}
+}
+
+function (): void {
+	HelloWorld::cb(function () {
+		$this->sayHello();
+	});
+};


### PR DESCRIPTION
## Bug

When a closure or arrow function has its `$this` type overridden via `@param-closure-this`, the `static`/`self`/`parent` keywords in return type declarations resolve to the **enclosing class** instead of the **bound class**.

### Reproducer

```php
final class CollectionMacros
{
    public static function boot(): void
    {
        Collection::macro(
            'asValueLabel',
            // PHPStan errors with:
            // Anonymous function should return static(\...\CollectionMacros)
            // but returns Illuminate\Support\Collection<int, array<string, mixed>>
            fn (): static => $this->map(fn ($l, $v) => ['value' => $v, 'label' => $l])->values(),
        );
    }
}
```

Where `Collection::macro()` has `@param-closure-this static $macro`, PHPStan correctly resolves `$this` inside the closure to `Collection`, but the `static` return type still resolves to `CollectionMacros` (the enclosing class) instead of `Collection`.

## Root Cause

Two layers:

1. **`inClosureBindScopeClasses` was never set** when `@param-closure-this` was applied. `NodeScopeResolver` only called `assignVariable('this', ...)` to change the `$this` type, but did not set `inClosureBindScopeClasses` — which is what `resolveTypeByName` checks when resolving `static`/`self`/`parent` keywords.

2. **`getFunctionType` used the enclosing class** to resolve `static` in return type declarations. The closure's return type `static` went through `InitializerExprTypeResolver::getFunctionType` → `ParserNodeTypeToPHPStanType::resolve`, which used `InitializerExprContext::fromScope($this)` — always returning the enclosing class via `$scope->getClassReflection()`.

## Fix

### `src/Analyser/NodeScopeResolver.php`
After `assignVariable('this', ...)`, chain `->withClosureBindScopeClasses(...)` so `static`/`self` resolve to the closure-this class. Applied to both closure and arrow function paths.

### `src/Analyser/MutatingScope.php`
- **`withClosureBindScopeClasses()`** (new method): Creates a new scope with `inClosureBindScopeClasses` set, preserving all other state.
- **`restoreThis()`**: Restore `inClosureBindScopeClasses` from the saved scope (was using `$this->`, now uses `$restoreThisScope->`).
- **`getFunctionType()`**: When `inClosureBindScopeClasses` is set and the type is `static`/`self`/`parent`, pass a context with the bound class to `InitializerExprTypeResolver` so the return type resolves correctly.

> [!NOTE]
> Technically it is possible to bind a closure to a newClass and not bind the `$this` instance:
> ```php
> public function Closure::bindTo(?object $newThis, object|string|null $newScope = 'static'): ?Closure;
> ```
> and if we wanted to support this then we would have to create an `@phpstan-closure-scope` tag. However, everything that I saw in the wild bound the `$newScope` to the same object as the `$this`; so I opted not to introduce this for the time being. The only time it would really be an issue would be if you wanted a closure to run in the context of a class, but not have a `$this` property set` (e.g., a static closure)

Closes https://github.com/phpstan/phpstan/issues/11010