### PR TITLE
Use a complete version constraint in FiniteTypeSetTest's RequiresPhp attribute

### DIFF
--- a/tests/PHPStan/Type/FiniteTypeSetTest.php
+++ b/tests/PHPStan/Type/FiniteTypeSetTest.php
@@ -31,7 +31,7 @@ use function sprintf;
  * self-analysis excludes those files below PHP 8.1, and a ::class would have PHPStan report
  * them as unknown classes there.
  */
-#[RequiresPhp('^8.1')]
+#[RequiresPhp('>= 8.1.0')]
 class FiniteTypeSetTest extends PHPStanTestCase
 {
 


### PR DESCRIPTION
`#[RequiresPhp('^8.1')]` in `FiniteTypeSetTest` (added in #6116) is flagged by phpstan-phpunit's `phpunit.attributeRequiresPhpVersion` rule: `^` is not one of the operators the rule accepts and `8.1` is a two-part, incomplete version. That makes the Infection job's initial static-analysis run exit 1 ("Version requirement is incomplete"), which fails Mutation Testing on every PR branched off current 2.2.x.

This uses `>= 8.1.0`, the form already used everywhere else in the suite (0 other usages use the caret form). The test still runs on 8.1+ as intended.