### PR TITLE
Parameter closure type extensions for array_map/filter/walk/find + native flavour resolution

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1281,7 +1281,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		return $this->getType($clonedNode);
 	}
 
-	public function doNotTreatPhpDocTypesAsCertain(): Scope
+	public function doNotTreatPhpDocTypesAsCertain(): self
 	{
 		return $this->promoteNativeTypes();
 	}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3691,6 +3691,14 @@ class NodeScopeResolver
 
 					if ($overwritingParameterType !== null) {
 						$parameterType = $overwritingParameterType;
+
+						// resolve the native flavour through the same extension on the
+						// natively-promoted scope, so the closure parameters keep
+						// their native precision too
+						$overwritingParameterNativeType = $this->getParameterTypeFromParameterClosureTypeExtension($callLike, $calleeReflection, $parameter, $scopeToPass->doNotTreatPhpDocTypesAsCertain());
+						if ($overwritingParameterNativeType !== null) {
+							$parameterNativeType = $overwritingParameterNativeType;
+						}
 					}
 				}
 
@@ -3766,6 +3774,14 @@ class NodeScopeResolver
 
 					if ($overwritingParameterType !== null) {
 						$parameterType = $overwritingParameterType;
+
+						// resolve the native flavour through the same extension on the
+						// natively-promoted scope, so the closure parameters keep
+						// their native precision too
+						$overwritingParameterNativeType = $this->getParameterTypeFromParameterClosureTypeExtension($callLike, $calleeReflection, $parameter, $scopeToPass->doNotTreatPhpDocTypesAsCertain());
+						if ($overwritingParameterNativeType !== null) {
+							$parameterNativeType = $overwritingParameterNativeType;
+						}
 					}
 				}
 

--- a/src/Type/Php/ArrayFilterParameterClosureTypeExtension.php
+++ b/src/Type/Php/ArrayFilterParameterClosureTypeExtension.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\FunctionParameterClosureTypeExtension;
+use PHPStan\Type\Type;
+use const ARRAY_FILTER_USE_BOTH;
+use const ARRAY_FILTER_USE_KEY;
+
+#[AutowiredService]
+final class ArrayFilterParameterClosureTypeExtension implements FunctionParameterClosureTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, ParameterReflection $parameter): bool
+	{
+		return $functionReflection->getName() === 'array_filter' && $parameter->getName() === 'callback';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
+			return null;
+		}
+
+		$arrayType = $scope->getType($args[0]->value);
+		$parameters = null;
+		if (isset($args[2])) {
+			$mode = $scope->getType($args[2]->value);
+			if ($mode instanceof ConstantIntegerType) {
+				if ($mode->getValue() === ARRAY_FILTER_USE_KEY) {
+					$parameters = [$this->createParameter('key', $scope->getIterableKeyType($arrayType))];
+				} elseif ($mode->getValue() === ARRAY_FILTER_USE_BOTH) {
+					$parameters = [
+						$this->createParameter('item', $scope->getIterableValueType($arrayType)),
+						$this->createParameter('key', $scope->getIterableKeyType($arrayType)),
+					];
+				}
+			}
+		}
+
+		$parameters ??= [$this->createParameter('item', $scope->getIterableValueType($arrayType))];
+
+		return new ClosureType($parameters, new BooleanType());
+	}
+
+	private function createParameter(string $name, Type $type): NativeParameterReflection
+	{
+		return new NativeParameterReflection($name, false, $type, PassedByReference::createNo(), false, null);
+	}
+
+}

--- a/src/Type/Php/ArrayFindParameterClosureTypeExtension.php
+++ b/src/Type/Php/ArrayFindParameterClosureTypeExtension.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\FunctionParameterClosureTypeExtension;
+use PHPStan\Type\Type;
+use function in_array;
+
+#[AutowiredService]
+final class ArrayFindParameterClosureTypeExtension implements FunctionParameterClosureTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, ParameterReflection $parameter): bool
+	{
+		return in_array($functionReflection->getName(), ['array_find', 'array_find_key', 'array_any', 'array_all'], true)
+			&& $parameter->getName() === 'callback';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
+			return null;
+		}
+
+		$arrayType = $scope->getType($args[0]->value);
+
+		return new ClosureType([
+			new NativeParameterReflection('value', false, $scope->getIterableValueType($arrayType), PassedByReference::createNo(), false, null),
+			new NativeParameterReflection('key', false, $scope->getIterableKeyType($arrayType), PassedByReference::createNo(), false, null),
+		], new BooleanType());
+	}
+
+}

--- a/src/Type/Php/ArrayMapParameterClosureTypeExtension.php
+++ b/src/Type/Php/ArrayMapParameterClosureTypeExtension.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\FunctionParameterClosureTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use function count;
+
+#[AutowiredService]
+final class ArrayMapParameterClosureTypeExtension implements FunctionParameterClosureTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, ParameterReflection $parameter): bool
+	{
+		return $functionReflection->getName() === 'array_map' && $parameter->getName() === 'callback';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
+			return null;
+		}
+
+		$callbackParameters = [];
+		$argCount = count($args);
+		for ($i = 1; $i < $argCount; $i++) {
+			$arg = $args[$i];
+			$arrayType = $scope->getType($arg->value);
+			if ($arg->unpack) {
+				$constantArrays = $arrayType->getConstantArrays();
+				if (count($constantArrays) === 0) {
+					return null;
+				}
+				foreach ($constantArrays as $constantArray) {
+					foreach ($constantArray->getValueTypes() as $valueType) {
+						$callbackParameters[] = $this->createParameter($scope->getIterableValueType($valueType));
+					}
+				}
+			} else {
+				$callbackParameters[] = $this->createParameter($scope->getIterableValueType($arrayType));
+			}
+		}
+
+		return new ClosureType($callbackParameters, new MixedType());
+	}
+
+	private function createParameter(Type $type): NativeParameterReflection
+	{
+		return new NativeParameterReflection('item', false, $type, PassedByReference::createNo(), false, null);
+	}
+
+}

--- a/src/Type/Php/ArrayWalkParameterClosureTypeExtension.php
+++ b/src/Type/Php/ArrayWalkParameterClosureTypeExtension.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\FunctionParameterClosureTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+
+#[AutowiredService]
+final class ArrayWalkParameterClosureTypeExtension implements FunctionParameterClosureTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, ParameterReflection $parameter): bool
+	{
+		return $functionReflection->getName() === 'array_walk' && $parameter->getName() === 'callback';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
+			return null;
+		}
+
+		$arrayType = $scope->getType($args[0]->value);
+		$parameters = [
+			new NativeParameterReflection('item', false, $scope->getIterableValueType($arrayType), PassedByReference::createReadsArgument(), false, null),
+			new NativeParameterReflection('key', false, $scope->getIterableKeyType($arrayType), PassedByReference::createNo(), false, null),
+		];
+		if (isset($args[2])) {
+			$parameters[] = new NativeParameterReflection('arg', false, $scope->getType($args[2]->value), PassedByReference::createNo(), false, null);
+		}
+
+		return new ClosureType($parameters, new MixedType());
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
@@ -63,7 +63,7 @@ function bug14904(string $string): void {
 		'/a|(?<b>b)/',
 		function (array $match): string {
 			assertType("array{0: non-empty-string, b: 'b'|null, 1: 'b'|null}", $match);
-			assertNativeType('array<int|string, string|null>', $match);
+			assertNativeType("array{0: non-empty-string, b: 'b'|null, 1: 'b'|null}", $match);
 			return '';
 		},
 		$string,


### PR DESCRIPTION
Ports the four `Array*ParameterClosureTypeExtension`s from the resolve-type-rewrite-2 branch and teaches the extension hook to resolve the native flavour.

**Commit 1** adds the extensions verbatim. The intrinsic blocks in `ParametersAcceptorSelector::selectFromArgs()` keep providing the same parameter types (and the rule-facing "expects callable(...)" messages come only from them, so they must stay) — analysis output does not change.

**Commit 2** invokes the matched extension a second time on the natively-promoted scope after a non-null phpdoc-side override, and overrides the native parameter type with the result. Extensions may now see a natively-promoted scope from `$scope->getType()`. This keeps closure parameters natively precise without relying on the intrinsic blocks — verified by locally neutering the array_map block's native side: `bug-11014.php` stays green through the extension path alone. The existing `PregReplaceCallbackClosureTypeExtension` now also resolves the native flavour, so the native side of its match shapes becomes precise (one expectation upgraded in `preg_replace_callback_shapes.php`).

Full test suite, `make phpstan` and `make cs` green; the only output change is the more precise native match shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7