### PR TITLE
Small extractions: isGenerator node memo, keep-void yield checks

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -592,9 +592,6 @@ final class ParametersAcceptorSelector
 		return self::hasAcceptorTemplateOrLateResolvableParameterType($acceptor);
 	}
 
-	/**
-	 * @internal
-	 */
 	public static function hasAcceptorTemplateOrLateResolvableParameterType(ParametersAcceptor $acceptor): bool
 	{
 		foreach ($acceptor->getParameters() as $parameter) {

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -277,17 +277,23 @@ class PhpFunctionFromParserNodeReflection implements FunctionReflection, Extende
 
 	public function isGenerator(): bool
 	{
-		return $this->nodeIsOrContainsYield($this->functionLike);
+		// the yield scan walks the whole body; reflections for the same node are
+		// recreated per ask, so the answer is memoized on the AST node itself
+		// and lives and dies with the parser-cached AST
+		$cached = $this->functionLike->getAttribute('phpstanIsGenerator');
+		if ($cached !== null) {
+			return $cached;
+		}
+
+		$isGenerator = NodeScanner::nodeIsOrContainsYield($this->functionLike);
+		$this->functionLike->setAttribute('phpstanIsGenerator', $isGenerator);
+
+		return $isGenerator;
 	}
 
 	public function acceptsNamedArguments(): TrinaryLogic
 	{
 		return TrinaryLogic::createFromBoolean($this->acceptsNamedArguments);
-	}
-
-	private function nodeIsOrContainsYield(Node $node): bool
-	{
-		return NodeScanner::nodeIsOrContainsYield($node);
 	}
 
 	public function getAsserts(): Assertions

--- a/src/Rules/Generators/YieldFromTypeRule.php
+++ b/src/Rules/Generators/YieldFromTypeRule.php
@@ -137,7 +137,7 @@ final class YieldFromTypeRule implements Rule
 			))->identifier('generator.sendType')->build();
 		}
 
-		if (!$scope->isInFirstLevelStatement() && $scope->getType($node)->isVoid()->yes()) {
+		if (!$scope->isInFirstLevelStatement() && $scope->getKeepVoidType($node)->isVoid()->yes()) {
 			$messages[] = RuleErrorBuilder::message('Result of yield from (void) is used.')
 				->identifier('generator.void')
 				->build();

--- a/src/Rules/Generators/YieldTypeRule.php
+++ b/src/Rules/Generators/YieldTypeRule.php
@@ -86,7 +86,7 @@ final class YieldTypeRule implements Rule
 				->identifier('generator.valueType')
 				->build();
 		}
-		if (!$scope->isInFirstLevelStatement() && $scope->getType($node)->isVoid()->yes()) {
+		if (!$scope->isInFirstLevelStatement() && $scope->getKeepVoidType($node)->isVoid()->yes()) {
 			$messages[] = RuleErrorBuilder::message('Result of yield (void) is used.')
 				->identifier('generator.void')
 				->build();


### PR DESCRIPTION
Three small branch-agnostic pieces extracted from the resolve-type-rewrite branch:

- `PhpFunctionFromParserNodeReflection::isGenerator()` memoizes the whole-body yield scan on the AST node (reflections for the same node are recreated per ask, so an instance property would not stick; the memo lives and dies with the parser-cached AST).
- `YieldFromTypeRule`/`YieldTypeRule` read the operand through `getKeepVoidType()` — behavior-neutral today (suite unchanged), keeps the void check honest independent of the void-to-null projection at value reads.
- Doc rider: drop the duplicated `@internal` docblock on `hasAcceptorTemplateOrLateResolvableParameterType()`.

All suites pass unchanged: NodeScopeResolverTest 1694, full suite 17811, `make phpstan`, `make cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7