### PR TITLE
Simplify `AccessoryArrayListType`

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -79,11 +79,9 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 
 	public function accepts(Type $type, bool $strictTypes): AcceptsResult
 	{
-		$isArray = $type->isArray();
 		$isList = $type->isList();
-		$isListArray = $isArray->and($isList);
 
-		if ($isListArray->yes()) {
+		if ($isList->yes()) {
 			return AcceptsResult::createYes();
 		}
 
@@ -91,7 +89,7 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 			return $type->isAcceptedBy($this, $strictTypes);
 		}
 
-		return new AcceptsResult($isListArray, []);
+		return new AcceptsResult($isList, []);
 	}
 
 	public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
@@ -104,7 +102,7 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 			return $type->isSubTypeOf($this);
 		}
 
-		return new IsSuperTypeOfResult($type->isArray()->and($type->isList()), []);
+		return new IsSuperTypeOfResult($type->isList(), []);
 	}
 
 	public function isSubTypeOf(Type $otherType): IsSuperTypeOfResult

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -113,8 +113,15 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
+		if ($otherType instanceof self) {
+			return new IsSuperTypeOfResult(
+				TrinaryLogic::createYes(),
+				[],
+			);
+		}
+
 		return new IsSuperTypeOfResult(
-			$otherType->isArray()->and($otherType->isList())->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			$otherType->isList()->and(TrinaryLogic::createMaybe()),
 			[],
 		);
 	}


### PR DESCRIPTION
these methods show up in profiles of https://github.com/phpstan/phpstan-src/blob/5b9c8d4f105b3943e59cdf61345f997f1e708810/tests/bench/data/bug-14624.php

<img width="624" height="466" alt="grafik" src="https://github.com/user-attachments/assets/d18a30f2-2995-4c2a-8e46-aa1c7b7f10f8" />
