### PR TITLE
Iterate in getBooleanExpressionDepth()

### DIFF
--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -162,7 +162,7 @@ final class BooleanAndHandler implements ExprHandler
 		return $types;
 	}
 
-	public static function getBooleanExpressionDepth(Expr $expr, int $depth = 0): int
+	public static function getBooleanExpressionDepth(Expr $expr): int
 	{
 		$depth = 0;
 		while (

--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -164,15 +164,16 @@ final class BooleanAndHandler implements ExprHandler
 
 	public static function getBooleanExpressionDepth(Expr $expr, int $depth = 0): int
 	{
+		$depth = 0;
 		while (
-			$expr instanceof BooleanOr
-			|| $expr instanceof LogicalOr
-			|| $expr instanceof BooleanAnd
-			|| $expr instanceof LogicalAnd
+			$expr instanceof BooleanOr ||
+			$expr instanceof LogicalOr ||
+			$expr instanceof BooleanAnd ||
+			$expr instanceof LogicalAnd
 		) {
-			return self::getBooleanExpressionDepth($expr->left, $depth + 1);
+			$depth++;
+			$expr = $expr->left;
 		}
-
 		return $depth;
 	}
 


### PR DESCRIPTION
remove unnecssary method call overhead in deep `||` or `&&` chains

similar to https://github.com/phpstan/phpstan-src/pull/6084