### PR TITLE
Let the compositional-key shortcut clear virtual-node keys on the invalidated side

### DIFF
--- a/src/Analyser/ScopeOps.php
+++ b/src/Analyser/ScopeOps.php
@@ -49,7 +49,12 @@ final class ScopeOps
 	private const CONTAINS_SUPER_GLOBAL_ATTRIBUTE_NAME = 'containsSuperGlobal';
 
 	/** Virtual-node key prefixes whose printers include all children verbatim. */
-	private const COMPOSITIONAL_VIRTUAL_KEY_PREFIXES = ['__phpstanPossiblyImpure(', '__phpstanRemembered('];
+	// A prefix may be listed only when the printer emits every getSubNodeNames()
+	// sub-node verbatim (or the node walks no sub-nodes at all). The foreach/
+	// parameter original-value markers (__phpstanOriginalForeachKey etc.) hide a
+	// synthesized Variable child on purpose - reassigning the variable must
+	// invalidate them through containment - so they can never be listed here.
+	private const COMPOSITIONAL_VIRTUAL_KEY_PREFIXES = ['__phpstanForeachValueByRef(', '__phpstanIntertwinedVariableByReference(', '__phpstanPossiblyImpure(', '__phpstanPropertyInitialization(', '__phpstanRemembered('];
 
 	/**
 	 * Mirrors MutatingScope::getNodeKey().
@@ -611,7 +616,7 @@ final class ScopeOps
 		// a substring cannot belong to an expression containing the invalidated one, so
 		// the much more expensive per-expression check can be skipped without being called.
 		$canUseKeyPrefilter = $exprStringToInvalidate !== '$this'
-			&& !str_contains($exprStringToInvalidate, '__phpstan')
+			&& !self::keyMayHideSubExpressions($exprStringToInvalidate)
 			&& !str_contains($exprStringToInvalidate, '/*');
 
 		foreach ($expressionTypes as $exprString => $exprTypeHolder) {
@@ -735,7 +740,7 @@ final class ScopeOps
 		// call's key embeds its receiver's key verbatim, so when the invalidated key
 		// does not occur in the entry's key, the receiver cannot match and the entry
 		// can be kept without re-printing the receiver.
-		$canUseKeyPrefilter = !str_contains($exprStringToInvalidate, '__phpstan')
+		$canUseKeyPrefilter = !self::keyMayHideSubExpressions($exprStringToInvalidate)
 			&& !str_contains($exprStringToInvalidate, '/*');
 
 		foreach ($expressionTypes as $exprString => $exprTypeHolder) {
@@ -844,7 +849,7 @@ final class ScopeOps
 		// - keys carrying a getNodeKey() suffix ('/*…*/') are not plain substrings.
 		if (
 			$exprStringToInvalidate !== '$this'
-			&& !str_contains($exprStringToInvalidate, '__phpstan')
+			&& !self::keyMayHideSubExpressions($exprStringToInvalidate)
 			&& !str_contains($exprStringToInvalidate, '/*')
 			&& !str_contains($exprString, $exprStringToInvalidate)
 			&& !self::keyMayHideSubExpressions($exprString)

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -20,7 +20,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '86312b7';
+	public const EXPECTED_EXTENSION_VERSION = '1ecf6e0';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/turbo-ext/src/ScopeOps.cpp
+++ b/turbo-ext/src/ScopeOps.cpp
@@ -795,7 +795,7 @@ public:
 		 * containing the invalidated one, so the much more expensive
 		 * per-expression check can be skipped without being called. */
 		const bool canUseKeyPrefilter = !query.isThis
-			&& !strContains(exprStringToInvalidate, "__phpstan", sizeof("__phpstan") - 1)
+			&& !keyMayHideSubExpressions(exprStringToInvalidate)
 			&& !strContains(exprStringToInvalidate, "/*", 2);
 
 		bool invalidated = false;
@@ -1006,7 +1006,7 @@ public:
 		 * method call's key embeds its receiver's key verbatim, so when the
 		 * invalidated key does not occur in the entry's key, the receiver cannot
 		 * match and the entry can be kept without re-printing the receiver. */
-		const bool canUseKeyPrefilter = !strContains(exprStringToInvalidate, "__phpstan", sizeof("__phpstan") - 1)
+		const bool canUseKeyPrefilter = !keyMayHideSubExpressions(exprStringToInvalidate)
 			&& !strContains(exprStringToInvalidate, "/*", 2);
 
 		for (auto entry : expressionTypes) {
@@ -1657,8 +1657,15 @@ private:
 	 */
 	static bool keyMayHideSubExpressions(zend_string *key)
 	{
+		/* Mirror of ScopeOps::COMPOSITIONAL_VIRTUAL_KEY_PREFIXES - a prefix may
+		 * be listed only when the printer emits every getSubNodeNames() sub-node
+		 * verbatim (or the node walks no sub-nodes at all); the foreach/parameter
+		 * original-value markers hide a synthesized Variable child on purpose. */
 		static const struct { const char *prefix; size_t len; } compositionalPrefixes[] = {
+			{ "__phpstanForeachValueByRef(", sizeof("__phpstanForeachValueByRef(") - 1 },
+			{ "__phpstanIntertwinedVariableByReference(", sizeof("__phpstanIntertwinedVariableByReference(") - 1 },
 			{ "__phpstanPossiblyImpure(", sizeof("__phpstanPossiblyImpure(") - 1 },
+			{ "__phpstanPropertyInitialization(", sizeof("__phpstanPropertyInitialization(") - 1 },
 			{ "__phpstanRemembered(", sizeof("__phpstanRemembered(") - 1 },
 		};
 
@@ -1901,7 +1908,7 @@ private:
 
 		/* Compositional-key substring gate */
 		if (!query.isThis
-			&& !strContains(query.exprStringToInvalidate, "__phpstan", sizeof("__phpstan") - 1)
+			&& !keyMayHideSubExpressions(query.exprStringToInvalidate)
 			&& !strContains(query.exprStringToInvalidate, "/*", 2)
 			&& !strContainsStr(exprString, query.exprStringToInvalidate)
 			&& !keyMayHideSubExpressions(exprString)) {


### PR DESCRIPTION
Extracted from the resolve-type-rewrite-2 branch (its f65dfcea13), where the same change plus a caller-prefilter port cut its invalidation-check volume 5.7×.

The invalidation pre-filters treated every `__phpstan` occurrence in the **invalidated** expression's key as non-compositional: invalidating a virtual-keyed expression (a `PossiblyImpureCallExpr` entry, a foreach marker, …) disabled the substring shortcut and swept the scope's whole holder population through per-holder containment work. The holder side already consulted `keyMayHideSubExpressions()`; the invalidated side now does too. Three more printers join the compositional whitelist — `ForeachValueByRef`, `IntertwinedVariableByReference`, `PropertyInitialization` — with a comment documenting the soundness contract and why the foreach/parameter original-value markers can never be listed (they hide a synthesized `Variable` child on purpose; it is their invalidation hook).

**Numbers** on a `src/Analyser src/Rules` run: `shouldInvalidateExpression()` calls **759k → 433k**, containment scans **629k → 297k**. CPU is neutral within noise (12 interleaved pairs: −0.1%) — the surviving scans on 2.2.x are small ones — so the value is the structural reduction and convergence: the rewrite branch already carries this change, and landing it here removes those hunks from the eventual merge diff.

Mirrored in the native twin. Full test suite green with and without the active extension, `make phpstan` and `make cs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7