### PR TITLE
Resolve __DIR__ and __FILE__ against the trait file in a trait context

### DIFF
--- a/src/Reflection/InitializerExprContext.php
+++ b/src/Reflection/InitializerExprContext.php
@@ -42,8 +42,19 @@ final class InitializerExprContext implements NamespaceAnswerer
 	{
 		$function = $scope->getFunction();
 
+		// __FILE__ and __DIR__ are resolved at compile time, so in a trait context they
+		// point at the file the trait is declared in, while Scope::getFile() returns the
+		// file of the class that uses the trait.
+		$file = $scope->getFile();
+		if ($scope->isInTrait()) {
+			$traitFileName = $scope->getTraitReflection()->getFileName();
+			if ($traitFileName !== null) {
+				$file = $traitFileName;
+			}
+		}
+
 		return new self(
-			$scope->getFile(),
+			$file,
 			$scope->getNamespace(),
 			$scope->isInClass() ? $scope->getClassReflection()->getName() : null,
 			$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,

--- a/src/Rules/Keywords/RequireFileExistsRule.php
+++ b/src/Rules/Keywords/RequireFileExistsRule.php
@@ -117,10 +117,10 @@ final class RequireFileExistsRule implements Rule
 	}
 
 	/**
-	 * The "calling script's own directory" fallback of a relative include is resolved
-	 * at compile time, so inside a trait it is the directory of the file the trait is
-	 * declared in - not the file of the class that uses it, which is what
-	 * Scope::getFile() returns in a trait context.
+	 * Both `__DIR__` and the "calling script's own directory" fallback of a relative
+	 * include are resolved at compile time, so inside a trait they point at the file
+	 * the trait is declared in - not at the file of the class that uses it, which is
+	 * what Scope::getFile() returns in a trait context.
 	 */
 	private function getScopeFile(Scope $scope): string
 	{
@@ -198,7 +198,7 @@ final class RequireFileExistsRule implements Rule
 
 			$paths = [];
 			foreach ($scope->getType($expr->right)->getConstantStrings() as $constantString) {
-				$paths[] = new ConstantStringType(dirname($scope->getFile()) . $constantString->getValue());
+				$paths[] = new ConstantStringType(dirname($this->getScopeFile($scope)) . $constantString->getValue());
 			}
 			return $paths;
 		}

--- a/tests/PHPStan/Analyser/PathConstantsTest.php
+++ b/tests/PHPStan/Analyser/PathConstantsTest.php
@@ -38,4 +38,11 @@ class PathConstantsTest extends TypeInferenceTestCase
 		];
 	}
 
+	protected static function getAdditionalAnalysedFiles(): array
+	{
+		return [
+			__DIR__ . '/data/path-constants-trait/PathConstantsTrait.php',
+		];
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/path-constants-trait/PathConstantsTrait.php
+++ b/tests/PHPStan/Analyser/data/path-constants-trait/PathConstantsTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PathConstantsTestTrait;
+
+use function PHPStan\Testing\assertType;
+
+trait PathConstantsTrait
+{
+
+	public function doFoo(): void
+	{
+		assertType('\'path-constants-trait\'', substr(__DIR__, -20));
+		assertType('\'PathConstantsTrait.php\'', substr(__FILE__, -22));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/pathConstants-win.php
+++ b/tests/PHPStan/Analyser/data/pathConstants-win.php
@@ -4,3 +4,10 @@ namespace PathConstantsTestWin;
 
 \PHPStan\Testing\assertType('\'Analyser\\\\data\'', substr(__DIR__, -13));
 \PHPStan\Testing\assertType('\'pathConstants-win.php\'', substr(__FILE__, -21));
+
+class PathConstantsClassWin
+{
+
+	use \PathConstantsTestTrait\PathConstantsTrait;
+
+}

--- a/tests/PHPStan/Analyser/data/pathConstants.php
+++ b/tests/PHPStan/Analyser/data/pathConstants.php
@@ -4,3 +4,10 @@ namespace PathConstantsTest;
 
 \PHPStan\Testing\assertType('\'Analyser/data\'', substr(__DIR__, -13));
 \PHPStan\Testing\assertType('\'pathConstants.php\'', substr(__FILE__, -17));
+
+class PathConstantsClass
+{
+
+	use \PathConstantsTestTrait\PathConstantsTrait;
+
+}

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
@@ -171,6 +171,19 @@ class RequireFileExistsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug15015(): void
+	{
+		$this->analyse([
+			__DIR__ . '/data/bug-15015/trait-dir/Bug15015Trait.php',
+			__DIR__ . '/data/bug-15015/class-dir/Bug15015Class.php',
+		], [
+			[
+				"Path in include() __DIR__ . '/only-in-class-dir.php' is not a file or it does not exist.",
+				15,
+			],
+		]);
+	}
+
 	public function testInFileExists(): void
 	{
 		$this->analyse([__DIR__ . '/data/include-in-file-exists.php'], []);

--- a/tests/PHPStan/Rules/Keywords/data/bug-15015/class-dir/Bug15015Class.php
+++ b/tests/PHPStan/Rules/Keywords/data/bug-15015/class-dir/Bug15015Class.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Bug15015;
+
+class Bug15015Class
+{
+
+	use Bug15015Trait;
+
+}

--- a/tests/PHPStan/Rules/Keywords/data/bug-15015/class-dir/only-in-class-dir.php
+++ b/tests/PHPStan/Rules/Keywords/data/bug-15015/class-dir/only-in-class-dir.php
@@ -1,0 +1,3 @@
+<?php
+
+return ['only-in-class-dir' => true];

--- a/tests/PHPStan/Rules/Keywords/data/bug-15015/trait-dir/Bug15015Trait.php
+++ b/tests/PHPStan/Rules/Keywords/data/bug-15015/trait-dir/Bug15015Trait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bug15015;
+
+trait Bug15015Trait
+{
+
+	public function magicDirInTraitDir(): void
+	{
+		include __DIR__ . '/only-in-trait-dir.php';
+	}
+
+	public function magicDirInClassDir(): void
+	{
+		include __DIR__ . '/only-in-class-dir.php';
+	}
+
+}

--- a/tests/PHPStan/Rules/Keywords/data/bug-15015/trait-dir/only-in-trait-dir.php
+++ b/tests/PHPStan/Rules/Keywords/data/bug-15015/trait-dir/only-in-trait-dir.php
@@ -1,0 +1,3 @@
+<?php
+
+return ['only-in-trait-dir' => true];


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/15015

`Scope::getFile()` returns the file of the class that uses a trait. PHP resolves `__DIR__` at compile time, so it points at the file that declares the trait. Two places get this wrong.

1. `RequireFileExistsRule::resolveFilePaths()`, the `__DIR__` branch behind the `magicDirInInclude` bleeding edge feature. The issue reports this case. It now reuses the `getScopeFile()` helper that https://github.com/phpstan/phpstan-src/pull/6127 added for the relative include.

2. `InitializerExprContext::fromScope()`, which feeds the types of `__DIR__` and `__FILE__`. Set `usePathConstantsAsConstantString: true` and you get the using class file. The default setting generalizes it to `literal-string&non-falsy-string`, which hides the wrong value instead of correcting it.

Rebased on 2.2.x now that #6127 has landed.
