### PR TITLE
Add regression test for #13253

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-13253.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13253.php
@@ -1,0 +1,80 @@
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
+
+namespace Bug13253;
+
+use Generator;
+use ReflectionFunction;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey
+ * @template TValue
+ */
+class Pfline
+{
+
+	/** @var iterable<TKey, TValue> */
+	private iterable $data;
+
+	/** @param iterable<TKey, TValue> $data */
+	public function __construct(iterable $data)
+	{
+		$this->data = $data;
+	}
+
+	/**
+	 * @return iterable<TKey, TValue>
+	 */
+	public function data(): iterable
+	{
+		return $this->data;
+	}
+
+	/**
+	 * @template TMapKey
+	 * @template TMapValue
+	 * @param null|callable(TValue): Generator<TMapKey, TMapValue> $func
+	 * @phpstan-self-out self<TMapKey, TMapValue>
+	 * @return self<TMapKey, TMapValue>
+	 */
+	public function map(?callable $func = null): self
+	{
+		return $this;
+	}
+
+}
+
+function (): void {
+	$reflection = new ReflectionFunction('strlen');
+	$params = $reflection->getParameters();
+
+	// Without chaining (each call advances the type through @phpstan-self-out)
+	$pipeline = new Pfline($params);
+	$pipeline->map(function ($param) {
+		assertType('ReflectionParameter', $param);
+		yield $param;
+	});
+	$pipeline->map(function ($param) {
+		assertType('ReflectionParameter', $param);
+		yield $param->getName();
+	});
+	$pipeline->map(function ($param) {
+		assertType('non-empty-string', $param);
+		yield substr_count('.', $param);
+	});
+
+	// With chaining (the type must advance through @return self<TMapKey, TMapValue>)
+	$pipeline = new Pfline($params);
+	$pipeline->map(function ($param) {
+		assertType('ReflectionParameter', $param);
+		yield $param;
+	})->map(function ($param) {
+		assertType('ReflectionParameter', $param);
+		yield $param->getName();
+	})->map(function ($param) {
+		assertType('non-empty-string', $param);
+		yield substr_count('.', $param);
+	});
+};


### PR DESCRIPTION
`@phpstan-self-out` chaining through a generic `map()` was fixed by the `MethodCallHandler` receiver conversion in `e847fb433c` (the third ExpressionResult-read batch): the receiver of the chained call is now read off the var result — where the self-out effect was applied during processing — instead of being re-priced on the after-scope, which lost the narrowing and produced `mixed`.

Verified test-first: the fixture fails on the pre-batch 2.2.x (`Expected: non-empty-string / Actual: mixed`) and passes since.

Closes https://github.com/phpstan/phpstan/issues/13253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b