### PR TITLE
Preserve maybe in BitwiseFlagHelper for bitwise-or with dynamic operands

### DIFF
--- a/src/Type/BitwiseFlagHelper.php
+++ b/src/Type/BitwiseFlagHelper.php
@@ -40,8 +40,8 @@ final class BitwiseFlagHelper
 		}
 
 		if ($expr instanceof BitwiseOr) {
-			return TrinaryLogic::createFromBoolean($this->bitwiseOrContainsConstant($expr->left, $scope, $constName)->yes() ||
-				$this->bitwiseOrContainsConstant($expr->right, $scope, $constName)->yes());
+			return $this->bitwiseOrContainsConstant($expr->left, $scope, $constName)
+				->or($this->bitwiseOrContainsConstant($expr->right, $scope, $constName));
 		}
 
 		$fqcn = new FullyQualified($constName);

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -52,6 +52,8 @@ class HelloWorld
 		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
 		assertType("list<string>|false", preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE));
 		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('list<array{string, int<0, max>}|string>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE | $flags));
+		assertType('list<array{string, int<0, max>}|string>|false', preg_split($pattern, $subject, $offset, $flags | PREG_SPLIT_DELIM_CAPTURE));
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -321,6 +321,16 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testJsonMaybeThrowWithDynamicFlags(): void
+	{
+		$this->analyse([__DIR__ . '/data/json-maybe-throw-dynamic-flags.php'], [
+			[
+				'Dead catch - JsonException is never thrown in the try block.',
+				35,
+			],
+		]);
+	}
+
 	public function testBug9066(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-9066.php'], [

--- a/tests/PHPStan/Rules/Exceptions/data/json-maybe-throw-dynamic-flags.php
+++ b/tests/PHPStan/Rules/Exceptions/data/json-maybe-throw-dynamic-flags.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace JsonMaybeThrowDynamicFlags;
+
+function (string $s, int $flags): void {
+	try {
+		json_decode($s, true, 512, JSON_BIGINT_AS_STRING | $flags);
+	} catch (\JsonException $e) {
+
+	}
+};
+
+function (string $s, int $flags): void {
+	try {
+		json_decode($s, true, 512, $flags | JSON_BIGINT_AS_STRING);
+	} catch (\JsonException $e) {
+
+	}
+};
+
+/**
+ * @param mixed $m
+ */
+function ($m, int $flags): void {
+	try {
+		json_encode($m, JSON_PRETTY_PRINT | $flags);
+	} catch (\JsonException $e) {
+
+	}
+};
+
+function (string $s): void {
+	try {
+		json_decode($s, true, 512, JSON_BIGINT_AS_STRING | JSON_INVALID_UTF8_IGNORE);
+	} catch (\JsonException $e) {
+
+	}
+};

--- a/tests/PHPStan/Type/BitwiseFlagHelperTest.php
+++ b/tests/PHPStan/Type/BitwiseFlagHelperTest.php
@@ -80,6 +80,30 @@ final class BitwiseFlagHelperTest extends PHPStanTestCase
 				TrinaryLogic::createNo(),
 			],
 			[
+				new BitwiseOr(
+					new ConstFetch(new FullyQualified('JSON_NUMERIC_CHECK')),
+					new Variable('integerVar'),
+				),
+				'JSON_THROW_ON_ERROR',
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new BitwiseOr(
+					new Variable('integerVar'),
+					new ConstFetch(new FullyQualified('JSON_THROW_ON_ERROR')),
+				),
+				'JSON_THROW_ON_ERROR',
+				TrinaryLogic::createYes(),
+			],
+			[
+				new BitwiseOr(
+					new ConstFetch(new FullyQualified('JSON_NUMERIC_CHECK')),
+					new Variable('stringVar'),
+				),
+				'JSON_THROW_ON_ERROR',
+				TrinaryLogic::createNo(),
+			],
+			[
 				new Variable('mixedVar'),
 				'JSON_THROW_ON_ERROR',
 				TrinaryLogic::createMaybe(),


### PR DESCRIPTION
The BitwiseOr branch of bitwiseOrContainsConstant() returned createFromBoolean(left->yes() || right->yes()), collapsing "maybe" to "no". For an expression like SOME_CONST | $dynamicInt it answered a definite "no" for a flag the dynamic operand may well contain. The correct trinary is left->or(right): yes if either side definitely contains the flag, no only if both sides definitely don't, maybe otherwise.

Callers acting on ->no() were affected:
- JsonThrowTypeExtension no longer reports a false-positive "Dead catch - JsonException" for json_encode()/json_decode() called with JSON_X | $dynamicFlags, and correctly attributes a possible JsonException throw type to such calls.
- PregSplitDynamicReturnTypeExtension now keeps the array{string, int<0, max>} element shape in the return type when PREG_SPLIT_OFFSET_CAPTURE may be present in dynamic flags.

Callers acting only on ->yes() are unaffected.