### PR TITLE
Narrow foreach body to non-empty regardless of polluteScopeWithAlwaysIterableForeach

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -46,6 +46,7 @@ parameters:
 		rawMessageInBaseline: false
 		reportNestedTooWideType: false
 		assignToByRefForeachExpr: false
+		narrowForeachBodyNonEmpty: false
 		curlSetOptArrayTypes: false
 		magicDirInInclude: false
 		checkDateIntervalConstructor: false

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -44,6 +44,7 @@ parametersSchema:
 		rawMessageInBaseline: bool()
 		reportNestedTooWideType: bool()
 		assignToByRefForeachExpr: bool()
+		narrowForeachBodyNonEmpty: bool()
 		curlSetOptArrayTypes: bool()
 		magicDirInInclude: bool()
 		checkDateIntervalConstructor: bool()

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -144,7 +144,6 @@ use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ClosureType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FileTypeMapper;
@@ -1708,33 +1707,6 @@ class NodeScopeResolver
 			}
 
 			$isIterableAtLeastOnce = $exprType->isIterableAtLeastOnce();
-
-			$iterateeCertainty = $finalScope->hasExpressionType($stmt->expr);
-			if (
-				$this->narrowForeachBodyNonEmpty
-				&& !$this->polluteScopeWithAlwaysIterableForeach
-				&& !$iterateeCertainty->no()
-				&& !$isIterableAtLeastOnce->yes()
-			) {
-				// With the flag off the after-loop scope must not assume the loop ran, so
-				// undo the body narrowing: restore the iteratee's possibly-empty-ness
-				// (keeping element types the body refined). Only the non-emptiness the
-				// narrowing added is stripped; an iteratee already non-empty before the
-				// loop keeps it, and a literal like `foreach ([1, 2] as $v)` is skipped.
-				$finalIterateeType = $finalScope->getType($stmt->expr);
-				if ($finalIterateeType->isArray()->yes()) {
-					$finalIterateeNativeType = $finalScope->getNativeType($stmt->expr);
-					$finalScope = $finalScope->specifyExpressionType(
-						$stmt->expr,
-						TypeCombinator::union($finalIterateeType, new ConstantArrayType([], [])),
-						$finalIterateeNativeType->isArray()->yes()
-							? TypeCombinator::union($finalIterateeNativeType, new ConstantArrayType([], []))
-							: $finalIterateeNativeType,
-						$iterateeCertainty,
-					);
-				}
-			}
-
 			if ($isIterableAtLeastOnce->maybe() || $exprType->isIterable()->no()) {
 				$finalScope = $finalScope->mergeWith($scope->filterByTruthyValue(new BooleanOr(
 					new BinaryOp\Identical(

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -144,6 +144,7 @@ use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ClosureType;
+use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FileTypeMapper;
@@ -263,6 +264,8 @@ class NodeScopeResolver
 		private readonly bool $polluteScopeWithLoopInitialAssignments,
 		#[AutowiredParameter]
 		private readonly bool $polluteScopeWithAlwaysIterableForeach,
+		#[AutowiredParameter(ref: '%featureToggles.narrowForeachBodyNonEmpty%')]
+		private readonly bool $narrowForeachBodyNonEmpty,
 		#[AutowiredParameter]
 		private readonly bool $polluteScopeWithBlock,
 		#[AutowiredParameter(ref: '%exceptions.implicitThrows%')]
@@ -1511,7 +1514,13 @@ class NodeScopeResolver
 			$originalStorage = $storage;
 			$unrolledEndScope = null;
 			$unrolledTotalKeys = null;
-			$iterateeScope = $this->polluteScopeWithAlwaysIterableForeach ? $scope->filterByTruthyValue($arrayComparisonExpr) : $scope;
+			// The loop body is only entered when the iteratee is non-empty. Under
+			// narrowForeachBodyNonEmpty we narrow it there (list to non-empty-list,
+			// array to non-empty-array) even with polluteScopeWithAlwaysIterableForeach
+			// off; with the toggle off the body scope is unchanged.
+			$iterateeScope = $this->narrowForeachBodyNonEmpty || $this->polluteScopeWithAlwaysIterableForeach
+				? $scope->filterByTruthyValue($arrayComparisonExpr)
+				: $scope;
 			if ($context->isTopLevel()) {
 				$storage = $originalStorage->duplicate();
 
@@ -1699,6 +1708,33 @@ class NodeScopeResolver
 			}
 
 			$isIterableAtLeastOnce = $exprType->isIterableAtLeastOnce();
+
+			$iterateeCertainty = $finalScope->hasExpressionType($stmt->expr);
+			if (
+				$this->narrowForeachBodyNonEmpty
+				&& !$this->polluteScopeWithAlwaysIterableForeach
+				&& !$iterateeCertainty->no()
+				&& !$isIterableAtLeastOnce->yes()
+			) {
+				// With the flag off the after-loop scope must not assume the loop ran, so
+				// undo the body narrowing: restore the iteratee's possibly-empty-ness
+				// (keeping element types the body refined). Only the non-emptiness the
+				// narrowing added is stripped; an iteratee already non-empty before the
+				// loop keeps it, and a literal like `foreach ([1, 2] as $v)` is skipped.
+				$finalIterateeType = $finalScope->getType($stmt->expr);
+				if ($finalIterateeType->isArray()->yes()) {
+					$finalIterateeNativeType = $finalScope->getNativeType($stmt->expr);
+					$finalScope = $finalScope->specifyExpressionType(
+						$stmt->expr,
+						TypeCombinator::union($finalIterateeType, new ConstantArrayType([], [])),
+						$finalIterateeNativeType->isArray()->yes()
+							? TypeCombinator::union($finalIterateeNativeType, new ConstantArrayType([], []))
+							: $finalIterateeNativeType,
+						$iterateeCertainty,
+					);
+				}
+			}
+
 			if ($isIterableAtLeastOnce->maybe() || $exprType->isIterable()->no()) {
 				$finalScope = $finalScope->mergeWith($scope->filterByTruthyValue(new BooleanOr(
 					new BinaryOp\Identical(

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -123,6 +123,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),
+			self::getContainer()->getParameter('featureToggles')['narrowForeachBodyNonEmpty'],
 			self::getContainer()->getParameter('polluteScopeWithBlock'),
 			self::getContainer()->getParameter('exceptions')['implicitThrows'],
 			$this->shouldTreatPhpDocTypesAsCertain(),

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -98,6 +98,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),
+			$container->getParameter('featureToggles')['narrowForeachBodyNonEmpty'],
 			$container->getParameter('polluteScopeWithBlock'),
 			$container->getParameter('exceptions')['implicitThrows'],
 			$container->getParameter('treatPhpDocTypesAsCertain'),

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -839,6 +839,7 @@ class AnalyserTest extends PHPStanTestCase
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			false,
 			true,
+			false,
 			true,
 			true,
 			$this->shouldTreatPhpDocTypesAsCertain(),

--- a/tests/PHPStan/Analyser/Bug13312NoPolluteTest.php
+++ b/tests/PHPStan/Analyser/Bug13312NoPolluteTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class Bug13312NoPolluteTest extends TypeInferenceTestCase
+{
+
+	public static function dataFileAsserts(): iterable
+	{
+		yield from self::gatherAssertTypes(__DIR__ . '/data/bug-13312-no-pollute.php');
+	}
+
+	/**
+	 * @param mixed ...$args
+	 */
+	#[DataProvider('dataFileAsserts')]
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/bug-13312-no-pollute.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/Bug13312StableTest.php
+++ b/tests/PHPStan/Analyser/Bug13312StableTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class Bug13312StableTest extends TypeInferenceTestCase
+{
+
+	public static function dataFileAsserts(): iterable
+	{
+		yield from self::gatherAssertTypes(__DIR__ . '/data/bug-13312-stable.php');
+	}
+
+	/**
+	 * @param mixed ...$args
+	 */
+	#[DataProvider('dataFileAsserts')]
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/bug-13312-stable.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
@@ -143,6 +143,7 @@ class FiberNodeScopeResolverRuleTest extends RuleTestCase
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),
+			self::getContainer()->getParameter('featureToggles')['narrowForeachBodyNonEmpty'],
 			self::getContainer()->getParameter('polluteScopeWithBlock'),
 			self::getContainer()->getParameter('exceptions')['implicitThrows'],
 			$this->shouldTreatPhpDocTypesAsCertain(),

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
@@ -76,6 +76,7 @@ class FiberNodeScopeResolverTest extends TypeInferenceTestCase
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),
+			$container->getParameter('featureToggles')['narrowForeachBodyNonEmpty'],
 			$container->getParameter('polluteScopeWithBlock'),
 			$container->getParameter('exceptions')['implicitThrows'],
 			$container->getParameter('treatPhpDocTypesAsCertain'),

--- a/tests/PHPStan/Analyser/bug-13312-no-pollute.neon
+++ b/tests/PHPStan/Analyser/bug-13312-no-pollute.neon
@@ -1,0 +1,4 @@
+parameters:
+	polluteScopeWithAlwaysIterableForeach: false
+	featureToggles:
+		narrowForeachBodyNonEmpty: true

--- a/tests/PHPStan/Analyser/bug-13312-stable.neon
+++ b/tests/PHPStan/Analyser/bug-13312-stable.neon
@@ -1,0 +1,2 @@
+parameters:
+	polluteScopeWithAlwaysIterableForeach: false

--- a/tests/PHPStan/Analyser/data/bug-13312-no-pollute.php
+++ b/tests/PHPStan/Analyser/data/bug-13312-no-pollute.php
@@ -1,21 +1,8 @@
-<?php // lint >= 8.0
+<?php declare(strict_types = 1);
 
-namespace Bug13312;
+namespace Bug13312NoPollute;
 
 use function PHPStan\Testing\assertType;
-
-function fooArr(array $arr): void {
-	assertType('array', $arr);
-	foreach ($arr as $v) {
-		assertType('non-empty-array', $arr);
-	}
-	assertType('array', $arr);
-
-	for ($i = 0; $i < count($arr); ++$i) {
-		assertType('non-empty-array', $arr);
-	}
-	assertType('array', $arr);
-}
 
 /** @param list<mixed> $arr */
 function foo(array $arr): void {
@@ -30,7 +17,6 @@ function foo(array $arr): void {
 	}
 	assertType('list<mixed>', $arr);
 }
-
 
 /** @param array<string, int> $arr */
 function fooStringKeyed(array $arr): void {
@@ -48,16 +34,4 @@ function fooReassign(array $arr): void {
 		assertType('array{}', $arr);
 	}
 	assertType('array{}', $arr);
-}
-
-function fooBar(mixed $mixed): void {
-	assertType('mixed', $mixed);
-	foreach ($mixed as $v) {
-		assertType('mixed~array{}', $mixed);
-	}
-	assertType('mixed', $mixed);
-
-	foreach ($mixed as $v) {}
-
-	assertType('mixed', $mixed);
 }

--- a/tests/PHPStan/Analyser/data/bug-13312-stable.php
+++ b/tests/PHPStan/Analyser/data/bug-13312-stable.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13312Stable;
+
+use function PHPStan\Testing\assertType;
+
+// With polluteScopeWithAlwaysIterableForeach off and narrowForeachBodyNonEmpty off
+// (the stable default), the foreach body does not narrow the iterated expression.
+// The for-loop narrowing is a separate mechanism and still applies.
+
+/** @param list<mixed> $arr */
+function foo(array $arr): void {
+	assertType('list<mixed>', $arr);
+	foreach ($arr as $v) {
+		assertType('list<mixed>', $arr);
+	}
+	assertType('list<mixed>', $arr);
+
+	for ($i = 0; $i < count($arr); ++$i) {
+		assertType('non-empty-list<mixed>', $arr);
+	}
+	assertType('list<mixed>', $arr);
+}
+
+/** @param array<string, int> $arr */
+function fooStringKeyed(array $arr): void {
+	assertType('array<string, int>', $arr);
+	foreach ($arr as $v) {
+		assertType('array<string, int>', $arr);
+	}
+	assertType('array<string, int>', $arr);
+}


### PR DESCRIPTION
Closes phpstan/phpstan#13312

```php
/** @param list<mixed> $arr */
function foo(array $arr): void {
	foreach ($arr as $v) {
		bar($arr);
	}
}

/** @param non-empty-list<mixed> $arr */
function bar(array $arr): void {}
```

This reproduces with `polluteScopeWithAlwaysIterableForeach: false`, which `phpstan-strict-rules` sets.

Inside the loop body `$arr` is provably non-empty. PHPStan already narrowed it there, but only as a side effect of `polluteScopeWithAlwaysIterableForeach`: with the flag off the in-body narrowing disappeared. A previous fix (phpstan-src#4162) added a test for it, but only under the default flag value, so the reported case kept failing under `phpstan-strict-rules` and the issue was reopened.

### Opt-in toggle

The narrowing is gated behind a new feature toggle `narrowForeachBodyNonEmpty`, off by default and not enabled under bleedingEdge.

- **off (default):** the body scope is built exactly as before, no behaviour change.
- **on:** the foreach body narrows the iterated expression regardless of the flag, so #13312 is fixed.

The narrowing also sharpens the after-loop scope: a value variable can be seen as defined where the iteratee is later proven non-empty (e.g. via `count() > 0`). This is more precise but changes what `polluteScopeWithAlwaysIterableForeach: false` reports, so the toggle stays opt-in for now rather than being enabled under bleedingEdge.

`Bug13312NoPolluteTest` covers the toggle on; `Bug13312StableTest` covers the default (off), where the foreach body is left as-is.