### PR TITLE
Read operand types from ExpressionResults in BinaryOp/BooleanOr/MethodCall/Match handlers

### DIFF
--- a/src/Analyser/ExprHandler/BinaryOpHandler.php
+++ b/src/Analyser/ExprHandler/BinaryOpHandler.php
@@ -92,7 +92,7 @@ final class BinaryOpHandler implements ExprHandler
 		$impurePoints = array_merge($leftResult->getImpurePoints(), $rightResult->getImpurePoints());
 		if (
 			($expr instanceof BinaryOp\Div || $expr instanceof BinaryOp\Mod) &&
-			!$leftResult->getScope()->getType($expr->right)->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
+			!$rightResult->getType()->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
 		) {
 			$throwPoints[] = InternalThrowPoint::createExplicit($leftResult->getScope(), new ObjectType(DivisionByZeroError::class), $expr, false);
 		}

--- a/src/Analyser/ExprHandler/BooleanOrHandler.php
+++ b/src/Analyser/ExprHandler/BooleanOrHandler.php
@@ -348,7 +348,7 @@ final class BooleanOrHandler implements ExprHandler
 		$leftResult = $nodeScopeResolver->processExprNode($stmt, $expr->left, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$leftFalseyScope = $leftResult->getFalseyScope();
 		$rightResult = $nodeScopeResolver->processExprNode($stmt, $expr->right, $leftFalseyScope, $storage, $nodeCallback, $context);
-		$rightExprType = $rightResult->getScope()->getType($expr->right);
+		$rightExprType = $rightResult->getType();
 		if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
 			$leftMergedWithRightScope = $leftResult->getTruthyScope();
 		} else {

--- a/src/Analyser/ExprHandler/MatchHandler.php
+++ b/src/Analyser/ExprHandler/MatchHandler.php
@@ -211,9 +211,9 @@ final class MatchHandler implements ExprHandler
 	{
 		$beforeScope = $scope;
 		$deepContext = $context->enterDeep();
-		$condType = $scope->getType($expr->cond);
-		$condNativeType = $scope->getNativeType($expr->cond);
 		$condResult = $nodeScopeResolver->processExprNode($stmt, $expr->cond, $scope, $storage, $nodeCallback, $deepContext);
+		$condType = $condResult->getType();
+		$condNativeType = $condResult->getNativeType();
 		$scope = $condResult->getScope();
 		$hasYield = $condResult->hasYield();
 		$throwPoints = $condResult->getThrowPoints();

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -100,7 +100,7 @@ final class MethodCallHandler implements ExprHandler
 		}
 		$parametersAcceptor = null;
 		$methodReflection = null;
-		$calledOnType = $scope->getType($expr->var);
+		$calledOnType = $varResult->getType();
 		if ($expr->name instanceof Identifier) {
 			$methodName = $expr->name->name;
 			$methodReflection = $scope->getMethodReflection($calledOnType, $methodName);


### PR DESCRIPTION
Third batch of converting handler `$scope->getType()` reads to `ExpressionResult` reads (independent PR on 2.2.x; follows the merged batches 1–2).

- `BinaryOpHandler`: the division-by-zero right-operand check — the right result's before-scope is exactly the left result's scope (exact equivalence).
- `BooleanOrHandler`: the right-side explicit-never check, matching the earlier `BooleanAndHandler` conversion.
- `MethodCallHandler`: the call receiver reads the var result — textually converging with the single-pass engine's shape.
- `MatchHandler`: the subject is processed first and read off its result instead of a pre-processing forward read (the read still resolves against the same entry scope, now stored as the result's before-scope).

Validation: full test suite green (17776 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b