### PR TITLE
Replace SpecifiedTypes::normalize() with symbolic alternative-form entries

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -69,7 +69,7 @@ parameters:
 		-
 			rawMessage: Casting to string something that's already string.
 			identifier: cast.useless
-			count: 1
+			count: 2
 			path: src/Analyser/MutatingScope.php
 
 		-

--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -105,9 +105,9 @@ final class BooleanAndHandler implements ExprHandler
 		if ($context->true()) {
 			$types = $leftTypes->unionWith($rightTypes);
 		} else {
-			$leftNormalized = $leftTypes->normalize($scope);
-			$rightNormalized = $rightTypes->normalize($rightScope);
-			$types = $leftNormalized->intersectWith($rightNormalized);
+			$leftNormalized = $this->conditionalExpressionHolderHelper->toSureTypes($leftTypes, $scope);
+			$rightNormalized = $this->conditionalExpressionHolderHelper->toSureTypes($rightTypes, $rightScope);
+			$types = $leftTypes->intersectWith($rightTypes);
 			$types = $this->conditionalExpressionHolderHelper->augmentDisjunctionTypes($scope, $rightScope, $leftNormalized, $rightNormalized, $expr->left, $expr->right, false, $types);
 		}
 		if ($context->false()) {
@@ -146,10 +146,10 @@ final class BooleanAndHandler implements ExprHandler
 					$rightCondTypes = new SpecifiedTypes($truthyRightTypes->getSureNotTypes(), $truthyRightTypes->getSureTypes());
 				}
 			}
-			$result = new SpecifiedTypes(
+			$result = (new SpecifiedTypes(
 				$types->getSureTypes(),
 				$types->getSureNotTypes(),
-			);
+			))->withAlternativeTypesOf($types);
 			if ($types->shouldOverwrite()) {
 				$result = $result->setAlwaysOverwriteTypes();
 			}

--- a/src/Analyser/ExprHandler/BooleanOrHandler.php
+++ b/src/Analyser/ExprHandler/BooleanOrHandler.php
@@ -148,16 +148,16 @@ final class BooleanOrHandler implements ExprHandler
 			if (
 				$scope->getType($expr->left)->toBoolean()->isFalse()->yes()
 			) {
-				$types = $rightTypes->normalize($rightScope);
+				$types = $this->conditionalExpressionHolderHelper->toSureTypes($rightTypes, $rightScope);
 			} elseif (
 				$scope->getType($expr->left)->toBoolean()->isTrue()->yes()
 				|| $scope->getType($expr->right)->toBoolean()->isFalse()->yes()
 			) {
-				$types = $leftTypes->normalize($scope);
+				$types = $this->conditionalExpressionHolderHelper->toSureTypes($leftTypes, $scope);
 			} else {
-				$leftNormalized = $leftTypes->normalize($scope);
-				$rightNormalized = $rightTypes->normalize($rightScope);
-				$types = $leftNormalized->intersectWith($rightNormalized);
+				$leftNormalized = $this->conditionalExpressionHolderHelper->toSureTypes($leftTypes, $scope);
+				$rightNormalized = $this->conditionalExpressionHolderHelper->toSureTypes($rightTypes, $rightScope);
+				$types = $leftTypes->intersectWith($rightTypes);
 				$types = $this->augmentBooleanOrTruthyWithConditionalHolders($typeSpecifier, $scope, $rightScope, $expr, $types);
 				$types = $this->conditionalExpressionHolderHelper->augmentDisjunctionTypes($scope, $rightScope, $leftNormalized, $rightNormalized, $expr->left, $expr->right, true, $types);
 			}
@@ -166,10 +166,10 @@ final class BooleanOrHandler implements ExprHandler
 		}
 
 		if ($context->true()) {
-			$result = new SpecifiedTypes(
+			$result = (new SpecifiedTypes(
 				$types->getSureTypes(),
 				$types->getSureNotTypes(),
-			);
+			))->withAlternativeTypesOf($types);
 			if ($types->shouldOverwrite()) {
 				$result = $result->setAlwaysOverwriteTypes();
 			}
@@ -243,7 +243,7 @@ final class BooleanOrHandler implements ExprHandler
 		$armSpecifiedTypes = [];
 		foreach ($arms as $arm) {
 			$armTypes = $typeSpecifier->specifyTypesInCondition($scope, $arm, $context);
-			$armSpecifiedTypes[] = $armTypes->normalize($scope);
+			$armSpecifiedTypes[] = $armTypes;
 		}
 
 		$types = $armSpecifiedTypes[0];
@@ -251,10 +251,10 @@ final class BooleanOrHandler implements ExprHandler
 			$types = $types->intersectWith($armSpecifiedTypes[$i]);
 		}
 
-		$result = new SpecifiedTypes(
+		$result = (new SpecifiedTypes(
 			$types->getSureTypes(),
 			$types->getSureNotTypes(),
-		);
+		))->withAlternativeTypesOf($types);
 		if ($types->shouldOverwrite()) {
 			$result = $result->setAlwaysOverwriteTypes();
 		}

--- a/src/Analyser/ExprHandler/Helper/ConditionalExpressionHolderHelper.php
+++ b/src/Analyser/ExprHandler/Helper/ConditionalExpressionHolderHelper.php
@@ -56,10 +56,13 @@ final class ConditionalExpressionHolderHelper
 		}
 
 		$existingSureTypes = $types->getSureTypes();
+		$existingAlternativeTypes = $types->getAlternativeTypes();
 
 		$viableCandidates = [];
 		foreach ($candidateExprs as $exprString => $targetExpr) {
-			if (isset($existingSureTypes[$exprString])) {
+			if (isset($existingSureTypes[$exprString]) || isset($existingAlternativeTypes[$exprString])) {
+				// an alternative-form entry already encodes the either-branch
+				// union for this expression, deferred to the application point
 				continue;
 			}
 			if (!$scope->hasExpressionType($targetExpr)->yes()) {
@@ -296,6 +299,35 @@ final class ConditionalExpressionHolderHelper
 		return $expr instanceof Expr\PropertyFetch
 			|| $expr instanceof Expr\ArrayDimFetch
 			|| $expr instanceof Expr\StaticPropertyFetch;
+	}
+
+	/**
+	 * The eager form of the old SpecifiedTypes::normalize(): folds sure-not
+	 * entries into sure entries by subtracting from the expression's type on
+	 * the given scope. Only for consumers that need concrete sure types at
+	 * composition time (conditional-holder building, decided operands) -
+	 * merge paths use SpecifiedTypes::intersectWith() and evaluate at the
+	 * application point instead.
+	 */
+	public function toSureTypes(SpecifiedTypes $types, Scope $scope): SpecifiedTypes
+	{
+		$sureTypes = $types->getSureTypes();
+
+		foreach ($types->getSureNotTypes() as $exprString => [$exprNode, $sureNotType]) {
+			if (!isset($sureTypes[$exprString])) {
+				$sureTypes[$exprString] = [$exprNode, TypeCombinator::remove($scope->getType($exprNode), $sureNotType)];
+				continue;
+			}
+
+			$sureTypes[$exprString][1] = TypeCombinator::remove($sureTypes[$exprString][1], $sureNotType);
+		}
+
+		$result = new SpecifiedTypes($sureTypes, []);
+		if ($types->shouldOverwrite()) {
+			$result = $result->setAlwaysOverwriteTypes();
+		}
+
+		return $result->setRootExpr($types->getRootExpr());
 	}
 
 }

--- a/src/Analyser/ExprHandler/Helper/EqualityTypeSpecifyingHelper.php
+++ b/src/Analyser/ExprHandler/Helper/EqualityTypeSpecifyingHelper.php
@@ -246,7 +246,7 @@ final class EqualityTypeSpecifyingHelper
 
 		return $context->true()
 			? $leftTypes->unionWith($rightTypes)
-			: $leftTypes->normalize($scope)->intersectWith($rightTypes->normalize($scope));
+			: $leftTypes->intersectWith($rightTypes);
 	}
 
 	public function specifyTypesForIdentical(Expr\BinaryOp\Identical $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
@@ -750,8 +750,8 @@ final class EqualityTypeSpecifyingHelper
 			}
 			return $leftTypes->unionWith($rightTypes);
 		} elseif ($context->false()) {
-			return $this->typeSpecifier->create($leftExpr, $leftType, $context, $scope)->setRootExpr($expr)->normalize($scope)
-				->intersectWith($this->typeSpecifier->create($rightExpr, $rightType, $context, $scope)->setRootExpr($expr)->normalize($scope));
+			return $this->typeSpecifier->create($leftExpr, $leftType, $context, $scope)->setRootExpr($expr)
+				->intersectWith($this->typeSpecifier->create($rightExpr, $rightType, $context, $scope)->setRootExpr($expr));
 		}
 
 		return (new SpecifiedTypes([], []))->setRootExpr($expr);

--- a/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
+++ b/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
@@ -81,7 +81,7 @@ final class NullsafeMethodCallHandler implements ExprHandler
 		)->setRootExpr($expr);
 
 		$nullSafeTypes = $typeSpecifier->handleDefaultTruthyOrFalseyContext($context, $expr, $scope);
-		return $context->true() ? $types->unionWith($nullSafeTypes) : $types->normalize($scope)->intersectWith($nullSafeTypes->normalize($scope));
+		return $context->true() ? $types->unionWith($nullSafeTypes) : $types->intersectWith($nullSafeTypes);
 	}
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult

--- a/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
@@ -81,7 +81,7 @@ final class NullsafePropertyFetchHandler implements ExprHandler
 		)->setRootExpr($expr);
 
 		$nullSafeTypes = $typeSpecifier->handleDefaultTruthyOrFalseyContext($context, $expr, $scope);
-		return $context->true() ? $types->unionWith($nullSafeTypes) : $types->normalize($scope)->intersectWith($nullSafeTypes->normalize($scope));
+		return $context->true() ? $types->unionWith($nullSafeTypes) : $types->intersectWith($nullSafeTypes);
 	}
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3308,11 +3308,26 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	{
 		$typeSpecifications = ScopeOps::buildTypeSpecifications($specifiedTypes->getSureTypes(), $specifiedTypes->getSureNotTypes());
 
+		foreach ($specifiedTypes->getAlternativeTypes() as $exprString => [$alternativeExpr, $terms]) {
+			if (
+				$alternativeExpr instanceof Node\Scalar
+				|| $alternativeExpr instanceof Expr\Array_
+				|| ($alternativeExpr instanceof Expr\UnaryMinus && $alternativeExpr->expr instanceof Node\Scalar)
+			) {
+				continue;
+			}
+			$typeSpecifications[] = [
+				'sure' => true,
+				'exprString' => (string) $exprString,
+				'expr' => $alternativeExpr,
+				'terms' => $terms,
+			];
+		}
+
 		$scope = $this;
 		$specifiedExpressions = [];
 		foreach ($typeSpecifications as $typeSpecification) {
 			$expr = $typeSpecification['expr'];
-			$type = $typeSpecification['type'];
 
 			if ($expr instanceof IssetExpr) {
 				$issetExpr = $expr;
@@ -3341,6 +3356,36 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				continue;
 			}
 
+			if (isset($typeSpecification['terms'])) {
+				// an alternative-form entry: the union over its terms of
+				// `(sure ?? current) minus subtract`, evaluated here at the
+				// application point - the deferred descendant of the old
+				// SpecifiedTypes::normalize()
+				$evaluate = static function (Type $current) use ($typeSpecification): Type {
+					$parts = [];
+					foreach ($typeSpecification['terms'] as [$sure, $subtract]) {
+						$base = $sure ?? $current;
+						$parts[] = $subtract !== null ? TypeCombinator::remove($base, $subtract) : $base;
+					}
+
+					return TypeCombinator::union(...$parts);
+				};
+				$originalExprType = $scope->getType($expr);
+				if (!$scope->isComplexUnionType($originalExprType)) {
+					$nativeType = $scope->getNativeType($expr);
+					$scope = $scope->specifyExpressionType(
+						$expr,
+						TypeCombinator::intersect($evaluate($originalExprType), $originalExprType),
+						TypeCombinator::intersect($evaluate($nativeType), $nativeType),
+						TrinaryLogic::createYes(),
+					);
+					$specifiedExpressions[$typeSpecification['exprString']] = ExpressionTypeHolder::createYes($expr, $scope->getScopeType($expr));
+				}
+
+				continue;
+			}
+
+			$type = $typeSpecification['type'];
 			if ($typeSpecification['sure']) {
 				if ($specifiedTypes->shouldOverwrite()) {
 					$scope = $scope->assignExpression($expr, $type, $type);

--- a/src/Analyser/SpecifiedTypes.php
+++ b/src/Analyser/SpecifiedTypes.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PhpParser\Node\Expr;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
@@ -17,6 +18,19 @@ final class SpecifiedTypes
 	private array $newConditionalExpressionHolders = [];
 
 	private ?Expr $rootExpr = null;
+
+	/**
+	 * Alternative-form entries produced by intersectWith() when the two sides
+	 * constrain the same expression with different kinds (a sure type in one
+	 * branch, a sure-not in the other). Each term (sure, subtract) reads as
+	 * `(sure ?? current type) minus subtract`; the entry's value is the union
+	 * of its terms, evaluated by MutatingScope::applySpecifiedTypes() against
+	 * the subject's type at the application point - the deferred form of what
+	 * the old SpecifiedTypes::normalize() computed eagerly with a scope.
+	 *
+	 * @var array<string, array{Expr, list<array{?Type, ?Type}>}>
+	 */
+	private array $alternativeTypes = [];
 
 	/**
 	 * @api
@@ -50,6 +64,7 @@ final class SpecifiedTypes
 	public function setAlwaysOverwriteTypes(): self
 	{
 		$self = new self($this->sureTypes, $this->sureNotTypes);
+		$self->alternativeTypes = $this->alternativeTypes;
 		$self->overwrite = true;
 		$self->newConditionalExpressionHolders = $this->newConditionalExpressionHolders;
 		$self->rootExpr = $this->rootExpr;
@@ -63,6 +78,7 @@ final class SpecifiedTypes
 	public function setRootExpr(?Expr $rootExpr): self
 	{
 		$self = new self($this->sureTypes, $this->sureNotTypes);
+		$self->alternativeTypes = $this->alternativeTypes;
 		$self->overwrite = $this->overwrite;
 		$self->newConditionalExpressionHolders = $this->newConditionalExpressionHolders;
 		$self->rootExpr = $rootExpr;
@@ -76,6 +92,7 @@ final class SpecifiedTypes
 	public function setNewConditionalExpressionHolders(array $newConditionalExpressionHolders): self
 	{
 		$self = new self($this->sureTypes, $this->sureNotTypes);
+		$self->alternativeTypes = $this->alternativeTypes;
 		$self->overwrite = $this->overwrite;
 		$self->newConditionalExpressionHolders = $newConditionalExpressionHolders;
 		$self->rootExpr = $this->rootExpr;
@@ -101,6 +118,30 @@ final class SpecifiedTypes
 		return $this->sureNotTypes;
 	}
 
+	/**
+	 * @return array<string, array{Expr, list<array{?Type, ?Type}>}>
+	 */
+	public function getAlternativeTypes(): array
+	{
+		return $this->alternativeTypes;
+	}
+
+	/**
+	 * A copy of this with the other's alternative-form entries - for the
+	 * composition tails that rebuild a SpecifiedTypes from the sure/sure-not
+	 * slots and must not drop the merged alternatives.
+	 */
+	public function withAlternativeTypesOf(self $other): self
+	{
+		$self = new self($this->sureTypes, $this->sureNotTypes);
+		$self->alternativeTypes = $other->alternativeTypes;
+		$self->overwrite = $this->overwrite;
+		$self->newConditionalExpressionHolders = $this->newConditionalExpressionHolders;
+		$self->rootExpr = $this->rootExpr;
+
+		return $self;
+	}
+
 	public function shouldOverwrite(): bool
 	{
 		return $this->overwrite;
@@ -123,10 +164,13 @@ final class SpecifiedTypes
 	{
 		$sureTypes = $this->sureTypes;
 		$sureNotTypes = $this->sureNotTypes;
+		$alternativeTypes = $this->alternativeTypes;
 		unset($sureTypes[$exprString]);
 		unset($sureNotTypes[$exprString]);
+		unset($alternativeTypes[$exprString]);
 
 		$self = new self($sureTypes, $sureNotTypes);
+		$self->alternativeTypes = $alternativeTypes;
 		$self->overwrite = $this->overwrite;
 		$self->newConditionalExpressionHolders = $this->newConditionalExpressionHolders;
 		$self->rootExpr = $this->rootExpr;
@@ -134,41 +178,126 @@ final class SpecifiedTypes
 		return $self;
 	}
 
-	/** @api */
+	/**
+	 * The either-branch merge: the result holds when at least one side holds
+	 * (the falsey narrowing of `&&`, the truthy narrowing of `||`). Same-kind
+	 * constraints merge exactly (sure: union of values, sure-not: intersection
+	 * of removed types); an expression constrained with different kinds on the
+	 * two sides becomes an alternative-form entry - `(sure ?? current) minus
+	 * subtract` per side, united at the application point. An expression
+	 * constrained on only one side is unconstrained in the merge.
+	 *
+	 * @api
+	 */
 	public function intersectWith(SpecifiedTypes $other): self
 	{
 		$sureTypeUnion = [];
 		$sureNotTypeUnion = [];
+		$alternativeUnion = [];
 		$rootExpr = $this->mergeRootExpr($this->rootExpr, $other->rootExpr);
 
-		foreach ($this->sureTypes as $exprString => [$exprNode, $type]) {
-			if (!isset($other->sureTypes[$exprString])) {
-				continue;
+		$keys = [];
+		foreach ([$this->sureTypes, $this->sureNotTypes, $this->alternativeTypes, $other->sureTypes, $other->sureNotTypes, $other->alternativeTypes] as $map) {
+			foreach ($map as $exprString => $entry) {
+				$keys[$exprString] = $entry[0];
 			}
-
-			$sureTypeUnion[$exprString] = [
-				$exprNode,
-				TypeCombinator::union($type, $other->sureTypes[$exprString][1]),
-			];
 		}
 
-		foreach ($this->sureNotTypes as $exprString => [$exprNode, $type]) {
-			if (!isset($other->sureNotTypes[$exprString])) {
+		foreach ($keys as $exprString => $exprNode) {
+			$thisTerms = $this->collectTerms($exprString);
+			$otherTerms = $other->collectTerms($exprString);
+			if ($thisTerms === null || $otherTerms === null) {
+				// unconstrained on one side - unconstrained in the merge
 				continue;
 			}
 
-			$sureNotTypeUnion[$exprString] = [
-				$exprNode,
-				TypeCombinator::intersect($type, $other->sureNotTypes[$exprString][1]),
-			];
+			$terms = array_merge($thisTerms, $otherTerms);
+			$sures = [];
+			$subtracts = [];
+			$pureSure = true;
+			$pureSureNot = true;
+			foreach ($terms as [$sure, $subtract]) {
+				if ($sure === null) {
+					$pureSure = false;
+				} else {
+					$sures[] = $sure;
+				}
+				if ($subtract === null) {
+					$pureSureNot = false;
+				} else {
+					$subtracts[] = $subtract;
+				}
+				if ($sure === null || $subtract === null) {
+					continue;
+				}
+
+				$pureSure = false;
+				$pureSureNot = false;
+			}
+
+			if ($pureSure) {
+				$sureTypeUnion[$exprString] = [$exprNode, TypeCombinator::union(...$sures)];
+			} elseif ($pureSureNot) {
+				$merged = TypeCombinator::intersect(...$subtracts);
+				if ($merged instanceof NeverType) {
+					// removing never removes nothing - a vacuous constraint
+					continue;
+				}
+				$sureNotTypeUnion[$exprString] = [$exprNode, $merged];
+			} else {
+				$alternativeUnion[$exprString] = [$exprNode, $terms];
+			}
 		}
 
 		$result = new self($sureTypeUnion, $sureNotTypeUnion);
+		$result->alternativeTypes = $alternativeUnion;
 		if ($this->overwrite && $other->overwrite) {
 			$result = $result->setAlwaysOverwriteTypes();
 		}
 
 		return $result->setRootExpr($rootExpr);
+	}
+
+	/**
+	 * This side's constraint on the expression as alternative-form terms, or
+	 * null when unconstrained. A sure and a sure-not on the same key are one
+	 * term (the sure with the sure-not removed) - both constraints hold here.
+	 *
+	 * @return list<array{?Type, ?Type}>|null
+	 */
+	private function collectTerms(string|int $exprString): ?array
+	{
+		if (isset($this->alternativeTypes[$exprString])) {
+			$terms = $this->alternativeTypes[$exprString][1];
+			// sure/sureNot on the same key as an alternative entry: fold them
+			// into every term (they hold in addition to the alternatives)
+			if (isset($this->sureTypes[$exprString]) || isset($this->sureNotTypes[$exprString])) {
+				$extraSure = $this->sureTypes[$exprString][1] ?? null;
+				$extraSubtract = $this->sureNotTypes[$exprString][1] ?? null;
+				$folded = [];
+				foreach ($terms as [$sure, $subtract]) {
+					if ($extraSure !== null) {
+						$sure = $sure === null ? $extraSure : TypeCombinator::intersect($sure, $extraSure);
+					}
+					if ($extraSubtract !== null) {
+						$subtract = $subtract === null ? $extraSubtract : TypeCombinator::union($subtract, $extraSubtract);
+					}
+					$folded[] = [$sure, $subtract];
+				}
+
+				return $folded;
+			}
+
+			return $terms;
+		}
+
+		$sure = $this->sureTypes[$exprString][1] ?? null;
+		$subtract = $this->sureNotTypes[$exprString][1] ?? null;
+		if ($sure === null && $subtract === null) {
+			return null;
+		}
+
+		return [[$sure, $subtract]];
 	}
 
 	/** @api */
@@ -201,6 +330,7 @@ final class SpecifiedTypes
 		}
 
 		$result = new self($sureTypeUnion, $sureNotTypeUnion);
+		$result->alternativeTypes = $this->alternativeTypes + $other->alternativeTypes;
 		if ($this->overwrite || $other->overwrite) {
 			$result = $result->setAlwaysOverwriteTypes();
 		}
@@ -216,27 +346,6 @@ final class SpecifiedTypes
 		$result->newConditionalExpressionHolders = $conditionalExpressionHolders;
 
 		return $result->setRootExpr($rootExpr);
-	}
-
-	public function normalize(Scope $scope): self
-	{
-		$sureTypes = $this->sureTypes;
-
-		foreach ($this->sureNotTypes as $exprString => [$exprNode, $sureNotType]) {
-			if (!isset($sureTypes[$exprString])) {
-				$sureTypes[$exprString] = [$exprNode, TypeCombinator::remove($scope->getType($exprNode), $sureNotType)];
-				continue;
-			}
-
-			$sureTypes[$exprString][1] = TypeCombinator::remove($sureTypes[$exprString][1], $sureNotType);
-		}
-
-		$result = new self($sureTypes, []);
-		if ($this->overwrite) {
-			$result = $result->setAlwaysOverwriteTypes();
-		}
-
-		return $result->setRootExpr($this->rootExpr);
 	}
 
 	private function mergeRootExpr(?Expr $rootExprA, ?Expr $rootExprB): ?Expr

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -91,7 +91,7 @@ final class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
 				}
 
 				$combinedMultipleItems = true;
-				$types = $context->true() ? $types->normalize($scope)->intersectWith($itemTypes->normalize($scope)) : $types->unionWith($itemTypes);
+				$types = $context->true() ? $types->intersectWith($itemTypes) : $types->unionWith($itemTypes);
 			}
 
 			if ($types !== null) {

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -34,6 +34,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -377,7 +378,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					self::createFunctionCall('random'),
 				),
 				[],
-				['$foo' => 'mixed'],
+				[],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -409,7 +410,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					),
 					self::createFunctionCall('random'),
 				),
-				['$foo' => 'mixed'],
+				[],
 				[],
 			],
 
@@ -1195,7 +1196,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-string|null'],
-				['$a' => 'mixed~non-empty-string & ~null'],
+				['$a' => '~null & mixed~non-empty-string'],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -1209,7 +1210,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-string|null'],
-				['$a' => 'mixed~non-empty-string & ~null'],
+				['$a' => '~non-empty-string|null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -1223,7 +1224,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-array<mixed, mixed>|null'],
-				['$a' => 'mixed~non-empty-array<mixed, mixed> & ~null'],
+				['$a' => '~non-empty-array<mixed, mixed>|null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanAnd(
@@ -1339,6 +1340,18 @@ class TypeSpecifierTest extends PHPStanTestCase
 
 		foreach ($specifiedTypes->getSureNotTypes() as $exprString => [$exprNode, $exprType]) {
 			$typesDescription[$exprString][] = '~' . $exprType->describe(VerbosityLevel::precise());
+		}
+
+		foreach ($specifiedTypes->getAlternativeTypes() as $exprString => [$exprNode, $terms]) {
+			// evaluate the alternative-form entry against the test scope, the
+			// same way filterBySpecifiedTypes() evaluates it at the application
+			// point - the readable result matches the old eager normalize form
+			$parts = [];
+			foreach ($terms as [$sure, $subtract]) {
+				$base = $sure ?? $this->scope->getType($exprNode);
+				$parts[] = $subtract !== null ? TypeCombinator::remove($base, $subtract) : $base;
+			}
+			$typesDescription[$exprString][] = TypeCombinator::union(...$parts)->describe(VerbosityLevel::precise());
 		}
 
 		$descriptions = [];

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use Override;
+use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Equal;
@@ -1323,6 +1324,52 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'(int) $float' => 'int',
 				],
 				[],
+			],
+			[
+				new Expr\NullsafeMethodCall(new Variable('fooOrNull'), new Identifier('doFoo')),
+				['$fooOrNull' => '~null'],
+				[],
+			],
+			[
+				new FuncCall(new Name('in_array'), [
+					new Arg(new Variable('string')),
+					new Arg(new Expr\Array_([
+						new Node\ArrayItem(new String_('foo')),
+						new Node\ArrayItem(new String_('bar')),
+					])),
+					new Arg(new ConstFetch(new Name('true'))),
+				]),
+				['$string' => '\'bar\'|\'foo\''],
+				['$string' => '~\'bar\'|\'foo\''],
+			],
+			[
+				new NotIdentical(
+					new Expr\NullsafeMethodCall(new Variable('fooOrNull'), new Identifier('doFoo')),
+					new ConstFetch(new Name('true')),
+				),
+				['$fooOrNull?->doFoo()' => '~true'],
+				['$fooOrNull' => '~null'],
+			],
+			[
+				new NotIdentical(
+					new FuncCall(new Name('in_array'), [
+						new Arg(new Variable('string')),
+						new Arg(new Expr\Array_([
+							new Node\ArrayItem(new String_('foo')),
+							new Node\ArrayItem(new String_('bar')),
+						])),
+						new Arg(new ConstFetch(new Name('true'))),
+					]),
+					new ConstFetch(new Name('true')),
+				),
+				[
+					'in_array($string, [\'foo\', \'bar\'], true)' => '~true',
+					'$string' => '~\'bar\'|\'foo\'',
+				],
+				[
+					'in_array($string, [\'foo\', \'bar\'], true)' => 'true',
+					'$string' => '\'bar\'|\'foo\'',
+				],
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-3991.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3991.php
@@ -18,11 +18,7 @@ class Foo
 		assertType('array|stdClass|null', $config);
 		if (empty($config))
 		{
-			// the native type should be `0|0.0|''|'0'|array{}|false|null`
-			// the problem is that `empty($config)` translates to `!isset($config) || !$config`
-			// and before specified types of the left and right side are intersected they are "normalized"
-			// by removing the sureNotType from $scope->getType() which is `stdClass|array|null` here
-			assertNativeType('array{}|null', $config);
+			assertNativeType('0|0.0|\'\'|\'0\'|array{}|false|null', $config);
 			assertType('array{}|null', $config);
 			$config = new \stdClass();
 		} elseif (! (is_array($config) || $config instanceof \stdClass)) {


### PR DESCRIPTION
Extracted from the `resolve-type-rewrite-2` branch (follows #6125, #6129, #6130, #6131, #6132) — re-authored against 2.2.x rather than cherry-picked, since the branch version is written against its callback world.

`SpecifiedTypes::normalize()` eagerly folded sure-not entries into sure entries by subtracting from `$scope->getType()` at composition time — baking the composing scope's view into the narrowing and producing artifacts when the merge result is applied elsewhere (bug-3991's fixture documents one). `intersectWith()` now emits symbolic alternative-form entries — `(sure ?? current) minus subtract` terms, united — and `MutatingScope::filterBySpecifiedTypes()` evaluates them at the application point, separately for the PHPDoc and native views. `normalize()` is deleted (public but not `@api`).

- Same-kind merges stay exact (sure → union, sure-not → intersect); vacuous never-subtractions collapse, so `['$foo' => 'mixed']`-style no-op entries disappear.
- Composition-time consumers of concrete sure types (conditional-holder building, decided boolean operands) use the new eager `ConditionalExpressionHolderHelper::toSureTypes()` — behavior-preserving at those sites.
- The disjunction union recovery skips keys carrying an alternative entry, as it skipped keys with an eager merge entry before.
- Expectation changes: five `TypeSpecifierTest` rows (vacuous-mixed entries gone, symbolic falsey forms) and the bug-3991 native type, which now matches what the fixture's own comment always said it should be.

Validation: full test suite green (17772 tests), self-analysis clean (one baseline count bump for the new `(string)` cast), code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b