### PR TITLE
Track containsNullsafe on ExpressionResult and propagate it through fetch/call chains

### DIFF
--- a/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
@@ -94,6 +94,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 				isAlwaysTerminating: $varResult->isAlwaysTerminating(),
 				throwPoints: $varResult->getThrowPoints(),
 				impurePoints: $varResult->getImpurePoints(),
+				containsNullsafe: $varResult->containsNullsafe(),
 			);
 		}
 
@@ -123,6 +124,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 			isAlwaysTerminating: $dimResult->isAlwaysTerminating() || $varResult->isAlwaysTerminating(),
 			throwPoints: $throwPoints,
 			impurePoints: $impurePoints,
+			containsNullsafe: $varResult->containsNullsafe(),
 		);
 	}
 

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -211,6 +211,7 @@ final class MethodCallHandler implements ExprHandler
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,
 			impurePoints: $impurePoints,
+			containsNullsafe: $varResult->containsNullsafe(),
 		);
 
 		$calledOnType = $originalScope->getType($expr->var);

--- a/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
+++ b/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
@@ -126,6 +126,7 @@ final class NullsafeMethodCallHandler implements ExprHandler
 			isAlwaysTerminating: false,
 			throwPoints: $exprResult->getThrowPoints(),
 			impurePoints: $exprResult->getImpurePoints(),
+			containsNullsafe: true,
 		);
 	}
 

--- a/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
@@ -105,6 +105,7 @@ final class NullsafePropertyFetchHandler implements ExprHandler
 			isAlwaysTerminating: false,
 			throwPoints: $exprResult->getThrowPoints(),
 			impurePoints: $exprResult->getImpurePoints(),
+			containsNullsafe: true,
 		);
 	}
 

--- a/src/Analyser/ExprHandler/PropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/PropertyFetchHandler.php
@@ -94,6 +94,7 @@ final class PropertyFetchHandler implements ExprHandler
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,
 			impurePoints: $impurePoints,
+			containsNullsafe: $varResult->containsNullsafe(),
 		);
 	}
 

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -88,6 +88,7 @@ final class StaticCallHandler implements ExprHandler
 		$throwPoints = [];
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
+		$containsNullsafe = false;
 		if ($expr->class instanceof Expr) {
 			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$hasYield = $classResult->hasYield();
@@ -96,6 +97,7 @@ final class StaticCallHandler implements ExprHandler
 			$isAlwaysTerminating = $classResult->isAlwaysTerminating();
 
 			$scope = $classResult->getScope();
+			$containsNullsafe = $classResult->containsNullsafe();
 		}
 
 		$parametersAcceptor = null;
@@ -299,6 +301,7 @@ final class StaticCallHandler implements ExprHandler
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,
 			impurePoints: $impurePoints,
+			containsNullsafe: $containsNullsafe,
 		);
 	}
 

--- a/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
@@ -66,6 +66,7 @@ final class StaticPropertyFetchHandler implements ExprHandler
 			),
 		];
 		$isAlwaysTerminating = false;
+		$containsNullsafe = false;
 		if ($expr->class instanceof Expr) {
 			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$hasYield = $classResult->hasYield();
@@ -73,6 +74,7 @@ final class StaticPropertyFetchHandler implements ExprHandler
 			$impurePoints = $classResult->getImpurePoints();
 			$isAlwaysTerminating = $classResult->isAlwaysTerminating();
 			$scope = $classResult->getScope();
+			$containsNullsafe = $classResult->containsNullsafe();
 		}
 		if (!$expr->name instanceof VarLikeIdentifier) {
 			$nameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, $context->enterDeep());
@@ -91,6 +93,7 @@ final class StaticPropertyFetchHandler implements ExprHandler
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,
 			impurePoints: $impurePoints,
+			containsNullsafe: $containsNullsafe,
 		);
 	}
 

--- a/src/Analyser/ExprHandler/VariableHandler.php
+++ b/src/Analyser/ExprHandler/VariableHandler.php
@@ -103,8 +103,8 @@ final class VariableHandler implements ExprHandler
 			$isAlwaysTerminating,
 			$throwPoints,
 			$impurePoints,
-			static fn (): MutatingScope => $scope->filterByTruthyValue($expr),
-			static fn (): MutatingScope => $scope->filterByFalseyValue($expr),
+			truthyScopeCallback: static fn (): MutatingScope => $scope->filterByTruthyValue($expr),
+			falseyScopeCallback: static fn (): MutatingScope => $scope->filterByFalseyValue($expr),
 		);
 	}
 

--- a/src/Analyser/ExpressionResult.php
+++ b/src/Analyser/ExpressionResult.php
@@ -34,6 +34,7 @@ final class ExpressionResult
 		private bool $isAlwaysTerminating,
 		private array $throwPoints,
 		private array $impurePoints,
+		private bool $containsNullsafe = false,
 		?callable $truthyScopeCallback = null,
 		?callable $falseyScopeCallback = null,
 	)
@@ -55,6 +56,17 @@ final class ExpressionResult
 	public function hasYield(): bool
 	{
 		return $this->hasYield;
+	}
+
+	/**
+	 * Whether this expression's chain contains a nullsafe operator (?->). A
+	 * fetch/call on a receiver whose chain short-circuits propagates null,
+	 * which a plain nullable receiver (e.g. a nullable variable) does not -
+	 * this flag is what tells them apart.
+	 */
+	public function containsNullsafe(): bool
+	{
+		return $this->containsNullsafe;
 	}
 
 	/**

--- a/src/Analyser/ExpressionResultFactory.php
+++ b/src/Analyser/ExpressionResultFactory.php
@@ -21,6 +21,7 @@ interface ExpressionResultFactory
 		bool $isAlwaysTerminating,
 		array $throwPoints,
 		array $impurePoints,
+		bool $containsNullsafe = false,
 		?callable $truthyScopeCallback = null,
 		?callable $falseyScopeCallback = null,
 	): ExpressionResult;


### PR DESCRIPTION
Extracted from the `resolve-type-rewrite-2` branch (independent PR on 2.2.x) — one of the non-callback `ExpressionResult` constructor arguments the eventual switch builds on.

A boolean flag on `ExpressionResult` recording whether the expression's chain contains a nullsafe operator, propagated through the fetch/call handlers (a fetch/call on a receiver whose chain short-circuits propagates null, which a plain nullable receiver does not — this flag is what tells them apart). Inert plumbing on 2.2.x for now — the branch's nullsafe short-circuit decisions consume it — landed with the branch's exact field ordering so the sweep diff shrinks; the one factory caller passing scope callbacks positionally switches to named arguments.

Validation: full test suite green (17778 tests), self-analysis clean, code style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wqGgaD7iqL44t1KgpJS7b