### PR TITLE
Deduplicate constant-condition vs impossible-check reports via collectors instead of asking the type specifier inline

### DIFF
--- a/src/Rules/Comparison/BooleanAndConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanAndConstantConditionRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PHPStan\Analyser\CollectedDataEmitter;
 use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
@@ -27,6 +28,7 @@ final class BooleanAndConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -87,16 +89,18 @@ final class BooleanAndConstantConditionRule implements Rule
 				}
 				$ruleError = $errorBuilder->build();
 				$hasLeftOrRightError = true;
-				if ($isInTrait) {
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($originalNode->left)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $originalNode->left, $leftType->getValue(), $ruleError);
+				} elseif ($isInTrait) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->left, $leftType->getValue(), $ruleError);
 				} else {
 					$errors[] = $ruleError;
 				}
 			} else {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
+				$this->emitNoError($scope, $originalNode->left);
 			}
 		} else {
-			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
+			$this->emitNoError($scope, $originalNode->left);
 		}
 
 		$rightScope = $node->getRightScope();
@@ -140,16 +144,18 @@ final class BooleanAndConstantConditionRule implements Rule
 				}
 				$ruleError = $errorBuilder->build();
 				$hasLeftOrRightError = true;
-				if ($isInTrait) {
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($originalNode->right)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $originalNode->right, $rightType->getValue(), $ruleError);
+				} elseif ($isInTrait) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->right, $rightType->getValue(), $ruleError);
 				} else {
 					$errors[] = $ruleError;
 				}
 			} else {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
+				$this->emitNoError($scope, $originalNode->right);
 			}
 		} else {
-			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
+			$this->emitNoError($scope, $originalNode->right);
 		}
 
 		if (count($errors) === 0 && !$hasLeftOrRightError && !$scope->isInFirstLevelStatement()) {
@@ -201,6 +207,18 @@ final class BooleanAndConstantConditionRule implements Rule
 		}
 
 		return $errors;
+	}
+
+	private function emitNoError(
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $expr,
+	): void
+	{
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($expr)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $expr);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $expr);
+		}
 	}
 
 }

--- a/src/Rules/Comparison/BooleanNotConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanNotConstantConditionRule.php
@@ -25,6 +25,7 @@ final class BooleanNotConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -78,6 +79,10 @@ final class BooleanNotConstantConditionRule implements Rule
 				$errorBuilder->identifier(sprintf('booleanNot.always%s', $exprType->getValue() ? 'False' : 'True'));
 
 				$ruleError = $errorBuilder->build();
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->expr)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->expr, !$exprType->getValue(), $ruleError);
+					return [];
+				}
 				if ($scope->isInTrait()) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->expr, !$exprType->getValue(), $ruleError);
 					return [];
@@ -87,7 +92,11 @@ final class BooleanNotConstantConditionRule implements Rule
 			}
 		}
 
-		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->expr);
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->expr)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $node->expr);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->expr);
+		}
 		return [];
 	}
 

--- a/src/Rules/Comparison/BooleanOrConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanOrConstantConditionRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PHPStan\Analyser\CollectedDataEmitter;
 use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
@@ -27,6 +28,7 @@ final class BooleanOrConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -87,16 +89,18 @@ final class BooleanOrConstantConditionRule implements Rule
 				}
 				$ruleError = $errorBuilder->build();
 				$hasLeftOrRightError = true;
-				if ($isInTrait) {
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($originalNode->left)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $originalNode->left, $leftType->getValue(), $ruleError);
+				} elseif ($isInTrait) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->left, $leftType->getValue(), $ruleError);
 				} else {
 					$messages[] = $ruleError;
 				}
 			} else {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
+				$this->emitNoError($scope, $originalNode->left);
 			}
 		} else {
-			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
+			$this->emitNoError($scope, $originalNode->left);
 		}
 
 		$rightScope = $node->getRightScope();
@@ -140,16 +144,18 @@ final class BooleanOrConstantConditionRule implements Rule
 				}
 				$ruleError = $errorBuilder->build();
 				$hasLeftOrRightError = true;
-				if ($isInTrait) {
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($originalNode->right)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $originalNode->right, $rightType->getValue(), $ruleError);
+				} elseif ($isInTrait) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->right, $rightType->getValue(), $ruleError);
 				} else {
 					$messages[] = $ruleError;
 				}
 			} else {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
+				$this->emitNoError($scope, $originalNode->right);
 			}
 		} else {
-			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
+			$this->emitNoError($scope, $originalNode->right);
 		}
 
 		if (count($messages) === 0 && !$hasLeftOrRightError && !$scope->isInFirstLevelStatement()) {
@@ -201,6 +207,18 @@ final class BooleanOrConstantConditionRule implements Rule
 		}
 
 		return $messages;
+	}
+
+	private function emitNoError(
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $expr,
+	): void
+	{
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($expr)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $expr);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $expr);
+		}
 	}
 
 }

--- a/src/Rules/Comparison/ConstantConditionRuleHelper.php
+++ b/src/Rules/Comparison/ConstantConditionRuleHelper.php
@@ -3,8 +3,6 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -15,14 +13,13 @@ final class ConstantConditionRuleHelper
 {
 
 	public function __construct(
-		private ImpossibleCheckTypeHelper $impossibleCheckTypeHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 	)
 	{
 	}
 
-	private function shouldSkip(Scope $scope, Expr $expr): bool
+	private function shouldSkip(Expr $expr): bool
 	{
 		if (
 			$expr instanceof Expr\BinaryOp\Equal
@@ -50,25 +47,12 @@ final class ConstantConditionRuleHelper
 			return true;
 		}
 
-		if (
-			(
-				$expr instanceof FuncCall
-				|| $expr instanceof MethodCall
-				|| $expr instanceof Expr\StaticCall
-			) && !$expr->isFirstClassCallable()
-		) {
-			$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $expr);
-			if ($isAlways !== null) {
-				return true;
-			}
-		}
-
 		return false;
 	}
 
 	public function getBooleanType(Scope $scope, Expr $expr): BooleanType
 	{
-		if ($this->shouldSkip($scope, $expr)) {
+		if ($this->shouldSkip($expr)) {
 			return new BooleanType();
 		}
 
@@ -81,7 +65,7 @@ final class ConstantConditionRuleHelper
 
 	public function getNativeBooleanType(Scope $scope, Expr $expr): BooleanType
 	{
-		if ($this->shouldSkip($scope, $expr)) {
+		if ($this->shouldSkip($expr)) {
 			return new BooleanType();
 		}
 

--- a/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
+++ b/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Continue_;
@@ -28,6 +29,7 @@ final class DoWhileLoopConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -44,23 +46,24 @@ final class DoWhileLoopConstantConditionRule implements Rule
 	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		$exprType = $this->helper->getBooleanType($scope, $node->getCond());
+		$isTypeCheckCandidate = $this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->getCond());
 		if ($exprType instanceof ConstantBooleanType) {
 			if ($exprType->getValue()) {
 				if ($node->hasYield()) {
-					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
+					$this->emitNoError($scope, $node->getCond(), $isTypeCheckCandidate);
 					return [];
 				}
 				foreach ($node->getExitPoints() as $exitPoint) {
 					$statement = $exitPoint->getStatement();
 					if (!$statement instanceof Continue_) {
-						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
+						$this->emitNoError($scope, $node->getCond(), $isTypeCheckCandidate);
 						return [];
 					}
 					if (!$statement->num instanceof Int_) {
 						continue;
 					}
 					if ($statement->num->value > 1) {
-						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
+						$this->emitNoError($scope, $node->getCond(), $isTypeCheckCandidate);
 						return [];
 					}
 				}
@@ -68,7 +71,7 @@ final class DoWhileLoopConstantConditionRule implements Rule
 				foreach ($node->getExitPoints() as $exitPoint) {
 					$statement = $exitPoint->getStatement();
 					if ($statement instanceof Break_) {
-						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
+						$this->emitNoError($scope, $node->getCond(), $isTypeCheckCandidate);
 						return [];
 					}
 				}
@@ -99,6 +102,10 @@ final class DoWhileLoopConstantConditionRule implements Rule
 				->line($node->getCond()->getStartLine())
 				->identifier(sprintf('doWhile.always%s', $exprType->getValue() ? 'True' : 'False'))
 				->build();
+			if ($isTypeCheckCandidate) {
+				$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->getCond(), $exprType->getValue(), $ruleError);
+				return [];
+			}
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->getCond(), $exprType->getValue(), $ruleError);
 				return [];
@@ -107,8 +114,21 @@ final class DoWhileLoopConstantConditionRule implements Rule
 			return [$ruleError];
 		}
 
-		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
+		$this->emitNoError($scope, $node->getCond(), $isTypeCheckCandidate);
 		return [];
+	}
+
+	private function emitNoError(
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $cond,
+		bool $isTypeCheckCandidate,
+	): void
+	{
+		if ($isTypeCheckCandidate) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $cond);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $cond);
+		}
 	}
 
 }

--- a/src/Rules/Comparison/ElseIfConstantConditionRule.php
+++ b/src/Rules/Comparison/ElseIfConstantConditionRule.php
@@ -25,6 +25,7 @@ final class ElseIfConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -79,6 +80,10 @@ final class ElseIfConstantConditionRule implements Rule
 				$errorBuilder->identifier(sprintf('elseif.always%s', $exprType->getValue() ? 'True' : 'False'));
 
 				$ruleError = $errorBuilder->build();
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
+					return [];
+				}
 				if ($scope->isInTrait()) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
 					return [];
@@ -88,7 +93,11 @@ final class ElseIfConstantConditionRule implements Rule
 			}
 		}
 
-		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $node->cond);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		}
 		return [];
 	}
 

--- a/src/Rules/Comparison/FunctionCallConstantConditionCollector.php
+++ b/src/Rules/Comparison/FunctionCallConstantConditionCollector.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * @implements Collector<never, array{class-string<Rule<covariant Node>>, trait-string|null, string, null}|array{class-string<Rule<covariant Node>>, trait-string|null, string, bool, Error|array<mixed>}>
+ */
+final class FunctionCallConstantConditionCollector implements Collector
+{
+
+	public function getNodeType(): string
+	{
+		throw new ShouldNotHappenException();
+	}
+
+	public function processNode(Node $node, Scope $scope)
+	{
+		throw new ShouldNotHappenException();
+	}
+
+}

--- a/src/Rules/Comparison/FunctionCallConstantConditionHelper.php
+++ b/src/Rules/Comparison/FunctionCallConstantConditionHelper.php
@@ -4,6 +4,9 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\CollectedDataEmitter;
 use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\RuleErrorTransformer;
@@ -17,7 +20,7 @@ use PHPStan\ShouldNotHappenException;
 use function sprintf;
 
 #[AutowiredService]
-final class ConstantConditionInTraitHelper
+final class FunctionCallConstantConditionHelper
 {
 
 	public function __construct(
@@ -33,21 +36,32 @@ final class ConstantConditionInTraitHelper
 	}
 
 	/**
+	 * Whether the condition is a function/method/static call that the
+	 * ImpossibleCheckType* rules might own. For these the constant-condition
+	 * reporting is deferred to FunctionCallConstantConditionRule, which
+	 * deduplicates against ImpossibleCheckTypeReportedCollector markers.
+	 */
+	public function isTypeCheckCandidate(Expr $expr): bool
+	{
+		return (
+			$expr instanceof FuncCall
+			|| $expr instanceof MethodCall
+			|| $expr instanceof StaticCall
+		) && !$expr->isFirstClassCallable();
+	}
+
+	/**
 	 * @param class-string<Rule<covariant Node>> $ruleName
 	 */
-	public function emitNoError(
+	public function emitFunctionCallNoError(
 		string $ruleName,
 		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 		Expr $expr,
 	): void
 	{
-		if (!$scope->isInTrait()) {
-			return;
-		}
-
-		$scope->emitCollectedData(ConstantConditionInTraitCollector::class, [
+		$scope->emitCollectedData(FunctionCallConstantConditionCollector::class, [
 			$ruleName,
-			$scope->getTraitReflection()->getName(),
+			$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
 			$this->exprString($expr),
 			null,
 		]);
@@ -56,7 +70,7 @@ final class ConstantConditionInTraitHelper
 	/**
 	 * @param class-string<Rule<covariant Node>> $ruleName
 	 */
-	public function emitError(
+	public function emitFunctionCallError(
 		string $ruleName,
 		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 		Expr $expr,
@@ -65,19 +79,25 @@ final class ConstantConditionInTraitHelper
 	): void
 	{
 		if ($ruleError instanceof FixableNodeRuleError) {
-			throw new ShouldNotHappenException('Fixable errors are not supported by ConstantConditionInTraitHelper.');
+			throw new ShouldNotHappenException('Fixable errors are not supported by FunctionCallConstantConditionHelper.');
 		}
 
-		if (!$scope->isInTrait()) {
-			return;
-		}
-
-		$scope->emitCollectedData(ConstantConditionInTraitCollector::class, [
+		$scope->emitCollectedData(FunctionCallConstantConditionCollector::class, [
 			$ruleName,
-			$scope->getTraitReflection()->getName(),
+			$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
 			$this->exprString($expr),
 			$value,
 			$this->ruleErrorTransformer->transform($ruleError, $scope, [], $expr),
+		]);
+	}
+
+	public function emitImpossibleCheckReported(
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $expr,
+	): void
+	{
+		$scope->emitCollectedData(ImpossibleCheckTypeReportedCollector::class, [
+			$this->exprString($expr),
 		]);
 	}
 

--- a/src/Rules/Comparison/FunctionCallConstantConditionRule.php
+++ b/src/Rules/Comparison/FunctionCallConstantConditionRule.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrors\TransformedRuleError;
+use function array_key_exists;
+use function array_values;
+use function count;
+use function is_array;
+use function var_export;
+
+/**
+ * Reports the constant-condition errors deferred by the consumer rules for
+ * function/method/static call conditions, after deduplicating them against the
+ * ImpossibleCheckType* rules (which own the same call sites) via the
+ * ImpossibleCheckTypeReportedCollector markers.
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+#[RegisteredRule(level: 4)]
+final class FunctionCallConstantConditionRule implements Rule
+{
+
+	private const NULL_TRAIT_KEY = "\0null-trait";
+
+	public function getNodeType(): string
+	{
+		return CollectedDataNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$reportedMarkers = [];
+		foreach ($node->get(ImpossibleCheckTypeReportedCollector::class) as $fileData) {
+			foreach ($fileData as $data) {
+				$reportedMarkers[$data[0]] = true;
+			}
+		}
+
+		$errorsByRuleTraitExprValue = [];
+		foreach ($node->get(FunctionCallConstantConditionCollector::class) as $fileData) {
+			foreach ($fileData as $data) {
+				$ruleName = $data[0];
+				$traitName = $data[1];
+				$traitKey = $traitName ?? self::NULL_TRAIT_KEY;
+				$exprString = $data[2];
+				$value = $data[3];
+				$valueKey = var_export($value, true);
+				if ($data[3] === null) {
+					$errorsByRuleTraitExprValue[$ruleName][$traitKey][$exprString][$valueKey][] = null;
+					// no error reported
+					continue;
+				}
+
+				$error = $data[4];
+				$errorsByRuleTraitExprValue[$ruleName][$traitKey][$exprString][$valueKey][] = $error;
+			}
+		}
+
+		$transformedErrors = [];
+		foreach ($errorsByRuleTraitExprValue as $ruleData) {
+			foreach ($ruleData as $traitKey => $traitData) {
+				$isTrait = $traitKey !== self::NULL_TRAIT_KEY;
+				foreach ($traitData as $exprString => $valueData) {
+					if (array_key_exists($exprString, $reportedMarkers)) {
+						// the ImpossibleCheckType* rule owns this call site
+						continue;
+					}
+
+					if ($isTrait && count($valueData) > 1) {
+						continue;
+					}
+
+					$uniquedErrors = [];
+					foreach ($valueData as $errors) {
+						foreach ($errors as $errorObject) {
+							if ($errorObject === null) {
+								continue;
+							}
+							if (is_array($errorObject)) {
+								$errorObject = Error::decode($errorObject);
+							}
+
+							$message = $errorObject->getMessage();
+							$uniquedErrors[$message] = $errorObject;
+						}
+					}
+
+					$uniquedErrors = array_values($uniquedErrors);
+					if (count($uniquedErrors) === 0) {
+						continue;
+					}
+
+					if (!$isTrait) {
+						foreach ($uniquedErrors as $uniquedError) {
+							$transformedErrors[] = new TransformedRuleError($uniquedError);
+						}
+						continue;
+					}
+
+					if (count($uniquedErrors) === 1) {
+						// report directly in trait, no "in context of"
+						$transformedErrors[] = new TransformedRuleError($uniquedErrors[0]->removeTraitContext());
+						continue;
+					}
+
+					// report each error in its context
+					foreach ($uniquedErrors as $uniquedError) {
+						$transformedErrors[] = new TransformedRuleError($uniquedError);
+					}
+				}
+			}
+		}
+
+		return $transformedErrors;
+	}
+
+}

--- a/src/Rules/Comparison/IfConstantConditionRule.php
+++ b/src/Rules/Comparison/IfConstantConditionRule.php
@@ -24,6 +24,7 @@ final class IfConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -68,6 +69,10 @@ final class IfConstantConditionRule implements Rule
 			)))
 				->identifier(sprintf('if.always%s', $exprType->getValue() ? 'True' : 'False'))
 				->line($node->cond->getStartLine())->build();
+			if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+				$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
+				return [];
+			}
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
 				return [];
@@ -76,7 +81,11 @@ final class IfConstantConditionRule implements Rule
 			return [$ruleError];
 		}
 
-		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $node->cond);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		}
 		return [];
 	}
 

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -24,6 +24,7 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		private ImpossibleCheckTypeHelper $impossibleCheckTypeHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -52,6 +53,8 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
+
+		$this->functionCallConstantConditionHelper->emitImpossibleCheckReported($scope, $node);
 
 		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $reasons): RuleErrorBuilder {
 			if ($reasons !== []) {

--- a/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
@@ -27,6 +27,7 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 		private ImpossibleCheckTypeHelper $impossibleCheckTypeHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -47,6 +48,7 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 		if (!$node->name instanceof Node\Identifier) {
 			return [];
 		}
+		$methodName = $node->name->name;
 
 		$reasons = [];
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node, $reasons);
@@ -54,6 +56,8 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
+
+		$this->functionCallConstantConditionHelper->emitImpossibleCheckReported($scope, $node);
 
 		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $reasons): RuleErrorBuilder {
 			if ($reasons !== []) {
@@ -78,7 +82,7 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 		};
 
 		if (!$isAlways) {
-			$method = $this->getMethod($node->var, $node->name->name, $scope);
+			$method = $this->getMethod($node->var, $methodName, $scope);
 			$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 				'Call to method %s::%s()%s will always evaluate to false.',
 				$method->getDeclaringClass()->getDisplayName(),
@@ -100,7 +104,7 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 			return [];
 		}
 
-		$method = $this->getMethod($node->var, $node->name->name, $scope);
+		$method = $this->getMethod($node->var, $methodName, $scope);
 		$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 			'Call to method %s::%s()%s will always evaluate to true.',
 			$method->getDeclaringClass()->getDisplayName(),

--- a/src/Rules/Comparison/ImpossibleCheckTypeReportedCollector.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeReportedCollector.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * @implements Collector<never, array{string}>
+ */
+final class ImpossibleCheckTypeReportedCollector implements Collector
+{
+
+	public function getNodeType(): string
+	{
+		throw new ShouldNotHappenException();
+	}
+
+	public function processNode(Node $node, Scope $scope)
+	{
+		throw new ShouldNotHappenException();
+	}
+
+}

--- a/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
@@ -27,6 +27,7 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 		private ImpossibleCheckTypeHelper $impossibleCheckTypeHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -47,6 +48,7 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 		if (!$node->name instanceof Node\Identifier) {
 			return [];
 		}
+		$methodName = $node->name->name;
 
 		$reasons = [];
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node, $reasons);
@@ -54,6 +56,8 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
+
+		$this->functionCallConstantConditionHelper->emitImpossibleCheckReported($scope, $node);
 
 		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $reasons): RuleErrorBuilder {
 			if ($reasons !== []) {
@@ -78,7 +82,7 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 		};
 
 		if (!$isAlways) {
-			$method = $this->getMethod($node->class, $node->name->name, $scope);
+			$method = $this->getMethod($node->class, $methodName, $scope);
 
 			$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 				'Call to static method %s::%s()%s will always evaluate to false.',
@@ -101,7 +105,7 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 			return [];
 		}
 
-		$method = $this->getMethod($node->class, $node->name->name, $scope);
+		$method = $this->getMethod($node->class, $methodName, $scope);
 		$errorBuilder = $addTip(RuleErrorBuilder::message(sprintf(
 			'Call to static method %s::%s()%s will always evaluate to true.',
 			$method->getDeclaringClass()->getDisplayName(),

--- a/src/Rules/Comparison/LogicalXorConstantConditionRule.php
+++ b/src/Rules/Comparison/LogicalXorConstantConditionRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\LogicalXor;
 use PHPStan\Analyser\CollectedDataEmitter;
 use PHPStan\Analyser\NodeCallbackInvoker;
@@ -26,6 +27,7 @@ final class LogicalXorConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -77,16 +79,18 @@ final class LogicalXorConstantConditionRule implements Rule
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
 				$ruleError = $errorBuilder->build();
-				if ($isInTrait) {
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->left)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->left, $leftType->getValue(), $ruleError);
+				} elseif ($isInTrait) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->left, $leftType->getValue(), $ruleError);
 				} else {
 					$errors[] = $ruleError;
 				}
 			} else {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->left);
+				$this->emitNoError($scope, $node->left);
 			}
 		} else {
-			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->left);
+			$this->emitNoError($scope, $node->left);
 		}
 
 		$rightType = $this->helper->getBooleanType($scope, $node->right);
@@ -124,19 +128,33 @@ final class LogicalXorConstantConditionRule implements Rule
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
 				$ruleError = $errorBuilder->build();
-				if ($isInTrait) {
+				if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->right)) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->right, $rightType->getValue(), $ruleError);
+				} elseif ($isInTrait) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->right, $rightType->getValue(), $ruleError);
 				} else {
 					$errors[] = $ruleError;
 				}
 			} else {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->right);
+				$this->emitNoError($scope, $node->right);
 			}
 		} else {
-			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->right);
+			$this->emitNoError($scope, $node->right);
 		}
 
 		return $errors;
+	}
+
+	private function emitNoError(
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $expr,
+	): void
+	{
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($expr)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $expr);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $expr);
+		}
 	}
 
 }

--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PHPStan\Analyser\CollectedDataEmitter;
 use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
@@ -34,6 +35,7 @@ final class MatchExpressionRule implements Rule
 		private ConstantConditionRuleHelper $constantConditionRuleHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 	)
@@ -67,14 +69,16 @@ final class MatchExpressionRule implements Rule
 			}
 			foreach ($armConditions as $armCondition) {
 				$armConditionScope = $armCondition->getScope();
+				$rawCondition = $armCondition->getCondition();
+				$isTypeCheckCandidate = $this->functionCallConstantConditionHelper->isTypeCheckCandidate($rawCondition);
 				$armConditionExpr = new Node\Expr\BinaryOp\Identical(
 					$matchCondition,
-					$armCondition->getCondition(),
+					$rawCondition,
 				);
 
 				$armConditionResult = $armConditionScope->getType($armConditionExpr);
 				if (!$armConditionResult instanceof ConstantBooleanType) {
-					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
+					$this->emitNoError($scope, $armConditionExpr, $rawCondition, $isTypeCheckCandidate);
 					continue;
 				}
 				if ($armConditionResult->getValue()) {
@@ -84,7 +88,7 @@ final class MatchExpressionRule implements Rule
 				if (!$this->treatPhpDocTypesAsCertain) {
 					$armConditionNativeResult = $armConditionScope->getNativeType($armConditionExpr);
 					if (!$armConditionNativeResult instanceof ConstantBooleanType) {
-						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
+						$this->emitNoError($scope, $armConditionExpr, $rawCondition, $isTypeCheckCandidate);
 						continue;
 					}
 					if ($armConditionNativeResult->getValue()) {
@@ -93,9 +97,9 @@ final class MatchExpressionRule implements Rule
 				}
 
 				if ($matchConditionType instanceof ConstantBooleanType) {
-					$armConditionStandaloneResult = $this->constantConditionRuleHelper->getBooleanType($armConditionScope, $armCondition->getCondition());
+					$armConditionStandaloneResult = $this->constantConditionRuleHelper->getBooleanType($armConditionScope, $rawCondition);
 					if (!$armConditionStandaloneResult instanceof ConstantBooleanType) {
-						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
+						$this->emitNoError($scope, $armConditionExpr, $rawCondition, $isTypeCheckCandidate);
 						continue;
 					}
 				}
@@ -105,11 +109,15 @@ final class MatchExpressionRule implements Rule
 					$errorBuilder = RuleErrorBuilder::message(sprintf(
 						'Match arm comparison between %s and %s is always false.',
 						$armConditionScope->getType($matchCondition)->describe(VerbosityLevel::value()),
-						$armConditionScope->getType($armCondition->getCondition())->describe(VerbosityLevel::value()),
+						$armConditionScope->getType($rawCondition)->describe(VerbosityLevel::value()),
 					))->line($armLine)->identifier('match.alwaysFalse');
 					$this->possiblyImpureTipHelper->addTip($armConditionScope, $armConditionExpr, $errorBuilder);
 					$ruleError = $errorBuilder->build();
-					if ($scope->isInTrait()) {
+					if ($isTypeCheckCandidate) {
+						// the constant-ness of a type-check call is owned by the
+						// ImpossibleCheckType* rules; defer and deduplicate against them
+						$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $rawCondition, false, $ruleError);
+					} elseif ($scope->isInTrait()) {
 						$this->constantConditionInTraitHelper->emitError(self::class, $scope, $armConditionExpr, false, $ruleError);
 					} else {
 						$errors[] = $ruleError;
@@ -118,14 +126,14 @@ final class MatchExpressionRule implements Rule
 				}
 
 				if ($i === $armsCount - 1) {
-					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
+					$this->emitNoError($scope, $armConditionExpr, $rawCondition, $isTypeCheckCandidate);
 					continue;
 				}
 
 				$message = sprintf(
 					'Match arm comparison between %s and %s is always true.',
 					$armConditionScope->getType($matchCondition)->describe(VerbosityLevel::value()),
-					$armConditionScope->getType($armCondition->getCondition())->describe(VerbosityLevel::value()),
+					$armConditionScope->getType($rawCondition)->describe(VerbosityLevel::value()),
 				);
 				$errorBuilder = RuleErrorBuilder::message($message)
 					->line($armLine)
@@ -133,7 +141,9 @@ final class MatchExpressionRule implements Rule
 					->tip('Remove remaining cases below this one and this error will disappear too.');
 				$this->possiblyImpureTipHelper->addTip($armConditionScope, $armConditionExpr, $errorBuilder);
 				$ruleError = $errorBuilder->build();
-				if ($scope->isInTrait()) {
+				if ($isTypeCheckCandidate) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $rawCondition, true, $ruleError);
+				} elseif ($scope->isInTrait()) {
 					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $armConditionExpr, true, $ruleError);
 				} else {
 					$errors[] = $ruleError;
@@ -165,6 +175,20 @@ final class MatchExpressionRule implements Rule
 		}
 
 		return $errors;
+	}
+
+	private function emitNoError(
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $armConditionExpr,
+		Expr $rawCondition,
+		bool $isTypeCheckCandidate,
+	): void
+	{
+		if ($isTypeCheckCandidate) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $rawCondition);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
+		}
 	}
 
 	private function isUnhandledMatchErrorCaught(Node $node): bool

--- a/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
+++ b/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
@@ -24,6 +24,7 @@ final class TernaryOperatorConstantConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -65,6 +66,10 @@ final class TernaryOperatorConstantConditionRule implements Rule
 				'Ternary operator condition is always %s.',
 				$exprType->getValue() ? 'true' : 'false',
 			)))->identifier(sprintf('ternary.always%s', $exprType->getValue() ? 'True' : 'False'))->build();
+			if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+				$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
+				return [];
+			}
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
 				return [];
@@ -73,7 +78,11 @@ final class TernaryOperatorConstantConditionRule implements Rule
 			return [$ruleError];
 		}
 
-		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $node->cond);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		}
 		return [];
 	}
 

--- a/src/Rules/Comparison/WhileLoopAlwaysFalseConditionRule.php
+++ b/src/Rules/Comparison/WhileLoopAlwaysFalseConditionRule.php
@@ -24,6 +24,7 @@ final class WhileLoopAlwaysFalseConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -65,6 +66,10 @@ final class WhileLoopAlwaysFalseConditionRule implements Rule
 			$ruleError = $addTip(RuleErrorBuilder::message('While loop condition is always false.'))->line($node->cond->getStartLine())
 				->identifier('while.alwaysFalse')
 				->build();
+			if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+				$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $node->cond, false, $ruleError);
+				return [];
+			}
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, false, $ruleError);
 				return [];
@@ -73,7 +78,11 @@ final class WhileLoopAlwaysFalseConditionRule implements Rule
 			return [$ruleError];
 		}
 
-		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		if ($this->functionCallConstantConditionHelper->isTypeCheckCandidate($node->cond)) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $node->cond);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
+		}
 		return [];
 	}
 

--- a/src/Rules/Comparison/WhileLoopAlwaysTrueConditionRule.php
+++ b/src/Rules/Comparison/WhileLoopAlwaysTrueConditionRule.php
@@ -28,6 +28,7 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
 		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
+		private FunctionCallConstantConditionHelper $functionCallConstantConditionHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -71,16 +72,25 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 		}
 		$originalNode = $node->getOriginalNode();
 		$exprType = $this->helper->getBooleanType($scope, $originalNode->cond);
+		$isTypeCheckCandidate = $this->functionCallConstantConditionHelper->isTypeCheckCandidate($originalNode->cond);
 		if ($exprType->isTrue()->yes()) {
 			if ($node->hasYield()) {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
+				if ($isTypeCheckCandidate) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $originalNode->cond);
+				} else {
+					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
+				}
 				return [];
 			}
 
 			$ref = $scope->getFunction() ?? $scope->getAnonymousFunctionReflection();
 
 			if ($ref !== null && $ref->getReturnType() instanceof NeverType) {
-				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
+				if ($isTypeCheckCandidate) {
+					$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $originalNode->cond);
+				} else {
+					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
+				}
 				return [];
 			}
 
@@ -105,6 +115,10 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 			$ruleError = $addTip(RuleErrorBuilder::message('While loop condition is always true.'))->line($originalNode->cond->getStartLine())
 				->identifier('while.alwaysTrue')
 				->build();
+			if ($isTypeCheckCandidate) {
+				$this->functionCallConstantConditionHelper->emitFunctionCallError(self::class, $scope, $originalNode->cond, true, $ruleError);
+				return [];
+			}
 			if ($scope->isInTrait()) {
 				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->cond, true, $ruleError);
 				return [];
@@ -113,7 +127,11 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 			return [$ruleError];
 		}
 
-		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
+		if ($isTypeCheckCandidate) {
+			$this->functionCallConstantConditionHelper->emitFunctionCallNoError(self::class, $scope, $originalNode->cond);
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
+		}
 		return [];
 	}
 

--- a/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
@@ -24,19 +24,55 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new BooleanAndConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->treatPhpDocTypesAsCertain,
-					),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				$this->reportAlwaysTrueInLastCondition,
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}
@@ -354,6 +390,11 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 	{
 		yield [false, []];
 		yield [true, [
+			[
+				'Call to function is_string() with string will always evaluate to true.',
+				12,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
 			[
 				'Result of && is always false.',
 				15,

--- a/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
@@ -23,19 +23,55 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new BooleanNotConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->treatPhpDocTypesAsCertain,
-					),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				$this->reportAlwaysTrueInLastCondition,
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -24,19 +24,55 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new BooleanOrConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->treatPhpDocTypesAsCertain,
-					),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				$this->reportAlwaysTrueInLastCondition,
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
@@ -19,18 +19,54 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new DoWhileLoopConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->shouldTreatPhpDocTypesAsCertain(),
-					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -24,19 +24,55 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new ElseIfConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->treatPhpDocTypesAsCertain,
-					),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				$this->reportAlwaysTrueInLastCondition,
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -21,18 +21,54 @@ class IfConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new IfConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->treatPhpDocTypesAsCertain,
-					),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}
@@ -54,6 +90,10 @@ class IfConstantConditionRuleTest extends RuleTestCase
 			[
 				'If condition is always false.',
 				45,
+			],
+			[
+				'Call to function is_object() with object will always evaluate to true.',
+				93,
 			],
 			[
 				'If condition is always true.',
@@ -114,6 +154,11 @@ class IfConstantConditionRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4043.php'], [
+			[
+				'Call to function assert() with true will always evaluate to true.',
+				13,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
 			[
 				'If condition is always false.',
 				43,
@@ -258,6 +303,22 @@ class IfConstantConditionRuleTest extends RuleTestCase
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-6211.php'], [
 			[
+				'Call to function method_exists() with Bug6211\Hell and \'test\' will always evaluate to true.',
+				34,
+			],
+			[
+				'Call to function method_exists() with \'Bug6211\\\\Hell\' and \'test\' will always evaluate to true.',
+				39,
+			],
+			[
+				'Call to function method_exists() with Bug6211\Bar and \'realMethod\' will always evaluate to true.',
+				62,
+			],
+			[
+				'Call to function property_exists() with Bug6211\Baz and \'realProp\' will always evaluate to true.',
+				87,
+			],
+			[
 				'If condition is always true.',
 				93,
 			],
@@ -266,8 +327,29 @@ class IfConstantConditionRuleTest extends RuleTestCase
 				100,
 			],
 			[
+				'Call to function method_exists() with Bug6211\Hell and \'test\' will always evaluate to true.',
+				106,
+			],
+			[
+				'Call to function method_exists() with Bug6211\Hell and \'test\' will always evaluate to true.',
+				107,
+			],
+			[
 				'If condition is always true.',
 				114,
+			],
+			[
+				'Call to function property_exists() with Bug6211\Baz and \'realProp\' will always evaluate to true.',
+				120,
+			],
+			[
+				'Call to function property_exists() with Bug6211\Baz and \'realProp\' will always evaluate to true.',
+				121,
+			],
+			[
+				'Call to function method_exists() with class-string<Bug6211\Foo> and \'test\' will always evaluate to true.',
+				136,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);
 	}
@@ -285,6 +367,23 @@ class IfConstantConditionRuleTest extends RuleTestCase
 			[
 				'If condition is always true.',
 				23,
+			],
+		]);
+	}
+
+	public function testConstantConditionFunctionCall(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/constant-condition-function-call.php'], [
+			[
+				// type-check call: owned by the ImpossibleCheckType rule, reported only once
+				'Call to function is_int() with int will always evaluate to true.',
+				13,
+			],
+			[
+				// non-type-check, always-truthy return: reported by the constant-condition rule
+				'If condition is always true.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -34,6 +34,7 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				$this->reportAlwaysTrueInLastCondition,
 				true,

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
@@ -21,6 +21,7 @@ class ImpossibleCheckTypeGenericOverwriteRuleTest extends RuleTestCase
 			),
 			new PossiblyImpureTipHelper(true),
 			self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+			self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 			true,
 			false,
 			true,

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
@@ -21,6 +21,7 @@ class ImpossibleCheckTypeMethodCallRuleEqualsTest extends RuleTestCase
 			),
 			new PossiblyImpureTipHelper(true),
 			self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+			self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 			true,
 			false,
 			true,

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -30,6 +30,7 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				$this->reportAlwaysTrueInLastCondition,
 				true,

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
@@ -30,6 +30,7 @@ class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				$this->reportAlwaysTrueInLastCondition,
 				true,

--- a/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
@@ -19,19 +19,55 @@ class LogicalXorConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new LogicalXorConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->shouldTreatPhpDocTypesAsCertain(),
-					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
 				false,
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				false,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				false,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				false,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -21,17 +21,53 @@ class MatchExpressionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new MatchExpressionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->treatPhpDocTypesAsCertain,
-					),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}
@@ -307,7 +343,16 @@ class MatchExpressionRuleTest extends RuleTestCase
 	public function testBug8937(): void
 	{
 		$this->treatPhpDocTypesAsCertain = false;
-		$this->analyse([__DIR__ . '/data/bug-8937.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-8937.php'], [
+			[
+				'Call to function is_array() with array will always evaluate to true.',
+				23,
+			],
+			[
+				'Call to function is_array() with non-empty-array<string> will always evaluate to true.',
+				24,
+			],
+		]);
 	}
 
 	#[RequiresPhp('>= 8.0.0')]

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -21,18 +21,54 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new TernaryOperatorConstantConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->treatPhpDocTypesAsCertain,
-					),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
@@ -19,18 +19,54 @@ class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new WhileLoopAlwaysFalseConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->shouldTreatPhpDocTypesAsCertain(),
-					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysTrueConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysTrueConditionRuleTest.php
@@ -19,18 +19,54 @@ class WhileLoopAlwaysTrueConditionRuleTest extends RuleTestCase
 		return new CompositeRule([
 			new WhileLoopAlwaysTrueConditionRule(
 				new ConstantConditionRuleHelper(
-					new ImpossibleCheckTypeHelper(
-						self::createReflectionProvider(),
-						$this->getTypeSpecifier(),
-						$this->shouldTreatPhpDocTypesAsCertain(),
-					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
 				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
 				true,
 			),
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					$this->shouldTreatPhpDocTypesAsCertain(),
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				self::getContainer()->getByType(FunctionCallConstantConditionHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+				true,
+			),
+			new FunctionCallConstantConditionRule(),
 			new ConstantConditionInTraitRule(),
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/data/constant-condition-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/constant-condition-function-call.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ConstantConditionFunctionCall;
+
+function retObj(): object
+{
+	return new \stdClass();
+}
+
+function doFoo(int $int): void
+{
+	// reported by the ImpossibleCheckType rule, NOT by the constant-condition rule
+	if (is_int($int)) {
+		echo 'always';
+	}
+
+	// reported by the constant-condition rule: an always-truthy return
+	// that is not a type-check
+	if (retObj()) {
+		echo 'always';
+	}
+}


### PR DESCRIPTION
Extracted from the `resolve-type-rewrite-2` branch (follows #6125, #6129, #6130, #6131).

`ConstantConditionRuleHelper::shouldSkip()` asked the type specifier inline (via `ImpossibleCheckTypeHelper::findSpecifiedType()`) for every call-shaped condition, just to decide whether the impossible-check rule would own the report. The rework replaces that inline ask with collector-based reconciliation:

- Constant-condition rules defer call-shaped conditions into `FunctionCallConstantConditionCollector` instead of asking the type specifier.
- The three `ImpossibleCheckType*CallRule`s emit an "I reported here" marker into `ImpossibleCheckTypeReportedCollector` when they actually report.
- A new `FunctionCallConstantConditionRule` (`CollectedDataNode`, level 4) reconciles: deferred constant-condition errors at call sites the impossible-check rules claimed are dropped; the rest are emitted with the same trait "in context of" handling as `ConstantConditionInTraitRule`.

Net user-visible behavior is intended to be identical; the dedup key becomes "did the impossible-check rule actually report" rather than "does the helper think it's always-X", which also removes an on-demand type-specifier ask from the rule path (one step toward the single-pass analyser). Rule unit tests change shape: the `CompositeRule` setups now include the impossible-check rules, so previously invisible impossible-check errors in shared fixtures become explicit expectations.

Adapted from the branch commit to 2.2.x: the rules keep listening on raw `FuncCall`/`MethodCall`/`StaticCall` nodes and the 3-arg `ImpossibleCheckTypeHelper`.

Validation: full test suite green (17772 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b