### PR TITLE
Read already-processed expression types from ExpressionResults in NodeScopeResolver

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1616,7 +1616,10 @@ class NodeScopeResolver
 						// the narrowed value-var type in place of the broader dim fetch type so
 						// the loop's final array rewrite below picks up the sharper element type.
 						if ($originalValueExpr !== null && $scopeWithIterableValueType->hasExpressionType($originalValueExpr)->yes()) {
-							$valueVarType = $scopeWithIterableValueType->getType($stmt->valueVar);
+							// read the loop value variable's narrowed type directly by name -
+							// it is an assigned (not processExprNode-processed) variable
+							// ($originalValueExpr !== null implies a string-named Variable)
+							$valueVarType = $scopeWithIterableValueType->getVariableType($stmt->valueVar->name);
 							if ($dimFetchType->isSuperTypeOf($valueVarType)->yes()) {
 								$dimFetchType = $valueVarType;
 							}
@@ -1629,7 +1632,7 @@ class NodeScopeResolver
 						$keyLoopNativeTypes[] = $scopeWithIterableValueType->getType($keyVarExpr);
 					} else {
 						// No key variable: the narrowed value var is the array element type directly.
-						$dimFetchType = $scopeWithIterableValueType->getType($stmt->valueVar);
+						$dimFetchType = $scopeWithIterableValueType->getVariableType($stmt->valueVar->name);
 						$dimFetchNativeType = $scopeWithIterableValueType->getNativeType($stmt->valueVar);
 					}
 					$arrayDimFetchLoopTypes[] = $dimFetchType;
@@ -1946,7 +1949,7 @@ class NodeScopeResolver
 					// only the last condition expression is relevant whether the loop continues
 					// see https://www.php.net/manual/en/control-structures.for.php
 					if ($condExpr === $lastCondExpr) {
-						$condTruthiness = ($this->treatPhpDocTypesAsCertain ? $condResultScope->getType($condExpr) : $condResultScope->getNativeType($condExpr))->toBoolean();
+						$condTruthiness = ($this->treatPhpDocTypesAsCertain ? $condResult->getType() : $condResult->getNativeType())->toBoolean();
 						$isIterableAtLeastOnce = $isIterableAtLeastOnce->and($condTruthiness->isTrue());
 					}
 
@@ -2504,7 +2507,7 @@ class NodeScopeResolver
 				} else {
 					$constantName = new Name\FullyQualified($const->name->toString());
 				}
-				$scope = $scope->assignExpression(new ConstFetch($constantName), $scope->getType($const->value), $scope->getNativeType($const->value));
+				$scope = $scope->assignExpression(new ConstFetch($constantName), $constResult->getType(), $constResult->getNativeType());
 			}
 		} elseif ($stmt instanceof Node\Stmt\ClassConst) {
 			$hasYield = false;
@@ -2520,8 +2523,8 @@ class NodeScopeResolver
 				}
 				$scope = $scope->assignExpression(
 					new Expr\ClassConstFetch(new Name\FullyQualified($scope->getClassReflection()->getName()), $const->name),
-					$scope->getType($const->value),
-					$scope->getNativeType($const->value),
+					$constResult->getType(),
+					$constResult->getNativeType(),
 				);
 			}
 		} elseif ($stmt instanceof Node\Stmt\EnumCase) {


### PR DESCRIPTION
Fifth batch of the ExpressionResult-read conversions (independent PR on 2.2.x) — reworked per feedback to straightforward reads only; the `Closure::call`/clone-with Noop-preprocessing pieces are dropped.

- The `for`-loop last-condition truthiness reads the condition result.
- `const` and class-const declaration values read their results (the assigning scope is exactly the value result's before-scope).
- The foreach loop-array-rewrite reads the narrowed value variable directly by name (`getVariableType()`) — it is an assigned variable, not a processed expression.

Inspected and left with the sweep: the match-arm condition read (it prices a synthetic `Identical`), the assign-value reorder (regresses bug-13623 without the coalesce isset-descriptor machinery), and the first-class-callable handler consolidation.

Observation for a separate look, not touched here: in the foreach rewrite, `$keyLoopNativeTypes[]` is filled via `getType($keyVarExpr)` — same as the phpdoc list — where `getNativeType` looks intended.

Validation: full test suite green (17776 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b