### PR TITLE
Do not let type narrowing define a certainly-undefined variable

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3327,6 +3327,17 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				continue;
 			}
 
+			if (
+				!$typeSpecification['sure']
+				&& $expr instanceof Variable && is_string($expr->name)
+				&& $scope->hasVariableType($expr->name)->no()
+			) {
+				// removing type from a certainly-undefined variable cannot make
+				// it defined; a sure specification (e.g. is_string($a)) still can -
+				// the condition can only hold for a defined variable
+				continue;
+			}
+
 			if ($typeSpecification['sure']) {
 				if ($specifiedTypes->shouldOverwrite()) {
 					$scope = $scope->assignExpression($expr, $type, $type);

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -1701,4 +1701,26 @@ class DefinedVariableRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug2032(): void
+	{
+		$this->cliArgumentsVariablesRegistered = true;
+		$this->polluteScopeWithLoopInitialAssignments = false;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithAlwaysIterableForeach = true;
+		$this->analyse([__DIR__ . '/data/bug-2032.php'], [
+			[
+				'Undefined variable: $undefined',
+				6,
+			],
+			[
+				'Undefined variable: $undefined',
+				9,
+			],
+			[
+				'Undefined variable: $undefined',
+				15,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-2032.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-2032.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug2032;
+
+function noloop(array $foo) {
+	if ($undefined) {}
+
+	foreach ($foo as $bar) {
+		if ($undefined) {}
+	}
+}
+
+function loop(array $foo) {
+	foreach ($foo as $bar) {
+		if ($undefined) {}
+	}
+}


### PR DESCRIPTION
Extracted from the `resolve-type-rewrite-2` branch (follows #6125 and #6129).

`filterBySpecifiedTypes()` created a type holder for a variable the scope knows is certainly undefined, making `isset()`-style narrowing "define" it — the classic false negative where only the first use of an undefined variable in a loop was reported. A sureNot specification now skips certainly-undefined variables; sure specifications still apply, since a condition like `is_string($a)` can only hold for a defined variable (one error at the test site, no cascade).

Verified test-first: the regression test fails on 2.2.x with the line-9 `Undefined variable` error missing and line 15 degraded to "might not be defined"; passes with the fix. Full test suite green (17757 tests), self-analysis clean, no other expectation changes.

Closes https://github.com/phpstan/phpstan/issues/2032

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b