### PR TITLE
Read operand types from ExpressionResults in expr handlers

### DIFF
--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -265,7 +265,7 @@ final class BooleanAndHandler implements ExprHandler
 		$leftResult = $nodeScopeResolver->processExprNode($stmt, $expr->left, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$leftTruthyScope = $leftResult->getTruthyScope();
 		$rightResult = $nodeScopeResolver->processExprNode($stmt, $expr->right, $leftTruthyScope, $storage, $nodeCallback, $context);
-		$rightExprType = $rightResult->getScope()->getType($expr->right);
+		$rightExprType = $rightResult->getType();
 		if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
 			$leftMergedWithRightScope = $leftResult->getFalseyScope();
 		} else {

--- a/src/Analyser/ExprHandler/CoalesceHandler.php
+++ b/src/Analyser/ExprHandler/CoalesceHandler.php
@@ -128,7 +128,7 @@ final class CoalesceHandler implements ExprHandler
 
 		$rightScope = $scope->filterByFalseyValue($expr);
 		$rightResult = $nodeScopeResolver->processExprNode($stmt, $expr->right, $rightScope, $storage, $nodeCallback, $context->enterDeep());
-		$rightExprType = $scope->getType($expr->right);
+		$rightExprType = $rightResult->getType();
 		if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
 			$scope = $scope->filterByTruthyValue(new Expr\Isset_([$expr->left]));
 		} else {

--- a/src/Analyser/ExprHandler/ThrowHandler.php
+++ b/src/Analyser/ExprHandler/ThrowHandler.php
@@ -48,7 +48,7 @@ final class ThrowHandler implements ExprHandler
 			expr: $expr,
 			hasYield: false,
 			isAlwaysTerminating: true,
-			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createExplicit($scope, $scope->getType($expr->expr), $expr, false)]),
+			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createExplicit($scope, $exprResult->getType(), $expr, false)]),
 			impurePoints: $exprResult->getImpurePoints(),
 		);
 	}


### PR DESCRIPTION
Stacked on #6134. First batch of a series: where a handler already holds a child's `ExpressionResult`, read types via `ExpressionResult::getType()` instead of `$scope->getType()` — `ThrowHandler`'s throw-point type and the right-side explicit-never checks in `BooleanAndHandler`/`CoalesceHandler`.

On 2.2.x, `ExpressionResult::getType()` resolves from the stored before-scope, so these sites stay behavior-identical (verified by the full suite); on the `resolve-type-rewrite-2` branch the same call sites are answered from the result's computed type without any scope walk. Each conversion shrinks the eventual resolveType-to-callback switch by one line, and only scope-insensitive consumers (never-checks, the thrown type) are converted — sites where the asking scope matters are left for later batches with individual validation.

More batches will follow on this branch (Ternary/ArrayDimFetch/PropertyFetch operands, offset virtual handlers, leaf handlers), each suite-validated separately.

Validation: full test suite green (17776 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b