### PR TITLE
Treat a property with a default value as always set in isset resolution

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1160,7 +1160,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			if ($propertyReflection->hasNativeType() && !$propertyReflection->isVirtual()->yes()) {
 				if (!$this->hasExpressionType($expr)->yes()) {
 					$nativeReflection = $propertyReflection->getNativeReflection();
-					if ($nativeReflection === null || !$nativeReflection->isPromoted() || (!$nativeReflection->isReadOnly() && !$nativeReflection->isHooked())) {
+					if (
+						($nativeReflection === null || !$nativeReflection->getNativeReflection()->hasDefaultValue())
+						&& ($nativeReflection === null || !$nativeReflection->isPromoted() || (!$nativeReflection->isReadOnly() && !$nativeReflection->isHooked()))
+					) {
 						if ($expr instanceof Node\Expr\PropertyFetch) {
 							return $this->issetCheckUndefined($expr->var);
 						}

--- a/tests/PHPStan/Analyser/nsrt/bug-10786.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10786.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10786;
+
+use function PHPStan\Testing\assertType;
+
+class Value {
+	public ?int	$value = null;
+}
+
+class HelloWorld
+{
+	public function sayHello(Value $a, Value $b): int
+	{
+		if (is_null($a->value) && is_null($b->value)) {
+			throw new \Exception();
+		}
+
+		assertType('int', $a->value ?? $b->value);
+
+		return $a->value ?? $b->value;
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/isset-coalesce-empty-type.php
+++ b/tests/PHPStan/Analyser/nsrt/isset-coalesce-empty-type.php
@@ -246,7 +246,7 @@ class FooNativeProp
 	public int $canBeUninitialized;
 
 	function doFoo(FooNativeProp $foo): void {
-		assertType('bool', isset($foo->hasDefaultValue));
+		assertType('true', isset($foo->hasDefaultValue));
 
 		$foo->isAssignedBefore = 5;
 		assertType('true', isset($foo->isAssignedBefore));

--- a/tests/PHPStan/Analyser/nsrt/isset-property-default-value.php
+++ b/tests/PHPStan/Analyser/nsrt/isset-property-default-value.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace IssetPropertyDefaultValue;
+
+use function PHPStan\Testing\assertType;
+
+class Holder
+{
+
+	public ?int $value = null;
+
+	public ?int $noDefault;
+
+}
+
+function coalesceWithDefault(Holder $a, Holder $b): void
+{
+	if ($a->value === null && $b->value === null) {
+		throw new \LogicException();
+	}
+
+	assertType('int', $a->value ?? $b->value);
+}
+
+function coalesceWithoutDefault(Holder $a, Holder $b): void
+{
+	if ($a->noDefault === null && $b->noDefault === null) {
+		throw new \LogicException();
+	}
+
+	assertType('int|null', $a->noDefault ?? $b->noDefault);
+}


### PR DESCRIPTION
Extracted from the `resolve-type-rewrite-2` branch (follows #6125, #6129, #6130).

`MutatingScope::issetCheck()` treated every native non-virtual property without a tracked expression type as possibly uninitialized — including properties with a default value, which can never be uninitialized. The guard now consults `hasDefaultValue()`.

Effects, verified test-first (new `nsrt/isset-property-default-value.php` fails on 2.2.x with `int|null`, passes with the fix):
- `$a->value ?? $b->value` narrows through an earlier `is_null && is_null` throw guard again (the coalesce only builds the left-is-null scope for its right side when the left is surely set).
- `isset($foo->hasDefaultValue)` on a defaulted non-nullable property now infers `true` — one expectation updated in `nsrt/isset-coalesce-empty-type.php`, consistent with the adjacent assigned-before case; a no-default contrast case in the new fixture pins that uninitialized properties keep the conservative `bool`.

Full test suite green (17764 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b

---

Note: the rule-side mirror of this logic in `Rules\IssetCheck` already consults `hasDefaultValue()` since 2f58f5f69a (#5327, phpstan/phpstan#14393) — this PR is the `MutatingScope::issetCheck()` catch-up, so type inference now agrees with what the isset/empty/coalesce rules already report.


Closes https://github.com/phpstan/phpstan/issues/10786
