### PR TITLE
Extract the intrinsic closure-parameter blocks into applyIntrinsicArgOverrides()

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -4,6 +4,7 @@ namespace PHPStan\Reflection;
 
 use Closure;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
@@ -80,6 +81,124 @@ final class ParametersAcceptorSelector
 	{
 		$types = [];
 		$unpack = false;
+		$parametersAcceptors = self::applyIntrinsicArgOverrides(
+			$args,
+			$parametersAcceptors,
+			$namedArgumentsVariants,
+			$scope,
+			static fn (Expr $e): Type => $scope->getType($e),
+			static fn (Expr $e): Type => $scope->getNativeType($e),
+			static fn (Type $t): Type => $scope->getIterableValueType($t),
+			static fn (Type $t): Type => $scope->getIterableKeyType($t),
+		);
+
+		if (count($parametersAcceptors) === 1) {
+			$acceptor = $parametersAcceptors[0];
+			if (!self::hasAcceptorTemplateOrLateResolvableType($acceptor)) {
+				return $acceptor;
+			}
+		}
+
+		$reorderedArgs = $args;
+		$parameters = null;
+		$singleParametersAcceptor = null;
+		if (count($parametersAcceptors) === 1) {
+			if (!array_is_list($args)) {
+				// actually $args parameter should be typed to list but we can't atm,
+				// because its a BC break.
+				$args = array_values($args);
+			}
+			$reorderedArgs = ArgumentsNormalizer::reorderArgs($parametersAcceptors[0], $args);
+			$singleParametersAcceptor = $parametersAcceptors[0];
+		}
+
+		$hasName = false;
+		foreach ($reorderedArgs ?? $args as $i => $arg) {
+			$originalArg = $arg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $arg;
+			$parameter = null;
+			if ($singleParametersAcceptor !== null) {
+				$parameters = $singleParametersAcceptor->getParameters();
+				if (isset($parameters[$i])) {
+					$parameter = $parameters[$i];
+				} elseif (count($parameters) > 0 && $singleParametersAcceptor->isVariadic()) {
+					$parameter = array_last($parameters);
+				}
+			}
+
+			if ($parameter !== null && $scope instanceof MutatingScope) {
+				$rememberTypes = !$originalArg->value instanceof Node\Expr\Closure && !$originalArg->value instanceof Node\Expr\ArrowFunction;
+				$scope = $scope->pushInFunctionCall(null, $parameter, $rememberTypes);
+			}
+
+			$type = $scope->getType($originalArg->value);
+
+			if ($parameter !== null && $scope instanceof MutatingScope) {
+				$scope = $scope->popInFunctionCall();
+			}
+
+			if ($originalArg->name !== null) {
+				$index = $originalArg->name->toString();
+				$hasName = true;
+			} else {
+				$index = $i;
+			}
+			if ($originalArg->unpack) {
+				$unpack = true;
+				$constantArrays = $type->getConstantArrays();
+				if (count($constantArrays) > 0) {
+					foreach ($constantArrays as $constantArray) {
+						$values = $constantArray->getValueTypes();
+						foreach ($constantArray->getKeyTypes() as $j => $keyType) {
+							$valueType = $values[$j];
+							$valueIndex = $keyType->getValue();
+							if (is_string($valueIndex)) {
+								$hasName = true;
+							} else {
+								$valueIndex = $i + $j;
+							}
+
+							$types[$valueIndex] = isset($types[$valueIndex])
+								? TypeCombinator::union($types[$valueIndex], $valueType)
+								: $valueType;
+						}
+					}
+				} else {
+					$types[$index] = $type->getIterableValueType();
+				}
+			} else {
+				$types[$index] = $type;
+			}
+		}
+
+		if ($hasName && $namedArgumentsVariants !== null) {
+			return self::selectFromTypes($types, $namedArgumentsVariants, $unpack);
+		}
+
+		return self::selectFromTypes($types, $parametersAcceptors, $unpack);
+	}
+
+	/**
+	 * @internal
+	 * @param Node\Arg[] $args
+	 * @param ParametersAcceptor[] $parametersAcceptors
+	 * @param ParametersAcceptor[]|null $namedArgumentsVariants
+	 * @param Closure(Expr): Type $typeGetter
+	 * @param Closure(Expr): Type $nativeTypeGetter
+	 * @param Closure(Type): Type $iterableValueTypeGetter
+	 * @param Closure(Type): Type $iterableKeyTypeGetter
+	 * @return ParametersAcceptor[]
+	 */
+	public static function applyIntrinsicArgOverrides(
+		array $args,
+		array $parametersAcceptors,
+		?array $namedArgumentsVariants,
+		Scope $scope,
+		Closure $typeGetter,
+		Closure $nativeTypeGetter,
+		Closure $iterableValueTypeGetter,
+		Closure $iterableKeyTypeGetter,
+	): array
+	{
 		if (
 			count($args) > 0
 			&& count($parametersAcceptors) > 0
@@ -89,15 +208,15 @@ final class ParametersAcceptorSelector
 				$callbackParameters = [];
 				$nativeCallbackParameters = [];
 				foreach ($arrayMapArgs as $arg) {
-					$argType = $scope->getType($arg->value);
-					$nativeArgType = $scope->getNativeType($arg->value);
+					$argType = ($typeGetter)($arg->value);
+					$nativeArgType = ($nativeTypeGetter)($arg->value);
 					if ($arg->unpack) {
 						$constantArrays = $argType->getConstantArrays();
 						if (count($constantArrays) > 0) {
 							foreach ($constantArrays as $constantArray) {
 								$valueTypes = $constantArray->getValueTypes();
 								foreach ($valueTypes as $valueType) {
-									$callbackParameters[] = new DummyParameter('item', $scope->getIterableValueType($valueType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
+									$callbackParameters[] = new DummyParameter('item', ($iterableValueTypeGetter)($valueType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 								}
 							}
 						}
@@ -106,13 +225,13 @@ final class ParametersAcceptorSelector
 							foreach ($nativeConstantArrays as $constantArray) {
 								$valueTypes = $constantArray->getValueTypes();
 								foreach ($valueTypes as $valueType) {
-									$nativeCallbackParameters[] = new DummyParameter('item', $scope->getIterableValueType($valueType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
+									$nativeCallbackParameters[] = new DummyParameter('item', ($iterableValueTypeGetter)($valueType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 								}
 							}
 						}
 					} else {
-						$callbackParameters[] = new DummyParameter('item', $scope->getIterableValueType($argType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
-						$nativeCallbackParameters[] = new DummyParameter('item', $scope->getIterableValueType($nativeArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
+						$callbackParameters[] = new DummyParameter('item', ($iterableValueTypeGetter)($argType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
+						$nativeCallbackParameters[] = new DummyParameter('item', ($iterableValueTypeGetter)($nativeArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 					}
 				}
 
@@ -133,7 +252,7 @@ final class ParametersAcceptorSelector
 			}
 
 			if (count($args) >= 3 && (bool) $args[0]->getAttribute(CurlSetOptArgVisitor::ATTRIBUTE_NAME)) {
-				$optType = $scope->getType($args[1]->value);
+				$optType = ($typeGetter)($args[1]->value);
 
 				$valueTypes = [];
 				foreach ($optType->getConstantScalarValues() as $scalarValue) {
@@ -177,7 +296,7 @@ final class ParametersAcceptorSelector
 			}
 
 			if (count($args) >= 2 && (bool) $args[1]->getAttribute(CurlSetOptArrayArgVisitor::ATTRIBUTE_NAME)) {
-				$optArrayType = $scope->getType($args[1]->value);
+				$optArrayType = ($typeGetter)($args[1]->value);
 
 				$hasTypes = false;
 				$builder = ConstantArrayTypeBuilder::createEmpty();
@@ -232,23 +351,23 @@ final class ParametersAcceptorSelector
 				$arrayFilterParameters = null;
 				$nativeArrayFilterParameters = null;
 				if (isset($args[2])) {
-					$mode = $scope->getType($args[2]->value);
+					$mode = ($typeGetter)($args[2]->value);
 					if ($mode instanceof ConstantIntegerType) {
 						if ($mode->getValue() === ARRAY_FILTER_USE_KEY) {
 							$arrayFilterParameters = [
-								new DummyParameter('key', $scope->getIterableKeyType($scope->getType($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('key', ($iterableKeyTypeGetter)(($typeGetter)($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 							];
 							$nativeArrayFilterParameters = [
-								new DummyParameter('key', $scope->getIterableKeyType($scope->getNativeType($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('key', ($iterableKeyTypeGetter)(($nativeTypeGetter)($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 							];
 						} elseif ($mode->getValue() === ARRAY_FILTER_USE_BOTH) {
 							$arrayFilterParameters = [
-								new DummyParameter('item', $scope->getIterableValueType($scope->getType($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
-								new DummyParameter('key', $scope->getIterableKeyType($scope->getType($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('item', ($iterableValueTypeGetter)(($typeGetter)($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('key', ($iterableKeyTypeGetter)(($typeGetter)($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 							];
 							$nativeArrayFilterParameters = [
-								new DummyParameter('item', $scope->getIterableValueType($scope->getNativeType($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
-								new DummyParameter('key', $scope->getIterableKeyType($scope->getNativeType($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('item', ($iterableValueTypeGetter)(($nativeTypeGetter)($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('key', ($iterableKeyTypeGetter)(($nativeTypeGetter)($args[0]->value)), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 							];
 						}
 					}
@@ -257,22 +376,22 @@ final class ParametersAcceptorSelector
 				$acceptor = $parametersAcceptors[0];
 				$parameters = $acceptor->getParameters();
 				if (isset($parameters[1])) {
-					$arrayArgType = $scope->getType($args[0]->value);
+					$arrayArgType = ($typeGetter)($args[0]->value);
 					$callableType = new UnionType([
 						new CallableType(
 							$arrayFilterParameters ?? [
-								new DummyParameter('item', $scope->getIterableValueType($arrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('item', ($iterableValueTypeGetter)($arrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 							],
 							new BooleanType(),
 							false,
 						),
 						new NullType(),
 					]);
-					$nativeArrayArgType = $scope->getNativeType($args[0]->value);
+					$nativeArrayArgType = ($nativeTypeGetter)($args[0]->value);
 					$nativeCallableType = new UnionType([
 						new CallableType(
 							$nativeArrayFilterParameters ?? [
-								new DummyParameter('item', $scope->getIterableValueType($nativeArrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+								new DummyParameter('item', ($iterableValueTypeGetter)($nativeArrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 							],
 							new BooleanType(),
 							false,
@@ -314,19 +433,19 @@ final class ParametersAcceptorSelector
 			}
 
 			if ((bool) $args[0]->getAttribute(ArrayWalkArgVisitor::ATTRIBUTE_NAME)) {
-				$arrayArgType = $scope->getType($args[0]->value);
-				$nativeArrayArgType = $scope->getNativeType($args[0]->value);
+				$arrayArgType = ($typeGetter)($args[0]->value);
+				$nativeArrayArgType = ($nativeTypeGetter)($args[0]->value);
 				$arrayWalkParameters = [
-					new DummyParameter('item', $scope->getIterableValueType($arrayArgType), optional: false, passedByReference: PassedByReference::createReadsArgument(), variadic: false, defaultValue: null),
-					new DummyParameter('key', $scope->getIterableKeyType($arrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+					new DummyParameter('item', ($iterableValueTypeGetter)($arrayArgType), optional: false, passedByReference: PassedByReference::createReadsArgument(), variadic: false, defaultValue: null),
+					new DummyParameter('key', ($iterableKeyTypeGetter)($arrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 				];
 				$nativeArrayWalkParameters = [
-					new DummyParameter('item', $scope->getIterableValueType($nativeArrayArgType), optional: false, passedByReference: PassedByReference::createReadsArgument(), variadic: false, defaultValue: null),
-					new DummyParameter('key', $scope->getIterableKeyType($nativeArrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+					new DummyParameter('item', ($iterableValueTypeGetter)($nativeArrayArgType), optional: false, passedByReference: PassedByReference::createReadsArgument(), variadic: false, defaultValue: null),
+					new DummyParameter('key', ($iterableKeyTypeGetter)($nativeArrayArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 				];
 				if (isset($args[2])) {
-					$arrayWalkParameters[] = new DummyParameter('arg', $scope->getType($args[2]->value), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
-					$nativeArrayWalkParameters[] = new DummyParameter('arg', $scope->getNativeType($args[2]->value), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
+					$arrayWalkParameters[] = new DummyParameter('arg', ($typeGetter)($args[2]->value), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
+					$nativeArrayWalkParameters[] = new DummyParameter('arg', ($nativeTypeGetter)($args[2]->value), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null);
 				}
 
 				$acceptor = $parametersAcceptors[0];
@@ -343,20 +462,20 @@ final class ParametersAcceptorSelector
 				$acceptor = $parametersAcceptors[0];
 				$parameters = $acceptor->getParameters();
 				if (isset($parameters[1])) {
-					$argType = $scope->getType($args[0]->value);
+					$argType = ($typeGetter)($args[0]->value);
 					$callableType = new CallableType(
 						[
-							new DummyParameter('value', $scope->getIterableValueType($argType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
-							new DummyParameter('key', $scope->getIterableKeyType($argType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+							new DummyParameter('value', ($iterableValueTypeGetter)($argType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+							new DummyParameter('key', ($iterableKeyTypeGetter)($argType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 						],
 						new BooleanType(),
 						false,
 					);
-					$nativeArgType = $scope->getNativeType($args[0]->value);
+					$nativeArgType = ($nativeTypeGetter)($args[0]->value);
 					$nativeCallableType = new CallableType(
 						[
-							new DummyParameter('value', $scope->getIterableValueType($nativeArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
-							new DummyParameter('key', $scope->getIterableKeyType($nativeArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+							new DummyParameter('value', ($iterableValueTypeGetter)($nativeArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
+							new DummyParameter('key', ($iterableKeyTypeGetter)($nativeArgType), optional: false, passedByReference: PassedByReference::createNo(), variadic: false, defaultValue: null),
 						],
 						new BooleanType(),
 						false,
@@ -371,7 +490,7 @@ final class ParametersAcceptorSelector
 				$closureBindToVar instanceof Node\Expr\Variable
 				&& is_string($closureBindToVar->name)
 			) {
-				$varType = $scope->getType($closureBindToVar);
+				$varType = ($typeGetter)($closureBindToVar);
 				if ((new ObjectType(Closure::class))->isSuperTypeOf($varType)->yes()) {
 					$inFunction = $scope->getFunction();
 					if ($inFunction !== null) {
@@ -458,89 +577,7 @@ final class ParametersAcceptorSelector
 			}
 		}
 
-		if (count($parametersAcceptors) === 1) {
-			$acceptor = $parametersAcceptors[0];
-			if (!self::hasAcceptorTemplateOrLateResolvableType($acceptor)) {
-				return $acceptor;
-			}
-		}
-
-		$reorderedArgs = $args;
-		$parameters = null;
-		$singleParametersAcceptor = null;
-		if (count($parametersAcceptors) === 1) {
-			if (!array_is_list($args)) {
-				// actually $args parameter should be typed to list but we can't atm,
-				// because its a BC break.
-				$args = array_values($args);
-			}
-			$reorderedArgs = ArgumentsNormalizer::reorderArgs($parametersAcceptors[0], $args);
-			$singleParametersAcceptor = $parametersAcceptors[0];
-		}
-
-		$hasName = false;
-		foreach ($reorderedArgs ?? $args as $i => $arg) {
-			$originalArg = $arg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $arg;
-			$parameter = null;
-			if ($singleParametersAcceptor !== null) {
-				$parameters = $singleParametersAcceptor->getParameters();
-				if (isset($parameters[$i])) {
-					$parameter = $parameters[$i];
-				} elseif (count($parameters) > 0 && $singleParametersAcceptor->isVariadic()) {
-					$parameter = array_last($parameters);
-				}
-			}
-
-			if ($parameter !== null && $scope instanceof MutatingScope) {
-				$rememberTypes = !$originalArg->value instanceof Node\Expr\Closure && !$originalArg->value instanceof Node\Expr\ArrowFunction;
-				$scope = $scope->pushInFunctionCall(null, $parameter, $rememberTypes);
-			}
-
-			$type = $scope->getType($originalArg->value);
-
-			if ($parameter !== null && $scope instanceof MutatingScope) {
-				$scope = $scope->popInFunctionCall();
-			}
-
-			if ($originalArg->name !== null) {
-				$index = $originalArg->name->toString();
-				$hasName = true;
-			} else {
-				$index = $i;
-			}
-			if ($originalArg->unpack) {
-				$unpack = true;
-				$constantArrays = $type->getConstantArrays();
-				if (count($constantArrays) > 0) {
-					foreach ($constantArrays as $constantArray) {
-						$values = $constantArray->getValueTypes();
-						foreach ($constantArray->getKeyTypes() as $j => $keyType) {
-							$valueType = $values[$j];
-							$valueIndex = $keyType->getValue();
-							if (is_string($valueIndex)) {
-								$hasName = true;
-							} else {
-								$valueIndex = $i + $j;
-							}
-
-							$types[$valueIndex] = isset($types[$valueIndex])
-								? TypeCombinator::union($types[$valueIndex], $valueType)
-								: $valueType;
-						}
-					}
-				} else {
-					$types[$index] = $type->getIterableValueType();
-				}
-			} else {
-				$types[$index] = $type;
-			}
-		}
-
-		if ($hasName && $namedArgumentsVariants !== null) {
-			return self::selectFromTypes($types, $namedArgumentsVariants, $unpack);
-		}
-
-		return self::selectFromTypes($types, $parametersAcceptors, $unpack);
+		return $parametersAcceptors;
 	}
 
 	private static function hasAcceptorTemplateOrLateResolvableType(ParametersAcceptor $acceptor): bool


### PR DESCRIPTION
Pure move, extracted from the resolve-type-rewrite-2 branch: the intrinsic closure-parameter blocks leave `selectFromArgs()` into `ParametersAcceptorSelector::applyIntrinsicArgOverrides()`, reading argument types through injected getter closures. The method body is byte-identical to the former inline region modulo the getter indirection (verified mechanically), and `selectFromArgs()` passes `$scope`-backed getters, so behavior is unchanged.

Full test suite, `make phpstan` and `make cs` green; zero analysis-output churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7