### PR TITLE
Fix FiberScope filtering, @var destructuring check, and deferred constant-condition reporting

### DIFF
--- a/src/Analyser/Fiber/FiberScope.php
+++ b/src/Analyser/Fiber/FiberScope.php
@@ -136,6 +136,7 @@ final class FiberScope extends MutatingScope
 		/** @var self $scope */
 		$scope = parent::filterByTruthyValue($expr);
 		$scope->truthyValueExprs = $this->truthyValueExprs;
+		$scope->falseyValueExprs = $this->falseyValueExprs;
 		$scope->truthyValueExprs[] = $expr;
 
 		return $scope;
@@ -144,7 +145,8 @@ final class FiberScope extends MutatingScope
 	public function filterByFalseyValue(Expr $expr): self
 	{
 		/** @var self $scope */
-		$scope = parent::filterByTruthyValue($expr);
+		$scope = parent::filterByFalseyValue($expr);
+		$scope->truthyValueExprs = $this->truthyValueExprs;
 		$scope->falseyValueExprs = $this->falseyValueExprs;
 		$scope->falseyValueExprs[] = $expr;
 

--- a/src/Rules/Comparison/FunctionCallConstantConditionRule.php
+++ b/src/Rules/Comparison/FunctionCallConstantConditionRule.php
@@ -37,19 +37,26 @@ final class FunctionCallConstantConditionRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$reportedMarkers = [];
-		foreach ($node->get(ImpossibleCheckTypeReportedCollector::class) as $fileData) {
+		$reportedMarkersByFile = [];
+		foreach ($node->get(ImpossibleCheckTypeReportedCollector::class) as $filePath => $fileData) {
 			foreach ($fileData as $data) {
 				$reportedMarkers[$data[0]] = true;
+				$reportedMarkersByFile[$filePath . "\0" . $data[0]] = true;
 			}
 		}
 
 		$errorsByRuleTraitExprValue = [];
-		foreach ($node->get(FunctionCallConstantConditionCollector::class) as $fileData) {
+		foreach ($node->get(FunctionCallConstantConditionCollector::class) as $filePath => $fileData) {
 			foreach ($fileData as $data) {
 				$ruleName = $data[0];
 				$traitName = $data[1];
 				$traitKey = $traitName ?? self::NULL_TRAIT_KEY;
-				$exprString = $data[2];
+				// A non-trait call site is per-file: the same printed condition at
+				// the same line in two different files must neither merge its
+				// deferred errors nor be suppressed by the other file's marker.
+				// Trait call sites keep merging across the analysed contexts -
+				// trait names are unique project-wide.
+				$exprString = $traitName === null ? $filePath . "\0" . $data[2] : $data[2];
 				$value = $data[3];
 				$valueKey = var_export($value, true);
 				if ($data[3] === null) {
@@ -68,7 +75,10 @@ final class FunctionCallConstantConditionRule implements Rule
 			foreach ($ruleData as $traitKey => $traitData) {
 				$isTrait = $traitKey !== self::NULL_TRAIT_KEY;
 				foreach ($traitData as $exprString => $valueData) {
-					if (array_key_exists($exprString, $reportedMarkers)) {
+					// non-trait keys carry their file, so only the same file's
+					// marker suppresses; trait entries match markers from any
+					// analysed context
+					if (array_key_exists($exprString, $isTrait ? $reportedMarkers : $reportedMarkersByFile)) {
 						// the ImpossibleCheckType* rule owns this call site
 						continue;
 					}

--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -70,7 +70,13 @@ final class MatchExpressionRule implements Rule
 			foreach ($armConditions as $armCondition) {
 				$armConditionScope = $armCondition->getScope();
 				$rawCondition = $armCondition->getCondition();
-				$isTypeCheckCandidate = $this->functionCallConstantConditionHelper->isTypeCheckCandidate($rawCondition);
+				// Only for a match(true)-style subject is the arm comparison the
+				// same fact as the call's own constant truthiness - the site the
+				// ImpossibleCheckType* rules own. For any other subject the
+				// comparison ("int is never true") is an independent finding and
+				// must not be deduplicated away against their markers.
+				$isTypeCheckCandidate = ($matchConditionType->isTrue()->yes() || $matchConditionType->isFalse()->yes())
+					&& $this->functionCallConstantConditionHelper->isTypeCheckCandidate($rawCondition);
 				$armConditionExpr = new Node\Expr\BinaryOp\Identical(
 					$matchCondition,
 					$rawCondition,

--- a/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
@@ -8,7 +8,7 @@ use PHPStan\Analyser\NameScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
-use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Node\Expr\NativeTypeExpr;
 use PHPStan\PhpDoc\NameScopeAlreadyBeingCreatedException;
 use PHPStan\PhpDoc\Tag\VarTag;
 use PHPStan\PhpDoc\TypeNodeResolver;
@@ -78,7 +78,13 @@ final class VarTagTypeRuleHelper
 					$dimExpr = $arrayItem->key;
 				}
 
-				$itemErrors = $this->checkVarType($scope, $arrayItem->value, new TypeExpr($scope->getType($expr)->getOffsetValueType($scope->getType($dimExpr))), $varTags, $assignedVariables);
+				// carry both flavours so the native-type check reads the native
+				// offset type, not the phpdoc one (mirrors the foreach key/value
+				// sites in WrongVariableNameInVarTagRule)
+				$itemErrors = $this->checkVarType($scope, $arrayItem->value, new NativeTypeExpr(
+					$scope->getType($expr)->getOffsetValueType($scope->getType($dimExpr)),
+					$scope->getNativeType($expr)->getOffsetValueType($scope->getNativeType($dimExpr)),
+				), $varTags, $assignedVariables);
 				foreach ($itemErrors as $error) {
 					$errors[] = $error;
 				}

--- a/tests/PHPStan/Analyser/FiberScopeFilterByValueRule.php
+++ b/tests/PHPStan/Analyser/FiberScopeFilterByValueRule.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use function count;
+use function is_string;
+use function sprintf;
+
+/**
+ * Exercises the rule-facing Scope::filterByTruthyValue()/filterByFalseyValue()
+ * API the way a third-party rule would: filtering the scope it received and
+ * reading state directly off the filtered scope.
+ *
+ * @implements Rule<FuncCall>
+ */
+class FiberScopeFilterByValueRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Name) {
+			return [];
+		}
+
+		$functionName = $node->name->getLast();
+		$args = $node->getArgs();
+
+		if ($functionName === 'probeFilter') {
+			if (count($args) < 2) {
+				return [];
+			}
+			$var = $args[1]->value;
+			if (!$var instanceof Variable || !is_string($var->name)) {
+				return [];
+			}
+
+			$truthyType = $scope->filterByTruthyValue($args[0]->value)->getVariableType($var->name);
+			$falseyType = $scope->filterByFalseyValue($args[0]->value)->getVariableType($var->name);
+
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'truthy: %s, falsey: %s',
+					$truthyType->describe(VerbosityLevel::precise()),
+					$falseyType->describe(VerbosityLevel::precise()),
+				))->identifier('tests.fiberScopeFilter')->build(),
+			];
+		}
+
+		if ($functionName === 'probeChainedFilter') {
+			if (count($args) < 3) {
+				return [];
+			}
+
+			$chainedType = $scope->filterByTruthyValue($args[0]->value)
+				->filterByFalseyValue($args[1]->value)
+				->getType($args[2]->value);
+
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'chained: %s',
+					$chainedType->describe(VerbosityLevel::precise()),
+				))->identifier('tests.fiberScopeFilter')->build(),
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/tests/PHPStan/Analyser/FiberScopeFilterByValueRuleTest.php
+++ b/tests/PHPStan/Analyser/FiberScopeFilterByValueRuleTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<FiberScopeFilterByValueRule>
+ */
+class FiberScopeFilterByValueRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new FiberScopeFilterByValueRule();
+	}
+
+	public function testFilterByValue(): void
+	{
+		$this->analyse([__DIR__ . '/data/fiber-scope-filter-by-value.php'], [
+			[
+				'truthy: int, falsey: null',
+				15,
+			],
+			[
+				'chained: int<min, 4>|int<6, max>',
+				20,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/fiber-scope-filter-by-value.php
+++ b/tests/PHPStan/Analyser/data/fiber-scope-filter-by-value.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace FiberScopeFilterByValue;
+
+function probeFilter(bool $condition, ?int $subject): void
+{
+}
+
+function probeChainedFilter(bool $conditionA, bool $conditionB, ?int $subject): void
+{
+}
+
+function testFilter(?int $x): void
+{
+	probeFilter($x !== null, $x);
+}
+
+function testChainedFilter(?int $a): void
+{
+	probeChainedFilter($a !== null, $a === 5, $a);
+}

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -388,4 +388,42 @@ class IfConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testDeferredErrorsAreNotCollapsedAcrossFiles(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([
+			__DIR__ . '/data/call-condition-cross-file-a.php',
+			__DIR__ . '/data/call-condition-cross-file-b.php',
+		], [
+			[
+				'If condition is always true.',
+				18,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+			[
+				'If condition is always true.',
+				18,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+		]);
+	}
+
+	public function testMarkerFromAnotherFileDoesNotSuppress(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([
+			__DIR__ . '/data/call-condition-cross-file-marker-a.php',
+			__DIR__ . '/data/call-condition-cross-file-marker-b.php',
+		], [
+			[
+				'Call to function is_int() with int will always evaluate to true.',
+				7,
+			],
+			[
+				'If condition is always true.',
+				7,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -570,4 +570,23 @@ class MatchExpressionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testMatchArmComparisonNotSuppressedByImpossibleCheck(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/match-arm-type-check-call.php'], [
+			[
+				'Call to function is_int() with int will always evaluate to true.',
+				8,
+			],
+			[
+				'Match arm comparison between int and true is always false.',
+				8,
+			],
+			[
+				'Call to function is_int() with int will always evaluate to true.',
+				16,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-a.php
+++ b/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-a.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace CallConditionCrossFileA;
+
+class Check
+{
+
+	/** @return true */
+	public function ok(): bool
+	{
+		return true;
+	}
+
+}
+
+function doFoo(Check $c): void
+{
+	if ($c->ok()) {
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-b.php
+++ b/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-b.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace CallConditionCrossFileB;
+
+class Check
+{
+
+	/** @return true */
+	public function ok(): bool
+	{
+		return true;
+	}
+
+}
+
+function doFoo(Check $c): void
+{
+	if ($c->ok()) {
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-marker-a.php
+++ b/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-marker-a.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace CallConditionCrossFileMarkerA;
+
+function doFoo(int $x): void
+{
+	if (is_int($x)) {
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-marker-b.php
+++ b/tests/PHPStan/Rules/Comparison/data/call-condition-cross-file-marker-b.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace CallConditionCrossFileMarkerB;
+
+function doBar(int $x): void
+{
+	if (is_int($x)) {
+	}
+}
+
+function is_int($value): \stdClass
+{
+	return new \stdClass();
+}

--- a/tests/PHPStan/Rules/Comparison/data/match-arm-type-check-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/match-arm-type-check-call.php
@@ -1,0 +1,19 @@
+<?php // lint >= 8.0
+
+namespace MatchArmTypeCheckCall;
+
+function doFoo(int $i, int $y): string
+{
+	return match ($i) {
+		is_int($y) => 'a',
+		default => 'b',
+	};
+}
+
+function doBar(int $y): string
+{
+	return match (true) {
+		is_int($y) => 'a',
+		default => 'b',
+	};
+}

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -627,4 +627,15 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/new-is-always-final-var-tag-type.php'], []);
 	}
 
+	public function testDestructuringChecksAgainstNativeOffsetType(): void
+	{
+		$this->checkTypeAgainstPhpDocType = true;
+		$this->analyse([__DIR__ . '/data/var-tag-destructuring-native.php'], [
+			[
+				'PHPDoc tag @var with type string is not subtype of type int.',
+				17,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/var-tag-destructuring-native.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/var-tag-destructuring-native.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace VarTagDestructuringNative;
+
+/** @return mixed[] */
+function makeArray(): array
+{
+	return [];
+}
+
+function doFoo(): void
+{
+	/** @var array{array{int}} $arr */
+	$arr = makeArray();
+	foreach ($arr as $item) {
+		/** @var string $s */
+		[$s] = $item;
+	}
+}


### PR DESCRIPTION
Four bug fixes from the resolve-type-rewrite branch review — these are the findings that apply to mainline (pre-existing, or arrived with the progressively merged chunks). Each commit adds a test that failed before the fix:

- **Filter FiberScope state in the falsey direction and carry both filter lists** — `filterByFalseyValue()` called `parent::filterByTruthyValue()`, so a rule filtering the scope it received saw inverted narrowing on direct state reads (`getVariableType()`, `toMutatingScope()`); chained `filterByTruthyValue()->filterByFalseyValue()` additionally dropped the truthy filter from fiber-routed type asks.
- **Check destructured @var items against the native offset type** — the destructuring branch wrapped the PHPDoc offset type in a plain `TypeExpr`, reporting a factually wrong `varTag.nativeType` error (unconditionally) instead of the flag-gated `varTag.type`.
- **Defer match arm comparison errors only for match(true)-style subjects** — `match ($i) { is_int($y) => … }` silently lost the "Match arm comparison between int and true is always false." error whenever an ImpossibleCheckType marker existed for the call; only for a constant-boolean subject is the arm comparison the same fact those rules own.
- **Scope deferred constant-condition errors and markers per file** — identical call conditions at the same print+line in two files collapsed into a single report, and a marker from one file suppressed an unrelated deferred error in another (e.g. a userland function shadowing a built-in type-check name). Trait entries keep cross-file merging.

Full test suite and self-analysis green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjrRao9kSNLAipk2Go5Kek