### PR TITLE
perf: Iterate through nullsafe expression chains

### DIFF
--- a/src/Analyser/ExprHandler/Helper/NullsafeShortCircuitingHelper.php
+++ b/src/Analyser/ExprHandler/Helper/NullsafeShortCircuitingHelper.php
@@ -19,36 +19,28 @@ final class NullsafeShortCircuitingHelper
 
 	public static function getType(MutatingScope $scope, Expr $expr, Type $type): Type
 	{
-		if ($expr instanceof NullsafePropertyFetch || $expr instanceof NullsafeMethodCall) {
-			$varType = $scope->getType($expr->var);
-			if (TypeCombinator::containsNull($varType)) {
-				return TypeCombinator::addNull($type);
+		while (true) {
+			if ($expr instanceof NullsafePropertyFetch || $expr instanceof NullsafeMethodCall) {
+				$varType = $scope->getType($expr->var);
+				if (TypeCombinator::containsNull($varType)) {
+					return TypeCombinator::addNull($type);
+				}
+
+				return $type;
+			}
+
+			if ($expr instanceof ArrayDimFetch || $expr instanceof PropertyFetch || $expr instanceof MethodCall) {
+				$expr = $expr->var;
+				continue;
+			}
+
+			if (($expr instanceof StaticPropertyFetch || $expr instanceof StaticCall) && $expr->class instanceof Expr) {
+				$expr = $expr->class;
+				continue;
 			}
 
 			return $type;
 		}
-
-		if ($expr instanceof ArrayDimFetch) {
-			return self::getType($scope, $expr->var, $type);
-		}
-
-		if ($expr instanceof PropertyFetch) {
-			return self::getType($scope, $expr->var, $type);
-		}
-
-		if ($expr instanceof StaticPropertyFetch && $expr->class instanceof Expr) {
-			return self::getType($scope, $expr->class, $type);
-		}
-
-		if ($expr instanceof MethodCall) {
-			return self::getType($scope, $expr->var, $type);
-		}
-
-		if ($expr instanceof StaticCall && $expr->class instanceof Expr) {
-			return self::getType($scope, $expr->class, $type);
-		}
-
-		return $type;
 	}
 
 }


### PR DESCRIPTION
While profiling PHPStan on the Sylius project, I found several optimization opportunities. This PR addresses the first one.

It replaces recursive calls in `NullsafeShortCircuitingHelper::getType()` with a loop while preserving the same expression-chain handling and return behavior. This helper is a CPU hotspot during expression type resolution. Iteration avoids repeated PHP method calls and stack frames.

In five uncached Sylius analysis runs per variant, covering 2,366 files with eight workers, median elapsed time fell from 28.35 s to 27.22 s (-4.0%), while median aggregate CPU time (user + sys) fell from 172.90 s to 170.65 s (-1.3%). In the combined candidate profile, CPU time attributed to this helper fell from 5.72 s to 2.70 s (-52.8%).

PHPBench showed -2.5% locally as well 🎉 

Benchmarks were run on an Apple M4 Max with PHP 8.5.7