### PR TITLE
Resolve a relative include against the trait file in a trait context

### DIFF
--- a/src/Rules/Keywords/RequireFileExistsRule.php
+++ b/src/Rules/Keywords/RequireFileExistsRule.php
@@ -104,7 +104,7 @@ final class RequireFileExistsRule implements Rule
 		$directories = array_merge(
 			[$this->currentWorkingDirectory],
 			explode(PATH_SEPARATOR, get_include_path()),
-			[dirname($scope->getFile())],
+			[dirname($this->getScopeFile($scope))],
 		);
 
 		foreach ($directories as $directory) {
@@ -114,6 +114,24 @@ final class RequireFileExistsRule implements Rule
 		}
 
 		return false;
+	}
+
+	/**
+	 * The "calling script's own directory" fallback of a relative include is resolved
+	 * at compile time, so inside a trait it is the directory of the file the trait is
+	 * declared in - not the file of the class that uses it, which is what
+	 * Scope::getFile() returns in a trait context.
+	 */
+	private function getScopeFile(Scope $scope): string
+	{
+		if ($scope->isInTrait()) {
+			$traitFileName = $scope->getTraitReflection()->getFileName();
+			if ($traitFileName !== null) {
+				return $this->fileHelper->normalizePath($traitFileName);
+			}
+		}
+
+		return $scope->getFile();
 	}
 
 	private function doesFileExistForDirectory(string $path, string $workingDirectory): bool

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
@@ -158,6 +158,19 @@ class RequireFileExistsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testRelativePathInTrait(): void
+	{
+		$this->analyse([
+			__DIR__ . '/data/include-relative-in-trait/trait-dir/IncludeRelativeTrait.php',
+			__DIR__ . '/data/include-relative-in-trait/class-dir/IncludeRelativeClass.php',
+		], [
+			[
+				'Path in include() "only-in-class-dir.php" is not a file or it does not exist.',
+				15,
+			],
+		]);
+	}
+
 	public function testInFileExists(): void
 	{
 		$this->analyse([__DIR__ . '/data/include-in-file-exists.php'], []);

--- a/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/class-dir/IncludeRelativeClass.php
+++ b/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/class-dir/IncludeRelativeClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace IncludeRelativeInTrait;
+
+class IncludeRelativeClass
+{
+
+	use IncludeRelativeTrait;
+
+}

--- a/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/class-dir/only-in-class-dir.php
+++ b/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/class-dir/only-in-class-dir.php
@@ -1,0 +1,3 @@
+<?php
+
+return ['only-in-class-dir' => true];

--- a/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/trait-dir/IncludeRelativeTrait.php
+++ b/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/trait-dir/IncludeRelativeTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace IncludeRelativeInTrait;
+
+trait IncludeRelativeTrait
+{
+
+	public function relativeInTraitDir(): void
+	{
+		include 'only-in-trait-dir.php';
+	}
+
+	public function relativeInClassDir(): void
+	{
+		include 'only-in-class-dir.php';
+	}
+
+}

--- a/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/trait-dir/only-in-trait-dir.php
+++ b/tests/PHPStan/Rules/Keywords/data/include-relative-in-trait/trait-dir/only-in-trait-dir.php
@@ -1,0 +1,3 @@
+<?php
+
+return ['only-in-trait-dir' => true];


### PR DESCRIPTION
Split out of https://github.com/phpstan/phpstan-src/pull/6126 after https://github.com/phpstan/phpstan-src/pull/6126#discussion_r3665573687. This part does not depend on the `magicDirInInclude` bleeding edge feature and dates back to the original implementation of the rule.

`doesFileExist()` looks for a relative include in three directories: the current working directory, the include path and `dirname($scope->getFile())`. That third one stands for the calling script's own directory. In a trait context `Scope::getFile()` returns the file of the class that uses the trait, while PHP resolves the include against the file that declares the trait.

So a trait method doing `include 'data.php'` with `data.php` next to the trait reports `include.fileNotFound`, and the same call finds nothing at runtime when `data.php` sits next to the using class instead.

I checked the runtime behaviour with the cwd set to `/`, include_path left at its default and the entry script in a third directory. The include still found the file next to the trait.
