### PR TITLE
Process call arguments in a single pass with type-driven acceptor selection

### DIFF
--- a/src/Analyser/ArgsResult.php
+++ b/src/Analyser/ArgsResult.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Reflection\ParametersAcceptor;
+
+/**
+ * Result of NodeScopeResolver::processArgs(): the scope/throw/impure state after
+ * processing all arguments (wrapped ExpressionResult) plus the ParametersAcceptor
+ * resolved from the arg types gathered on the arg-to-arg evolving scope. The
+ * resolved acceptor is type-driven (selectFromTypes) so its generics are resolved
+ * against the actual argument types - callers wire it into the call's return
+ * type. Null when the call had no variants (dynamic callee).
+ */
+final class ArgsResult
+{
+
+	public function __construct(
+		private ExpressionResult $expressionResult,
+		private ?ParametersAcceptor $resolvedParametersAcceptor,
+	)
+	{
+	}
+
+	public function getScope(): MutatingScope
+	{
+		return $this->expressionResult->getScope();
+	}
+
+	public function hasYield(): bool
+	{
+		return $this->expressionResult->hasYield();
+	}
+
+	public function isAlwaysTerminating(): bool
+	{
+		return $this->expressionResult->isAlwaysTerminating();
+	}
+
+	/**
+	 * @return InternalThrowPoint[]
+	 */
+	public function getThrowPoints(): array
+	{
+		return $this->expressionResult->getThrowPoints();
+	}
+
+	/**
+	 * @return ImpurePoint[]
+	 */
+	public function getImpurePoints(): array
+	{
+		return $this->expressionResult->getImpurePoints();
+	}
+
+	public function getResolvedParametersAcceptor(): ?ParametersAcceptor
+	{
+		return $this->resolvedParametersAcceptor;
+	}
+
+}

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -120,6 +120,8 @@ final class FuncCallHandler implements ExprHandler
 	{
 		$beforeScope = $scope;
 		$parametersAcceptor = null;
+		$variants = [];
+		$namedArgumentsVariants = null;
 		$functionReflection = null;
 		$throwPoints = [];
 		$impurePoints = [];
@@ -130,12 +132,11 @@ final class FuncCallHandler implements ExprHandler
 			$nameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$nameType = $nameResult->getType();
 			if (!$nameType->isCallable()->no()) {
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-					$scope,
-					$expr->getArgs(),
-					$nameType->getCallableParametersAcceptors($scope),
-					null,
-				);
+				$variants = $nameType->getCallableParametersAcceptors($scope);
+				// A structural acceptor (names/positions/variadic) drives the per-arg
+				// metadata and the throw/impure points - generics are resolved
+				// type-driven by processArgs() into $resolvedParametersAcceptor.
+				$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization($expr->getArgs(), $variants, null);
 			}
 
 			$scope = $nameResult->getScope();
@@ -160,16 +161,12 @@ final class FuncCallHandler implements ExprHandler
 			}
 		} elseif ($this->reflectionProvider->hasFunction($expr->name, $scope)) {
 			$functionReflection = $this->reflectionProvider->getFunction($expr->name, $scope);
-			$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-				$scope,
-				$expr->getArgs(),
-				$functionReflection->getVariants(),
-				$functionReflection->getNamedArgumentsVariants(),
-			);
-			$impurePoint = SimpleImpurePoint::createFromVariant($functionReflection, $parametersAcceptor, $scope, $expr->getArgs());
-			if ($impurePoint !== null) {
-				$impurePoints[] = new ImpurePoint($scope, $expr, $impurePoint->getIdentifier(), $impurePoint->getDescription(), $impurePoint->isCertain());
-			}
+			$variants = $functionReflection->getVariants();
+			$namedArgumentsVariants = $functionReflection->getNamedArgumentsVariants();
+			// A structural acceptor (names/positions/variadic) drives argument
+			// normalization, the impure point and the throw points - generics are
+			// resolved type-driven by processArgs() into $resolvedParametersAcceptor.
+			$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization($expr->getArgs(), $variants, $namedArgumentsVariants);
 		} else {
 			$impurePoints[] = new ImpurePoint(
 				$scope,
@@ -291,12 +288,23 @@ final class FuncCallHandler implements ExprHandler
 		}
 
 		$scopeBeforeArgs = $scope;
-		$argsResult = $nodeScopeResolver->processArgs($stmt, $functionReflection, null, $parametersAcceptor, $normalizedExpr, $scope, $storage, $nodeCallbackForArgs, $context);
+		$argsResult = $nodeScopeResolver->processArgs($stmt, $functionReflection, null, $variants, $namedArgumentsVariants, $normalizedExpr, $scope, $storage, $nodeCallbackForArgs, $context);
+		$resolvedParametersAcceptor = $argsResult->getResolvedParametersAcceptor();
 		$scope = $argsResult->getScope();
 		$hasYield = $argsResult->hasYield();
 		$throwPoints = array_merge($throwPoints, $argsResult->getThrowPoints());
 		$impurePoints = array_merge($impurePoints, $argsResult->getImpurePoints());
 		$isAlwaysTerminating = $isAlwaysTerminating || $argsResult->isAlwaysTerminating();
+
+		if ($functionReflection !== null) {
+			// created after the args were processed - the side-effect flip
+			// parameters (print_r's $return, ...) read an argument's type, which
+			// is only available once the argument was processed
+			$impurePoint = SimpleImpurePoint::createFromVariant($functionReflection, $parametersAcceptor, $scope, $expr->getArgs());
+			if ($impurePoint !== null) {
+				$impurePoints[] = new ImpurePoint($scopeBeforeArgs, $expr, $impurePoint->getIdentifier(), $impurePoint->getDescription(), $impurePoint->isCertain());
+			}
+		}
 
 		if ($arrayWalkValueTypes !== null && $arrayWalkArrayArg !== null) {
 			$arrayWalkValueType = $arrayWalkValueTypes[0];
@@ -336,6 +344,13 @@ final class FuncCallHandler implements ExprHandler
 		}
 
 		if ($functionReflection !== null) {
+			// A conditional-return never (e.g. `($x is Foo ? never : string)`) only
+			// resolves to never once the actual argument types are folded in by the
+			// type-driven resolved acceptor.
+			if ($resolvedParametersAcceptor !== null) {
+				$resolvedReturnType = $resolvedParametersAcceptor->getReturnType();
+				$isAlwaysTerminating = $isAlwaysTerminating || ($resolvedReturnType instanceof NeverType && $resolvedReturnType->isExplicit());
+			}
 			$functionThrowPoint = $this->getFunctionThrowPoint($functionReflection, $parametersAcceptor, $normalizedExpr, $scope, $context);
 			if ($functionThrowPoint !== null) {
 				$throwPoints[] = $functionThrowPoint;

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -99,19 +99,20 @@ final class MethodCallHandler implements ExprHandler
 			$scope = $scope->restoreOriginalScopeAfterClosureBind($originalScope);
 		}
 		$parametersAcceptor = null;
+		$variants = [];
+		$namedArgumentsVariants = null;
 		$methodReflection = null;
 		$calledOnType = $varResult->getType();
 		if ($expr->name instanceof Identifier) {
 			$methodName = $expr->name->name;
 			$methodReflection = $scope->getMethodReflection($calledOnType, $methodName);
 			if ($methodReflection !== null) {
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-					$scope,
-					$expr->getArgs(),
-					$methodReflection->getVariants(),
-					$methodReflection->getNamedArgumentsVariants(),
-				);
-
+				$variants = $methodReflection->getVariants();
+				$namedArgumentsVariants = $methodReflection->getNamedArgumentsVariants();
+				// A structural acceptor (names/positions/variadic) drives argument
+				// normalization, the impure point and the throw point - generics are
+				// resolved type-driven by processArgs() into $resolvedParametersAcceptor.
+				$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization($expr->getArgs(), $variants, $namedArgumentsVariants);
 			}
 		} else {
 			$methodNameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, $context->enterDeep());
@@ -145,16 +146,26 @@ final class MethodCallHandler implements ExprHandler
 			$stmt,
 			$methodReflection,
 			$methodReflection !== null ? $scope->getNakedMethod($calledOnType, $methodReflection->getName()) : null,
-			$parametersAcceptor,
+			$variants,
+			$namedArgumentsVariants,
 			$normalizedExpr,
 			$scope,
 			$storage,
 			$nodeCallback,
 			$context,
 		);
+		$resolvedParametersAcceptor = $argsResult->getResolvedParametersAcceptor();
 		$scope = $argsResult->getScope();
 
 		if ($methodReflection !== null) {
+			// The early structural check above only sees the unresolved acceptor
+			// return type; a conditional-return never (e.g. `($x is Foo ? never :
+			// string)`) only resolves to never once the actual argument types are
+			// folded in by the type-driven resolved acceptor.
+			if ($resolvedParametersAcceptor !== null) {
+				$resolvedReturnType = $resolvedParametersAcceptor->getReturnType();
+				$isAlwaysTerminating = $isAlwaysTerminating || ($resolvedReturnType instanceof NeverType && $resolvedReturnType->isExplicit());
+			}
 			$methodThrowPoint = $this->methodThrowPointHelper->getThrowPoint($methodReflection, $parametersAcceptor, $normalizedExpr, $scope, $context);
 			if ($methodThrowPoint !== null) {
 				$throwPoints[] = $methodThrowPoint;
@@ -164,21 +175,27 @@ final class MethodCallHandler implements ExprHandler
 				$nodeScopeResolver->callNodeCallback($nodeCallback, new InvalidateExprNode($normalizedExpr->var), $scope, $storage);
 				$scope = $scope->invalidateExpression($normalizedExpr->var, true, $methodReflection->getDeclaringClass());
 			} elseif ($this->rememberPossiblyImpureFunctionValues && $methodReflection->hasSideEffects()->maybe() && !$methodReflection->getDeclaringClass()->isBuiltin()) {
+				// the remembered call value and the @phpstan-self-out type are
+				// generic-sensitive: resolve them from the type-driven acceptor
+				// processArgs() selected (generics resolved against the actual arg
+				// types), falling back to the structural acceptor for dynamic callees.
+				$acceptorForGenerics = $resolvedParametersAcceptor ?? $parametersAcceptor;
 				$scope = $scope->assignExpression(
 					new PossiblyImpureCallExpr($normalizedExpr, $normalizedExpr->var, sprintf('%s::%s()', $methodReflection->getDeclaringClass()->getDisplayName(), $methodReflection->getName())),
-					$parametersAcceptor->getReturnType(),
+					$acceptorForGenerics->getReturnType(),
 					new MixedType(),
 				);
 			}
 			if (!$methodReflection->isStatic()) {
 				$selfOutType = $methodReflection->getSelfOutType();
 				if ($selfOutType !== null) {
+					$acceptorForGenerics = $resolvedParametersAcceptor ?? $parametersAcceptor;
 					$scope = $scope->assignExpression(
 						$normalizedExpr->var,
 						TemplateTypeHelper::resolveTemplateTypes(
 							$selfOutType,
-							$parametersAcceptor->getResolvedTemplateTypeMap(),
-							$parametersAcceptor instanceof ExtendedParametersAcceptor ? $parametersAcceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
+							$acceptorForGenerics->getResolvedTemplateTypeMap(),
+							$acceptorForGenerics instanceof ExtendedParametersAcceptor ? $acceptorForGenerics->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
 							TemplateTypeVariance::createCovariant(),
 						),
 						$scope->getNativeType($normalizedExpr->var),

--- a/src/Analyser/ExprHandler/NewHandler.php
+++ b/src/Analyser/ExprHandler/NewHandler.php
@@ -37,6 +37,7 @@ use PHPStan\Parser\NewAssignedToPropertyVisitor;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Dummy\DummyConstructorReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ExtendedParametersAcceptor;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
@@ -122,12 +123,10 @@ final class NewHandler implements ExprHandler
 			$classReflection = $this->reflectionProvider->getAnonymousClassReflection($expr->class, $scope); // populates $expr->class->name
 			if ($classReflection->hasConstructor()) {
 				$constructorReflection = $classReflection->getConstructor();
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-					$scope,
-					$expr->getArgs(),
-					$constructorReflection->getVariants(),
-					$constructorReflection->getNamedArgumentsVariants(),
-				);
+				// A structural acceptor (names/positions/variadic) drives argument
+				// normalization and the throw point - generics are resolved
+				// type-driven by processArgs() into the resolved acceptor.
+				$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization($expr->getArgs(), $constructorReflection->getVariants(), $constructorReflection->getNamedArgumentsVariants());
 
 				if ($constructorReflection->getDeclaringClass()->getName() === $classReflection->getName()) {
 					$constructorResult = null;
@@ -208,7 +207,9 @@ final class NewHandler implements ExprHandler
 			}
 		}
 
-		$argsResult = $nodeScopeResolver->processArgs($stmt, $constructorReflection, null, $parametersAcceptor, $normalizedExpr, $scope, $storage, $nodeCallback, $context);
+		$variants = $constructorReflection !== null ? $constructorReflection->getVariants() : [];
+		$namedArgumentsVariants = $constructorReflection !== null ? $constructorReflection->getNamedArgumentsVariants() : null;
+		$argsResult = $nodeScopeResolver->processArgs($stmt, $constructorReflection, null, $variants, $namedArgumentsVariants, $normalizedExpr, $scope, $storage, $nodeCallback, $context);
 		$scope = $argsResult->getScope();
 		$hasYield = $hasYield || $argsResult->hasYield();
 		$throwPoints = array_merge($throwPoints, $argsResult->getThrowPoints());
@@ -245,7 +246,7 @@ final class NewHandler implements ExprHandler
 	}
 
 	/**
-	 * @return array{?MethodReflection, ?ClassReflection, ?ParametersAcceptor, ImpurePoint[]}
+	 * @return array{?ExtendedMethodReflection, ?ClassReflection, ?ParametersAcceptor, ImpurePoint[]}
 	 */
 	private function processConstructorReflection(string $className, New_ $expr, MutatingScope $scope, bool $isDynamic): array
 	{
@@ -258,12 +259,10 @@ final class NewHandler implements ExprHandler
 			$classReflection = $this->reflectionProvider->getClass($className);
 			if ($classReflection->hasConstructor()) {
 				$constructorReflection = $classReflection->getConstructor();
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-					$scope,
-					$expr->getArgs(),
-					$constructorReflection->getVariants(),
-					$constructorReflection->getNamedArgumentsVariants(),
-				);
+				// A structural acceptor (names/positions/variadic) drives argument
+				// normalization and the throw point - generics are resolved
+				// type-driven by processArgs() into the resolved acceptor.
+				$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization($expr->getArgs(), $constructorReflection->getVariants(), $constructorReflection->getNamedArgumentsVariants());
 			}
 		}
 

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -101,62 +101,69 @@ final class StaticCallHandler implements ExprHandler
 		}
 
 		$parametersAcceptor = null;
+		$variants = [];
+		$namedArgumentsVariants = null;
 		$methodReflection = null;
-		$closureBindScope = null;
+		$closureBindScopeFactory = null;
 		if ($expr->name instanceof Identifier) {
 			if ($expr->class instanceof Name) {
 				$classType = $scope->resolveTypeByName($expr->class);
 				$methodName = $expr->name->name;
 				if ($classType->hasMethod($methodName)->yes()) {
 					$methodReflection = $classType->getMethod($methodName, $scope);
-					$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-						$scope,
-						$expr->getArgs(),
-						$methodReflection->getVariants(),
-						$methodReflection->getNamedArgumentsVariants(),
-					);
+					$variants = $methodReflection->getVariants();
+					$namedArgumentsVariants = $methodReflection->getNamedArgumentsVariants();
+					// A structural acceptor (names/positions/variadic) drives argument
+					// normalization, the impure point and the throw point - generics are
+					// resolved type-driven by processArgs() into $resolvedParametersAcceptor.
+					$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization($expr->getArgs(), $variants, $namedArgumentsVariants);
 
 					$declaringClass = $methodReflection->getDeclaringClass();
 					if (
 						$declaringClass->getName() === 'Closure'
 						&& strtolower($methodName) === 'bind'
 					) {
-						$thisType = null;
-						$nativeThisType = null;
-						if (isset($expr->getArgs()[1])) {
-							$argType = $scope->getType($expr->getArgs()[1]->value);
-							if ($argType->isNull()->yes()) {
-								$thisType = null;
-							} else {
-								$thisType = $argType;
-							}
-
-							$nativeArgType = $scope->getNativeType($expr->getArgs()[1]->value);
-							if ($nativeArgType->isNull()->yes()) {
-								$nativeThisType = null;
-							} else {
-								$nativeThisType = $nativeArgType;
-							}
-						}
-						$scopeClasses = ['static'];
-						if (isset($expr->getArgs()[2])) {
-							$argValue = $expr->getArgs()[2]->value;
-							$argValueType = $scope->getType($argValue);
-
-							$directClassNames = $argValueType->getObjectClassNames();
-							if (count($directClassNames) > 0) {
-								$scopeClasses = $directClassNames;
-								$thisTypes = [];
-								foreach ($directClassNames as $directClassName) {
-									$thisTypes[] = new ObjectType($directClassName);
+						// deferred until the closure argument is processed: with
+						// closures processed last, the bound $this/scope arguments
+						// are already evaluated on the scope the factory receives
+						$closureBindScopeFactory = static function (MutatingScope $boundScope) use ($expr): MutatingScope {
+							$thisType = null;
+							$nativeThisType = null;
+							if (isset($expr->getArgs()[1])) {
+								$argType = $boundScope->getType($expr->getArgs()[1]->value);
+								if ($argType->isNull()->yes()) {
+									$thisType = null;
+								} else {
+									$thisType = $argType;
 								}
-								$thisType = TypeCombinator::union(...$thisTypes);
-							} else {
-								$thisType = $argValueType->getClassStringObjectType();
-								$scopeClasses = $thisType->getObjectClassNames();
+
+								$nativeArgType = $boundScope->getNativeType($expr->getArgs()[1]->value);
+								if ($nativeArgType->isNull()->yes()) {
+									$nativeThisType = null;
+								} else {
+									$nativeThisType = $nativeArgType;
+								}
 							}
-						}
-						$closureBindScope = $scope->enterClosureBind($thisType, $nativeThisType, $scopeClasses);
+							$scopeClasses = ['static'];
+							if (isset($expr->getArgs()[2])) {
+								$argValue = $expr->getArgs()[2]->value;
+								$argValueType = $boundScope->getType($argValue);
+
+								$directClassNames = $argValueType->getObjectClassNames();
+								if (count($directClassNames) > 0) {
+									$scopeClasses = $directClassNames;
+									$thisTypes = [];
+									foreach ($directClassNames as $directClassName) {
+										$thisTypes[] = new ObjectType($directClassName);
+									}
+									$thisType = TypeCombinator::union(...$thisTypes);
+								} else {
+									$thisType = $argValueType->getClassStringObjectType();
+									$scopeClasses = $thisType->getObjectClassNames();
+								}
+							}
+							return $boundScope->enterClosureBind($thisType, $nativeThisType, $scopeClasses);
+						};
 					}
 				} else {
 					$throwPoints[] = InternalThrowPoint::createImplicit($scope, $expr);
@@ -166,12 +173,9 @@ final class StaticCallHandler implements ExprHandler
 				$methodName = $expr->name->name;
 				$methodReflection = $scope->getMethodReflection($classType, $methodName);
 				if ($methodReflection !== null) {
-					$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-						$scope,
-						$expr->getArgs(),
-						$methodReflection->getVariants(),
-						$methodReflection->getNamedArgumentsVariants(),
-					);
+					$variants = $methodReflection->getVariants();
+					$namedArgumentsVariants = $methodReflection->getNamedArgumentsVariants();
+					$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization($expr->getArgs(), $variants, $namedArgumentsVariants);
 				}
 			}
 		} else {
@@ -219,11 +223,20 @@ final class StaticCallHandler implements ExprHandler
 			$returnType = $parametersAcceptor->getReturnType();
 			$isAlwaysTerminating = $isAlwaysTerminating || ($returnType instanceof NeverType && $returnType->isExplicit());
 		}
-		$argsResult = $nodeScopeResolver->processArgs($stmt, $methodReflection, null, $parametersAcceptor, $normalizedExpr, $scope, $storage, $nodeCallback, $context, $closureBindScope);
+		$argsResult = $nodeScopeResolver->processArgs($stmt, $methodReflection, null, $variants, $namedArgumentsVariants, $normalizedExpr, $scope, $storage, $nodeCallback, $context, $closureBindScopeFactory);
+		$resolvedParametersAcceptor = $argsResult->getResolvedParametersAcceptor();
 		$scope = $argsResult->getScope();
 		$scopeFunction = $scope->getFunction();
 
 		if ($methodReflection !== null) {
+			// The early structural check above only sees the unresolved acceptor
+			// return type; a conditional-return never (e.g. `($x is Foo ? never :
+			// string)`) only resolves to never once the actual argument types are
+			// folded in by the type-driven resolved acceptor.
+			if ($resolvedParametersAcceptor !== null) {
+				$resolvedReturnType = $resolvedParametersAcceptor->getReturnType();
+				$isAlwaysTerminating = $isAlwaysTerminating || ($resolvedReturnType instanceof NeverType && $resolvedReturnType->isExplicit());
+			}
 			$methodThrowPoint = $this->methodThrowPointHelper->getThrowPoint($methodReflection, $parametersAcceptor, $normalizedExpr, $scope, $context);
 			if ($methodThrowPoint !== null) {
 				$throwPoints[] = $methodThrowPoint;
@@ -253,9 +266,13 @@ final class StaticCallHandler implements ExprHandler
 			&& $methodReflection->hasSideEffects()->maybe()
 			&& !$methodReflection->getDeclaringClass()->isBuiltin()
 		) {
+			// the remembered call value is generic-sensitive: resolve it from the
+			// type-driven acceptor processArgs() selected (generics resolved against
+			// the actual arg types), falling back to the structural acceptor.
+			$acceptorForGenerics = $resolvedParametersAcceptor ?? $parametersAcceptor;
 			$scope = $scope->assignExpression(
 				new PossiblyImpureCallExpr($normalizedExpr, new Variable('this'), sprintf('%s::%s()', $methodReflection->getDeclaringClass()->getDisplayName(), $methodReflection->getName())),
-				$parametersAcceptor->getReturnType(),
+				$acceptorForGenerics->getReturnType(),
 				new MixedType(),
 			);
 		}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3345,15 +3345,14 @@ class NodeScopeResolver
 					$classReflection = $this->reflectionProvider->getClass($className);
 					if ($classReflection->hasConstructor()) {
 						$constructorReflection = $classReflection->getConstructor();
-						$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-							$scope,
+						$parametersAcceptor = ParametersAcceptorSelector::combineVariantsForNormalization(
 							$attr->args,
 							$constructorReflection->getVariants(),
 							$constructorReflection->getNamedArgumentsVariants(),
 						);
 						$expr = new New_($attr->name, $attr->args);
 						$expr = ArgumentsNormalizer::reorderNewArguments($parametersAcceptor, $expr) ?? $expr;
-						$this->processArgs($stmt, $constructorReflection, null, $parametersAcceptor, $expr, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+						$this->processArgs($stmt, $constructorReflection, null, $constructorReflection->getVariants(), $constructorReflection->getNamedArgumentsVariants(), $expr, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
 						$this->callNodeCallback($nodeCallback, $attr, $scope, $storage);
 						continue;
 					}
@@ -3540,27 +3539,69 @@ class NodeScopeResolver
 
 	/**
 	 * @param MethodReflection|FunctionReflection|null $calleeReflection
+	 * @param ParametersAcceptor[] $parametersAcceptors
+	 * @param ParametersAcceptor[]|null $namedArgumentsVariants
 	 * @param callable(Node $node, Scope $scope): void $nodeCallback
+	 * @param (callable(MutatingScope): MutatingScope)|null $closureBindScopeFactory
 	 */
 	public function processArgs(
 		Node\Stmt $stmt,
 		$calleeReflection,
 		?ExtendedMethodReflection $nakedMethodReflection,
-		?ParametersAcceptor $parametersAcceptor,
+		array $parametersAcceptors,
+		?array $namedArgumentsVariants,
 		CallLike $callLike,
 		MutatingScope $scope,
 		ExpressionResultStorage $storage,
 		callable $nodeCallback,
 		ExpressionContext $context,
-		?MutatingScope $closureBindScope = null,
-	): ExpressionResult
+		?callable $closureBindScopeFactory = null,
+	): ArgsResult
 	{
 		$args = $callLike->getArgs();
 
-		$parameters = null;
-		if ($parametersAcceptor !== null) {
-			$parameters = $parametersAcceptor->getParameters();
-		}
+		// Evolving-scope arg types: gathered as each argument is processed on the
+		// scope that evolves arg-to-arg. They select the FINAL resolved acceptor
+		// (the call's return type, by-ref OUT types), which type-resolves generics
+		// from the actual argument types.
+		$gatheredTypes = [];
+		$gatheredUnpack = false;
+		$gatheredHasName = false;
+		$gatheredArgTypeByIndex = [];
+
+		// The intrinsic argument overrides (array_map/filter/walk/find, curl_setopt,
+		// implode, Closure::bind) rewrite a callback parameter's type from its
+		// sibling arguments. Apply them up front on the entry scope - the parameter
+		// pushed on the in-function-call stack while each argument is processed (and
+		// priced, e.g. a closure's inferred return type) must be the overridden one,
+		// exactly as when the caller pre-selected via selectFromArgs().
+		$parametersAcceptors = ParametersAcceptorSelector::applyIntrinsicArgOverrides(
+			$args,
+			$parametersAcceptors,
+			$namedArgumentsVariants,
+			$scope,
+			static fn (Expr $e): Type => $scope->getType($e),
+			static fn (Expr $e): Type => $scope->getNativeType($e),
+			static fn (Type $t): Type => $scope->getIterableValueType($t),
+			static fn (Type $t): Type => $scope->getIterableKeyType($t),
+		);
+
+		// Metadata acceptor base - NO forward read. The per-argument resolution below picks the
+		// count-correct variant (the by-ref/variadic STRUCTURE is variant-stable except where it is
+		// keyed off the argument count, e.g. sscanf - and the count is known structurally) and
+		// resolves generic parameter types from the args gathered so far; the call's return type
+		// comes from the post-loop resolved acceptor.
+		$metadataAcceptor = $parametersAcceptors[0] ?? null;
+
+		// Whether selecting an acceptor is type-driven at all: multiple variants to
+		// choose between, templates or conditionals to resolve from the arg types,
+		// or named-argument variants. When it is not, the gathered arg types can
+		// never influence the selected acceptor, so the faithful-return gather walk
+		// of a closure/arrow argument (gatherClosureArgType()) would be pure waste -
+		// a plain mixed keeps the count/name bookkeeping correct.
+		$typeDrivenAcceptorSelection = count($parametersAcceptors) > 1
+			|| $namedArgumentsVariants !== null
+			|| ($metadataAcceptor !== null && ParametersAcceptorSelector::hasAcceptorTemplateOrLateResolvableType($metadataAcceptor));
 
 		$hasYield = false;
 		$throwPoints = [];
@@ -3572,33 +3613,94 @@ class NodeScopeResolver
 		$deferredByRefClosureResults = [];
 
 		$processingOrder = array_keys($args);
-		$hasReorderedArgs = false;
-		foreach ($args as $arg) {
-			if ($arg->hasAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE)) {
-				$hasReorderedArgs = true;
-				break;
+		usort($processingOrder, static function (int $a, int $b) use ($args): int {
+			$aOriginalArg = $args[$a]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
+			$bOriginalArg = $args[$b]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
+			$aValue = $aOriginalArg !== null ? $aOriginalArg->value : $args[$a]->value;
+			$bValue = $bOriginalArg !== null ? $bOriginalArg->value : $args[$b]->value;
+			$aIsClosure = $aValue instanceof Expr\Closure || $aValue instanceof Expr\ArrowFunction;
+			$bIsClosure = $bValue instanceof Expr\Closure || $bValue instanceof Expr\ArrowFunction;
+			if ($aIsClosure !== $bIsClosure) {
+				// closures sort after non-closures so every sibling feeding an
+				// intrinsic override / generic callable(T) is in scope first
+				return $aIsClosure ? 1 : -1;
 			}
-		}
-		if ($hasReorderedArgs) {
-			usort($processingOrder, static function (int $a, int $b) use ($args): int {
-				$aOriginal = $args[$a]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
-				$bOriginal = $args[$b]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
-				if ($aOriginal === null && $bOriginal === null) {
-					return $a <=> $b;
-				}
-				if ($aOriginal === null) {
-					return 1;
-				}
-				if ($bOriginal === null) {
-					return -1;
-				}
 
-				return $aOriginal->getStartTokenPos() <=> $bOriginal->getStartTokenPos();
-			});
-		}
+			$aOriginal = $args[$a]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
+			$bOriginal = $args[$b]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
+			if ($aOriginal === null && $bOriginal === null) {
+				return $a <=> $b;
+			}
+			if ($aOriginal === null) {
+				return 1;
+			}
+			if ($bOriginal === null) {
+				return -1;
+			}
 
+			return $aOriginal->getStartTokenPos() <=> $bOriginal->getStartTokenPos();
+		});
+
+		$countStableMetadataAcceptor = null;
 		foreach ($processingOrder as $i) {
 			$arg = $args[$i];
+
+			if ($arg->value instanceof Expr\Closure || $arg->value instanceof Expr\ArrowFunction) {
+				// Gather the closure/arrow type for the FINAL resolved acceptor on
+				// the evolving scope, BEFORE the body is processed with a possibly
+				// generic-resolved parameter injected, so the inferred return type
+				// stays faithful to the closure's own declaration and its own
+				// contribution (a TValue from its return) participates in the final
+				// resolution (see gatherClosureArgType()).
+				$originalArgForGather = $arg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $arg;
+				$gatheredArgTypeByIndex[$i] = $typeDrivenAcceptorSelection
+					? $this->gatherClosureArgType($parametersAcceptors, $i, $arg->value, $scope)
+					: new MixedType();
+				$this->addGatheredArgType($gatheredTypes, $gatheredUnpack, $gatheredHasName, $originalArgForGather, $i, $gatheredArgTypeByIndex[$i]);
+			}
+
+			$argMetadataAcceptor = $metadataAcceptor;
+			if (
+				$metadataAcceptor !== null
+				&& (count($parametersAcceptors) > 1 || ParametersAcceptorSelector::hasAcceptorTemplateOrLateResolvableParameterType($metadataAcceptor))
+			) {
+				if ($this->argConsumesResolvedParameterType($arg->value)) {
+					// Resolve the acceptor for this argument from the args gathered SO FAR, padded to the
+					// full argument count with mixed. Closures sort last and by-ref out-params follow the
+					// args that pin them, so determining siblings are already processed; the mixed pad keeps
+					// the argument COUNT correct so the by-ref/variadic variant stays stable (e.g. sscanf),
+					// while processed siblings resolve a generic callable(T) parameter. No forward read.
+					$paddedTypes = [];
+					$paddedUnpack = false;
+					$paddedHasName = false;
+					foreach ($args as $j => $paddedArg) {
+						$paddedOriginalArg = $paddedArg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $paddedArg;
+						$this->addGatheredArgType($paddedTypes, $paddedUnpack, $paddedHasName, $paddedOriginalArg, $j, $gatheredArgTypeByIndex[$j] ?? new MixedType());
+					}
+					$argMetadataAcceptor = $this->selectArgsMetadataAcceptor($args, $paddedTypes, $parametersAcceptors, $namedArgumentsVariants, $paddedHasName, $paddedUnpack, $scope);
+				} else {
+					// Only a closure/arrow function consumes the generic-RESOLVED
+					// parameter type: its body is inferred from the resolved
+					// callable(T) - directly, or through the in-function-call stack
+					// when nested anywhere inside the argument. Every other argument
+					// reads variant-stable facts off its parameter (by-ref flag,
+					// callable bookkeeping), so one all-mixed count-stable selection
+					// serves them all instead of a full template inference per argument.
+					if ($countStableMetadataAcceptor === null) {
+						$paddedTypes = [];
+						$paddedUnpack = false;
+						$paddedHasName = false;
+						foreach ($args as $j => $paddedArg) {
+							$paddedOriginalArg = $paddedArg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $paddedArg;
+							$this->addGatheredArgType($paddedTypes, $paddedUnpack, $paddedHasName, $paddedOriginalArg, $j, new MixedType());
+						}
+						$countStableMetadataAcceptor = $this->selectArgsMetadataAcceptor($args, $paddedTypes, $parametersAcceptors, $namedArgumentsVariants, $paddedHasName, $paddedUnpack, $scope);
+					}
+					$argMetadataAcceptor = $countStableMetadataAcceptor;
+				}
+			}
+			$parameters = $argMetadataAcceptor !== null ? $argMetadataAcceptor->getParameters() : null;
+
 			$assignByReference = false;
 			$parameter = null;
 			$parameterType = null;
@@ -3624,7 +3726,7 @@ class NodeScopeResolver
 						$parameterNativeType = $matchedParameter->getNativeType();
 					}
 					$parameter = $matchedParameter;
-				} elseif (count($parameters) > 0 && $parametersAcceptor->isVariadic()) {
+				} elseif (count($parameters) > 0 && $argMetadataAcceptor->isVariadic()) {
 					$lastParameter = array_last($parameters);
 					$assignByReference = $lastParameter->passedByReference()->createsNewVariable();
 					$parameterType = $lastParameter->getType();
@@ -3663,14 +3765,15 @@ class NodeScopeResolver
 
 			$originalScope = $scope;
 			$scopeToPass = $scope;
-			if ($i === 0 && $closureBindScope !== null && ($arg->value instanceof Expr\Closure || $arg->value instanceof Expr\ArrowFunction)) {
-				$scopeToPass = $closureBindScope;
+			if ($i === 0 && $closureBindScopeFactory !== null && ($arg->value instanceof Expr\Closure || $arg->value instanceof Expr\ArrowFunction)) {
+				$scopeToPass = $closureBindScopeFactory($scope);
 			}
 
 			if ($arg->value instanceof Expr\Closure) {
+
 				$restoreThisScope = null;
 				if (
-					$closureBindScope === null
+					$closureBindScopeFactory === null
 					&& $parameter instanceof ExtendedParameterReflection
 					&& !$arg->value->static
 				) {
@@ -3753,8 +3856,9 @@ class NodeScopeResolver
 					$deferredInvalidateExpressions[] = [$invalidateExpressions, $uses];
 				}
 			} elseif ($arg->value instanceof Expr\ArrowFunction) {
+
 				if (
-					$closureBindScope === null
+					$closureBindScopeFactory === null
 					&& $parameter instanceof ExtendedParameterReflection
 					&& !$arg->value->static
 				) {
@@ -3826,6 +3930,9 @@ class NodeScopeResolver
 						}
 					}
 				}
+
+				$gatheredArgTypeByIndex[$i] = $exprType;
+				$this->addGatheredArgType($gatheredTypes, $gatheredUnpack, $gatheredHasName, $originalArg, $i, $gatheredArgTypeByIndex[$i]);
 			}
 
 			if ($assignByReference && $lookForUnset) {
@@ -3836,7 +3943,7 @@ class NodeScopeResolver
 				$scope = $scope->popInFunctionCall();
 			}
 
-			if ($i !== 0 || $closureBindScope === null) {
+			if ($i !== 0 || $closureBindScopeFactory === null) {
 				continue;
 			}
 
@@ -3851,14 +3958,36 @@ class NodeScopeResolver
 			$scope = $deferredClosureResult->applyByRefUseScope($scope);
 		}
 
-		if ($parameters !== null) {
+		// Type-driven resolved acceptor: the arg types gathered on the evolving
+		// scope select (and generic-resolve) the acceptor that drives the call's
+		// return type. Intrinsic overrides are applied on the final scope,
+		// mirroring the original selectFromArgs().
+		$resolvedAcceptor = null;
+		if ($parametersAcceptors !== []) {
+			$resolvedAcceptor = $this->selectArgsMetadataAcceptor($args, $gatheredTypes, $parametersAcceptors, $namedArgumentsVariants, $gatheredHasName, $gatheredUnpack, $scope);
+		}
+
+		// The by-ref OUT writeback reads the metadata acceptor: it is selected from
+		// the full argument count (stable variant). When that single acceptor still
+		// carries templates (fast path), its OUT types need generic-resolving from the
+		// now-complete gathered arg types - the post-loop $resolvedAcceptor is exactly
+		// that (same variant, resolved); otherwise the metadata acceptor is already resolved.
+		$writebackAcceptor = $metadataAcceptor;
+		if (
+			$metadataAcceptor !== null
+			&& (count($parametersAcceptors) > 1 || ParametersAcceptorSelector::hasAcceptorTemplateOrLateResolvableParameterType($metadataAcceptor))
+		) {
+			$writebackAcceptor = $resolvedAcceptor;
+		}
+		$writebackParameters = $writebackAcceptor !== null ? $writebackAcceptor->getParameters() : null;
+		if ($writebackParameters !== null) {
 			foreach ($args as $i => $arg) {
 				$assignByReference = false;
 				$currentParameter = null;
-				if (isset($parameters[$i])) {
-					$currentParameter = $parameters[$i];
-				} elseif (count($parameters) > 0 && $parametersAcceptor->isVariadic()) {
-					$currentParameter = array_last($parameters);
+				if (isset($writebackParameters[$i])) {
+					$currentParameter = $writebackParameters[$i];
+				} elseif (count($writebackParameters) > 0 && $writebackAcceptor->isVariadic()) {
+					$currentParameter = array_last($writebackParameters);
 				}
 
 				if ($currentParameter !== null) {
@@ -3909,11 +4038,12 @@ class NodeScopeResolver
 					if (!$argType->isObject()->no()) {
 						$nakedReturnType = null;
 						if ($nakedMethodReflection !== null) {
-							$nakedParametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-								$scope,
-								$args,
+							$nakedParametersAcceptor = $this->selectArgsAcceptor(
+								$gatheredTypes,
 								$nakedMethodReflection->getVariants(),
 								$nakedMethodReflection->getNamedArgumentsVariants(),
+								$gatheredHasName,
+								$gatheredUnpack,
 							);
 							$nakedReturnType = $nakedParametersAcceptor->getReturnType();
 						}
@@ -3934,7 +4064,154 @@ class NodeScopeResolver
 		}
 
 		// not storing this, it's scope after processing all args
-		return $this->expressionResultFactory->create($scope, $scope, $callLike, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+		return new ArgsResult(
+			$this->expressionResultFactory->create($scope, $scope, $callLike, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints),
+			$resolvedAcceptor,
+		);
+	}
+
+	/**
+	 * Applies the intrinsic argument overrides (array_map/filter/walk/find,
+	 * curl_setopt, implode, Closure::bind) on the arg-to-arg evolved scope,
+	 * then type-selects the metadata acceptor over
+	 * the arg types gathered so far. The overrides read sibling arg types - which
+	 * closures-last ordering keeps in scope/$gatheredTypes before any closure.
+	 *
+	 * @param Node\Arg[] $args
+	 * @param array<int|string, Type> $gatheredTypes
+	 * @param ParametersAcceptor[] $parametersAcceptors
+	 * @param ParametersAcceptor[]|null $namedArgumentsVariants
+	 */
+	private function selectArgsMetadataAcceptor(array $args, array $gatheredTypes, array $parametersAcceptors, ?array $namedArgumentsVariants, bool $hasName, bool $unpack, MutatingScope $scope): ParametersAcceptor
+	{
+		$overridden = ParametersAcceptorSelector::applyIntrinsicArgOverrides(
+			$args,
+			$parametersAcceptors,
+			$namedArgumentsVariants,
+			$scope,
+			static fn (Expr $e): Type => $scope->getType($e),
+			static fn (Expr $e): Type => $scope->getNativeType($e),
+			static fn (Type $t): Type => $scope->getIterableValueType($t),
+			static fn (Type $t): Type => $scope->getIterableKeyType($t),
+		);
+
+		return $this->selectArgsAcceptor($gatheredTypes, $overridden, $namedArgumentsVariants, $hasName, $unpack);
+	}
+
+	/**
+	 * @param array<int|string, Type> $types
+	 * @param ParametersAcceptor[] $parametersAcceptors
+	 * @param ParametersAcceptor[]|null $namedArgumentsVariants
+	 */
+	private function selectArgsAcceptor(array $types, array $parametersAcceptors, ?array $namedArgumentsVariants, bool $hasName, bool $unpack): ParametersAcceptor
+	{
+		return $hasName && $namedArgumentsVariants !== null
+			? ParametersAcceptorSelector::selectFromTypes($types, $namedArgumentsVariants, $unpack)
+			: ParametersAcceptorSelector::selectFromTypes($types, $parametersAcceptors, $unpack);
+	}
+
+	/**
+	 * Ports the gather-keying of ParametersAcceptorSelector::selectFromArgs():
+	 * indexes the gathered arg type by name (sets $hasName) vs position, and
+	 * expands unpacked constant arrays / falls back to the iterable value type
+	 * (sets $unpack), so selectFromTypes() picks the matching variant.
+	 *
+	 * @param array<int|string, Type> $types
+	 */
+	private function addGatheredArgType(array &$types, bool &$unpack, bool &$hasName, Node\Arg $originalArg, int $i, Type $type): void
+	{
+		if ($originalArg->name !== null) {
+			$index = $originalArg->name->toString();
+			$hasName = true;
+		} else {
+			$index = $i;
+		}
+
+		if ($originalArg->unpack) {
+			$unpack = true;
+			$constantArrays = $type->getConstantArrays();
+			if (count($constantArrays) > 0) {
+				foreach ($constantArrays as $constantArray) {
+					$values = $constantArray->getValueTypes();
+					foreach ($constantArray->getKeyTypes() as $j => $keyType) {
+						$valueType = $values[$j];
+						$valueIndex = $keyType->getValue();
+						if (is_string($valueIndex)) {
+							$hasName = true;
+						} else {
+							$valueIndex = $i + $j;
+						}
+
+						$types[$valueIndex] = isset($types[$valueIndex])
+							? TypeCombinator::union($types[$valueIndex], $valueType)
+							: $valueType;
+					}
+				}
+			} else {
+				$types[$index] = $type->getIterableValueType();
+			}
+		} else {
+			$types[$index] = $type;
+		}
+	}
+
+	/**
+	 * Resolves the type of a closure/arrow function argument for the generic
+	 * gather, mirroring ParametersAcceptorSelector::selectFromArgs(): the closure
+	 * type is read with the RAW (un-generic-resolved) acceptor parameter pushed
+	 * onto the in-function-call stack, so its body sees the template parameter
+	 * (effectively mixed for an untyped param) rather than a parameter already
+	 * resolved from sibling args. That keeps the inferred return type (the U in
+	 * callable(T): U) faithful to the closure's own declaration.
+	 *
+	 * @param ParametersAcceptor[] $parametersAcceptors
+	 */
+	private function gatherClosureArgType(array $parametersAcceptors, int $i, Expr $closureExpr, MutatingScope $scope): Type
+	{
+		$rawParameter = null;
+		if (count($parametersAcceptors) === 1) {
+			$rawParameters = $parametersAcceptors[0]->getParameters();
+			if (isset($rawParameters[$i])) {
+				$rawParameter = $rawParameters[$i];
+			} elseif (count($rawParameters) > 0 && $parametersAcceptors[0]->isVariadic()) {
+				$rawParameter = array_last($rawParameters);
+			}
+		}
+
+		if ($rawParameter !== null) {
+			$scope = $scope->pushInFunctionCall(null, $rawParameter, false);
+		}
+
+		return $scope->getType($closureExpr);
+	}
+
+	/**
+	 * Whether processing this argument consumes the generic-RESOLVED parameter
+	 * type: a closure/arrow function does - its parameters and body scope are
+	 * typed from the resolved callable(T) - whether it IS the argument or is
+	 * nested anywhere inside it (the enclosing parameter is pushed on the
+	 * in-function-call stack and the nested closure types itself from there).
+	 * Every other argument only reads variant-stable facts off its parameter.
+	 */
+	private function argConsumesResolvedParameterType(Expr $value): bool
+	{
+		if ($value instanceof Expr\Closure || $value instanceof Expr\ArrowFunction) {
+			return true;
+		}
+
+		// cached on the node - args are re-processed across convergence passes
+		$cached = $value->getAttribute('phpstanArgContainsClosure');
+		if ($cached !== null) {
+			return $cached;
+		}
+
+		$contains = (new NodeFinder())->findFirst(
+			[$value],
+			static fn (Node $node): bool => $node instanceof Expr\Closure || $node instanceof Expr\ArrowFunction,
+		) !== null;
+		$value->setAttribute('phpstanArgContainsClosure', $contains);
+
+		return $contains;
 	}
 
 	/**

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3593,6 +3593,12 @@ class NodeScopeResolver
 		// comes from the post-loop resolved acceptor.
 		$metadataAcceptor = $parametersAcceptors[0] ?? null;
 
+		// Both predicates are hoisted out of the per-argument loop - they traverse
+		// the acceptor's parameter/return types.
+		$hasTemplateParameterType = $metadataAcceptor !== null
+			&& ParametersAcceptorSelector::hasAcceptorTemplateOrLateResolvableParameterType($metadataAcceptor);
+		$argMetadataIsTypeDriven = count($parametersAcceptors) > 1 || $hasTemplateParameterType;
+
 		// Whether selecting an acceptor is type-driven at all: multiple variants to
 		// choose between, templates or conditionals to resolve from the arg types,
 		// or named-argument variants. When it is not, the gathered arg types can
@@ -3601,7 +3607,8 @@ class NodeScopeResolver
 		// a plain mixed keeps the count/name bookkeeping correct.
 		$typeDrivenAcceptorSelection = count($parametersAcceptors) > 1
 			|| $namedArgumentsVariants !== null
-			|| ($metadataAcceptor !== null && ParametersAcceptorSelector::hasAcceptorTemplateOrLateResolvableType($metadataAcceptor));
+			|| $hasTemplateParameterType
+			|| ($metadataAcceptor !== null && $metadataAcceptor->getReturnType()->hasTemplateOrLateResolvableType());
 
 		$hasYield = false;
 		$throwPoints = [];
@@ -3660,10 +3667,7 @@ class NodeScopeResolver
 			}
 
 			$argMetadataAcceptor = $metadataAcceptor;
-			if (
-				$metadataAcceptor !== null
-				&& (count($parametersAcceptors) > 1 || ParametersAcceptorSelector::hasAcceptorTemplateOrLateResolvableParameterType($metadataAcceptor))
-			) {
+			if ($metadataAcceptor !== null && $argMetadataIsTypeDriven) {
 				if ($this->argConsumesResolvedParameterType($arg->value)) {
 					// Resolve the acceptor for this argument from the args gathered SO FAR, padded to the
 					// full argument count with mixed. Closures sort last and by-ref out-params follow the
@@ -3961,10 +3965,14 @@ class NodeScopeResolver
 		// Type-driven resolved acceptor: the arg types gathered on the evolving
 		// scope select (and generic-resolve) the acceptor that drives the call's
 		// return type. Intrinsic overrides are applied on the final scope,
-		// mirroring the original selectFromArgs().
+		// mirroring the original selectFromArgs(). When the selection is not
+		// type-driven, the single (already-overridden) acceptor IS the resolved
+		// acceptor - the fast path selectFromArgs() used to take.
 		$resolvedAcceptor = null;
 		if ($parametersAcceptors !== []) {
-			$resolvedAcceptor = $this->selectArgsMetadataAcceptor($args, $gatheredTypes, $parametersAcceptors, $namedArgumentsVariants, $gatheredHasName, $gatheredUnpack, $scope);
+			$resolvedAcceptor = $typeDrivenAcceptorSelection
+				? $this->selectArgsMetadataAcceptor($args, $gatheredTypes, $parametersAcceptors, $namedArgumentsVariants, $gatheredHasName, $gatheredUnpack, $scope)
+				: $metadataAcceptor;
 		}
 
 		// The by-ref OUT writeback reads the metadata acceptor: it is selected from
@@ -3973,10 +3981,7 @@ class NodeScopeResolver
 		// now-complete gathered arg types - the post-loop $resolvedAcceptor is exactly
 		// that (same variant, resolved); otherwise the metadata acceptor is already resolved.
 		$writebackAcceptor = $metadataAcceptor;
-		if (
-			$metadataAcceptor !== null
-			&& (count($parametersAcceptors) > 1 || ParametersAcceptorSelector::hasAcceptorTemplateOrLateResolvableParameterType($metadataAcceptor))
-		) {
+		if ($metadataAcceptor !== null && $argMetadataIsTypeDriven) {
 			$writebackAcceptor = $resolvedAcceptor;
 		}
 		$writebackParameters = $writebackAcceptor !== null ? $writebackAcceptor->getParameters() : null;

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -580,12 +580,23 @@ final class ParametersAcceptorSelector
 		return $parametersAcceptors;
 	}
 
-	private static function hasAcceptorTemplateOrLateResolvableType(ParametersAcceptor $acceptor): bool
+	/**
+	 * @internal
+	 */
+	public static function hasAcceptorTemplateOrLateResolvableType(ParametersAcceptor $acceptor): bool
 	{
 		if ($acceptor->getReturnType()->hasTemplateOrLateResolvableType()) {
 			return true;
 		}
 
+		return self::hasAcceptorTemplateOrLateResolvableParameterType($acceptor);
+	}
+
+	/**
+	 * @internal
+	 */
+	public static function hasAcceptorTemplateOrLateResolvableParameterType(ParametersAcceptor $acceptor): bool
+	{
 		foreach ($acceptor->getParameters() as $parameter) {
 			if (
 				$parameter instanceof ExtendedParameterReflection
@@ -720,6 +731,34 @@ final class ParametersAcceptorSelector
 		}
 
 		return GenericParametersAcceptorResolver::resolve($types, self::combineAcceptors($winningAcceptors));
+	}
+
+	/**
+	 * Picks the structural ParametersAcceptor (parameter names/positions/variadic
+	 * only) that drives argument normalization / reordering. Unlike selectFromArgs()
+	 * it never reads argument types from a Scope, so it is safe to call before the
+	 * arguments have been processed - generics are resolved separately, type-driven.
+	 *
+	 * @internal
+	 * @param Node\Arg[] $args
+	 * @param ParametersAcceptor[] $variants
+	 * @param ParametersAcceptor[]|null $namedArgumentsVariants
+	 */
+	public static function combineVariantsForNormalization(array $args, array $variants, ?array $namedArgumentsVariants): ParametersAcceptor
+	{
+		$hasName = false;
+		foreach ($args as $arg) {
+			if ($arg->name !== null) {
+				$hasName = true;
+				break;
+			}
+		}
+
+		$selectedVariants = $hasName && $namedArgumentsVariants !== null ? $namedArgumentsVariants : $variants;
+
+		return count($selectedVariants) === 1
+			? $selectedVariants[0]
+			: self::combineAcceptors($selectedVariants);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/closure-bind-nullable-this.php
+++ b/tests/PHPStan/Analyser/nsrt/closure-bind-nullable-this.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ClosureBindNullableThis;
+
+use Closure;
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public int $prop = 1;
+
+}
+
+function (?Foo $foo): void {
+	Closure::bind(function () {
+		assertType('ClosureBindNullableThis\Foo|null', $this);
+		assertNativeType('ClosureBindNullableThis\Foo|null', $this);
+	}, $foo);
+};
+
+function (Foo $foo): void {
+	Closure::bind(function () {
+		assertType('ClosureBindNullableThis\Foo', $this);
+	}, $foo);
+};
+
+function (): void {
+	Closure::bind(function () {
+		assertType('*ERROR*', $this);
+	}, null);
+};


### PR DESCRIPTION
Extracted from the resolve-type-rewrite branch: `processArgs()` no longer receives a pre-selected `ParametersAcceptor` — it receives the callee's variants and selects the acceptor itself, from argument types gathered while the arguments are processed.

**What changes**

- **Closures process last.** Arguments are walked in closures-after-non-closures order (stable within each group by original position), so every sibling feeding a generic `callable(T)` parameter or an intrinsic argument override is evaluated before the closure body is analysed.
- **Type-driven selection inside `processArgs()`.** Argument types are gathered on the arg-to-arg evolving scope; a closure/arrow argument resolves its parameter metadata from the args gathered so far (padded to the full count with `mixed`, keeping count-keyed by-ref/variadic variants stable, e.g. `sscanf`). The post-loop resolved acceptor is returned via the new `ArgsResult` value object. No argument's type is read before that argument is processed.
- **Callers** use the new `ParametersAcceptorSelector::combineVariantsForNormalization()` for argument normalization and structural metadata, and read the resolved acceptor off `ArgsResult` for the explicit-never terminating check (conditional-return `never` only resolves once actual argument types are folded in) and the generic-sensitive `@phpstan-self-out` / remembered-call-value types.
- **`Closure::bind`'s bind scope** became a deferred factory, evaluated once the bound `$this`/scope arguments have been processed — sound now that they precede the closure in processing order.
- **Intrinsic argument overrides** (`array_map`/`array_filter`/`array_walk`/`array_find`, `curl_setopt`, `implode`, `Closure::bind`) are applied once at the head of `processArgs()`, so the parameter pushed on the in-function-call stack while an argument is processed is the overridden one — exactly as when the callers pre-selected via `selectFromArgs()`.

All suites pass unchanged: NodeScopeResolverTest 1693/1693, full suite 17809 tests, `make phpstan`, `make cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7