### PR TITLE
Read operand types from ExpressionResults in Ternary/ArrayDimFetch/PropertyFetch handlers

### DIFF
--- a/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
@@ -103,7 +103,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 		$impurePoints = array_merge($dimResult->getImpurePoints(), $varResult->getImpurePoints());
 		$scope = $varResult->getScope();
 
-		$varType = $scope->getType($expr->var);
+		$varType = $varResult->getType();
 		if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
 			$throwPoints = array_merge($throwPoints, $nodeScopeResolver->processExprNode(
 				$stmt,

--- a/src/Analyser/ExprHandler/PropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/PropertyFetchHandler.php
@@ -64,7 +64,7 @@ final class PropertyFetchHandler implements ExprHandler
 		if ($expr->name instanceof Identifier) {
 			if ($this->phpVersion->supportsPropertyHooks()) {
 				$propertyName = $expr->name->toString();
-				$propertyHolderType = $scopeBeforeVar->getType($expr->var);
+				$propertyHolderType = $varResult->getType();
 				$propertyReflection = $scopeBeforeVar->getInstancePropertyReflection($propertyHolderType, $propertyName);
 				if ($propertyReflection !== null) {
 					$propertyDeclaringClass = $propertyReflection->getDeclaringClass();

--- a/src/Analyser/ExprHandler/TernaryHandler.php
+++ b/src/Analyser/ExprHandler/TernaryHandler.php
@@ -122,7 +122,7 @@ final class TernaryHandler implements ExprHandler
 			$impurePoints = array_merge($impurePoints, $ifResult->getImpurePoints());
 			$hasYield = $hasYield || $ifResult->hasYield();
 			$ifTrueScope = $ifResult->getScope();
-			$ifTrueType = $ifTrueScope->getType($expr->if);
+			$ifTrueType = $ifResult->getType();
 
 			$elseResult = $nodeScopeResolver->processExprNode($stmt, $expr->else, $ifFalseScope, $storage, $nodeCallback, $context);
 			$throwPoints = array_merge($throwPoints, $elseResult->getThrowPoints());
@@ -131,7 +131,7 @@ final class TernaryHandler implements ExprHandler
 			$ifFalseScope = $elseResult->getScope();
 		}
 
-		$condType = $scope->getType($expr->cond);
+		$condType = $ternaryCondResult->getType();
 		if ($condType->isTrue()->yes()) {
 			$finalScope = $ifTrueScope;
 		} elseif ($condType->isFalse()->yes()) {
@@ -140,7 +140,7 @@ final class TernaryHandler implements ExprHandler
 			if ($ifTrueType instanceof NeverType && $ifTrueType->isExplicit()) {
 				$finalScope = $ifFalseScope;
 			} else {
-				$ifFalseType = $ifFalseScope->getType($expr->else);
+				$ifFalseType = $elseResult->getType();
 
 				if ($ifFalseType instanceof NeverType && $ifFalseType->isExplicit()) {
 					$finalScope = $ifTrueScope;


### PR DESCRIPTION
Second batch of converting handler `$scope->getType()` reads to `ExpressionResult` reads (follows the first batch merged in `346dfbba83`; independent PR based on 2.2.x).

Five sites where the handler already holds the child's result:
- `TernaryHandler`: the condition type (the entry scope is exactly the condition result's before-scope — an exact equivalence) and the two branch explicit-never checks.
- `PropertyFetchHandler`: the property-hook holder type (`$scopeBeforeVar` is exactly the var result's before-scope — exact equivalence).
- `ArrayDimFetchHandler`: the var type feeding the `ArrayAccess` check and `offsetGet` throw-point synthesis.

On 2.2.x these resolve from the stored before-scope, keeping behavior identical (full suite green); on the `resolve-type-rewrite-2` branch the same call sites are answered from the result's computed type without a scope walk. The branch's offset-virtual-handler batch was inspected and skipped — it is inseparable from the callback world.

Validation: full test suite green (17776 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b