### PR TITLE
Faster handling of enums with lots of cases

### DIFF
--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -76,6 +76,9 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 	private ?Type $arrayKeyType = null;
 
+	/** @var array<int, string> */
+	private array $cachedDescriptions = [];
+
 	/** @api */
 	public function __construct(private string $value, private bool $isClassString = false)
 	{
@@ -119,9 +122,15 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 	public function describe(VerbosityLevel $level): string
 	{
+		$levelValue = $level->getLevelValue();
+
+		if (isset($this->cachedDescriptions[$levelValue])) {
+			return $this->cachedDescriptions[$levelValue];
+		}
+
 		return $level->handle(
 			static fn (): string => 'string',
-			function (): string {
+			function () use ($levelValue): string {
 				$value = $this->value;
 
 				if (!$this->isClassString) {
@@ -132,9 +141,9 @@ class ConstantStringType extends StringType implements ConstantScalarType
 					}
 				}
 
-				return self::export($value);
+				return $this->cachedDescriptions[$levelValue] = self::export($value);
 			},
-			fn (): string => self::export($this->value),
+			fn (): string => $this->cachedDescriptions[$levelValue] = self::export($this->value),
 		);
 	}
 


### PR DESCRIPTION
reproducer from https://github.com/phpstan/phpstan/issues/14978

before this PR: ~3.32 seconds
after this PR: ~2.73 seconds

speedup lies in slow `ConstantStrintType->export()`

before profile
<img width="627" height="278" alt="grafik" src="https://github.com/user-attachments/assets/ce57b1f6-7241-4d36-a5b4-cec1d82b413f" />


---

the PR here combined with https://github.com/phpstan/phpstan-src/pull/6116 will bring the reproducer down to ~1,4 seconds
