### PR TITLE
Apply specified types in place on a batched working copy

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -69,7 +69,7 @@ parameters:
 		-
 			rawMessage: Casting to string something that's already string.
 			identifier: cast.useless
-			count: 2
+			count: 1
 			path: src/Analyser/MutatingScope.php
 
 		-

--- a/src/Analyser/ConditionalExpressionHolderRecipe.php
+++ b/src/Analyser/ConditionalExpressionHolderRecipe.php
@@ -15,7 +15,7 @@ use function array_key_exists;
  * composed. The state-dependent math - the condition complements against the
  * current type, the holder target types, the vacuity checks - runs in
  * evaluate() against the scope the narrowing is applied to
- * (MutatingScope::filterBySpecifiedTypes()), never the scope the composition ran
+ * (MutatingScope::applySpecifiedTypes()), never the scope the composition ran
  * on.
  */
 final class ConditionalExpressionHolderRecipe

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -877,8 +877,8 @@ final class AssignHandler implements ExprHandler
 					$condScope = $nodeScopeResolver->processExprNode($stmt, $assignedExpr->cond, $scope, $storage->duplicate(), new NoopNodeCallback(), ExpressionContext::createDeep())->getScope();
 					$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $assignedExpr->cond, TypeSpecifierContext::createTruthy());
 					$falseySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $assignedExpr->cond, TypeSpecifierContext::createFalsey());
-					$truthyScope = $condScope->filterBySpecifiedTypes($truthySpecifiedTypes);
-					$falsyScope = $condScope->filterBySpecifiedTypes($falseySpecifiedTypes);
+					$truthyScope = $condScope->applySpecifiedTypes($truthySpecifiedTypes);
+					$falsyScope = $condScope->applySpecifiedTypes($falseySpecifiedTypes);
 					$truthyType = $truthyScope->getType($if);
 					$falseyType = $falsyScope->getType($assignedExpr->else);
 

--- a/src/Analyser/ExprHandler/Helper/ConditionalExpressionHolderHelper.php
+++ b/src/Analyser/ExprHandler/Helper/ConditionalExpressionHolderHelper.php
@@ -34,7 +34,7 @@ final class ConditionalExpressionHolderHelper
 	 * Captures the either-branch union recovery as a deferred augment: the
 	 * branch types are read from the operand-walk filtered scopes here at
 	 * compose time, while the does-it-actually-narrow gates run against the
-	 * applying scope when MutatingScope::filterBySpecifiedTypes() evaluates it.
+	 * applying scope when MutatingScope::applySpecifiedTypes() evaluates it.
 	 *
 	 * The filtered scopes are thunks resolved only when there are candidate
 	 * expressions - deriving them per level of a deep boolean chain is
@@ -111,7 +111,7 @@ final class ConditionalExpressionHolderHelper
 	/**
 	 * Captures the raw entries of a boolean-decomposition holder pair as a
 	 * recipe; the state-dependent complement/target math runs against the
-	 * applying scope when MutatingScope::filterBySpecifiedTypes() evaluates it.
+	 * applying scope when MutatingScope::applySpecifiedTypes() evaluates it.
 	 *
 	 * The condition side asserts that its sub-expression evaluates truthy.
 	 * When that sub-expression is itself a compound boolean (e.g. `$a && $b`),

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3248,18 +3248,28 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		);
 	}
 
-	private function setExpressionCertainty(Expr $expr, TrinaryLogic $certainty): self
+	/**
+	 * Certainty change for applySpecifiedTypes():
+	 * it keeps the type already held for the expression instead of re-reading it
+	 * via getType(). getType() only reports the type of Yes-certainty holders, so
+	 * for a maybe-defined variable it broadens to the original type - which would
+	 * overwrite a co-applied narrowing (e.g. isset's $a -> null in the else branch).
+	 */
+	private function setExpressionCertaintyKeepingType(Expr $expr, TrinaryLogic $certainty): self
 	{
-		if ($this->hasExpressionType($expr)->no()) {
+		$exprString = $this->getNodeKey($expr);
+		if (!array_key_exists($exprString, $this->expressionTypes)) {
 			throw new ShouldNotHappenException();
 		}
 
-		$originalExprType = $this->getType($expr);
-		$nativeType = $this->getNativeType($expr);
+		$exprType = $this->expressionTypes[$exprString]->getType();
+		$nativeType = array_key_exists($exprString, $this->nativeExpressionTypes)
+			? $this->nativeExpressionTypes[$exprString]->getType()
+			: $exprType;
 
 		return $this->specifyExpressionType(
 			$expr,
-			$originalExprType,
+			$exprType,
 			$nativeType,
 			$certainty,
 		);
@@ -3453,7 +3463,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				$expr = $issetExpr->getExpr();
 
 				if ($typeSpecification['sure']) {
-					$scope = $scope->setExpressionCertainty(
+					$scope = $scope->setExpressionCertaintyKeepingType(
 						$expr,
 						TrinaryLogic::createMaybe(),
 					);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3411,6 +3411,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		$scope = $this;
+		// one unpublished working copy takes all in-place specifications of the
+		// batch; operations that go through other scope derivations publish it
+		// and a fresh copy opens on the next specification
+		$scopeIsWorkingCopy = false;
 		$specifiedExpressions = [];
 		foreach ($typeSpecifications as $typeSpecification) {
 			$expr = $typeSpecification['expr'];
@@ -3427,6 +3431,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				} else {
 					$scope = $scope->unsetExpression($expr);
 				}
+				$scopeIsWorkingCopy = false;
 
 				continue;
 			}
@@ -3459,12 +3464,15 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				$originalExprType = $scope->getType($expr);
 				if (!$scope->isComplexUnionType($originalExprType)) {
 					$nativeType = $scope->getNativeType($expr);
-					$scope = $scope->specifyExpressionType(
-						$expr,
-						TypeCombinator::intersect($evaluate($originalExprType), $originalExprType),
-						TypeCombinator::intersect($evaluate($nativeType), $nativeType),
-						TrinaryLogic::createYes(),
-					);
+					$newType = TypeCombinator::intersect($evaluate($originalExprType), $originalExprType);
+					$newNativeType = TypeCombinator::intersect($evaluate($nativeType), $nativeType);
+					if (!$this->isSpecifyExpressionTypeNoop($expr, $newType)) {
+						if (!$scopeIsWorkingCopy) {
+							$scope = $scope->openSpecificationScope();
+							$scopeIsWorkingCopy = true;
+						}
+						$scope->specifyExpressionTypeInPlace($expr, $newType, $newNativeType, TrinaryLogic::createYes());
+					}
 					$specifiedExpressions[$typeSpecification['exprString']] = ExpressionTypeHolder::createYes($expr, $scope->getScopeType($expr));
 				}
 
@@ -3475,47 +3483,42 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			if ($typeSpecification['sure']) {
 				if ($specifiedTypes->shouldOverwrite()) {
 					$scope = $scope->assignExpression($expr, $type, $type);
+					$scopeIsWorkingCopy = false;
 				} else {
-					$scope = $scope->addTypeToExpression($expr, $type);
+					// addTypeToExpression(), writing into the working copy
+					$originalExprType = $scope->getType($expr);
+					if (!$scope->isComplexUnionType($originalExprType)) {
+						$nativeType = $scope->getNativeType($expr);
+						$newType = TypeCombinator::intersect($type, $originalExprType);
+						$newNativeType = $originalExprType->equals($nativeType) ? $newType : TypeCombinator::intersect($type, $nativeType);
+						if (!$this->isSpecifyExpressionTypeNoop($expr, $newType)) {
+							if (!$scopeIsWorkingCopy) {
+								$scope = $scope->openSpecificationScope();
+								$scopeIsWorkingCopy = true;
+							}
+							$scope->specifyExpressionTypeInPlace($expr, $newType, $newNativeType, TrinaryLogic::createYes());
+						}
+					}
 				}
-			} else {
-				$scope = $scope->removeTypeFromExpression($expr, $type);
+			} elseif (!$type instanceof NeverType) {
+				// removeTypeFromExpression(), writing into the working copy
+				$exprType = $scope->getType($expr);
+				if (!$exprType instanceof NeverType && !$scope->isComplexUnionType($exprType)) {
+					$newType = TypeCombinator::remove($exprType, $type);
+					$newNativeType = TypeCombinator::remove($scope->getNativeType($expr), $type);
+					if (!$this->isSpecifyExpressionTypeNoop($expr, $newType)) {
+						if (!$scopeIsWorkingCopy) {
+							$scope = $scope->openSpecificationScope();
+							$scopeIsWorkingCopy = true;
+						}
+						$scope->specifyExpressionTypeInPlace($expr, $newType, $newNativeType, TrinaryLogic::createYes());
+					}
+				}
 			}
 			$specifiedExpressions[$typeSpecification['exprString']] = ExpressionTypeHolder::createYes($expr, $scope->getScopeType($expr));
 		}
 
-		[$conditions] = ScopeOps::matchConditionalExpressions($scope->conditionalExpressions, $specifiedExpressions);
-
-		return $this->applyFilteredConditions($scope, $conditions, $specifiedTypes);
-	}
-
-	/**
-	 * @param array<string, ConditionalExpressionHolder[]> $conditions
-	 * @return static
-	 */
-	private function applyFilteredConditions(self $scope, array $conditions, SpecifiedTypes $specifiedTypes): self
-	{
-		foreach ($conditions as $conditionalExprString => $expressions) {
-			$certainty = TrinaryLogic::lazyExtremeIdentity($expressions, static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getCertainty());
-			if ($certainty->no()) {
-				unset($scope->expressionTypes[$conditionalExprString]);
-			} else {
-				if (array_key_exists($conditionalExprString, $scope->expressionTypes)) {
-					$type = $expressions[0]->getTypeHolder()->getType();
-					for ($i = 1, $count = count($expressions); $i < $count; $i++) {
-						$type = TypeCombinator::intersect($type, $expressions[$i]->getTypeHolder()->getType());
-					}
-
-					$scope->expressionTypes[$conditionalExprString] = new ExpressionTypeHolder(
-						$scope->expressionTypes[$conditionalExprString]->getExpr(),
-						TypeCombinator::intersect($scope->expressionTypes[$conditionalExprString]->getType(), $type),
-						TrinaryLogic::maxMin($scope->expressionTypes[$conditionalExprString]->getCertainty(), $certainty),
-					);
-				} else {
-					$scope->expressionTypes[$conditionalExprString] = $expressions[0]->getTypeHolder();
-				}
-			}
-		}
+		$scope = $scope->processConditionalExpressionsAfterSpecifying($specifiedExpressions);
 
 		$newConditionalExpressionHolders = $specifiedTypes->getNewConditionalExpressionHolders();
 		foreach ($specifiedTypes->getConditionalExpressionHolderRecipes() as $recipe) {
@@ -3540,6 +3543,45 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$scope->inFirstLevelStatement,
 			$scope->afterExtractCall,
 		);
+	}
+
+	/**
+	 * Matches already-registered conditional expressions against the just-specified
+	 * expression type holders and applies the matching consequences.
+	 *
+	 * Mutates and returns $this - only to be called on an intermediate scope
+	 * that is about to be rebuilt through the scope factory.
+	 *
+	 * @param array<string, ExpressionTypeHolder> $specifiedExpressions
+	 */
+	private function processConditionalExpressionsAfterSpecifying(array $specifiedExpressions): self
+	{
+		$scope = $this;
+		[$conditions] = ScopeOps::matchConditionalExpressions($scope->conditionalExpressions, $specifiedExpressions);
+
+		foreach ($conditions as $conditionalExprString => $expressions) {
+			$certainty = TrinaryLogic::lazyExtremeIdentity($expressions, static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getCertainty());
+			if ($certainty->no()) {
+				unset($scope->expressionTypes[$conditionalExprString]);
+			} else {
+				if (array_key_exists($conditionalExprString, $scope->expressionTypes)) {
+					$type = $expressions[0]->getTypeHolder()->getType();
+					for ($i = 1, $count = count($expressions); $i < $count; $i++) {
+						$type = TypeCombinator::intersect($type, $expressions[$i]->getTypeHolder()->getType());
+					}
+
+					$scope->expressionTypes[$conditionalExprString] = new ExpressionTypeHolder(
+						$scope->expressionTypes[$conditionalExprString]->getExpr(),
+						TypeCombinator::intersect($scope->expressionTypes[$conditionalExprString]->getType(), $type),
+						TrinaryLogic::maxMin($scope->expressionTypes[$conditionalExprString]->getCertainty(), $certainty),
+					);
+				} else {
+					$scope->expressionTypes[$conditionalExprString] = $expressions[0]->getTypeHolder();
+				}
+			}
+		}
+
+		return $scope;
 	}
 
 	/**

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -130,6 +130,7 @@ use function strlen;
 use function strtolower;
 use function substr;
 use function uksort;
+use function usort;
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 use const PHP_VERSION_ID;
@@ -3392,23 +3393,49 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$specifiedTypes = $specifiedTypes->unionWith($augmentTypes);
 		}
 
-		$typeSpecifications = ScopeOps::buildTypeSpecifications($specifiedTypes->getSureTypes(), $specifiedTypes->getSureNotTypes());
-
-		foreach ($specifiedTypes->getAlternativeTypes() as $exprString => [$alternativeExpr, $terms]) {
-			if (
-				$alternativeExpr instanceof Node\Scalar
-				|| $alternativeExpr instanceof Expr\Array_
-				|| ($alternativeExpr instanceof Expr\UnaryMinus && $alternativeExpr->expr instanceof Node\Scalar)
-			) {
+		$typeSpecifications = [];
+		foreach ($specifiedTypes->getSureTypes() as $exprString => [$expr, $type]) {
+			if ($expr instanceof Node\Scalar || $expr instanceof Expr\Array_ || $expr instanceof Expr\UnaryMinus && $expr->expr instanceof Node\Scalar) {
 				continue;
 			}
 			$typeSpecifications[] = [
 				'sure' => true,
-				'exprString' => (string) $exprString,
-				'expr' => $alternativeExpr,
+				'exprString' => $exprString,
+				'expr' => $expr,
+				'type' => $type,
+			];
+		}
+		foreach ($specifiedTypes->getSureNotTypes() as $exprString => [$expr, $type]) {
+			if ($expr instanceof Node\Scalar || $expr instanceof Expr\Array_ || $expr instanceof Expr\UnaryMinus && $expr->expr instanceof Node\Scalar) {
+				continue;
+			}
+			$typeSpecifications[] = [
+				'sure' => false,
+				'exprString' => $exprString,
+				'expr' => $expr,
+				'type' => $type,
+			];
+		}
+		foreach ($specifiedTypes->getAlternativeTypes() as $exprString => [$expr, $terms]) {
+			if ($expr instanceof Node\Scalar || $expr instanceof Expr\Array_ || $expr instanceof Expr\UnaryMinus && $expr->expr instanceof Node\Scalar) {
+				continue;
+			}
+			$typeSpecifications[] = [
+				'sure' => true,
+				'exprString' => $exprString,
+				'expr' => $expr,
 				'terms' => $terms,
 			];
 		}
+
+		usort($typeSpecifications, static function (array $a, array $b): int {
+			$length = strlen($a['exprString']) - strlen($b['exprString']);
+			if ($length !== 0) {
+				return $length;
+			}
+
+			return $b['sure'] - $a['sure']; // @phpstan-ignore minus.leftNonNumeric, minus.rightNonNumeric
+		});
 
 		$scope = $this;
 		// one unpublished working copy takes all in-place specifications of the

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3349,7 +3349,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this, $expr, TypeSpecifierContext::createTruthy());
-		$scope = $this->filterBySpecifiedTypes($specifiedTypes);
+		$scope = $this->applySpecifiedTypes($specifiedTypes);
 		$this->truthyScopes[$exprString] = $scope;
 
 		return $scope;
@@ -3366,16 +3366,18 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this, $expr, TypeSpecifierContext::createFalsey());
-		$scope = $this->filterBySpecifiedTypes($specifiedTypes);
+		$scope = $this->applySpecifiedTypes($specifiedTypes);
 		$this->falseyScopes[$exprString] = $scope;
 
 		return $scope;
 	}
 
 	/**
+	 * Applies computed narrowing to this scope.
+	 *
 	 * @return static
 	 */
-	public function filterBySpecifiedTypes(SpecifiedTypes $specifiedTypes): self
+	public function applySpecifiedTypes(SpecifiedTypes $specifiedTypes): self
 	{
 		// deferred augments see this scope's pre-application state - the
 		// application point of the narrowing; their entries join this batch

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2989,14 +2989,43 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 
 	public function specifyExpressionType(Expr $expr, Type $type, Type $nativeType, TrinaryLogic $certainty): self
 	{
-		if ($expr instanceof Scalar) {
+		if ($this->isSpecifyExpressionTypeNoop($expr, $type)) {
 			return $this;
+		}
+
+		$scope = $this->openSpecificationScope();
+		$scope->specifyExpressionTypeInPlace($expr, $type, $nativeType, $certainty);
+
+		return $scope;
+	}
+
+	/** An unpublished copy of this scope that in-place specification may mutate. */
+	private function openSpecificationScope(): self
+	{
+		/** @var static */
+		return ScopeOps::scopeWith(
+			$this,
+			$this->expressionTypes,
+			$this->nativeExpressionTypes,
+			$this->conditionalExpressions,
+			$this->currentlyAssignedExpressions,
+			$this->currentlyAllowedUndefinedExpressions,
+			$this->inFunctionCallsStack,
+			$this->inFirstLevelStatement,
+			$this->afterExtractCall,
+		);
+	}
+
+	private function isSpecifyExpressionTypeNoop(Expr $expr, Type $type): bool
+	{
+		if ($expr instanceof Scalar) {
+			return true;
 		}
 
 		if ($expr instanceof ConstFetch) {
 			$loweredConstName = strtolower($expr->name->toString());
 			if (in_array($loweredConstName, ['true', 'false', 'null'], true)) {
-				return $this;
+				return true;
 			}
 		}
 
@@ -3007,11 +3036,25 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				'is_file',
 				'file_exists',
 			], true)) {
-				return $this;
+				return true;
 			}
 		}
 
-		$scope = $this;
+		return false;
+	}
+
+	/**
+	 * The body of specifyExpressionType() writing straight into this scope's
+	 * holder maps - only to be called on an unpublished scope (see
+	 * openSpecificationScope()). Batching callers avoid one whole-map copy and
+	 * scope construction per specification (and per array-dim level).
+	 */
+	private function specifyExpressionTypeInPlace(Expr $expr, Type $type, Type $nativeType, TrinaryLogic $certainty): void
+	{
+		if ($this->isSpecifyExpressionTypeNoop($expr, $type)) {
+			return;
+		}
+
 		if (
 			$expr instanceof Expr\ArrayDimFetch
 			&& $expr->dim !== null
@@ -3020,9 +3063,9 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			&& !$expr->dim instanceof Expr\PostDec
 			&& !$expr->dim instanceof Expr\PostInc
 		) {
-			$dimType = $scope->getType($expr->dim)->toArrayKey();
+			$dimType = $this->getType($expr->dim)->toArrayKey();
 			if ($dimType->isInteger()->yes() || $dimType->isString()->yes()) {
-				$exprVarType = $scope->getType($expr->var);
+				$exprVarType = $this->getType($expr->var);
 				$isArray = $exprVarType->isArray();
 				if (!$exprVarType instanceof MixedType && !$isArray->no()) {
 					$varType = $exprVarType;
@@ -3043,10 +3086,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 						}
 					}
 
-					$scope = $scope->specifyExpressionType(
+					$this->specifyExpressionTypeInPlace(
 						$expr->var,
 						$varType,
-						$scope->getNativeType($expr->var),
+						$this->getNativeType($expr->var),
 						$certainty,
 					);
 				}
@@ -3058,29 +3101,23 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		$exprString = $this->getNodeKey($expr);
-		$expressionTypes = $scope->expressionTypes;
-		$expressionTypes[$exprString] = new ExpressionTypeHolder($expr, $type, $certainty);
-		$nativeTypes = $scope->nativeExpressionTypes;
-		$nativeTypes[$exprString] = new ExpressionTypeHolder($expr, $nativeType, $certainty);
+		$this->expressionTypes[$exprString] = new ExpressionTypeHolder($expr, $type, $certainty);
+		$this->nativeExpressionTypes[$exprString] = new ExpressionTypeHolder($expr, $nativeType, $certainty);
+		// the writes invalidate every lazily-derived view of this scope; reset
+		// them to their fresh-constructor defaults, exactly as deriving a new
+		// scope per specification did
+		$this->resolvedTypes = [];
+		$this->truthyScopes = [];
+		$this->falseyScopes = [];
+		$this->fiberScope = null;
+		$this->scopeOutOfFirstLevelStatement = null;
+		$this->scopeWithPromotedNativeTypes = null;
 
-		/** @var static $scope */
-		$scope = ScopeOps::scopeWith(
-			$this,
-			$expressionTypes,
-			$nativeTypes,
-			$this->conditionalExpressions,
-			$this->currentlyAssignedExpressions,
-			$this->currentlyAllowedUndefinedExpressions,
-			$this->inFunctionCallsStack,
-			$this->inFirstLevelStatement,
-			$this->afterExtractCall,
-		);
-
-		if ($expr instanceof AlwaysRememberedExpr) {
-			return $scope->specifyExpressionType($expr->expr, $type, $nativeType, $certainty);
+		if (!($expr instanceof AlwaysRememberedExpr)) {
+			return;
 		}
 
-		return $scope;
+		$this->specifyExpressionTypeInPlace($expr->expr, $type, $nativeType, $certainty);
 	}
 
 	public function assignExpression(Expr $expr, Type $type, Type $nativeType): self

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1167,7 +1167,7 @@ class NodeScopeResolver
 				$this->callNodeCallback($nodeCallback, new NoopExpressionNode($stmt->expr, $hasAssign), $scope, $storage);
 			}
 			$scope = $result->getScope();
-			$scope = $scope->filterBySpecifiedTypes($this->typeSpecifier->specifyTypesInCondition(
+			$scope = $scope->applySpecifiedTypes($this->typeSpecifier->specifyTypesInCondition(
 				$scope,
 				$stmt->expr,
 				TypeSpecifierContext::createNull(),

--- a/src/Analyser/ScopeOps.php
+++ b/src/Analyser/ScopeOps.php
@@ -891,7 +891,7 @@ final class ScopeOps
 
 	/**
 	 * The conditional-expressions fixed-point matching of
-	 * MutatingScope::filterBySpecifiedTypes().
+	 * MutatingScope::applySpecifiedTypes().
 	 *
 	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
 	 * @param array<string, ExpressionTypeHolder> $specifiedExpressions

--- a/src/Analyser/ScopeOps.php
+++ b/src/Analyser/ScopeOps.php
@@ -4,7 +4,6 @@ namespace PHPStan\Analyser;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
@@ -37,7 +36,6 @@ use function str_contains;
 use function strlen;
 use function strpos;
 use function substr_compare;
-use function usort;
 
 /**
  * Hot scope-table operations extracted from MutatingScope.
@@ -889,51 +887,6 @@ final class ScopeOps
 			return self::getIntertwinedRefRootVariableName($expr->var);
 		}
 		return null;
-	}
-
-	/**
-	 * The sorted type-specification list of MutatingScope::filterBySpecifiedTypes().
-	 *
-	 * @param array<string|int, array{Expr, Type}> $sureTypes
-	 * @param array<string|int, array{Expr, Type}> $sureNotTypes
-	 * @return list<array{sure: bool, exprString: string, expr: Expr, type: Type}>
-	 */
-	public static function buildTypeSpecifications(array $sureTypes, array $sureNotTypes): array
-	{
-		$typeSpecifications = [];
-		foreach ($sureTypes as $exprString => [$expr, $type]) {
-			if ($expr instanceof Node\Scalar || $expr instanceof Array_ || $expr instanceof Expr\UnaryMinus && $expr->expr instanceof Node\Scalar) {
-				continue;
-			}
-			$typeSpecifications[] = [
-				'sure' => true,
-				'exprString' => (string) $exprString,
-				'expr' => $expr,
-				'type' => $type,
-			];
-		}
-		foreach ($sureNotTypes as $exprString => [$expr, $type]) {
-			if ($expr instanceof Node\Scalar || $expr instanceof Array_ || $expr instanceof Expr\UnaryMinus && $expr->expr instanceof Node\Scalar) {
-				continue;
-			}
-			$typeSpecifications[] = [
-				'sure' => false,
-				'exprString' => (string) $exprString,
-				'expr' => $expr,
-				'type' => $type,
-			];
-		}
-
-		usort($typeSpecifications, static function (array $a, array $b): int {
-			$length = strlen($a['exprString']) - strlen($b['exprString']);
-			if ($length !== 0) {
-				return $length;
-			}
-
-			return $b['sure'] - $a['sure']; // @phpstan-ignore minus.leftNonNumeric, minus.rightNonNumeric
-		});
-
-		return $typeSpecifications;
 	}
 
 	/**

--- a/src/Analyser/SpecifiedTypes.php
+++ b/src/Analyser/SpecifiedTypes.php
@@ -26,7 +26,7 @@ final class SpecifiedTypes
 
 	/**
 	 * Deferred boolean-decomposition holders, evaluated against the applying
-	 * scope by MutatingScope::filterBySpecifiedTypes().
+	 * scope by MutatingScope::applySpecifiedTypes().
 	 *
 	 * @var list<ConditionalExpressionHolderRecipe>
 	 */
@@ -34,7 +34,7 @@ final class SpecifiedTypes
 
 	/**
 	 * State-dependent augmentations evaluated against the applying scope by
-	 * MutatingScope::filterBySpecifiedTypes(); their entries join the applied
+	 * MutatingScope::applySpecifiedTypes(); their entries join the applied
 	 * batch.
 	 *
 	 * @var list<DeferredSpecifiedTypesAugment>

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -20,7 +20,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '1ecf6e0';
+	public const EXPECTED_EXTENSION_VERSION = '127ffe8';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -1391,7 +1391,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 
 		foreach ($specifiedTypes->getAlternativeTypes() as $exprString => [$exprNode, $terms]) {
 			// evaluate the alternative-form entry against the test scope, the
-			// same way filterBySpecifiedTypes() evaluates it at the application
+			// same way applySpecifiedTypes() evaluates it at the application
 			// point - the readable result matches the old eager normalize form
 			$parts = [];
 			foreach ($terms as [$sure, $subtract]) {

--- a/turbo-ext/src/ScopeOps.cpp
+++ b/turbo-ext/src/ScopeOps.cpp
@@ -1088,47 +1088,6 @@ public:
 	}
 
 	/*
-	 * Mirrors ScopeOps::buildTypeSpecifications(); the usort becomes a qsort
-	 * over a flat working set, kept stable via a sequence number.
-	 */
-	static zv::Val buildTypeSpecifications(zv::TableRef sureTypes, zv::TableRef sureNotTypes)
-	{
-		uint32_t capacity = sureTypes.size() + sureNotTypes.size();
-		TypeSpec *specs = capacity > 0 ? (TypeSpec *) emalloc(capacity * sizeof(TypeSpec)) : NULL;
-		uint32_t count = 0;
-
-		if (UNEXPECTED(!collectTypeSpecifications(sureTypes, true, specs, &count))
-			|| UNEXPECTED(!collectTypeSpecifications(sureNotTypes, false, specs, &count))) {
-			for (uint32_t i = 0; i < count; i++) {
-				zend_string_release(specs[i].exprString);
-			}
-			if (specs != NULL) {
-				efree(specs);
-			}
-			return zv::Val();
-		}
-
-		if (count > 1) {
-			qsort(specs, count, sizeof(TypeSpec), compareTypeSpecifications);
-		}
-
-		zv::Arr result = zv::Arr::create(count);
-		for (uint32_t i = 0; i < count; i++) {
-			zv::Arr item = zv::Arr::create(4);
-			item.set("sure", zv::Val::boolean(specs[i].sure));
-			item.set("exprString", zv::Val::adoptString(specs[i].exprString));
-			item.set("expr", zv::Val::copyOf(zv::Ref(&specs[i].expr)));
-			item.set("type", zv::Val::copyOf(zv::Ref(&specs[i].type)));
-			result.push(std::move(item));
-		}
-
-		if (specs != NULL) {
-			efree(specs);
-		}
-		return zv::Val(std::move(result));
-	}
-
-	/*
 	 * Mirrors ScopeOps::matchConditionalExpressions(): the fixed-point loop
 	 * with an exact-match pass and a supertype-match pass per expression.
 	 * Returns [conditions, specifiedExpressions].
@@ -1279,16 +1238,6 @@ private:
 		zval *expressionToInvalidate;
 		zval *invalidatingClass; /* may be NULL */
 		bool isThis;
-	};
-
-	/* One row of buildTypeSpecifications()' sortable working set. */
-	struct TypeSpec
-	{
-		zend_string *exprString; /* owned */
-		zval expr;               /* borrowed */
-		zval type;               /* borrowed */
-		bool sure;
-		uint32_t seq;
 	};
 
 	static zv::Val trinarySingleton(zend_long value)
@@ -1980,80 +1929,6 @@ private:
 		return true;
 	}
 
-	/* Collects one sureTypes/sureNotTypes table into the sortable working set. */
-	static bool collectTypeSpecifications(zv::TableRef input, bool sure, TypeSpec *specs, uint32_t *count)
-	{
-		zend_class_entry *scalarCe = pt_class(PT_CLASS_SCALAR);
-		zend_class_entry *arrayExprCe = pt_class(PT_CLASS_ARRAY_EXPR);
-		zend_class_entry *unaryMinusCe = pt_class(PT_CLASS_UNARY_MINUS);
-
-		if (UNEXPECTED(scalarCe == NULL || arrayExprCe == NULL || unaryMinusCe == NULL)) {
-			return false;
-		}
-
-		for (auto entry : input) {
-			zv::Ref pair = entry.value().deref();
-			if (UNEXPECTED(!pair.isArray())) {
-				zend_throw_error(NULL, "phpstan_turbo: sure type entry is not an array");
-				return false;
-			}
-			zval *exprSlot = zend_hash_index_find(pair.asArrayTable(), 0);
-			zval *typeSlot = zend_hash_index_find(pair.asArrayTable(), 1);
-			if (UNEXPECTED(exprSlot == NULL || typeSlot == NULL)) {
-				zend_throw_error(NULL, "phpstan_turbo: malformed sure type entry");
-				return false;
-			}
-			zv::Ref expr = zv::Ref(exprSlot).deref();
-			zv::Ref type = zv::Ref(typeSlot).deref();
-			if (UNEXPECTED(!expr.isObject() || !type.isObject())) {
-				zend_throw_error(NULL, "phpstan_turbo: malformed sure type entry");
-				return false;
-			}
-
-			zend_class_entry *exprCe = expr.asObject()->ce;
-			if (instanceof_function(exprCe, scalarCe) || instanceof_function(exprCe, arrayExprCe)) {
-				continue;
-			}
-			if (instanceof_function(exprCe, unaryMinusCe)) {
-				int32_t subOffset = pt_instance_prop_offset(exprCe, "expr", sizeof("expr") - 1);
-				if (subOffset >= 0) {
-					zv::Ref sub = zv::ObjRef(expr.asObject()).propAtOffset((uint32_t) subOffset).deref();
-					if (sub.instanceOf(scalarCe)) {
-						continue;
-					}
-				}
-			}
-
-			TypeSpec *spec = &specs[*count];
-			zend_string *key = entry.stringKeyOrNull();
-			spec->exprString = key != NULL ? zend_string_copy(key) : zend_long_to_str((zend_long) entry.indexKey());
-			ZVAL_COPY_VALUE(&spec->expr, expr.raw());
-			ZVAL_COPY_VALUE(&spec->type, type.raw());
-			spec->sure = sure;
-			spec->seq = *count;
-			(*count)++;
-		}
-
-		return true;
-	}
-
-	/* buildTypeSpecifications()'s usort comparator (stable via seq) */
-	static int compareTypeSpecifications(const void *a, const void *b)
-	{
-		const TypeSpec *specA = (const TypeSpec *) a;
-		const TypeSpec *specB = (const TypeSpec *) b;
-		size_t lengthA = ZSTR_LEN(specA->exprString);
-		size_t lengthB = ZSTR_LEN(specB->exprString);
-
-		if (lengthA != lengthB) {
-			return lengthA < lengthB ? -1 : 1;
-		}
-		if (specA->sure != specB->sure) {
-			return specB->sure - specA->sure; /* sure=true first */
-		}
-		return specA->seq < specB->seq ? -1 : (specA->seq > specB->seq ? 1 : 0);
-	}
-
 	/*
 	 * matchConditionalExpressions()' shared tail of both passes:
 	 * $conditions[$exprString][] = $conditionalExpression and
@@ -2210,19 +2085,6 @@ void pt_register_scope_ops()
 			Z_PARAM_OBJECT(expr)
 		ZEND_PARSE_PARAMETERS_END();
 		zv::Val result = ScopeOps::getIntertwinedRefRootVariableName(Z_OBJ_P(expr));
-		if (UNEXPECTED(result.isUndef())) {
-			RETURN_THROWS();
-		}
-		result.intoReturnValue(return_value);
-	});
-
-	cls.method("buildTypeSpecifications", reg::PublicStatic, 2, { reg::arrayArg("sureTypes"), reg::arrayArg("sureNotTypes") }, [](INTERNAL_FUNCTION_PARAMETERS) {
-		HashTable *sure_types, *sure_not_types;
-		ZEND_PARSE_PARAMETERS_START(2, 2)
-			Z_PARAM_ARRAY_HT(sure_types)
-			Z_PARAM_ARRAY_HT(sure_not_types)
-		ZEND_PARSE_PARAMETERS_END();
-		zv::Val result = ScopeOps::buildTypeSpecifications(zv::TableRef(sure_types), zv::TableRef(sure_not_types));
 		if (UNEXPECTED(result.isUndef())) {
 			RETURN_THROWS();
 		}

--- a/turbo-ext/tests/smoke.php
+++ b/turbo-ext/tests/smoke.php
@@ -565,36 +565,6 @@ foreach ($scopeOpsClasses as $side => $scopeOpsClass) {
 }
 check($mergeResults['php'] === $mergeResults['native'], 'ScopeOps mergeVariableHolders: merged keys, certainties and types');
 
-// buildTypeSpecifications — pure, so both sides can share the inputs; the
-// scalar/array/unary-minus entries must be dropped and the result ordered by
-// expression-string length with sure-before-not tie-breaking
-$specInt = new \PHPStan\Type\IntegerType();
-$specString = new \PHPStan\Type\StringType();
-$specSure = [
-	'$bb' => [new \PhpParser\Node\Expr\Variable('bb'), $specInt],
-	'$a' => [new \PhpParser\Node\Expr\Variable('a'), $specInt],
-	"'lit'" => [new \PhpParser\Node\Scalar\String_('lit'), $specString],
-	'-5' => [new \PhpParser\Node\Expr\UnaryMinus(new \PhpParser\Node\Scalar\Int_(5)), $specInt],
-	'[]' => [new \PhpParser\Node\Expr\Array_([]), $specInt],
-];
-$specSureNot = [
-	'$a' => [new \PhpParser\Node\Expr\Variable('a'), $specString],
-	'$o->p' => [new \PhpParser\Node\Expr\PropertyFetch(new \PhpParser\Node\Expr\Variable('o'), 'p'), $specString],
-];
-$specResults = [];
-foreach ($scopeOpsClasses as $side => $scopeOpsClass) {
-	$specResults[$side] = array_map(
-		static fn (array $specification): array => [
-			$specification['sure'],
-			$specification['exprString'],
-			spl_object_id($specification['expr']),
-			$specification['type']->describe(\PHPStan\Type\VerbosityLevel::precise()),
-		],
-		$scopeOpsClass::buildTypeSpecifications($specSure, $specSureNot),
-	);
-}
-check($specResults['php'] === $specResults['native'], 'ScopeOps buildTypeSpecifications: filtering, ordering and tie-breaking');
-
 // matchConditionalExpressions — a holder whose conditions are all among the
 // specified expressions must resolve, transitively (fixed point); '$c'
 // resolves only after '$b' did, '$unmatched' never does


### PR DESCRIPTION
Applying a `SpecifiedTypes` batch derived one whole scope — a full holder-map copy plus scope construction — per specification, and one more per array-dim level of the parent-intersection cascade inside `specifyExpressionType()`. This PR restructures the apply side to write in place:

- `specifyExpressionType()` opens a single unpublished copy (`openSpecificationScope()`) and writes holders straight into its maps (`specifyExpressionTypeInPlace()`). Every lazily-derived view (`resolvedTypes`, truthy/falsey scopes, the promoted-native scope) is reset after each write, so every read answers exactly as it did on a per-specification fresh scope.
- The application loop batches all consecutive specifications into one working copy, inlining the `addTypeToExpression()`/`removeTypeFromExpression()` math; operations that go through other scope derivations (isset certainty, overwriting assignment) publish it and the next specification opens a fresh one. The conditional-expressions tail moves to `processConditionalExpressionsAfterSpecifying()`.
- The type-specification list is now built inline at its only caller, with alternative-form entries sorted together with sure/sure-not entries — restoring the shortest-expression-first guarantee (parents before children) for them too. `ScopeOps::buildTypeSpecifications()` and its native mirror are removed (smoke differential and signature parity green).
- `filterBySpecifiedTypes()` is renamed to `applySpecifiedTypes()` — the method does not filter, it applies computed narrowing. It is public but not `@api`.
- The isset-certainty path keeps the held type instead of re-reading it via `getType()`, which broadens Maybe-certainty holders and would overwrite a co-applied narrowing.

Zero expectation churn: full test suite green in both turbo modes (17844 tests), self-analysis and CS clean, turbo smoke differential + signature parity green.

Benchmark note: the local machine is currently running a backup; I will post a commit-toggled ABBA user-CPU comparison as a comment once it quiets down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7
