### PR TITLE
Check the subtracted type when a subtracted mixed accepts a value

### DIFF
--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -208,7 +208,7 @@ final class RuleLevelHelper
 			return new FoundTypeResult(
 				$type instanceof TemplateMixedType
 					? $type->toStrictMixedType()
-					: new StrictMixedType(),
+					: new StrictMixedType($type->getSubtractedType()),
 				[],
 				[],
 				null,

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -74,7 +74,7 @@ final class RuleLevelHelper
 					|| (!$type->isExplicitMixed() && $this->checkImplicitMixed)
 				)
 			) {
-				return new StrictMixedType();
+				return new StrictMixedType($type->getSubtractedType());
 			}
 
 			return $traverse($type);

--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -58,7 +58,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 			$this->strategy,
 			$this->variance,
 			$this->name,
-			new StrictMixedType(),
+			new StrictMixedType($this->getSubtractedType()),
 			$this->default,
 		);
 	}

--- a/src/Type/Generic/TemplateStrictMixedType.php
+++ b/src/Type/Generic/TemplateStrictMixedType.php
@@ -27,6 +27,8 @@ final class TemplateStrictMixedType extends StrictMixedType implements TemplateT
 		?Type $default,
 	)
 	{
+		parent::__construct();
+
 		$this->scope = $scope;
 		$this->strategy = $templateTypeStrategy;
 		$this->variance = $templateTypeVariance;

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -100,6 +100,20 @@ class MixedType implements CompoundType, SubtractableType
 
 	public function accepts(Type $type, bool $strictTypes): AcceptsResult
 	{
+		if (
+			$this->subtractedType !== null
+			&& !$type instanceof NeverType
+			&& $this->subtractedType->isSuperTypeOf($type)->yes()
+		) {
+			return AcceptsResult::createNo([
+				sprintf(
+					'Type %s has already been eliminated from %s.',
+					$this->subtractedType->describe(VerbosityLevel::precise()),
+					$this->describe(VerbosityLevel::typeOnly()),
+				),
+			]);
+		}
+
 		return AcceptsResult::createYes();
 	}
 

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -23,7 +23,9 @@ use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
+use PHPStan\Type\Traits\SubstractableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
+use function sprintf;
 
 class StrictMixedType implements CompoundType
 {
@@ -33,6 +35,16 @@ class StrictMixedType implements CompoundType
 	use NonIterableTypeTrait;
 	use NonRemoveableTypeTrait;
 	use NonGeneralizableTypeTrait;
+	use SubstractableTypeTrait;
+
+	public function __construct(private ?Type $subtractedType = null)
+	{
+	}
+
+	public function getSubtractedType(): ?Type
+	{
+		return $this->subtractedType;
+	}
 
 	public function getReferencedClasses(): array
 	{
@@ -56,6 +68,20 @@ class StrictMixedType implements CompoundType
 
 	public function accepts(Type $type, bool $strictTypes): AcceptsResult
 	{
+		if (
+			$this->subtractedType !== null
+			&& !$type instanceof NeverType
+			&& $this->subtractedType->isSuperTypeOf($type)->yes()
+		) {
+			return AcceptsResult::createNo([
+				sprintf(
+					'Type %s has already been eliminated from %s.',
+					$this->subtractedType->describe(VerbosityLevel::precise()),
+					$this->describe(VerbosityLevel::typeOnly()),
+				),
+			]);
+		}
+
 		return AcceptsResult::createYes();
 	}
 
@@ -90,7 +116,19 @@ class StrictMixedType implements CompoundType
 
 	public function equals(Type $type): bool
 	{
-		return $type instanceof self;
+		if (!$type instanceof self) {
+			return false;
+		}
+
+		if ($this->subtractedType === null) {
+			return $type->subtractedType === null;
+		}
+
+		if ($type->subtractedType === null) {
+			return false;
+		}
+
+		return $this->subtractedType->equals($type->subtractedType);
 	}
 
 	public function describe(VerbosityLevel $level): string
@@ -98,8 +136,8 @@ class StrictMixedType implements CompoundType
 		return $level->handle(
 			static fn () => 'mixed',
 			static fn () => 'mixed',
-			static fn () => 'mixed',
-			static fn () => 'strict-mixed',
+			fn () => 'mixed' . $this->describeSubtractedType($this->subtractedType, $level),
+			fn () => 'strict-mixed' . $this->describeSubtractedType($this->subtractedType, $level),
 		);
 	}
 

--- a/src/Type/VerbosityLevel.php
+++ b/src/Type/VerbosityLevel.php
@@ -128,33 +128,9 @@ final class VerbosityLevel
 	 */
 	public static function getRecommendedLevelByType(Type $acceptingType, ?Type $acceptedType = null): self
 	{
-		// A subtracted mixed only makes sense in an error message when the subtraction
-		// is spelled out. Template bounds are skipped - the subtraction there belongs
-		// to the bound, not to the type being described.
-		$hasSubtractedMixed = false;
-		TypeTraverser::map($acceptingType, static function (Type $type, callable $traverse) use (&$hasSubtractedMixed): Type {
-			if ($hasSubtractedMixed || $type instanceof TemplateType) {
-				return $type;
-			}
-
-			if (
-				($type instanceof MixedType || $type instanceof StrictMixedType)
-				&& $type->getSubtractedType() !== null
-			) {
-				$hasSubtractedMixed = true;
-				return $type;
-			}
-
-			return $traverse($type);
-		});
-
-		if ($hasSubtractedMixed) {
-			return self::precise();
-		}
-
 		$moreVerbose = false;
 		$veryVerbose = false;
-		$moreVerboseCallback = static function (Type $type, callable $traverse) use (&$moreVerbose, &$veryVerbose): Type {
+		$flagsCallback = static function (Type $type, callable $traverse) use (&$moreVerbose, &$veryVerbose): Type {
 			// stop deep traversal to not waste resources.
 			if ($veryVerbose) {
 				return $type;
@@ -211,6 +187,29 @@ final class VerbosityLevel
 				return $type;
 			}
 			return $traverse($type);
+		};
+		$moreVerboseCallback = static function (Type $type, callable $traverse) use (&$veryVerbose, $flagsCallback): Type {
+			// stop deep traversal to not waste resources.
+			if ($veryVerbose) {
+				return $type;
+			}
+
+			// A subtracted mixed only makes sense in an error message when the subtraction
+			// is spelled out. Template subtrees switch to the plain flags callback -
+			// the subtraction there belongs to the bound, not to the type being described.
+			if ($type instanceof TemplateType) {
+				TypeTraverser::map($type, $flagsCallback);
+				return $type;
+			}
+			if (
+				($type instanceof MixedType || $type instanceof StrictMixedType)
+				&& $type->getSubtractedType() !== null
+			) {
+				$veryVerbose = true;
+				return $type;
+			}
+
+			return $flagsCallback($type, $traverse);
 		};
 
 		TypeTraverser::map($acceptingType, $moreVerboseCallback);

--- a/src/Type/VerbosityLevel.php
+++ b/src/Type/VerbosityLevel.php
@@ -128,6 +128,30 @@ final class VerbosityLevel
 	 */
 	public static function getRecommendedLevelByType(Type $acceptingType, ?Type $acceptedType = null): self
 	{
+		// A subtracted mixed only makes sense in an error message when the subtraction
+		// is spelled out. Template bounds are skipped - the subtraction there belongs
+		// to the bound, not to the type being described.
+		$hasSubtractedMixed = false;
+		TypeTraverser::map($acceptingType, static function (Type $type, callable $traverse) use (&$hasSubtractedMixed): Type {
+			if ($hasSubtractedMixed || $type instanceof TemplateType) {
+				return $type;
+			}
+
+			if (
+				($type instanceof MixedType || $type instanceof StrictMixedType)
+				&& $type->getSubtractedType() !== null
+			) {
+				$hasSubtractedMixed = true;
+				return $type;
+			}
+
+			return $traverse($type);
+		});
+
+		if ($hasSubtractedMixed) {
+			return self::precise();
+		}
+
 		$moreVerbose = false;
 		$veryVerbose = false;
 		$moreVerboseCallback = static function (Type $type, callable $traverse) use (&$moreVerbose, &$veryVerbose): Type {

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -566,6 +566,14 @@ class ClassConstantRuleTest extends RuleTestCase
 				'Class constant name for object must be a string, but mixed was given.',
 				39,
 			],
+			[
+				'Class constant name for ClassConstantDynamicStringableAccess\Baz must be a string, but mixed~null was given.',
+				53,
+			],
+			[
+				'Class constant name for ClassConstantDynamicStringableAccess\Baz must be a string, but T of mixed~null (method ClassConstantDynamicStringableAccess\Baz::testSubtractedTemplate(), argument) was given.',
+				66,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Classes/data/dynamic-constant-stringable-access.php
+++ b/tests/PHPStan/Rules/Classes/data/dynamic-constant-stringable-access.php
@@ -40,3 +40,30 @@ final class Bar extends Foo
 	}
 
 }
+
+final class Baz
+{
+
+	public function testSubtractedMixed(mixed $mixed): void
+	{
+		if ($mixed === null) {
+			return;
+		}
+
+		echo self::{$mixed};
+	}
+
+	/**
+	 * @template T
+	 * @param T $name
+	 */
+	public function testSubtractedTemplate($name): void
+	{
+		if ($name === null) {
+			return;
+		}
+
+		echo self::{$name};
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleInArrayHaystackFiniteTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleInArrayHaystackFiniteTypesRuleTest.php
@@ -42,7 +42,7 @@ class ImpossibleInArrayHaystackFiniteTypesRuleTest extends RuleTestCase
 				38,
 			],
 			[
-				'Value \'installed\' in the haystack passed to in_array() can never be identical to the needle type mixed.',
+				'Value \'installed\' in the haystack passed to in_array() can never be identical to the needle type mixed~\'installed\'.',
 				99,
 				'Type \'installed\' has already been eliminated from mixed.',
 			],

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -3018,6 +3018,56 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11894.php'], []);
 	}
 
+	public static function dataNonEmptyMixedParameter(): iterable
+	{
+		yield [false];
+		yield [true];
+	}
+
+	#[DataProvider('dataNonEmptyMixedParameter')]
+	public function testNonEmptyMixedParameter(bool $checkExplicitMixed): void
+	{
+		$this->checkExplicitMixed = $checkExplicitMixed;
+		$this->checkImplicitMixed = $checkExplicitMixed;
+		$this->analyse([__DIR__ . '/data/non-empty-mixed-parameter.php'], [
+			[
+				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), \'\' given.',
+				17,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), \'0\' given.',
+				18,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), 0 given.',
+				19,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), 0.0 given.',
+				20,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), array{} given.',
+				21,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), false given.',
+				22,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), null given.',
+				23,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+		]);
+	}
+
 	public function testBug11494(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-11494.php'], [

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -3025,10 +3025,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	}
 
 	#[DataProvider('dataNonEmptyMixedParameter')]
-	public function testNonEmptyMixedParameter(bool $checkExplicitMixed): void
+	public function testNonEmptyMixedParameter(bool $checkImplicitAndExplicitMixed): void
 	{
-		$this->checkExplicitMixed = $checkExplicitMixed;
-		$this->checkImplicitMixed = $checkExplicitMixed;
+		$this->checkExplicitMixed = $checkImplicitAndExplicitMixed;
+		$this->checkImplicitMixed = $checkImplicitAndExplicitMixed;
 		$this->analyse([__DIR__ . '/data/non-empty-mixed-parameter.php'], [
 			[
 				'Parameter #1 $value of function NonEmptyMixedParameter\acceptsNonEmptyMixed expects mixed~(0|0.0|\'\'|\'0\'|array{}|false|null), \'\' given.',

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -6,6 +6,7 @@ use PHPStan\Rules\FunctionReturnTypeCheck;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
@@ -436,6 +437,36 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->checkNullables = true;
 		$this->checkExplicitMixed = false;
 		$this->analyse([__DIR__ . '/../../Analyser/nsrt/bug-14428.php'], []);
+	}
+
+	public static function dataNonEmptyMixedReturn(): iterable
+	{
+		yield [false];
+		yield [true];
+	}
+
+	#[DataProvider('dataNonEmptyMixedReturn')]
+	public function testNonEmptyMixedReturn(bool $checkExplicitMixed): void
+	{
+		$this->checkNullables = true;
+		$this->checkExplicitMixed = $checkExplicitMixed;
+		$this->analyse([__DIR__ . '/data/non-empty-mixed-return.php'], [
+			[
+				'Function NonEmptyMixedReturn\returnsEmptyString() should return mixed~(0|0.0|\'\'|\'0\'|array{}|false|null) but returns \'\'.',
+				8,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Function NonEmptyMixedReturn\returnsNull() should return mixed~(0|0.0|\'\'|\'0\'|array{}|false|null) but returns null.',
+				14,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+			[
+				'Function NonEmptyMixedReturn\returnsEmptyArray() should return mixed~(0|0.0|\'\'|\'0\'|array{}|false|null) but returns array{}.',
+				20,
+				'Type 0|0.0|\'\'|\'0\'|array{}|false|null has already been eliminated from mixed.',
+			],
+		]);
 	}
 
 	public function testBug13565(): void

--- a/tests/PHPStan/Rules/Functions/data/non-empty-mixed-parameter.php
+++ b/tests/PHPStan/Rules/Functions/data/non-empty-mixed-parameter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace NonEmptyMixedParameter;
+
+/** @param non-empty-mixed $value */
+function acceptsNonEmptyMixed($value): void
+{
+}
+
+/** @param mixed $value */
+function acceptsPlainMixed($value): void
+{
+}
+
+function doFoo(string $string, int $int, bool $bool): void
+{
+	acceptsNonEmptyMixed('');
+	acceptsNonEmptyMixed('0');
+	acceptsNonEmptyMixed(0);
+	acceptsNonEmptyMixed(0.0);
+	acceptsNonEmptyMixed([]);
+	acceptsNonEmptyMixed(false);
+	acceptsNonEmptyMixed(null);
+
+	acceptsNonEmptyMixed('x');
+	acceptsNonEmptyMixed(1);
+	acceptsNonEmptyMixed(true);
+	acceptsNonEmptyMixed([1]);
+	acceptsNonEmptyMixed($string);
+	acceptsNonEmptyMixed($int);
+	acceptsNonEmptyMixed($bool);
+
+	acceptsPlainMixed('');
+	acceptsPlainMixed(null);
+}
+
+/** @param mixed $value */
+function forwardsSubtractedMixed($value): void
+{
+	if ($value === null) {
+		return;
+	}
+
+	acceptsPlainMixed($value);
+}

--- a/tests/PHPStan/Rules/Functions/data/non-empty-mixed-return.php
+++ b/tests/PHPStan/Rules/Functions/data/non-empty-mixed-return.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace NonEmptyMixedReturn;
+
+/** @return non-empty-mixed */
+function returnsEmptyString()
+{
+	return '';
+}
+
+/** @return non-empty-mixed */
+function returnsNull()
+{
+	return null;
+}
+
+/** @return non-empty-mixed */
+function returnsEmptyArray()
+{
+	return [];
+}
+
+/** @return non-empty-mixed */
+function returnsNonEmptyString()
+{
+	return 'x';
+}
+
+/**
+ * @param string $string
+ * @return non-empty-mixed
+ */
+function returnsGeneralString($string)
+{
+	return $string;
+}
+
+/**
+ * @param mixed $value
+ * @return non-empty-mixed
+ */
+function returnsPlainMixed($value)
+{
+	return $value;
+}

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -171,6 +171,84 @@ class MixedTypeTest extends PHPStanTestCase
 		);
 	}
 
+	public static function dataAccepts(): array
+	{
+		return [
+			[
+				new MixedType(),
+				new NullType(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(true),
+				new ConstantStringType(''),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new ConstantStringType(''),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new NullType(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new ConstantArrayType([], []),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new ConstantBooleanType(false),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new ConstantStringType('x'),
+				TrinaryLogic::createYes(),
+			],
+			[
+				// a general string may be '' or '0', but mixed acceptance stays loose on partial overlap
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new StringType(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new MixedType(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(true, StaticTypeFactory::falsey()),
+				new NeverType(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(subtractedType: new NullType()),
+				new NullType(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(subtractedType: new NullType()),
+				new ConstantStringType(''),
+				TrinaryLogic::createYes(),
+			],
+		];
+	}
+
+	#[DataProvider('dataAccepts')]
+	public function testAccepts(MixedType $type, Type $otherType, TrinaryLogic $expectedResult): void
+	{
+		$actualResult = $type->accepts($otherType, true)->result;
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
+		);
+	}
+
 	public static function dataSubstractedIsArray(): array
 	{
 		return [


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/15033

`MixedType::accepts` (and `StrictMixedType`, reached once `RuleLevelHelper` rewrites an explicit `MixedType` for `checkExplicitMixed`) accepted every value unconditionally, so a subtracted mixed like `non-empty-mixed` rejected nothing at argument or return boundaries, even though the same subtraction already powered narrowing and reachability (`identical.alwaysFalse`, `if.alwaysTrue`, etc.).

Acceptance now turns to `No` only on a *definite* hit (`subtractedType->isSuperTypeOf($given)->yes()`), so partial overlaps (e.g. a general `string` into `non-empty-mixed`, which may or may not be `''`) stay accepted — this preserves `mixed`'s usual looseness and is why the fix isn't `isSuperTypeOf(...)->toAcceptsResult()`. `NeverType` is exempted, mirroring `MixedType::isSuperTypeOf`.

`RuleLevelHelper::transformCommonType` now carries the subtraction through when it converts an explicit `MixedType` into `StrictMixedType`, instead of discarding it — otherwise level max stayed silent even with `MixedType` fixed. `VerbosityLevel::getRecommendedLevelByType` escalates to `precise()` when a subtracted (Strict)MixedType is involved, so messages render the subtraction instead of a bare, uninformative `mixed`.
