### PR TITLE
Prevent duplicate `filterByTruthyValue()` work in `NodeScopeResolver`

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1506,10 +1506,11 @@ class NodeScopeResolver
 			$originalStorage = $storage;
 			$unrolledEndScope = null;
 			$unrolledTotalKeys = null;
+			$iterateeScope = $this->polluteScopeWithAlwaysIterableForeach ? $scope->filterByTruthyValue($arrayComparisonExpr) : $scope;
 			if ($context->isTopLevel()) {
 				$storage = $originalStorage->duplicate();
 
-				$originalScope = $this->polluteScopeWithAlwaysIterableForeach ? $scope->filterByTruthyValue($arrayComparisonExpr) : $scope;
+				$originalScope = $iterateeScope;
 				$unrolledResult = $this->tryProcessUnrolledConstantArrayForeach($stmt, $originalScope, $originalStorage, $context);
 				if ($unrolledResult !== null) {
 					$bodyScope = $unrolledResult['bodyScope'];
@@ -1520,7 +1521,7 @@ class NodeScopeResolver
 					$count = 0;
 					do {
 						$prevScope = $bodyScope;
-						$bodyScope = $bodyScope->mergeWith($this->polluteScopeWithAlwaysIterableForeach ? $scope->filterByTruthyValue($arrayComparisonExpr) : $scope);
+						$bodyScope = $bodyScope->mergeWith($iterateeScope);
 						$storage = $originalStorage->duplicate();
 						$bodyScope = $this->enterForeach($bodyScope, $storage, $originalScope, $stmt, $nodeCallback);
 						$bodyScopeResult = $this->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, new NoopNodeCallback(), $context->enterDeep())->filterOutLoopExitPoints();
@@ -1540,7 +1541,7 @@ class NodeScopeResolver
 				}
 			}
 
-			$bodyScope = $bodyScope->mergeWith($this->polluteScopeWithAlwaysIterableForeach ? $scope->filterByTruthyValue($arrayComparisonExpr) : $scope);
+			$bodyScope = $bodyScope->mergeWith($iterateeScope);
 			$storage = $originalStorage;
 			$bodyScope = $this->enterForeach($bodyScope, $storage, $originalScope, $stmt, $nodeCallback);
 			$finalPassContext = $unrolledTotalKeys !== null ? $context->enterUnrolledForeach($unrolledTotalKeys) : $context;


### PR DESCRIPTION
with `polluteScopeWithAlwaysIterableForeach: true`

before this PR:
```
➜  phpstan-src git:(2.2.x) ✗ hyperfine 'php bin/phpstan analyze src/Analyser/MutatingScope.php -v --debug' -i --runs=5
Benchmark 1: php bin/phpstan analyze src/Analyser/MutatingScope.php -v --debug
  Time (mean ± σ):      2.241 s ±  0.180 s    [User: 1.948 s, System: 0.287 s]
  Range (min … max):    2.104 s …  2.539 s    5 runs
```

after this PR:
```
➜  phpstan-src git:(2.2.x) ✗ hyperfine 'php bin/phpstan analyze src/Analyser/MutatingScope.php -v --debug' -i --runs=5
Benchmark 1: php bin/phpstan analyze src/Analyser/MutatingScope.php -v --debug
  Time (mean ± σ):      2.101 s ±  0.021 s    [User: 1.835 s, System: 0.260 s]
  Range (min … max):    2.081 s …  2.132 s    5 runs
```