### PR TITLE
Fix PHP 7.4 build

### DIFF
--- a/src/Analyser/ConditionalExpressionHolder.php
+++ b/src/Analyser/ConditionalExpressionHolder.php
@@ -9,10 +9,7 @@ use function count;
 use function implode;
 use function sprintf;
 
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\ConditionalExpressionHolder',
-	implementation: __DIR__ . '/../../turbo-ext/src/ConditionalExpressionHolder.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\ConditionalExpressionHolder', implementation: __DIR__ . '/../../turbo-ext/src/ConditionalExpressionHolder.cpp')]
 final class ConditionalExpressionHolder
 {
 

--- a/src/Analyser/ExpressionResultStorage.php
+++ b/src/Analyser/ExpressionResultStorage.php
@@ -10,10 +10,7 @@ use PHPStan\Analyser\Fiber\ParkFiberRequest;
 use PHPStan\Turbo\ShadowedByTurboExtension;
 use function spl_object_id;
 
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\ExpressionResultStorage',
-	implementation: __DIR__ . '/../../turbo-ext/src/ExpressionResultStorage.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\ExpressionResultStorage', implementation: __DIR__ . '/../../turbo-ext/src/ExpressionResultStorage.cpp')]
 final class ExpressionResultStorage
 {
 

--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -8,10 +8,7 @@ use PHPStan\Turbo\ShadowedByTurboExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\ExpressionTypeHolder',
-	implementation: __DIR__ . '/../../turbo-ext/src/ExpressionTypeHolder.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\ExpressionTypeHolder', implementation: __DIR__ . '/../../turbo-ext/src/ExpressionTypeHolder.cpp')]
 final class ExpressionTypeHolder
 {
 

--- a/src/Analyser/ScopeOps.php
+++ b/src/Analyser/ScopeOps.php
@@ -41,10 +41,7 @@ use function usort;
 /**
  * Hot scope-table operations extracted from MutatingScope.
  */
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\ScopeOps',
-	implementation: __DIR__ . '/../../turbo-ext/src/ScopeOps.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\ScopeOps', implementation: __DIR__ . '/../../turbo-ext/src/ScopeOps.cpp')]
 final class ScopeOps
 {
 

--- a/src/Cache/ArenaCache.php
+++ b/src/Cache/ArenaCache.php
@@ -27,10 +27,7 @@ use PHPStan\Turbo\ShadowedByTurboExtension;
  *
  * @internal
  */
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\ArenaCache',
-	implementation: __DIR__ . '/../../turbo-ext/src/ArenaCache.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\ArenaCache', implementation: __DIR__ . '/../../turbo-ext/src/ArenaCache.cpp')]
 final class ArenaCache
 {
 

--- a/src/Internal/CombinationsHelper.php
+++ b/src/Internal/CombinationsHelper.php
@@ -6,10 +6,7 @@ use PHPStan\Turbo\ShadowedByTurboExtension;
 use Traversable;
 use function array_pop;
 
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\CombinationsHelper',
-	implementation: __DIR__ . '/../../turbo-ext/src/CombinationsHelper.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\CombinationsHelper', implementation: __DIR__ . '/../../turbo-ext/src/CombinationsHelper.cpp')]
 final class CombinationsHelper
 {
 

--- a/src/Node/NodeScanner.php
+++ b/src/Node/NodeScanner.php
@@ -9,10 +9,7 @@ use function is_array;
 /**
  * Recursive AST queries over php-parser node graphs.
  */
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\NodeScanner',
-	implementation: __DIR__ . '/../../turbo-ext/src/NodeScanner.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\NodeScanner', implementation: __DIR__ . '/../../turbo-ext/src/NodeScanner.cpp')]
 final class NodeScanner
 {
 

--- a/src/Parser/ParserRunner.php
+++ b/src/Parser/ParserRunner.php
@@ -13,10 +13,7 @@ use PHPStan\Turbo\ShadowedByTurboExtension;
  * falling back to $parser->parse() for anything else. Without the extension
  * this delegation is all there is.
  */
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\ParserRunner',
-	implementation: __DIR__ . '/../../turbo-ext/src/parser/ParserRunner.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\ParserRunner', implementation: __DIR__ . '/../../turbo-ext/src/parser/ParserRunner.cpp')]
 final class ParserRunner
 {
 

--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -37,10 +37,7 @@ use function min;
  * @api
  * @see https://phpstan.org/developing-extensions/trinary-logic
  */
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\TrinaryLogic',
-	implementation: __DIR__ . '/../turbo-ext/src/TrinaryLogic.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\TrinaryLogic', implementation: __DIR__ . '/../turbo-ext/src/TrinaryLogic.cpp')]
 final class TrinaryLogic
 {
 

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -56,7 +56,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '4dc2b81';
+	public const EXPECTED_EXTENSION_VERSION = 'fea0195';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/src/Type/TypeCombinatorCache.php
+++ b/src/Type/TypeCombinatorCache.php
@@ -18,10 +18,7 @@ use PHPStan\Turbo\ShadowedByTurboExtension;
  *
  * @internal
  */
-#[ShadowedByTurboExtension(
-	turboClass: 'PHPStanTurbo\TypeCombinatorCache',
-	implementation: __DIR__ . '/../../turbo-ext/src/TypeCombinatorCache.cpp',
-)]
+#[ShadowedByTurboExtension(turboClass: 'PHPStanTurbo\TypeCombinatorCache', implementation: __DIR__ . '/../../turbo-ext/src/TypeCombinatorCache.cpp')]
 final class TypeCombinatorCache
 {
 


### PR DESCRIPTION
multi line attributes are not supported on 7.4.

I guess we might bump the minimum PHP version in the near future. until that happens, lets just use single-line attributes instead