### PR TITLE
Do not narrow the falsey branch of a nested isset() at its intermediate offset

### DIFF
--- a/src/Analyser/ExprHandler/IssetHandler.php
+++ b/src/Analyser/ExprHandler/IssetHandler.php
@@ -196,6 +196,10 @@ final class IssetHandler implements ExprHandler
 			if (
 				$issetExpr instanceof ArrayDimFetch
 				&& $issetExpr->dim !== null
+				// When the var is itself an offset access (a nested isset like
+				// $r['K']['Port']), narrowing it in the falsey branch leaks the
+				// intermediate offset's existence into the enclosing scope.
+				&& !($issetExpr->var instanceof ArrayDimFetch)
 			) {
 				$varType = $scope->getType($issetExpr->var);
 				if (!$varType instanceof MixedType) {

--- a/tests/PHPStan/Analyser/nsrt/bug-15005.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-15005.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15005;
+
+use function PHPStan\Testing\assertType;
+
+/** @param array<string, array{Port: int, Secure: string|null}> $r */
+function nestedIssetLeak(array $r): void
+{
+	assertType('array{Port: int, Secure: string|null}|null', $r['K'] ?? null);
+
+	$port = isset($r['K']['Port']) ? $r['K']['Port'] : null;
+
+	assertType('array{Port: int, Secure: string|null}|null', $r['K'] ?? null);
+
+	$secure = $r['K']['Secure'] ?? null;
+
+	echo $port, $secure;
+}
+
+/** @param array<string, array{Port: int, Secure: string|null}> $r */
+function alsoAfterPlainIf(array $r): void
+{
+	if (isset($r['K']['Port'])) {
+		echo $r['K']['Port'];
+	}
+
+	assertType('array{Port: int, Secure: string|null}|null', $r['K'] ?? null);
+}
+
+/** @param array<string, array{Port: int, Secure: string|null}> $r */
+function notWithCoalesce(array $r): void
+{
+	$port = $r['K']['Port'] ?? null;
+	assertType('array{Port: int, Secure: string|null}|null', $r['K'] ?? null);
+	echo $port;
+}
+
+/** @param array<string, string|null> $r */
+function notWithSingleLevel(array $r): void
+{
+	$port = isset($r['K']) ? $r['K'] : null;
+	assertType('string|null', $r['K'] ?? null);
+	echo $port;
+}
+
+/** @param array<string, array<string, array{Port: int}>> $r */
+function threeLevels(array $r): void
+{
+	if (isset($r['A']['B']['Port'])) {
+		echo $r['A']['B']['Port'];
+	}
+
+	assertType('array{Port: int}|null', $r['A']['B'] ?? null);
+	assertType('array<string, array{Port: int}>|null', $r['A'] ?? null);
+}
+
+class Holder
+{
+
+	/** @var array<string, array{Port: int, Secure: string|null}> */
+	public array $arr = [];
+
+	public function doFoo(): void
+	{
+		if (isset($this->arr['K']['Port'])) {
+			echo $this->arr['K']['Port'];
+		}
+
+		assertType('array{Port: int, Secure: string|null}|null', $this->arr['K'] ?? null);
+	}
+
+}


### PR DESCRIPTION
Since 2.1.40 (#4983), `isset()` on a nested array offset narrows the intermediate offset in the falsey branch, and that narrowing leaks the offset's existence into the enclosing scope. After `isset($r['K']['Port'])`, `$r['K']` is treated as definitely existing for the rest of the scope, so `$r['K'] ?? null` loses its `|null`.

The falsey-branch narrowing block in `IssetHandler::specifyTypes()` was written for the single-level case, where the isset target's var is a plain variable or property. For a nested isset like `isset($r['K']['Port'])`, the target's var is itself an `ArrayDimFetch` (`$r['K']`), an offset that may not exist, and narrowing that intermediate offset in the falsey branch is what leaks its existence outward.

This skips the block when the target's var is itself an offset access, which is the case that leaks. Single-level isset (variable or property base) is unchanged, so the narrowing #4983 added still applies where it is sound.

This is the minimal fix. #6110 addresses the same issue by keeping the narrowing where the intermediate offset is known to exist (`isAlwaysSet()`); this PR is the smaller alternative, so you can compare the CI impact of both.

The regression test covers the reporter's cases (ternary and plain `if`), deeper nesting, a property base, and the `??` and single-level controls that were already correct.

Closes https://github.com/phpstan/phpstan/issues/15005
