### PR TITLE
Fix flickering of trait errors deduplicated into the trait file

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -321,12 +321,17 @@ jobs:
               ../../bin/phpstan clear-result-cache
               OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan --error-format=raw")
               ../bashunit -a contains 'FooTrait.php:10:Strict comparison using === between int<0, max> and false will always evaluate to false.' "$OUTPUT"
-              # An ignoreErrors path may target the error by the trait file or by the using-class
-              # file - both keep working (no BC break).
+              # The deduplicated error is attributed to the trait file: an ignoreErrors path
+              # targeting the trait file matches, a using-class path does not - consistently
+              # with both an empty and a primed result cache.
               ../../bin/phpstan clear-result-cache
               ../bashunit -a exit_code "0" "../../bin/phpstan analyse --error-format=raw -c ignore-trait-path.neon"
+              ../bashunit -a exit_code "0" "../../bin/phpstan analyse --error-format=raw -c ignore-trait-path.neon"
               ../../bin/phpstan clear-result-cache
-              ../bashunit -a exit_code "0" "../../bin/phpstan analyse --error-format=raw -c ignore-class-path.neon"
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse --error-format=raw -c ignore-class-path.neon")
+              ../bashunit -a contains 'FooTrait.php:10:Strict comparison using === between int<0, max> and false will always evaluate to false.' "$OUTPUT"
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse --error-format=raw -c ignore-class-path.neon")
+              ../bashunit -a contains 'FooTrait.php:10:Strict comparison using === between int<0, max> and false will always evaluate to false.' "$OUTPUT"
               # A generated baseline suppresses the error on re-run, with both an empty and a
               # primed result cache (the issue reported baseline generation as impossible).
               ../../bin/phpstan --generate-baseline=baseline.neon

--- a/build/baseline-8.0.neon
+++ b/build/baseline-8.0.neon
@@ -22,4 +22,4 @@ parameters:
 			message: '#^Strict comparison using \=\=\= between list\<non\-falsy\-string\> and false will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
-			path: ../src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+			path: ../src/Type/Php/MbFunctionsReturnTypeExtensionTrait.php

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -14,6 +14,7 @@ use Throwable;
 use function array_merge;
 use function count;
 use function get_class;
+use function ksort;
 use function sprintf;
 
 #[AutowiredService]
@@ -44,7 +45,9 @@ final class AnalyserResultFinalizer
 		}
 
 		$nodeType = CollectedDataNode::class;
-		$node = new CollectedDataNode($analyserResult->getCollectedData(), $onlyFiles);
+		$collectedData = $analyserResult->getCollectedData();
+		ksort($collectedData);
+		$node = new CollectedDataNode($collectedData, $onlyFiles);
 
 		$file = 'N/A';
 		$scope = $this->scopeFactory->create(ScopeContext::create($file));

--- a/src/Analyser/Error.php
+++ b/src/Analyser/Error.php
@@ -117,7 +117,7 @@ final class Error implements JsonSerializable
 			$this->traitFilePath,
 			$this->line,
 			$this->canBeIgnored,
-			$this->filePath,
+			$this->traitFilePath,
 			$this->traitFilePath,
 			$this->tip,
 			$this->nodeLine,

--- a/tests/PHPStan/Analyser/ErrorTest.php
+++ b/tests/PHPStan/Analyser/ErrorTest.php
@@ -25,12 +25,17 @@ class ErrorTest extends PHPStanTestCase
 		$withoutTraitContext = $error->removeTraitContext();
 		// The error is now reported directly in the trait: the displayed file is
 		// the trait, and traitFilePath is kept so the editor URL and the
-		// trait-file ignore lookups resolve to the trait (#14718). filePath stays
-		// the using-class file, so an ignoreErrors path keyed on either the trait
-		// or the using-class file keeps matching (no BC break).
+		// trait-file ignore lookups resolve to the trait (#14718).
 		$this->assertSame('trait.php', $withoutTraitContext->getFile());
-		$this->assertSame('user.php', $withoutTraitContext->getFilePath());
 		$this->assertSame('trait.php', $withoutTraitContext->getTraitFilePath());
+	}
+
+	public function testRemoveTraitContextAttributesErrorToTraitFile(): void
+	{
+		$error = new Error('Message', 'trait.php (in context of class C)', 11, true, 'user.php', 'trait.php');
+
+		$withoutTraitContext = $error->removeTraitContext();
+		$this->assertSame('trait.php', $withoutTraitContext->getFilePath());
 	}
 
 	public static function dataValidIdentifier(): iterable


### PR DESCRIPTION
Possible fix for https://github.com/phpstan/phpstan/issues/14932

When a constant-condition error inside a trait is deduplicated and reported "directly in the trait", the reported error invisibly carried the file path of one of the classes using the trait — and which class was picked depended on the run type (cold, warm, partial).

Symptoms:

- an error appears on one run and disappears on the next, with zero changes to any file (reproduction in https://github.com/phpstan/phpstan/issues/14932#issuecomment-5030586787);
- a path-scoped `ignoreErrors` entry for such an error matches only on the runs that happen to pick that class;
- `--generate-baseline` records a different path depending on which run generated it (usually dev vs CI, it depends on amount and timing of workers).

With the proposed modifications, the error belongs to the trait file. Ignoring works by targeting the trait file's path, matches identically on every run, and survives adding or removing classes that use the trait. `--generate-baseline` writes the trait path as well.

The first commit makes the winner deterministic - fixes the run-to-run flicker on its own, but still attributes the error to the alphabetically last class that uses the trait. 
The second makes the attribution independent of the set of using classes. BC break for single-use traits, but necessary for multiple uses. Baseline now matches behavior of the CLI output.