### PR TITLE
feat: support nullable and never types in @param-closure-this

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2186,6 +2186,33 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		);
 	}
 
+	public function withoutThis(): self
+	{
+		$expressionTypes = $this->expressionTypes;
+		$nativeExpressionTypes = $this->nativeExpressionTypes;
+		unset($expressionTypes['$this']);
+		unset($nativeExpressionTypes['$this']);
+
+		return $this->scopeFactory->create(
+			$this->context,
+			$this->isDeclareStrictTypes(),
+			$this->getFunction(),
+			$this->getNamespace(),
+			$expressionTypes,
+			$nativeExpressionTypes,
+			$this->conditionalExpressions,
+			$this->inClosureBindScopeClasses,
+			$this->anonymousFunctionReflection,
+			$this->isInFirstLevelStatement(),
+			$this->currentlyAssignedExpressions,
+			$this->currentlyAllowedUndefinedExpressions,
+			$this->inFunctionCallsStack,
+			$this->afterExtractCall,
+			$this->parentScope,
+			$this->nativeTypesPromoted,
+		);
+	}
+
 	/**
 	 * @api
 	 * @param ParameterReflection[]|null $callableParameters
@@ -2302,25 +2329,32 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$expressionTypes[$exprString] = $typeHolder;
 		}
 
-		if ($this->hasVariableType('this')->yes() && !$closure->static) {
+		if (isset($this->expressionTypes['$this']) && !$closure->static) {
 			$node = new Variable('this');
-			$expressionTypes['$this'] = ExpressionTypeHolder::createYes($node, $this->getType($node));
-			$nativeTypes['$this'] = ExpressionTypeHolder::createYes($node, $this->getNativeType($node));
+			$thisType = $this->getType($node);
+			$thisCertainty = $this->expressionTypes['$this']->getCertainty();
+			if ($thisCertainty->yes()) {
+				$expressionTypes['$this'] = ExpressionTypeHolder::createYes($node, $thisType);
+				$nativeTypes['$this'] = ExpressionTypeHolder::createYes($node, $this->getNativeType($node));
 
-			if ($this->phpVersion->supportsReadOnlyProperties()) {
-				foreach ($nonStaticExpressions as $exprString => $typeHolder) {
-					$expr = $typeHolder->getExpr();
+				if ($this->phpVersion->supportsReadOnlyProperties()) {
+					foreach ($nonStaticExpressions as $exprString => $typeHolder) {
+						$expr = $typeHolder->getExpr();
 
-					if (!$expr instanceof PropertyFetch) {
-						continue;
+						if (!$expr instanceof PropertyFetch) {
+							continue;
+						}
+
+						if (!$this->isReadonlyPropertyFetch($expr, true)) {
+							continue;
+						}
+
+						$expressionTypes[$exprString] = $typeHolder;
 					}
-
-					if (!$this->isReadonlyPropertyFetch($expr, true)) {
-						continue;
-					}
-
-					$expressionTypes[$exprString] = $typeHolder;
 				}
+			} else {
+				$expressionTypes['$this'] = ExpressionTypeHolder::createMaybe($node, $thisType);
+				$nativeTypes['$this'] = ExpressionTypeHolder::createMaybe($node, $this->getNativeType($node));
 			}
 		}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2044,8 +2044,15 @@ class NodeScopeResolver
 					$closureThisType = $this->resolveClosureThisType($callLike, $calleeReflection, $parameter, $scopeToPass);
 					if ($closureThisType !== null) {
 						$restoreThisScope = $scopeToPass;
-						$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes())
-							->withClosureBindScopeClasses($closureThisType->getObjectClassNames());
+						if ($closureThisType->isNull()->yes()) {
+							$scopeToPass = $scopeToPass->withoutThis()
+								->withClosureBindScopeClasses([]);
+						} else {
+							$isOptionalBinding = $closureThisType->isNull()->maybe();
+							$objectThisType = TypeCombinator::removeNull($closureThisType);
+							$scopeToPass = $scopeToPass->assignVariable('this', $objectThisType, new ObjectWithoutClassType(), $isOptionalBinding ? TrinaryLogic::createMaybe() : TrinaryLogic::createYes())
+								->withClosureBindScopeClasses($objectThisType->getObjectClassNames());
+						}
 					}
 				}
 

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -38,6 +38,7 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -412,11 +413,14 @@ final class PhpDocNodeResolver
 		foreach (['@param-closure-this', '@phpstan-param-closure-this'] as $tagName) {
 			foreach ($phpDocNode->getParamClosureThisTagValues($tagName) as $tagValue) {
 				$parameterName = substr($tagValue->parameterName, 1);
+				$resolvedType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
+				$isOptionalBinding = $resolvedType->isNull()->maybe();
+				$objectType = TypeCombinator::intersect(
+					TypeCombinator::removeNull($resolvedType),
+					new ObjectWithoutClassType(),
+				);
 				$closureThisTypes[$parameterName] = new ParamClosureThisTag(
-					TypeCombinator::intersect(
-						$this->typeNodeResolver->resolve($tagValue->type, $nameScope),
-						new ObjectWithoutClassType(),
-					),
+					$isOptionalBinding ? TypeCombinator::union($objectType, new NullType()) : $objectType,
 				);
 			}
 		}

--- a/tests/PHPStan/Analyser/nsrt/param-closure-this.php
+++ b/tests/PHPStan/Analyser/nsrt/param-closure-this.php
@@ -317,6 +317,43 @@ class ImplicitInheritanceMoreComplicated extends Foo
 
 }
 
+class WithOptionalThis
+{
+
+	/**
+	 * @param-closure-this ?Foo $cb
+	 */
+	public function runOptional(callable $cb): void
+	{
+
+	}
+
+	/**
+	 * @param-closure-this never $cb
+	 */
+	public function runUnbound(callable $cb): void
+	{
+
+	}
+
+}
+
+function testOptionalClosureThis(WithOptionalThis $o): void
+{
+	$o->runOptional(function () {
+		if (isset($this)) {
+			assertType(Foo::class, $this);
+		}
+	});
+}
+
+function testUnboundClosureThis(WithOptionalThis $o): void
+{
+	$o->runUnbound(function () {
+		assertType('never', $this);
+	});
+}
+
 class FooParent
 {
 

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -1701,6 +1701,20 @@ class DefinedVariableRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testParamClosureThisOptional(): void
+	{
+		$this->cliArgumentsVariablesRegistered = false;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithLoopInitialAssignments = false;
+		$this->polluteScopeWithAlwaysIterableForeach = false;
+		$this->analyse([__DIR__ . '/data/param-closure-this-optional.php'], [
+			[
+				'Variable $this might not be defined.',
+				29,
+			],
+		]);
+	}
+
 	public function testBug2032(): void
 	{
 		$this->cliArgumentsVariablesRegistered = true;

--- a/tests/PHPStan/Rules/Variables/data/param-closure-this-optional.php
+++ b/tests/PHPStan/Rules/Variables/data/param-closure-this-optional.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace ParamClosureThisOptional;
+
+class Foo
+{
+
+	public function method(): void
+	{
+	}
+
+}
+
+class Bar
+{
+
+	/**
+	 * @param-closure-this ?Foo $cb
+	 */
+	public function runOptional(callable $cb): void
+	{
+	}
+
+}
+
+function test(Bar $b): void
+{
+	$b->runOptional(function () {
+		$this->method(); // Variable $this might not be defined.
+		if (isset($this)) {
+			$this->method(); // no error
+		}
+	});
+}


### PR DESCRIPTION
## Problem

Laravel's Carbon library (and similar APIs) register macros that are invoked either bound to a model instance *or* statically, with no `$this`:

```php
// Carbon registers this macro; when called on an instance $this is Carbon,
// when called statically $this is unbound
Carbon::macro('humanDiff', function () {
    if (isset($this)) {
        return $this->diffForHumans(); // $this is Carbon here
    }
    return 'N/A';
});
```

Previously there was no way to tell PHPStan about the optional-binding case: `@param-closure-this` only accepted concrete object types. Specifying `?Foo` silently stripped the `null` (via intersection with `ObjectWithoutClassType`), so PHPStan always treated `$this` as definitely bound, making `isset($this)` always-true noise.

## Solution

### `@param-closure-this ?Foo $cb` — optionally bound

`$this` is propagated into the closure with **Maybe certainty**. `isset($this)` narrows to `Foo` in the truthy branch. Accessing `$this` without the guard raises *"Variable $this might not be defined"*.

```php
class Collection {
    /**
     * @param-closure-this ?static $callback
     */
    public function tap(callable $callback): static { ... }
}

$collection->tap(function () {
    $this->method(); // ⚠ Variable $this might not be defined

    if (isset($this)) {
        $this->method(); // ✅ $this is Collection here
    }
});
```

### `@param-closure-this never $cb` — always unbound

`$this` inside the body has type `never`. Any property/method access is a type error.

This matches the PHP runtime behaviour of explicitly unbinding a closure:

```php
class Runner {
    /** @param-closure-this never $cb */
    public function run(callable $cb): void
    {
        // Explicitly strip $this before invoking — closure::bind with null
        // unbinds $this so it does not exist inside the callback at all.
        // isset($this) would return false at runtime.
        $unbound = Closure::bind($cb, null, static::class);
        $unbound();
    }
}

$runner->run(function () {
    $this->method(); // ✅ PHPStan error: $this is never — correctly models the unbound call
});
```

(`null` is also accepted as a synonym for `never` — `TypeCombinator::removeNull(NullType)` produces `NeverType` — so `@param-closure-this null $cb` produces identical analysis.)

## Implementation

- **`PhpDocNodeResolver`**: For nullable union types (`?Foo`), strip null, intersect the object part with `ObjectWithoutClassType`, then re-add `null` as an optional-binding signal that threads through the parameter reflection chain unchanged.
- **`NodeScopeResolver`**: Three-way dispatch on the resolved `closureThisType`:
  - Definitely null/never → `withoutThis()` removes `$this` from scope entirely
  - Nullable union → `assignVariable` with `TrinaryLogic::createMaybe()`
  - Non-nullable → original `TrinaryLogic::createYes()` path (no behavior change)
- **`MutatingScope::withoutThis()`**: New helper that removes `$this` from the expression-types map for the always-unbound case.
- **`MutatingScope::enterAnonymousFunctionWithoutReflection`**: Changed from `hasVariableType('this')->yes()` to `isset(expressionTypes['$this'])` so that `$this` with either `Yes` or `Maybe` certainty is propagated into the closure scope, enabling `isset($this)` narrowing through the standard variable-certainty path.