### PR TITLE
Support generic trait @use tags in class-level PHPDocs

### DIFF
--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -448,6 +448,18 @@ final class DependencyResolver
 					}
 				}
 			}
+
+			if ($scope->isInClass()) {
+				$declaringReflection = $scope->isInTrait() ? $scope->getTraitReflection() : $scope->getClassReflection();
+				$resolvedPhpDoc = $declaringReflection->getResolvedPhpDoc();
+				if ($resolvedPhpDoc !== null) {
+					foreach ($resolvedPhpDoc->getUsesTags() as $usesTag) {
+						foreach ($usesTag->getType()->getReferencedClasses() as $referencedClass) {
+							$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+						}
+					}
+				}
+			}
 		} elseif ($node instanceof Node\Expr\Instanceof_) {
 			if ($node->class instanceof Name) {
 				$this->addClassToDependencies($scope->resolveName($node->class), $dependenciesReflections);

--- a/src/Rules/Generics/ClassLevelUsedTraitsRule.php
+++ b/src/Rules/Generics/ClassLevelUsedTraitsRule.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\DependencyInjection\ValidatesStubFiles;
+use PHPStan\Internal\SprintfHelper;
+use PHPStan\PhpDoc\PhpDocStringResolver;
+use PHPStan\PhpDoc\Tag\UsesTag;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\Type;
+use function array_map;
+use function count;
+use function sprintf;
+use function ucfirst;
+
+/**
+ * Validates `@use` tags in class-level PHPDocs, the counterpart of UsedTraitsRule
+ * which validates `@use` tags above individual trait use statements.
+ *
+ * @implements Rule<Node\Stmt\ClassLike>
+ */
+#[RegisteredRule(level: 2)]
+#[ValidatesStubFiles]
+final class ClassLevelUsedTraitsRule implements Rule
+{
+
+	public function __construct(
+		private PhpDocStringResolver $phpDocStringResolver,
+		private FileTypeMapper $fileTypeMapper,
+		private GenericAncestorsCheck $genericAncestorsCheck,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\ClassLike::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$docComment = $node->getDocComment();
+		if ($docComment === null) {
+			return [];
+		}
+
+		if (!isset($node->namespacedName)) {
+			// anonymous class
+			return [];
+		}
+
+		if ($node instanceof Node\Stmt\Class_) {
+			$typeDescription = 'class';
+		} elseif ($node instanceof Node\Stmt\Interface_) {
+			$typeDescription = 'interface';
+		} elseif ($node instanceof Node\Stmt\Trait_) {
+			$typeDescription = 'trait';
+		} elseif ($node instanceof Node\Stmt\Enum_) {
+			$typeDescription = 'enum';
+		} else {
+			return [];
+		}
+
+		// resolving the PHPDoc types of every class-like is not for free and can
+		// change the outcome of recursion detection in phpdoc type resolution,
+		// so bail out early unless the doc comment really contains @use tags
+		$phpDocNode = $this->phpDocStringResolver->resolve($docComment->getText());
+		$hasUsesTagValues = false;
+		foreach (['@use', '@template-use', '@phpstan-use'] as $tagName) {
+			if (count($phpDocNode->getUsesTagValues($tagName)) > 0) {
+				$hasUsesTagValues = true;
+				break;
+			}
+		}
+		if (!$hasUsesTagValues) {
+			return [];
+		}
+
+		$className = (string) $node->namespacedName;
+		$resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+			$scope->getFile(),
+			$className,
+			null,
+			null,
+			$docComment->getText(),
+		);
+		$useTags = $resolvedPhpDoc->getUsesTags();
+		if (count($useTags) === 0) {
+			return [];
+		}
+
+		$traitNames = [];
+		foreach ($node->getTraitUses() as $traitUse) {
+			foreach ($traitUse->traits as $traitNameNode) {
+				$traitNames[] = $traitNameNode;
+			}
+		}
+
+		$description = sprintf('%s %s', $typeDescription, SprintfHelper::escapeFormatString($className));
+		$escapedDescription = SprintfHelper::escapeFormatString($description);
+		$upperCaseDescription = ucfirst($description);
+		$escapedUpperCaseDescription = SprintfHelper::escapeFormatString($upperCaseDescription);
+
+		return $this->genericAncestorsCheck->check(
+			$traitNames,
+			array_map(static fn (UsesTag $tag): Type => $tag->getType(), $useTags),
+			sprintf('%s @use tag contains incompatible type %%s.', $escapedUpperCaseDescription),
+			sprintf('%s @use tag contains unresolvable type.', $upperCaseDescription),
+			sprintf('%s has @use tag, but does not use any trait.', $upperCaseDescription),
+			sprintf('The @use tag of %s describes %%s but the %s uses %%s.', $escapedDescription, $typeDescription),
+			'PHPDoc tag @use contains generic type %s but %s %s is not generic.',
+			'Generic type %s in PHPDoc tag @use does not specify all template types of %s %s: %s',
+			'Generic type %s in PHPDoc tag @use specifies %d template types, but %s %s supports only %d: %s',
+			'Type %s in generic type %s in PHPDoc tag @use is not subtype of template type %s of %s %s.',
+			'Call-site variance annotation of %s in generic type %s in PHPDoc tag @use is not allowed.',
+			'PHPDoc tag @use has invalid type %s.',
+			sprintf('%s uses generic trait %%s but does not specify its types: %%s', $escapedUpperCaseDescription),
+			sprintf('in used type %%s of %s', $escapedDescription),
+			// the missing-generics check is left entirely to UsedTraitsRule, which runs
+			// for every trait use statement and takes class-level @use tags into account
+			array_map(static fn (Node\Name $traitNameNode): string => $traitNameNode->toString(), $traitNames),
+		);
+	}
+
+}

--- a/src/Rules/Generics/GenericAncestorsCheck.php
+++ b/src/Rules/Generics/GenericAncestorsCheck.php
@@ -49,6 +49,7 @@ final class GenericAncestorsCheck
 	/**
 	 * @param array<Node\Name> $nameNodes
 	 * @param array<Type> $ancestorTypes
+	 * @param list<string> $namesWithTypesSpecifiedElsewhere names exempt from the missing-generics check because a tag for them exists in another location (e.g. a class-level `@use` tag)
 	 * @return list<IdentifierRuleError>
 	 */
 	public function check(
@@ -66,6 +67,7 @@ final class GenericAncestorsCheck
 		string $invalidTypeMessage,
 		string $genericClassInNonGenericObjectType,
 		string $invalidVarianceMessage,
+		array $namesWithTypesSpecifiedElsewhere = [],
 	): array
 	{
 		$names = array_fill_keys(array_map(static fn (Name $nameNode): string => $nameNode->toString(), $nameNodes), true);
@@ -165,6 +167,9 @@ final class GenericAncestorsCheck
 
 		if ($this->checkMissingTypehints) {
 			foreach (array_keys($unusedNames) as $unusedName) {
+				if (in_array($unusedName, $namesWithTypesSpecifiedElsewhere, true)) {
+					continue;
+				}
 				if (!$this->reflectionProvider->hasClass($unusedName)) {
 					continue;
 				}

--- a/src/Rules/Generics/UsedTraitsRule.php
+++ b/src/Rules/Generics/UsedTraitsRule.php
@@ -12,6 +12,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
+use function array_keys;
 use function array_map;
 use function sprintf;
 use function strtolower;
@@ -61,6 +62,13 @@ final class UsedTraitsRule implements Rule
 			$useTags = $resolvedPhpDoc->getUsesTags();
 		}
 
+		$classLevelUseTags = [];
+		$declaringReflection = $scope->isInTrait() ? $scope->getTraitReflection() : $scope->getClassReflection();
+		$classLevelResolvedPhpDoc = $declaringReflection->getResolvedPhpDoc();
+		if ($classLevelResolvedPhpDoc !== null) {
+			$classLevelUseTags = $classLevelResolvedPhpDoc->getUsesTags();
+		}
+
 		$typeDescription = strtolower($scope->getClassReflection()->getClassTypeDescription());
 		$description = sprintf('%s %s', $typeDescription, SprintfHelper::escapeFormatString($className));
 		if ($traitName !== null) {
@@ -87,6 +95,7 @@ final class UsedTraitsRule implements Rule
 			'PHPDoc tag @use has invalid type %s.',
 			sprintf('%s uses generic trait %%s but does not specify its types: %%s', $escapedUpperCaseDescription),
 			sprintf('in used type %%s of %s', $escapedDescription),
+			array_keys($classLevelUseTags),
 		);
 	}
 

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -21,6 +21,7 @@ use PHPStan\PhpDoc\PhpDocNodeResolver;
 use PHPStan\PhpDoc\PhpDocStringResolver;
 use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDoc\Tag\TemplateTag;
+use PHPStan\PhpDoc\Tag\UsesTag;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
@@ -255,19 +256,24 @@ final class FileTypeMapper
 						null,
 						$traitDocComment,
 					)->getUsesTags();
-					$useType = null;
-					foreach ($useTags as $useTag) {
-						$useTagType = $useTag->getType();
-						if (!$useTagType instanceof GenericObjectType) {
-							continue;
+					$useType = self::findUseTagType($useTags, $traitReflection->getName());
+					if ($useType === null) {
+						// no statement-level @use tag matched the trait - fall back
+						// to @use tags in the PHPDoc of the class-like using the trait
+						$traitUseClassLikeName = $lookForTraitName ?? $traitClassName;
+						if ($reflectionProvider->hasClass($traitUseClassLikeName)) {
+							$traitUseClassLikeDocComment = $reflectionProvider->getClass($traitUseClassLikeName)->getNativeReflection()->getDocComment();
+							if ($traitUseClassLikeDocComment !== false) {
+								$classLevelUseTags = $this->getResolvedPhpDoc(
+									$traitFileName,
+									$traitClassName,
+									$lookForTraitName,
+									null,
+									$traitUseClassLikeDocComment,
+								)->getUsesTags();
+								$useType = self::findUseTagType($classLevelUseTags, $traitReflection->getName());
+							}
 						}
-
-						if ($useTagType->getClassName() !== $traitReflection->getName()) {
-							continue;
-						}
-
-						$useType = $useTagType;
-						break;
 					}
 					$traitTemplateTypeMap = $traitReflection->getTemplateTypeMap();
 					$namesToUnset = [];
@@ -781,6 +787,27 @@ final class FileTypeMapper
 		}
 
 		return $resolved;
+	}
+
+	/**
+	 * @param array<string, UsesTag> $useTags
+	 */
+	private static function findUseTagType(array $useTags, string $traitName): ?GenericObjectType
+	{
+		foreach ($useTags as $useTag) {
+			$useTagType = $useTag->getType();
+			if (!$useTagType instanceof GenericObjectType) {
+				continue;
+			}
+
+			if ($useTagType->getClassName() !== $traitName) {
+				continue;
+			}
+
+			return $useTagType;
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/class-level-use-tag.php
+++ b/tests/PHPStan/Analyser/nsrt/class-level-use-tag.php
@@ -1,0 +1,148 @@
+<?php // lint >= 8.1
+
+namespace ClassLevelUseTag;
+
+use function PHPStan\Testing\assertType;
+
+/** @template T */
+trait GenericTrait
+{
+
+	/** @var T */
+	private $value;
+
+	/** @return T */
+	public function get()
+	{
+		return $this->value;
+	}
+
+}
+
+/** @template TOther */
+trait OtherGenericTrait
+{
+
+	/** @return TOther */
+	public function getOther()
+	{
+		throw new \Exception();
+	}
+
+}
+
+/**
+ * @use GenericTrait<int>
+ */
+class ClassLevelUse
+{
+
+	use GenericTrait;
+
+}
+
+/**
+ * @phpstan-use GenericTrait<string>
+ */
+class PrefixedClassLevelUse
+{
+
+	use GenericTrait;
+
+}
+
+class NoUseTag
+{
+
+	use GenericTrait;
+
+}
+
+/**
+ * @use GenericTrait<int>
+ */
+class StatementLevelWins
+{
+
+	/** @use GenericTrait<string> */
+	use GenericTrait;
+
+}
+
+/**
+ * @use GenericTrait<int>
+ * @use OtherGenericTrait<string>
+ */
+class MultipleTraits
+{
+
+	use GenericTrait;
+	use OtherGenericTrait;
+
+}
+
+/**
+ * @template T
+ * @use GenericTrait<T>
+ */
+class ForwardedTemplate
+{
+
+	use GenericTrait;
+
+}
+
+/**
+ * @template TNested
+ * @use GenericTrait<TNested>
+ */
+trait NestedTrait
+{
+
+	use GenericTrait;
+
+}
+
+/**
+ * @use NestedTrait<bool>
+ */
+class UsesNestedTrait
+{
+
+	use NestedTrait;
+
+}
+
+/**
+ * @use OtherGenericTrait<int>
+ */
+enum SomeEnum
+{
+
+	use OtherGenericTrait;
+
+}
+
+/**
+ * @param ForwardedTemplate<\DateTimeImmutable> $forwarded
+ */
+function test(
+	ClassLevelUse $a,
+	PrefixedClassLevelUse $b,
+	NoUseTag $c,
+	StatementLevelWins $d,
+	MultipleTraits $e,
+	ForwardedTemplate $forwarded,
+	UsesNestedTrait $f,
+	SomeEnum $g,
+): void {
+	assertType('int', $a->get());
+	assertType('string', $b->get());
+	assertType('mixed', $c->get());
+	assertType('string', $d->get());
+	assertType('int', $e->get());
+	assertType('string', $e->getOther());
+	assertType('DateTimeImmutable', $forwarded->get());
+	assertType('bool', $f->get());
+	assertType('int', $g->getOther());
+}

--- a/tests/PHPStan/Analyser/nsrt/class-level-use-tag.php
+++ b/tests/PHPStan/Analyser/nsrt/class-level-use-tag.php
@@ -2,6 +2,7 @@
 
 namespace ClassLevelUseTag;
 
+use ClassLevelUseTag\GenericTrait as AliasedGenericTrait;
 use function PHPStan\Testing\assertType;
 
 /** @template T */
@@ -48,6 +49,16 @@ class PrefixedClassLevelUse
 {
 
 	use GenericTrait;
+
+}
+
+/**
+ * @use AliasedGenericTrait<float>
+ */
+class AliasedClassLevelUse
+{
+
+	use AliasedGenericTrait;
 
 }
 
@@ -129,6 +140,7 @@ enum SomeEnum
 function test(
 	ClassLevelUse $a,
 	PrefixedClassLevelUse $b,
+	AliasedClassLevelUse $aliased,
 	NoUseTag $c,
 	StatementLevelWins $d,
 	MultipleTraits $e,
@@ -138,6 +150,7 @@ function test(
 ): void {
 	assertType('int', $a->get());
 	assertType('string', $b->get());
+	assertType('float', $aliased->get());
 	assertType('mixed', $c->get());
 	assertType('string', $d->get());
 	assertType('int', $e->get());

--- a/tests/PHPStan/Rules/Generics/ClassLevelUsedTraitsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassLevelUsedTraitsRuleTest.php
@@ -65,6 +65,10 @@ class ClassLevelUsedTraitsRuleTest extends RuleTestCase
 				'Interface ClassLevelUsedTraits\SomeInterface has @use tag, but does not use any trait.',
 				90,
 			],
+			[
+				'Type int in generic type ClassLevelUsedTraits\GenericTrait<int> in PHPDoc tag @use is not subtype of template type T of object of trait ClassLevelUsedTraits\GenericTrait.',
+				100,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generics/ClassLevelUsedTraitsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassLevelUsedTraitsRuleTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PHPStan\PhpDoc\PhpDocStringResolver;
+use PHPStan\Rules\PhpDoc\UnresolvableTypeHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @extends RuleTestCase<ClassLevelUsedTraitsRule>
+ */
+class ClassLevelUsedTraitsRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ClassLevelUsedTraitsRule(
+			self::getContainer()->getByType(PhpDocStringResolver::class),
+			self::getContainer()->getByType(FileTypeMapper::class),
+			new GenericAncestorsCheck(
+				self::createReflectionProvider(),
+				new GenericObjectTypeCheck(),
+				new VarianceCheck(),
+				new UnresolvableTypeHelper(),
+				[],
+				true,
+			),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/class-level-used-traits.php'], [
+			[
+				'PHPDoc tag @use contains generic type ClassLevelUsedTraits\NongenericTrait<stdClass> but trait ClassLevelUsedTraits\NongenericTrait is not generic.',
+				17,
+			],
+			[
+				'Type int in generic type ClassLevelUsedTraits\GenericTrait<int> in PHPDoc tag @use is not subtype of template type T of object of trait ClassLevelUsedTraits\GenericTrait.',
+				25,
+			],
+			[
+				'Class ClassLevelUsedTraits\NoTraits has @use tag, but does not use any trait.',
+				41,
+			],
+			[
+				'The @use tag of class ClassLevelUsedTraits\WrongTrait describes ClassLevelUsedTraits\NongenericTrait but the class uses ClassLevelUsedTraits\GenericTrait.',
+				47,
+			],
+			[
+				'Generic type ClassLevelUsedTraits\GenericTrait<stdClass, Exception> in PHPDoc tag @use specifies 2 template types, but trait ClassLevelUsedTraits\GenericTrait supports only 1: T',
+				55,
+			],
+			[
+				'Call-site variance annotation of covariant Throwable in generic type ClassLevelUsedTraits\GenericTrait<covariant Throwable> in PHPDoc tag @use is not allowed.',
+				63,
+			],
+			[
+				'Type mixed in generic type ClassLevelUsedTraits\GenericTrait<mixed> in PHPDoc tag @use is not subtype of template type T of object of trait ClassLevelUsedTraits\GenericTrait.',
+				74,
+			],
+			[
+				'Interface ClassLevelUsedTraits\SomeInterface has @use tag, but does not use any trait.',
+				90,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Generics/UsedTraitsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/UsedTraitsRuleTest.php
@@ -59,6 +59,10 @@ class UsedTraitsRuleTest extends RuleTestCase
 				'Call-site variance annotation of covariant Throwable in generic type UsedTraits\GenericTrait<covariant Throwable> in PHPDoc tag @use is not allowed.',
 				69,
 			],
+			[
+				'Class UsedTraits\WithUnrelatedClassLevelUseTag uses generic trait UsedTraits\GenericTrait but does not specify its types: T',
+				99,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generics/data/class-level-used-traits.php
+++ b/tests/PHPStan/Rules/Generics/data/class-level-used-traits.php
@@ -91,3 +91,15 @@ interface SomeInterface
 {
 
 }
+
+namespace ClassLevelUsedTraitsAlias;
+
+use ClassLevelUsedTraits\GenericTrait as AliasedGenericTrait;
+
+/** @use AliasedGenericTrait<int> */
+class InvalidBound
+{
+
+	use AliasedGenericTrait;
+
+}

--- a/tests/PHPStan/Rules/Generics/data/class-level-used-traits.php
+++ b/tests/PHPStan/Rules/Generics/data/class-level-used-traits.php
@@ -1,0 +1,93 @@
+<?php // lint >= 8.1
+
+namespace ClassLevelUsedTraits;
+
+trait NongenericTrait
+{
+
+}
+
+/** @template T of object */
+trait GenericTrait
+{
+
+}
+
+/** @use NongenericTrait<\stdClass> */
+class Foo
+{
+
+	use NongenericTrait;
+
+}
+
+/** @use GenericTrait<int> */
+class Bar
+{
+
+	use GenericTrait;
+
+}
+
+/** @use GenericTrait<\stdClass> */
+class Ok
+{
+
+	use GenericTrait;
+
+}
+
+/** @use GenericTrait<\stdClass> */
+class NoTraits
+{
+
+}
+
+/** @use NongenericTrait<\stdClass> */
+class WrongTrait
+{
+
+	use GenericTrait;
+
+}
+
+/** @use GenericTrait<\stdClass, \Exception> */
+class TooManyTypes
+{
+
+	use GenericTrait;
+
+}
+
+/** @use GenericTrait<covariant \Throwable> */
+class CallSiteVariance
+{
+
+	use GenericTrait;
+
+}
+
+/**
+ * @template T
+ * @use GenericTrait<T>
+ */
+trait NestedTrait
+{
+
+	use GenericTrait;
+
+}
+
+/** @use GenericTrait<\stdClass> */
+enum SomeEnum
+{
+
+	use GenericTrait;
+
+}
+
+/** @use GenericTrait<\stdClass> */
+interface SomeInterface
+{
+
+}

--- a/tests/PHPStan/Rules/Generics/data/used-traits.php
+++ b/tests/PHPStan/Rules/Generics/data/used-traits.php
@@ -83,3 +83,19 @@ class Sit
 	use GenericDefault;
 
 }
+
+/** @use GenericTrait<\stdClass> */
+class WithClassLevelUseTag
+{
+
+	use GenericTrait;
+
+}
+
+/** @use NongenericTrait<\stdClass> */
+class WithUnrelatedClassLevelUseTag
+{
+
+	use GenericTrait;
+
+}


### PR DESCRIPTION
Hey there, I'm looking to add this so I can put all my `@use` statements at the top of the class, rather than on each `use` statement in the class body. Just a nice visual clean-up.

This supersedes #2638, which targeted the v1.x branch.

There are a few failing tests, but I think they might be preexisting issues.

This was all from claude/codex so let me know if there are any issues!

Notes from Codex below:

---

Closes phpstan/phpstan#7486

## Summary

Allow generic trait `@use` annotations to be placed on the PHPDoc of the class-like using the trait:

```php
/**
 * @use GenericTrait<string>
 */
final class Example
{
    use GenericTrait;
}
```

Previously, PHPStan only used annotations attached directly to the trait-use statement. Some PHPDoc consumers do not support that placement, making it difficult to share these annotations across tools.

This change:

- Uses class-level `@use`, `@template-use`, and `@phpstan-use` tags for generic trait type resolution.
- Preserves existing statement-level behavior, with a matching statement-level annotation taking precedence.
- Adds a separate rule to validate class-level annotations, as proposed in the issue.
- Includes referenced class-level annotation types in dependency tracking.
- Covers multiple traits, nested traits, invalid and unmatched annotations, template forwarding, enums, prefixed tags, and imported trait aliases.
- Adds type-inference and diagnostic regression tests.

Statement-level annotations remain fully supported:

```php
final class Example
{
    /** @use GenericTrait<string> */
    use GenericTrait;
}
```

## Validation

- `vendor/bin/phpunit tests/PHPStan/Rules/Generics/ClassLevelUsedTraitsRuleTest.php tests/PHPStan/Rules/Generics/UsedTraitsRuleTest.php`
- `vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php --filter class-level-use-tag`
