### PR TITLE
Fix `nullsafe.neverNull` false positive when the `?->` operand is nullable

### DIFF
--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -31,6 +31,8 @@ final class IssetCheck
 		private bool $checkAdvancedIsset,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
+		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
+		private bool $treatPhpDocTypesAsCertainTip,
 	)
 	{
 	}
@@ -259,15 +261,35 @@ final class IssetCheck
 		}
 
 		if ($expr instanceof Expr\NullsafePropertyFetch) {
-			if ($expr->name instanceof Node\Identifier) {
-				return RuleErrorBuilder::message(sprintf('Using nullsafe property access "?->%s" %s is unnecessary. Use -> instead.', $expr->name->name, $operatorDescription))
-					->identifier('nullsafe.neverNull')
-					->build();
+			// Only redundant when the operand itself is never null; otherwise the
+			// ?-> produces the null that ??/isset()/empty() handles. A nullable
+			// operand can still wrap a never-null one ($a?->b?->c), so recurse.
+			$operandType = $this->treatPhpDocTypesAsCertain
+				? $scope->getScopeType($expr->var)
+				: $scope->getScopeNativeType($expr->var);
+			if (!$operandType->isNull()->no()) {
+				if ($expr->var instanceof Expr\NullsafePropertyFetch) {
+					return $this->check($expr->var, $scope, $operatorDescription, $identifier, $typeMessageCallback);
+				}
+
+				return null;
 			}
 
-			return RuleErrorBuilder::message(sprintf('Using nullsafe property access "?->(Expression)" %s is unnecessary. Use -> instead.', $operatorDescription))
-				->identifier('nullsafe.neverNull')
-				->build();
+			$message = $expr->name instanceof Node\Identifier
+				? sprintf('Using nullsafe property access "?->%s" %s is unnecessary. Use -> instead.', $expr->name->name, $operatorDescription)
+				: sprintf('Using nullsafe property access "?->(Expression)" %s is unnecessary. Use -> instead.', $operatorDescription);
+
+			$ruleErrorBuilder = RuleErrorBuilder::message($message)->identifier('nullsafe.neverNull');
+
+			if (
+				$this->treatPhpDocTypesAsCertain
+				&& $this->treatPhpDocTypesAsCertainTip
+				&& !$scope->getScopeNativeType($expr->var)->isNull()->no()
+			) {
+				$ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
+			}
+
+			return $ruleErrorBuilder->build();
 		}
 
 		return null;

--- a/tests/PHPStan/Rules/Properties/data/bug-7109.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7109.php
@@ -62,7 +62,7 @@ class HelloWorld
 	public ?HelloWorld $prop = null;
 	public function edgeCaseWithMethodCall(): void
 	{
-		// only ?->aaa should be reported
+		// nothing to report: every ?-> operand can be null (phpstan/phpstan#14311)
 		$this->get()?->prop?->get()?->aaa ?? 'edge';
 		isset($this->get()?->prop?->get()?->aaa) ?: 'edge';
 		empty($this->get()?->prop?->get()?->aaa) ?: 'edge';

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -25,6 +25,7 @@ class EmptyRuleTest extends RuleTestCase
 			new PropertyReflectionFinder(),
 			true,
 			$this->treatPhpDocTypesAsCertain,
+			true,
 		));
 	}
 
@@ -117,27 +118,11 @@ class EmptyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7109.php'], [
 			[
 				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
-				19,
-			],
-			[
-				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
-				30,
-			],
-			[
-				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
 				42,
-			],
-			[
-				'Using nullsafe property access "?->notFalsy" in empty() is unnecessary. Use -> instead.',
-				54,
 			],
 			[
 				'Expression in empty() is not falsy.',
 				59,
-			],
-			[
-				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
-				68,
 			],
 			[
 				'Using nullsafe property access "?->(Expression)" in empty() is unnecessary. Use -> instead.',

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -24,6 +24,7 @@ class IssetRuleTest extends RuleTestCase
 			new PropertyReflectionFinder(),
 			true,
 			$this->treatPhpDocTypesAsCertain,
+			true,
 		));
 	}
 
@@ -336,20 +337,8 @@ class IssetRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7109.php'], [
 			[
-				'Using nullsafe property access "?->aaa" in isset() is unnecessary. Use -> instead.',
-				18,
-			],
-			[
-				'Using nullsafe property access "?->aaa" in isset() is unnecessary. Use -> instead.',
-				29,
-			],
-			[
 				'Expression in isset() is not nullable.',
 				41,
-			],
-			[
-				'Using nullsafe property access "?->aaa" in isset() is unnecessary. Use -> instead.',
-				67,
 			],
 			[
 				'Expression in isset() is not nullable.',

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -23,6 +23,7 @@ class NullCoalesceRuleTest extends RuleTestCase
 			new PropertyReflectionFinder(),
 			true,
 			$this->shouldTreatPhpDocTypesAsCertain(),
+			true,
 		), true);
 	}
 
@@ -264,24 +265,27 @@ class NullCoalesceRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7109.php'], [
 			[
-				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
-				17,
-			],
-			[
-				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
-				28,
-			],
-			[
 				'Expression on left side of ?? is not nullable.',
 				40,
 			],
 			[
-				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
-				66,
-			],
-			[
 				'Expression on left side of ?? is not nullable.',
 				73,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug14311(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14311.php'], [
+			[
+				'Expression on left side of ?? is not nullable.',
+				33,
+			],
+			[
+				'Using nullsafe property access "?->inner" on left side of ?? is unnecessary. Use -> instead.',
+				47,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Variables/data/bug-14311.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-14311.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace Bug14311;
+
+final class Node
+{
+
+	public int $id = 5;
+
+}
+
+function resolve(bool $flag): ?Node
+{
+	return $flag ? new Node() : null;
+}
+
+function make(): Node
+{
+	return new Node();
+}
+
+function coalesce(bool $flag): int
+{
+	// $node is nullable, so the ?-> is required, not redundant.
+	$node = resolve($flag);
+
+	return $node?->id ?? 0;
+}
+
+function neverNullOperand(): int
+{
+	// make() never returns null, so the ?-> is redundant.
+	return make()?->id ?? 0;
+}
+
+final class Outer
+{
+
+	public ?Node $inner = null;
+
+}
+
+function chain(Outer $outer): int
+{
+	// $outer is never null so ?->inner is redundant; $outer->inner is
+	// nullable so ?->id is required.
+	return $outer?->inner?->id ?? 0;
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#14311

`$a?->b` on the left of `??`, or inside `isset()`/`empty()`, was reported as an unnecessary nullsafe access whenever the whole `$a?->b` expression came out nullable, without looking at whether `$a` itself could be null. When `$a` is nullable the `?->` is exactly what produces the null the surrounding construct then handles, so it is required. Following the advice and switching to `->` fatals at runtime when `$a` is null.

Small repro:

```php
function resolve(bool $flag): ?Node { return $flag ? new Node() : null; }

$node = resolve($flag);   // Node|null
return $node?->id ?? 0;   // reported as "unnecessary. Use -> instead."
```

The check in `IssetCheck` now only reports when the operand is never null. When the operand is itself a nullsafe fetch with a never-null operand of its own (`$nonNull?->nullable?->x`), it recurses so that inner redundant link is still reported, which keeps parity with `NullsafePropertyFetchRule` outside these contexts. I also added the `treatPhpDocTypesAsCertain` tip that the sibling rule emits.

`bug-7109` had assertions that encoded the old behaviour (its `$this->get()?->aaa ?? 6`, where `get(): ?HelloWorld`, was expected to be reported), so I corrected those and added `bug-14311` for the fix.
