### PR TITLE
Use a patch file to update the package in the result-cache-package-update e2e test

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -405,13 +405,15 @@ jobs:
               cd e2e/result-cache-package-update
               composer install
               ../../bin/phpstan analyse
-              # Simulate a single Composer package being updated by changing its recorded reference in
-              # vendor/composer/installed.php. The cache must be invalidated only for files depending on
-              # that package (src/Foo.php uses psr/log), not for the whole project.
-              php -r '$f = "vendor/composer/installed.php"; $d = require $f; $d["versions"]["psr/log"]["reference"] = "0000000000000000000000000000000000000000"; file_put_contents($f, "<?php return " . var_export($d, true) . ";" . PHP_EOL);'
+              # Update a single Composer package by bumping its version with a patch and letting Composer
+              # reinstall it, which changes its recorded reference in vendor/composer/installed.php. The
+              # cache must be invalidated only for files depending on that package (src/Foo.php uses
+              # test/logger), not for the whole project.
+              patch -p1 < updatePackage.patch
+              composer update test/logger --no-cache
               OUTPUT=$(../bashunit -a exit_code "0" "../../bin/phpstan analyse -vv")
               echo "$OUTPUT"
-              ../bashunit -a contains 'Composer packages changed (psr/log); re-analysing only the files depending on them.' "$OUTPUT"
+              ../bashunit -a contains 'Composer packages changed (test/logger); re-analysing only the files depending on them.' "$OUTPUT"
               ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
           - script: |
               cd e2e/bug-12606

--- a/e2e/result-cache-package-update/composer.json
+++ b/e2e/result-cache-package-update/composer.json
@@ -1,7 +1,16 @@
 {
 	"name": "phpstan/result-cache-package-update-e2e",
+	"repositories": [
+		{
+			"type": "path",
+			"url": "./logger",
+			"options": {
+				"symlink": false
+			}
+		}
+	],
 	"require": {
-		"psr/log": "^3.0"
+		"test/logger": "*"
 	},
 	"autoload": {
 		"classmap": ["src"]

--- a/e2e/result-cache-package-update/logger/composer.json
+++ b/e2e/result-cache-package-update/logger/composer.json
@@ -1,0 +1,1 @@
+{ "name": "test/logger", "version": "1.0.0", "autoload": { "classmap": ["src"] } }

--- a/e2e/result-cache-package-update/logger/src/Logger.php
+++ b/e2e/result-cache-package-update/logger/src/Logger.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Test\Logger;
+
+class Logger
+{
+
+	public function info(string $message): void
+	{
+	}
+
+}

--- a/e2e/result-cache-package-update/src/Foo.php
+++ b/e2e/result-cache-package-update/src/Foo.php
@@ -2,12 +2,12 @@
 
 namespace ResultCachePackageUpdateE2E;
 
-use Psr\Log\LoggerInterface;
+use Test\Logger\Logger;
 
 class Foo
 {
 
-	public function __construct(private LoggerInterface $logger)
+	public function __construct(private Logger $logger)
 	{
 	}
 

--- a/e2e/result-cache-package-update/updatePackage.patch
+++ b/e2e/result-cache-package-update/updatePackage.patch
@@ -1,0 +1,5 @@
+--- a/logger/composer.json
++++ b/logger/composer.json
+@@ -1 +1 @@
+-{ "name": "test/logger", "version": "1.0.0", "autoload": { "classmap": ["src"] } }
++{ "name": "test/logger", "version": "2.0.0", "autoload": { "classmap": ["src"] } }


### PR DESCRIPTION
Follow-up to #6086, as requested in review: converting the result-cache e2e tests to use a patch file instead of inline mutations.

`result-cache-package-update` now ships a local path-repo package (`test/logger`) and updates it with a committed `updatePackage.patch` that bumps its version, then `composer update test/logger --no-cache` re-mirrors it and changes its recorded reference in `vendor/composer/installed.php`. This replaces the inline `php -r` edit of `installed.php` and matches the patch-file style from #6088. I validated the full sequence locally: the cold run is clean, the reference changes on update, and the warm run still prints "Composer packages changed (test/logger); re-analysing only the files depending on them." and "Result cache restored. 1 file will be reanalysed."

`result-cache-composer-lock` keeps its `jq` content-hash change. Its `composer.lock` is gitignored and regenerated by `composer install` (per the earlier review here), so there is no committed file for a patch to apply against, and the test's whole point is to flip only the lock's content-hash without touching any package. The `jq` does exactly that.
