### PR TITLE
Fix intermittent `MissingMethodImplementationRuleTest` error

### DIFF
--- a/tests/PHPStan/Rules/Methods/MissingMethodImplementationRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodImplementationRuleTest.php
@@ -40,6 +40,7 @@ class MissingMethodImplementationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3469.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug3958(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-3958.php'], []);


### PR DESCRIPTION
`SimpleXMLElement` started implementing `RecursiveIterator` with PHP8.0, see https://www.php.net/SimpleXMLElement

phpstorm-stubs define `class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator, Stringable, RecursiveIterator` unconditionally of php-version.

see also AI description in https://github.com/phpstan/phpstan-src/pull/6059

closes https://github.com/phpstan/phpstan/issues/14964