### PR TITLE
Reuse the scope factory of the other flavour

### DIFF
--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -17,6 +17,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\ExpressionTypeResolverExtension;
+use WeakReference;
 
 #[GenerateFactory(interface: InternalScopeFactoryFactory::class, resultType: LazyInternalScopeFactory::class)]
 final class LazyInternalScopeFactory implements InternalScopeFactory
@@ -45,6 +46,11 @@ final class LazyInternalScopeFactory implements InternalScopeFactory
 	private ?PhpVersion $phpVersionType = null;
 
 	private ?AttributeReflectionFactory $attributeReflectionFactory = null;
+
+	private ?self $twin = null;
+
+	/** @var WeakReference<self>|null */
+	private ?WeakReference $origin = null;
 
 	/**
 	 * @param callable(Node $node, Scope $scope): void|null $nodeCallback
@@ -131,12 +137,43 @@ final class LazyInternalScopeFactory implements InternalScopeFactory
 
 	public function toFiberFactory(): InternalScopeFactory
 	{
-		return new self($this->container, $this->nodeCallback, true);
+		return $this->fiber ? $this : $this->twin();
 	}
 
 	public function toMutatingFactory(): InternalScopeFactory
 	{
-		return new self($this->container, $this->nodeCallback, false);
+		return $this->fiber ? $this->twin() : $this;
+	}
+
+	/**
+	 * The factory for the other scope flavour, created once. Scopes switch
+	 * flavour constantly, and a fresh factory would start with empty memos —
+	 * resolving every service above out of the container again on its first
+	 * create().
+	 *
+	 * The pair is held one way strongly and the other way weakly: a factory
+	 * belongs to a single analysed file (ScopeFactory::create() makes one per
+	 * file, closing over that file's node callback), and a strong cycle here
+	 * would keep every file's callback alive for the whole run — PHPStan runs
+	 * with the cycle collector disabled, so nothing would ever free it.
+	 */
+	private function twin(): self
+	{
+		if ($this->twin !== null) {
+			return $this->twin;
+		}
+
+		if ($this->origin !== null) {
+			$origin = $this->origin->get();
+			if ($origin !== null) {
+				return $origin;
+			}
+		}
+
+		$this->twin = new self($this->container, $this->nodeCallback, !$this->fiber);
+		$this->twin->origin = WeakReference::create($this);
+
+		return $this->twin;
 	}
 
 }


### PR DESCRIPTION
`LazyInternalScopeFactory::create()` memoizes the nine services it resolves out of the container with `??=`. Those memos never survived, because `toFiberFactory()` and `toMutatingFactory()` returned a freshly constructed factory on every call — and scopes switch flavour constantly (`MutatingScope::toFiberScope()`, `FiberScope::toMutatingScope()`).

Every switch therefore built a factory that re-read two services in its constructor and then resolved nine more on its first `create()`.

Found while profiling with the turbo extension enabled (SPX, `SPX_FP_LIMIT=20000`) for something unrelated — the container showing up with 1.6M `getByType` calls is what gave it away.

### Effect on a self-analysis of `src/Type`

| | before | after |
| --- | --- | --- |
| `LazyInternalScopeFactory::__construct` | 192.8K | 791 |
| `MemoizingContainer::getByType` | 1.6M | 94.7K |
| `getParameter` / `getService` / `getExtensionsCollection` | 192.9K each | ~800 each |
| total userland calls | 200.9M | 196.7M |

### Benchmark

Interleaved A/B, pair order alternated (ABBA), user CPU, result cache cleared before every run, turbo extension enabled, machine otherwise idle:

| slice | base | this branch | delta | pairs won | paired t |
| --- | --- | --- | --- | --- | --- |
| `src` | 63.38s | 61.78s | **−2.53%** | 8/8 | 18.4 |
| `src/Type` | 22.20s | 21.87s | **−1.46%** | 9/10 | 6.2 |

### Correctness

The factory is immutable apart from those memo fields, so returning a shared instance where a new one used to be built is equivalent — the two flavours differ only in the `$fiber` flag. The twin is paired both ways, so a scope round-tripping between flavours reuses the original rather than allocating a third factory.

`--error-format=raw` output over `src` is unchanged, and `tests/PHPStan/Analyser` (2869 tests) plus `tests/PHPStan/Rules/Methods`, `Rules/Variables`, `Node` and `Type` (3819 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhKccs7xeB1wRTAQEemc2
