### PR TITLE
Check `bench/data` files with RequiredPhpVersionCommentTest

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Command;
 
+use DateTimeImmutable;
 use OndraM\CiDetector\CiDetector;
 use Override;
 use PHPStan\Analyser\InternalError;
@@ -35,6 +36,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Throwable;
@@ -63,6 +65,7 @@ use function str_contains;
 use function stream_get_contents;
 use function strlen;
 use function substr;
+use function time;
 use const PATHINFO_BASENAME;
 use const PATHINFO_EXTENSION;
 
@@ -140,6 +143,34 @@ final class AnalyseCommand extends Command
 	#[Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
+		if ($output instanceof ConsoleOutputInterface) {
+			$errorOutput = $output->getErrorOutput();
+			$errorOutput->writeln('');
+			$errorOutput->writeln("⚠️  You're running an old version of PHPStan.️");
+			$errorOutput->writeln('');
+			$errorOutput->writeln('The last release in the 1.12.x series with new features');
+
+			$lastRelease = new DateTimeImmutable('2025-07-17 00:00:00');
+			$daysSince = (time() - $lastRelease->getTimestamp()) / 60 / 60 / 24;
+			$errorOutput->writeln('and bugfixes was released on <fg=red>July 17th 2025</>,');
+			$errorOutput->writeln(sprintf('that\'s <fg=red>%d days ago.</>', (int) $daysSince));
+			$errorOutput->writeln('');
+
+			$errorOutput->writeln('Since then more than <fg=cyan>65 new PHPStan versions</> were released');
+			$errorOutput->writeln('with hundreds of new features, bugfixes, and other');
+			$errorOutput->writeln('quality of life improvements.');
+			$errorOutput->writeln('');
+
+			$errorOutput->writeln("To learn about what you're missing out on, check out");
+			$errorOutput->writeln('this blog with articles about the latest major releases:');
+			$errorOutput->writeln('<options=underscore>https://phpstan.org/blog</>');
+			$errorOutput->writeln('');
+
+			$errorOutput->writeln('Upgrade today to <fg=green>PHPStan 2.2 or newer</> by using');
+			$errorOutput->writeln('<fg=cyan>"phpstan/phpstan": "^2.2"</> in your <fg=cyan>composer.json</>.');
+			$errorOutput->writeln('');
+		}
+
 		$paths = $input->getArgument('paths');
 		$memoryLimit = $input->getOption('memory-limit');
 		$autoloadFile = $input->getOption('autoload-file');

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Command;
 
-use DateTimeImmutable;
 use OndraM\CiDetector\CiDetector;
 use Override;
 use PHPStan\Analyser\InternalError;
@@ -36,7 +35,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Throwable;
@@ -65,7 +63,6 @@ use function str_contains;
 use function stream_get_contents;
 use function strlen;
 use function substr;
-use function time;
 use const PATHINFO_BASENAME;
 use const PATHINFO_EXTENSION;
 
@@ -143,34 +140,6 @@ final class AnalyseCommand extends Command
 	#[Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
-		if ($output instanceof ConsoleOutputInterface) {
-			$errorOutput = $output->getErrorOutput();
-			$errorOutput->writeln('');
-			$errorOutput->writeln("⚠️  You're running an old version of PHPStan.️");
-			$errorOutput->writeln('');
-			$errorOutput->writeln('The last release in the 1.12.x series with new features');
-
-			$lastRelease = new DateTimeImmutable('2025-07-17 00:00:00');
-			$daysSince = (time() - $lastRelease->getTimestamp()) / 60 / 60 / 24;
-			$errorOutput->writeln('and bugfixes was released on <fg=red>July 17th 2025</>,');
-			$errorOutput->writeln(sprintf('that\'s <fg=red>%d days ago.</>', (int) $daysSince));
-			$errorOutput->writeln('');
-
-			$errorOutput->writeln('Since then more than <fg=cyan>65 new PHPStan versions</> were released');
-			$errorOutput->writeln('with hundreds of new features, bugfixes, and other');
-			$errorOutput->writeln('quality of life improvements.');
-			$errorOutput->writeln('');
-
-			$errorOutput->writeln("To learn about what you're missing out on, check out");
-			$errorOutput->writeln('this blog with articles about the latest major releases:');
-			$errorOutput->writeln('<options=underscore>https://phpstan.org/blog</>');
-			$errorOutput->writeln('');
-
-			$errorOutput->writeln('Upgrade today to <fg=green>PHPStan 2.2 or newer</> by using');
-			$errorOutput->writeln('<fg=cyan>"phpstan/phpstan": "^2.2"</> in your <fg=cyan>composer.json</>.');
-			$errorOutput->writeln('');
-		}
-
 		$paths = $input->getArgument('paths');
 		$memoryLimit = $input->getOption('memory-limit');
 		$autoloadFile = $input->getOption('autoload-file');

--- a/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php
+++ b/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php
@@ -32,6 +32,7 @@ final class RequiredPhpVersionCommentTest extends TestCase
 			__DIR__ . '/../Analyser/data',
 			__DIR__ . '/../Analyser/nsrt',
 			__DIR__ . '/../Analyser/Fiber/data',
+			__DIR__ . '/../../bench/data',
 		];
 
 		$dataFinder = new Finder();

--- a/tests/bench/data/bug-11283.php
+++ b/tests/bench/data/bug-11283.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php // lint >= 8.0
+
+declare(strict_types=1);
 
 namespace Bug11283;
 

--- a/tests/bench/data/bug-12159.php
+++ b/tests/bench/data/bug-12159.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.3
 
 namespace Bug12159;
 

--- a/tests/bench/data/bug-13352.php
+++ b/tests/bench/data/bug-13352.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug13352;
 

--- a/tests/bench/data/bug-14319.php
+++ b/tests/bench/data/bug-14319.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace BenchBug14319;
 

--- a/tests/bench/data/impure-call-columns.php
+++ b/tests/bench/data/impure-call-columns.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace ImpureCallColumnsBench;
 

--- a/tests/bench/data/union-fast-path.php
+++ b/tests/bench/data/union-fast-path.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace UnionFastPath;
 

--- a/tests/bench/data/wordpress-user.php
+++ b/tests/bench/data/wordpress-user.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace BenchComplexUnion;
 


### PR DESCRIPTION
cleanup to support https://github.com/phpstan/phpstan-src/pull/6121

----

Fixes

```
There were 10 failures:

1) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/bug-14869-enum.php" ('/Users/m.staab/dvl/phpstan-sr...um.php')
Fixture uses enums on line 16 which requires PHP 8.1. Add a `<?php // lint >= 8.1` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80100 or is greater than 80100.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

2) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/impure-call-columns.php" ('/Users/m.staab/dvl/phpstan-sr...ns.php')
Fixture uses the mixed type on line 8 which requires PHP 8.0. Add a `<?php // lint >= 8.0` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80000 or is greater than 80000.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

3) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/union-fast-path.php" ('/Users/m.staab/dvl/phpstan-sr...th.php')
Fixture uses the mixed type on line 14 which requires PHP 8.0. Add a `<?php // lint >= 8.0` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80000 or is greater than 80000.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

4) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/wordpress-user.php" ('/Users/m.staab/dvl/phpstan-sr...er.php')
Fixture uses the mixed type on line 14 which requires PHP 8.0. Add a `<?php // lint >= 8.0` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80000 or is greater than 80000.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

5) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/bug-14319.php" ('/Users/m.staab/dvl/phpstan-sr...19.php')
Fixture uses union types on line 5 which requires PHP 8.0. Add a `<?php // lint >= 8.0` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80000 or is greater than 80000.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

6) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/bug-10979.php" ('/Users/m.staab/dvl/phpstan-sr...79.php')
Fixture uses enums on line 7 which requires PHP 8.1. Add a `<?php // lint >= 8.1` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80100 or is greater than 80100.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

7) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/bug-11283.php" ('/Users/m.staab/dvl/phpstan-sr...83.php')
Fixture uses the mixed type on line 119 which requires PHP 8.0. Add a `<?php // lint >= 8.0` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80000 or is greater than 80000.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

8) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/bug-10772.php" ('/Users/m.staab/dvl/phpstan-sr...72.php')
Fixture uses enums on line 21 which requires PHP 8.1. Add a `<?php // lint >= 8.1` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80100 or is greater than 80100.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

9) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/bug-12159.php" ('/Users/m.staab/dvl/phpstan-sr...59.php')
Fixture uses typed class constants on line 29 which requires PHP 8.3. Add a `<?php // lint >= 8.3` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80300 or is greater than 80300.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

10) PHPStan\Build\RequiredPhpVersionCommentTest::testFixtureHasRequiredLintComment with data set "/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/../../bench/data/bug-13352.php" ('/Users/m.staab/dvl/phpstan-sr...52.php')
Fixture uses the mixed type on line 32 which requires PHP 8.0. Add a `<?php // lint >= 8.0` comment on the first line so the fixture is skipped on older PHP versions in CI.
Failed asserting that 0 is equal to 80000 or is greater than 80000.

/Users/m.staab/dvl/phpstan-src/tests/PHPStan/Build/RequiredPhpVersionCommentTest.php:102

FAILURES!
Tests: 17558, Assertions: 89823, Failures: 10, Skipped: 188.
make: *** [tests] Error 1
```