### PR TITLE
Resolve early-terminating calls to an explicit never type in the call handlers

### DIFF
--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -19,6 +19,7 @@ use PHPStan\Analyser\ExpressionResult;
 use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
+use PHPStan\Analyser\ExprHandler\Helper\EarlyTerminatingCallHelper;
 use PHPStan\Analyser\ExprHandler\Helper\OutputBufferHelper;
 use PHPStan\Analyser\ExprHandler\Helper\VoidToNullTypeTransformer;
 use PHPStan\Analyser\ImpurePoint;
@@ -95,6 +96,7 @@ final class FuncCallHandler implements ExprHandler
 	 * @param ExtensionsCollection<DynamicFunctionThrowTypeExtension> $dynamicFunctionThrowTypeExtensions
 	 */
 	public function __construct(
+		private EarlyTerminatingCallHelper $earlyTerminatingCallHelper,
 		private ReflectionProvider $reflectionProvider,
 		#[AutowiredExtensions(of: DynamicFunctionThrowTypeExtension::class)]
 		private ExtensionsCollection $dynamicFunctionThrowTypeExtensions,
@@ -811,6 +813,13 @@ final class FuncCallHandler implements ExprHandler
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type
 	{
+		if (
+			$expr->name instanceof Name
+			&& $this->earlyTerminatingCallHelper->isEarlyTerminatingFunctionCall($expr->name->toString())
+		) {
+			return new NeverType(true);
+		}
+
 		if ($expr->name instanceof Expr) {
 			$calledOnType = $scope->getType($expr->name);
 			if ($calledOnType->isCallable()->no()) {

--- a/src/Analyser/ExprHandler/Helper/EarlyTerminatingCallHelper.php
+++ b/src/Analyser/ExprHandler/Helper/EarlyTerminatingCallHelper.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ExprHandler\Helper;
+
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Type;
+use function array_key_exists;
+use function array_merge;
+use function in_array;
+use function strtolower;
+
+/**
+ * Decides whether a method/function call is configured as early-terminating
+ * (`parameters.earlyTerminatingMethodCalls` / `earlyTerminatingFunctionCalls`).
+ * The call handlers use this to give such a call an explicit NeverType, from
+ * which NodeScopeResolver derives the statement's exit point - so the engine no
+ * longer reaches Scope::getType() to find early-terminating expressions.
+ */
+#[AutowiredService]
+final class EarlyTerminatingCallHelper
+{
+
+	/** @var array<string, true> */
+	private array $earlyTerminatingMethodNames;
+
+	/**
+	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])
+	 * @param array<int, string> $earlyTerminatingFunctionCalls
+	 */
+	public function __construct(
+		private ReflectionProvider $reflectionProvider,
+		#[AutowiredParameter]
+		private array $earlyTerminatingMethodCalls,
+		#[AutowiredParameter]
+		private array $earlyTerminatingFunctionCalls,
+	)
+	{
+		$earlyTerminatingMethodNames = [];
+		foreach ($this->earlyTerminatingMethodCalls as $methodNames) {
+			foreach ($methodNames as $methodName) {
+				$earlyTerminatingMethodNames[strtolower($methodName)] = true;
+			}
+		}
+		$this->earlyTerminatingMethodNames = $earlyTerminatingMethodNames;
+	}
+
+	public function isEarlyTerminatingMethodCall(string $methodName, Type $calledOnType): bool
+	{
+		if (!array_key_exists(strtolower($methodName), $this->earlyTerminatingMethodNames)) {
+			return false;
+		}
+
+		foreach ($calledOnType->getObjectClassNames() as $referencedClass) {
+			if (!$this->reflectionProvider->hasClass($referencedClass)) {
+				continue;
+			}
+
+			$classReflection = $this->reflectionProvider->getClass($referencedClass);
+			foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
+				if (!isset($this->earlyTerminatingMethodCalls[$className])) {
+					continue;
+				}
+
+				if (in_array($methodName, $this->earlyTerminatingMethodCalls[$className], true)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public function isEarlyTerminatingFunctionCall(string $functionName): bool
+	{
+		return in_array($functionName, $this->earlyTerminatingFunctionCalls, true);
+	}
+
+}

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\ExpressionResult;
 use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
+use PHPStan\Analyser\ExprHandler\Helper\EarlyTerminatingCallHelper;
 use PHPStan\Analyser\ExprHandler\Helper\MethodCallReturnTypeHelper;
 use PHPStan\Analyser\ExprHandler\Helper\MethodThrowPointHelper;
 use PHPStan\Analyser\ExprHandler\Helper\NullsafeShortCircuitingHelper;
@@ -56,6 +57,7 @@ final class MethodCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private EarlyTerminatingCallHelper $earlyTerminatingCallHelper,
 		private MethodCallReturnTypeHelper $methodCallReturnTypeHelper,
 		private MethodThrowPointHelper $methodThrowPointHelper,
 		private ReflectionProvider $reflectionProvider,
@@ -246,6 +248,13 @@ final class MethodCallHandler implements ExprHandler
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type
 	{
+		if (
+			$expr->name instanceof Identifier
+			&& $this->earlyTerminatingCallHelper->isEarlyTerminatingMethodCall($expr->name->name, $scope->getType($expr->var))
+		) {
+			return new NeverType(true);
+		}
+
 		if ($expr->name instanceof Identifier) {
 			if ($scope->nativeTypesPromoted) {
 				$methodReflection = $scope->getMethodReflection(

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -17,6 +17,7 @@ use PHPStan\Analyser\ExpressionResult;
 use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
+use PHPStan\Analyser\ExprHandler\Helper\EarlyTerminatingCallHelper;
 use PHPStan\Analyser\ExprHandler\Helper\MethodCallReturnTypeHelper;
 use PHPStan\Analyser\ExprHandler\Helper\MethodThrowPointHelper;
 use PHPStan\Analyser\ExprHandler\Helper\NullsafeShortCircuitingHelper;
@@ -64,6 +65,7 @@ final class StaticCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private EarlyTerminatingCallHelper $earlyTerminatingCallHelper,
 		private MethodCallReturnTypeHelper $methodCallReturnTypeHelper,
 		private MethodThrowPointHelper $methodThrowPointHelper,
 		private ReflectionProvider $reflectionProvider,
@@ -302,6 +304,15 @@ final class StaticCallHandler implements ExprHandler
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type
 	{
+		if ($expr->name instanceof Identifier) {
+			$earlyTerminatingClassType = $expr->class instanceof Name
+				? $scope->resolveTypeByName($expr->class)
+				: $scope->getType($expr->class);
+			if ($this->earlyTerminatingCallHelper->isEarlyTerminatingMethodCall($expr->name->name, $earlyTerminatingClassType)) {
+				return new NeverType(true);
+			}
+		}
+
 		if ($expr->name instanceof Identifier) {
 			if ($scope->nativeTypesPromoted) {
 				if ($expr->class instanceof Name) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -206,17 +206,12 @@ class NodeScopeResolver
 	private array $analysedFiles = [];
 
 	/** @var array<string, true> */
-	private array $earlyTerminatingMethodNames;
-
-	/** @var array<string, true> */
 	private array $calledMethodStack = [];
 
 	/** @var array<string, MutatingScope|null> */
 	private array $calledMethodResults = [];
 
 	/**
-	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])
-	 * @param array<int, string> $earlyTerminatingFunctionCalls
 	 * @param ExtensionsCollection<FunctionParameterOutTypeExtension> $functionParameterOutTypeExtensions
 	 * @param ExtensionsCollection<MethodParameterOutTypeExtension> $methodParameterOutTypeExtensions
 	 * @param ExtensionsCollection<StaticMethodParameterOutTypeExtension> $staticMethodParameterOutTypeExtensions
@@ -268,10 +263,6 @@ class NodeScopeResolver
 		private readonly bool $polluteScopeWithAlwaysIterableForeach,
 		#[AutowiredParameter]
 		private readonly bool $polluteScopeWithBlock,
-		#[AutowiredParameter]
-		private readonly array $earlyTerminatingMethodCalls,
-		#[AutowiredParameter]
-		private readonly array $earlyTerminatingFunctionCalls,
 		#[AutowiredParameter(ref: '%exceptions.implicitThrows%')]
 		private readonly bool $implicitThrows,
 		#[AutowiredParameter]
@@ -280,13 +271,6 @@ class NodeScopeResolver
 		protected readonly ExpressionResultFactory $expressionResultFactory,
 	)
 	{
-		$earlyTerminatingMethodNames = [];
-		foreach ($this->earlyTerminatingMethodCalls as $methodNames) {
-			foreach ($methodNames as $methodName) {
-				$earlyTerminatingMethodNames[strtolower($methodName)] = true;
-			}
-		}
-		$this->earlyTerminatingMethodNames = $earlyTerminatingMethodNames;
 	}
 
 	/**
@@ -2758,43 +2742,6 @@ class NodeScopeResolver
 
 	private function findEarlyTerminatingExpr(Expr $expr, Scope $scope): ?Expr
 	{
-		if (($expr instanceof MethodCall || $expr instanceof Expr\StaticCall) && $expr->name instanceof Node\Identifier) {
-			if (array_key_exists($expr->name->toLowerString(), $this->earlyTerminatingMethodNames)) {
-				if ($expr instanceof MethodCall) {
-					$methodCalledOnType = $scope->getType($expr->var);
-				} else {
-					if ($expr->class instanceof Name) {
-						$methodCalledOnType = $scope->resolveTypeByName($expr->class);
-					} else {
-						$methodCalledOnType = $scope->getType($expr->class);
-					}
-				}
-
-				foreach ($methodCalledOnType->getObjectClassNames() as $referencedClass) {
-					if (!$this->reflectionProvider->hasClass($referencedClass)) {
-						continue;
-					}
-
-					$classReflection = $this->reflectionProvider->getClass($referencedClass);
-					foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
-						if (!isset($this->earlyTerminatingMethodCalls[$className])) {
-							continue;
-						}
-
-						if (in_array((string) $expr->name, $this->earlyTerminatingMethodCalls[$className], true)) {
-							return $expr;
-						}
-					}
-				}
-			}
-		}
-
-		if ($expr instanceof FuncCall && $expr->name instanceof Name) {
-			if (in_array((string) $expr->name, $this->earlyTerminatingFunctionCalls, true)) {
-				return $expr;
-			}
-		}
-
 		if ($expr instanceof Expr\Exit_ || $expr instanceof Expr\Throw_) {
 			return $expr;
 		}

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -126,8 +126,6 @@ abstract class RuleTestCase extends PHPStanTestCase
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),
 			self::getContainer()->getParameter('polluteScopeWithBlock'),
-			[],
-			[],
 			self::getContainer()->getParameter('exceptions')['implicitThrows'],
 			$this->shouldTreatPhpDocTypesAsCertain(),
 			self::getContainer()->getByType(ImplicitToStringCallHelper::class),

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -101,8 +101,6 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),
 			$container->getParameter('polluteScopeWithBlock'),
-			static::getEarlyTerminatingMethodCalls(),
-			static::getEarlyTerminatingFunctionCalls(),
 			$container->getParameter('exceptions')['implicitThrows'],
 			$container->getParameter('treatPhpDocTypesAsCertain'),
 			$container->getByType(ImplicitToStringCallHelper::class),
@@ -496,18 +494,6 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 
 	/** @return string[] */
 	protected static function getAdditionalAnalysedFiles(): array
-	{
-		return [];
-	}
-
-	/** @return string[][] */
-	protected static function getEarlyTerminatingMethodCalls(): array
-	{
-		return [];
-	}
-
-	/** @return string[] */
-	protected static function getEarlyTerminatingFunctionCalls(): array
 	{
 		return [];
 	}

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -842,8 +842,6 @@ class AnalyserTest extends PHPStanTestCase
 			false,
 			true,
 			true,
-			[],
-			[],
 			true,
 			$this->shouldTreatPhpDocTypesAsCertain(),
 			$container->getByType(ImplicitToStringCallHelper::class),

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
@@ -146,8 +146,6 @@ class FiberNodeScopeResolverRuleTest extends RuleTestCase
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),
 			self::getContainer()->getParameter('polluteScopeWithBlock'),
-			[],
-			[],
 			self::getContainer()->getParameter('exceptions')['implicitThrows'],
 			$this->shouldTreatPhpDocTypesAsCertain(),
 			self::getContainer()->getByType(ImplicitToStringCallHelper::class),

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
@@ -79,8 +79,6 @@ class FiberNodeScopeResolverTest extends TypeInferenceTestCase
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),
 			$container->getParameter('polluteScopeWithBlock'),
-			static::getEarlyTerminatingMethodCalls(),
-			static::getEarlyTerminatingFunctionCalls(),
 			$container->getParameter('exceptions')['implicitThrows'],
 			$container->getParameter('treatPhpDocTypesAsCertain'),
 			$container->getByType(ImplicitToStringCallHelper::class),

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -46,6 +46,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		return [
 			__DIR__ . '/../../../conf/bleedingEdge.neon',
 			__DIR__ . '/typeAliases.neon',
+			__DIR__ . '/nodeScopeResolverEarlyTerminating.neon',
 		];
 	}
 
@@ -90,21 +91,6 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 			$this->assertTrue($scope->hasVariableType('var')->yes());
 			$this->assertTrue($scope->hasVariableType('foo')->no());
 		});
-	}
-
-	protected static function getEarlyTerminatingMethodCalls(): array
-	{
-		return [
-			\EarlyTermination\Foo::class => [
-				'doFoo',
-				'doBar',
-			],
-		];
-	}
-
-	protected static function getEarlyTerminatingFunctionCalls(): array
-	{
-		return ['baz'];
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -355,6 +355,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			[
 				__DIR__ . '/../../../conf/bleedingEdge.neon',
 				__DIR__ . '/typeAliases.neon',
+				__DIR__ . '/nodeScopeResolverEarlyTerminating.neon',
 			],
 		);
 	}
@@ -367,21 +368,6 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			__DIR__ . '/data/methodPhpDocs-recursive-trait-defined.php',
 			__DIR__ . '/data/anonymous-class-name-in-trait-trait.php',
 		];
-	}
-
-	protected static function getEarlyTerminatingMethodCalls(): array
-	{
-		return [
-			\EarlyTermination\Foo::class => [
-				'doFoo',
-				'doBar',
-			],
-		];
-	}
-
-	protected static function getEarlyTerminatingFunctionCalls(): array
-	{
-		return ['baz'];
 	}
 
 }

--- a/tests/PHPStan/Analyser/nodeScopeResolverEarlyTerminating.neon
+++ b/tests/PHPStan/Analyser/nodeScopeResolverEarlyTerminating.neon
@@ -1,0 +1,7 @@
+parameters:
+	earlyTerminatingMethodCalls:
+		EarlyTermination\Foo:
+			- doFoo
+			- doBar
+	earlyTerminatingFunctionCalls:
+		- baz


### PR DESCRIPTION
Extracted from the `resolve-type-rewrite-2` branch (adapted to the resolveType world; follows the #6125–#6133 series).

Calls configured as `earlyTerminatingMethodCalls` / `earlyTerminatingFunctionCalls` now resolve to an explicit `NeverType` in `FuncCallHandler` / `MethodCallHandler` / `StaticCallHandler`, via a shared `EarlyTerminatingCallHelper` (`#[AutowiredService]`, fed the parameters directly). `NodeScopeResolver::findEarlyTerminatingExpr()` drops its duplicate list-matching — its existing explicit-never check now covers configured calls exactly like `exit`/`die`/`throw` and signature-`never` calls — and the two lists leave `NodeScopeResolver`'s constructor. `TypeInferenceTestCase::getEarlyTerminatingMethodCalls()` / `getEarlyTerminatingFunctionCalls()` overrides are replaced by an additional config file (`nodeScopeResolverEarlyTerminating.neon`), matching how the branch migrates them.

Net effect: configured calls now genuinely type as `never` (visible to rules and inference), instead of being special-cased only for exit-point detection.

Validation: full test suite green (17776 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b