### PR TITLE
Remember an expression's printed form as the printer produces it

### DIFF
--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser;
 
+use PhpParser\Node as PhpParserNode;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
@@ -12,6 +13,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
@@ -91,7 +93,7 @@ final class ArgumentsNormalizer
 		return [$parametersAcceptor, new FuncCall(
 			$callbackArg->value,
 			$passThruArgs,
-			$callUserFuncCall->getAttributes(),
+			self::attributesWithoutPrintedForm($callUserFuncCall),
 		), $acceptsNamedArguments];
 	}
 
@@ -161,7 +163,7 @@ final class ArgumentsNormalizer
 				$item->value,
 				$item->byRef,
 				$item->unpack,
-				$item->getAttributes(),
+				self::attributesWithoutPrintedForm($item),
 				is_string($key) ? new Identifier($key) : null,
 			);
 		}
@@ -187,7 +189,7 @@ final class ArgumentsNormalizer
 		return [$parametersAcceptor, new FuncCall(
 			$callbackArg->value,
 			$passThruArgs,
-			$callUserFuncArrayCall->getAttributes(),
+			self::attributesWithoutPrintedForm($callUserFuncArrayCall),
 		), $acceptsNamedArguments];
 	}
 
@@ -211,7 +213,7 @@ final class ArgumentsNormalizer
 		return new FuncCall(
 			$functionCall->name,
 			$reorderedArgs,
-			$functionCall->getAttributes(),
+			self::attributesWithoutPrintedForm($functionCall),
 		);
 	}
 
@@ -236,7 +238,7 @@ final class ArgumentsNormalizer
 			$methodCall->var,
 			$methodCall->name,
 			$reorderedArgs,
-			$methodCall->getAttributes(),
+			self::attributesWithoutPrintedForm($methodCall),
 		);
 	}
 
@@ -261,7 +263,7 @@ final class ArgumentsNormalizer
 			$staticCall->class,
 			$staticCall->name,
 			$reorderedArgs,
-			$staticCall->getAttributes(),
+			self::attributesWithoutPrintedForm($staticCall),
 		);
 	}
 
@@ -285,7 +287,7 @@ final class ArgumentsNormalizer
 		return new New_(
 			$new->class,
 			$reorderedArgs,
-			$new->getAttributes(),
+			self::attributesWithoutPrintedForm($new),
 		);
 	}
 
@@ -437,6 +439,22 @@ final class ArgumentsNormalizer
 		}
 
 		return $reorderedArgs;
+	}
+
+	/**
+	 * The printed form of an expression is derived from its own arguments, so
+	 * it must not travel to a node whose arguments were just reordered — the
+	 * normalized call would report the original's expression key, named
+	 * arguments and all.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function attributesWithoutPrintedForm(PhpParserNode $node): array
+	{
+		$attributes = $node->getAttributes();
+		unset($attributes[ExprPrinter::ATTRIBUTE_CACHE_KEY]);
+
+		return $attributes;
 	}
 
 }

--- a/src/Node/Printer/Printer.php
+++ b/src/Node/Printer/Printer.php
@@ -4,6 +4,7 @@ namespace PHPStan\Node\Printer;
 
 use Override;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -36,6 +37,7 @@ use PHPStan\Node\StaticMethodCallableNode;
 use PHPStan\Type\VerbosityLevel;
 use function preg_match;
 use function sprintf;
+use function str_contains;
 
 /**
  * @api
@@ -43,6 +45,48 @@ use function sprintf;
 #[AutowiredService(as: Printer::class)]
 final class Printer extends Standard
 {
+
+	/**
+	 * Every construct the printer descends into comes back through here, and
+	 * each level of a chain is printed again in turn for its own expression
+	 * key, so a chain of depth N costs O(N^2). Remembering each expression's
+	 * printed form on its node makes the levels below it O(1) — and it is the
+	 * very same cache ExprPrinter fills, so a key printed once is never
+	 * rebuilt, wherever it was first reached from.
+	 *
+	 * Only the standalone form is remembered: at a lower precedence the
+	 * printer may parenthesise, and a form containing a newline was indented
+	 * for the level it was printed at, while expression keys are printed at
+	 * the top level.
+	 */
+	#[Override]
+	protected function p(
+		Node $node,
+		int $precedence = self::MAX_PRECEDENCE,
+		int $lhsPrecedence = self::MAX_PRECEDENCE,
+		bool $parentFormatPreserved = false,
+	): string
+	{
+		if (
+			!$node instanceof Expr
+			|| $precedence !== self::MAX_PRECEDENCE
+			|| $lhsPrecedence !== self::MAX_PRECEDENCE
+		) {
+			return parent::p($node, $precedence, $lhsPrecedence, $parentFormatPreserved);
+		}
+
+		$printed = $node->getAttribute(ExprPrinter::ATTRIBUTE_CACHE_KEY);
+		if ($printed !== null) {
+			return $printed;
+		}
+
+		$printed = parent::p($node, parentFormatPreserved: $parentFormatPreserved);
+		if (!str_contains($printed, "\n")) {
+			$node->setAttribute(ExprPrinter::ATTRIBUTE_CACHE_KEY, $printed);
+		}
+
+		return $printed;
+	}
 
 	/**
 	 * Normalize curly-brace member access with a constant string name to the


### PR DESCRIPTION
Every level of a chain is printed for its own expression key, and printing a level descends through everything below it — so the levels were already being printed as part of the level above, just never remembered. A chain of depth N was printed O(N²) times over.

Found by profiling `tests/bench/data/nullsafe-chain-walk.php` (the stock SPX build dies on these chains — `STACK_CAPACITY exceeded` — so this needed a build with the frame limit raised). The printer was ~40s of a 50.7s profile:

| exclusive | calls | function |
| --- | --- | --- |
| 10.30s | 2.5M | `PrettyPrinterAbstract::p` |
| 9.49s | 2.4M | `Standard::pDereferenceLhs` |
| 9.40s | 2.3M | `Standard::pExpr_PropertyFetch` |
| 4.99s | 2.4M | `dereferenceLhsRequiresParens` |
| 4.86s | 2.3M | `Printer::pObjectProperty` |

4 chains × 800 levels ⇒ Σk ≈ 2.5M, matching the call counts.

### The change

`p()` is where the printer descends into every construct, so remembering each expression's printed form there makes the levels below it O(1) — and it fills the same cache `ExprPrinter` reads, so a key printed once is never rebuilt no matter which expression first reached it. Only the standalone form is remembered: at a lower precedence the printer may parenthesise, and a form containing a newline was indented for the level it was printed at, while expression keys are printed at the top level.

`ArgumentsNormalizer` copied the whole attribute set onto the calls it rebuilds, handing a reordered call the printed form of the original — `foo(need: true)` as the key for `foo(true)`. That was already so before this change (28 occurrences in the Analyser test suite), harmless because nothing recomputed the key; remembering more of them would have made it reachable, so the derived form is now left behind.

### Effect on the bench

| | before | after |
| --- | --- | --- |
| userland calls | 27.0M | **9.8M** |
| `PrettyPrinterAbstract::p` | 10.30s / 2.5M | 0.37s / 79K |
| `pDereferenceLhs` | 9.49s / 2.4M | 0.22s / 65K |
| `pExpr_PropertyFetch` | 9.40s / 2.3M | 0.17s / 46K |

### Benchmark

Interleaved A/B, pair order alternated (ABBA), user CPU, result cache cleared before every run, turbo extension enabled, machine otherwise idle:

| slice | base | this branch | delta | pairs won | paired t |
| --- | --- | --- | --- | --- | --- |
| `nullsafe-chain-walk.php` | 2.27s | 1.53s | **−32.6%** | 8/8 | 12.4 |
| `src` (ordinary code) | 59.23s | 58.81s | −0.72% | 6/8 | 1.05 |
| `src` peak RSS | 702.6MB | 701.3MB | −1.38MB | 5/8 | 0.48 |

Ordinary code is neutral — the direction is favourable but not significant, so it should be read as "no regression" rather than a win. Profiling `src/Type` before and after confirms why: printer work drops there too (`PrettyPrinterAbstract::p` 837K→515K calls, `pExpr_Variable` 180K→36K, `pDereferenceLhs` 130K→45K), against exactly three added costs — the new `Printer::p` frame (628K calls, +348ms), `getAttribute` (+400K, +51ms) and `setAttribute` (+267K, +21ms). Peak memory was measured on every A/B, not just CPU.

### Correctness

A differential comparing each cached hit against a fresh re-print found zero mismatches over 6.5M comparisons on the bench plus the Analyser, Properties, Methods and Comparison suites. It caught two real bugs while developing this: a closure inside a chain prints multi-line and its form depends on the indentation level it was printed at (hence the newline guard), and the `ArgumentsNormalizer` attribute copying above.

`--error-format=raw` output over `src` is byte-identical, and 4,287 tests pass.

Closes https://github.com/phpstan/phpstan/issues/14991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhKccs7xeB1wRTAQEemc2
