### PR TITLE
Do not extend Expr in the isset/empty/coalesce rule-facing virtual nodes

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2912,7 +2912,7 @@ class NodeScopeResolver
 	 */
 	public function callNodeCallbackWithExpression(
 		callable $nodeCallback,
-		Expr $expr,
+		Node $expr,
 		MutatingScope $scope,
 		ExpressionResultStorage $storage,
 		ExpressionContext $context,

--- a/src/Node/CoalesceExpressionNode.php
+++ b/src/Node/CoalesceExpressionNode.php
@@ -4,6 +4,7 @@ namespace PHPStan\Node;
 
 use Override;
 use PhpParser\Node\Expr;
+use PhpParser\NodeAbstract;
 use PHPStan\Analyser\ExpressionResult;
 
 /**
@@ -14,7 +15,7 @@ use PHPStan\Analyser\ExpressionResult;
  *
  * @internal
  */
-final class CoalesceExpressionNode extends Expr implements VirtualNode
+final class CoalesceExpressionNode extends NodeAbstract implements VirtualNode
 {
 
 	public function __construct(

--- a/src/Node/EmptyExpressionNode.php
+++ b/src/Node/EmptyExpressionNode.php
@@ -3,8 +3,8 @@
 namespace PHPStan\Node;
 
 use Override;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Empty_;
+use PhpParser\NodeAbstract;
 use PHPStan\Analyser\ExpressionResult;
 
 /**
@@ -14,7 +14,7 @@ use PHPStan\Analyser\ExpressionResult;
  *
  * @internal
  */
-final class EmptyExpressionNode extends Expr implements VirtualNode
+final class EmptyExpressionNode extends NodeAbstract implements VirtualNode
 {
 
 	public function __construct(Empty_ $originalNode, private ExpressionResult $exprResult)

--- a/src/Node/IssetExpressionNode.php
+++ b/src/Node/IssetExpressionNode.php
@@ -3,8 +3,8 @@
 namespace PHPStan\Node;
 
 use Override;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Isset_;
+use PhpParser\NodeAbstract;
 use PHPStan\Analyser\ExpressionResult;
 
 /**
@@ -14,7 +14,7 @@ use PHPStan\Analyser\ExpressionResult;
  *
  * @internal
  */
-final class IssetExpressionNode extends Expr implements VirtualNode
+final class IssetExpressionNode extends NodeAbstract implements VirtualNode
 {
 
 	/**

--- a/tests/PHPStan/Analyser/GetTypeOnEveryNodeRuleTest.php
+++ b/tests/PHPStan/Analyser/GetTypeOnEveryNodeRuleTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Third-party collectors and rules commonly call $scope->getType() on every
+ * expression they receive. Virtual nodes emitted to node callbacks must
+ * therefore either not be expressions at all or be resolvable and printable -
+ * an isset()/empty()/?? statement used to emit Expr-extending virtual nodes
+ * with no printer method, crashing the type-cache key printer.
+ *
+ * @extends RuleTestCase<Rule<Node>>
+ */
+class GetTypeOnEveryNodeRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new class implements Rule {
+
+			public function getNodeType(): string
+			{
+				return Node::class;
+			}
+
+			public function processNode(Node $node, Scope $scope): array
+			{
+				if ($node instanceof Expr) {
+					$scope->getType($node);
+				}
+
+				return [];
+			}
+
+		};
+	}
+
+	public function testGetTypeOnEveryNode(): void
+	{
+		$this->analyse([__DIR__ . '/data/get-type-on-every-node.php'], []);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/get-type-on-every-node.php
+++ b/tests/PHPStan/Analyser/data/get-type-on-every-node.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace GetTypeOnEveryNode;
+
+class HelloWorld
+{
+
+	/** @var array<string, string> */
+	private array $data = [];
+
+	public function sayHello(?string $name): string
+	{
+		if (isset($this->data[$name])) {
+			return $this->data[$name];
+		}
+
+		if (empty($this->data)) {
+			return 'empty';
+		}
+
+		$fallback = $name ?? 'anonymous';
+		$this->data[$fallback] ??= 'hello';
+
+		return $this->data[$fallback];
+	}
+
+}


### PR DESCRIPTION
Fixes the reported integration crash:

```
Internal error: Call to undefined method PHPStan\Node\Printer\Printer::pPHPStan_Node_IssetExpressionNode()
```

`IssetExpressionNode`, `EmptyExpressionNode` and `CoalesceExpressionNode` are emitted to node callbacks for their rules, and third-party collectors/rules commonly call `$scope->getType()` on every `Expr` they receive — which reached the type-cache key printer with no printer method for these nodes. The codebase convention for rule-facing virtual nodes is to extend `NodeAbstract` (`MatchExpressionNode`, `BooleanAndNode`, …) precisely so they can never be passed to `getType()`; these three now follow, and `callNodeCallbackWithExpression()` accepts any `Node` (it only adjusts the scope for deep contexts).

The regression test mimics the crashing collector: a `Node::class` rule calling `$scope->getType()` on every expression over an isset/empty/??/??= fixture — red with the exact production error before the fix, green after.

Full test suite green with and without the active turbo extension, `make phpstan` and `make cs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7