### PR TITLE
Store PhpStorm stub paths in the reflection cache relative to the stubs root

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -480,6 +480,18 @@ jobs:
               ../bashunit -a contains 'test.php:10:Variable $yetAnotherUndefined might not be defined.' "$OUTPUT"
               ../bashunit -a contains 'test.php:12:Ignoring all errors on a line is not allowed.' "$OUTPUT"
               ../bashunit -a contains 'test.php:12:Variable $yetYetAnotherUndefined might not be defined.' "$OUTPUT"
+          - script: |
+              # The reflection cache for PHP built-in symbols stores absolute paths to the
+              # PhpStorm stub files, but its cache key contains only package versions. The
+              # cache in sys_get_temp_dir() survives moving the PHPStan installation (for
+              # example when the project with PHPStan in vendor/ is moved or the CI
+              # workspace path changes), so the next run must not crash importing
+              # reflections that point to the previous installation path.
+              cp -R . /tmp/phpstan-install-1
+              cd e2e/moved-phpstan-installation
+              /tmp/phpstan-install-1/bin/phpstan analyse -l 8 -vvv test.php
+              mv /tmp/phpstan-install-1 /tmp/phpstan-install-2
+              /tmp/phpstan-install-2/bin/phpstan analyse -l 8 -vvv test.php
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/e2e/moved-phpstan-installation/test.php
+++ b/e2e/moved-phpstan-installation/test.php
@@ -1,0 +1,4 @@
+<?php
+
+$date = new DateTimeImmutable('2024-01-01');
+echo strlen($date->format('Y-m-d')) . PHP_EOL;

--- a/src/Internal/ComposerHelper.php
+++ b/src/Internal/ComposerHelper.php
@@ -7,6 +7,7 @@ use Nette\Utils\JsonException;
 use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\FileReader;
 use function basename;
+use function dirname;
 use function getenv;
 use function is_file;
 use function is_string;
@@ -94,6 +95,11 @@ final class ComposerHelper
 	private static function getInstalled(): array
 	{
 		return self::$installed ??= require __DIR__ . '/../../vendor/composer/installed.php';
+	}
+
+	public static function getPhpStormStubsDir(): string
+	{
+		return dirname(__DIR__, 2) . '/vendor/jetbrains/phpstorm-stubs';
 	}
 
 	public static function getPhpStanVersion(): string

--- a/src/Reflection/BetterReflection/SourceLocator/CachedPhpInternalSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/CachedPhpInternalSourceLocator.php
@@ -17,8 +17,14 @@ use PHPStan\Internal\ComposerHelper;
 use PHPStan\Php\PhpVersion;
 use function array_key_exists;
 use function is_array;
+use function is_file;
+use function is_string;
 use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function strpos;
 use function strtolower;
+use function substr;
 
 /**
  * Caches the reflections built from the PhpStorm stubs the way the optimized
@@ -30,11 +36,24 @@ use function strtolower;
  * The stubber's output depends on the stubs package, the reflection library
  * and the target PHP version (stub members are version-filtered), so all
  * three are part of the cache key.
+ *
+ * The exported blob contains the absolute path of the stub file, but the
+ * cache key deliberately contains no paths - the same entries are shared by
+ * every PHPStan installation with the same package versions, and survive the
+ * installation being moved. The path is therefore stored relative to the
+ * phpstorm-stubs package root and resolved against the current installation
+ * on import (https://github.com/phpstan/phpstan/issues/15023).
  */
 final class CachedPhpInternalSourceLocator implements SourceLocator
 {
 
+	private const STUBS_DIR_MARKER = '/jetbrains/phpstorm-stubs/';
+
+	private const RELATIVE_FILENAME_PREFIX = 'phpstorm-stubs:';
+
 	private ?string $variableCacheKey = null;
+
+	private ?string $stubsRootDir = null;
 
 	public function __construct(
 		private SourceLocator $inner,
@@ -55,6 +74,9 @@ final class CachedPhpInternalSourceLocator implements SourceLocator
 		$variableCacheKey = $this->getVariableCacheKey();
 
 		$cached = $this->cache->load($cacheKey, $variableCacheKey);
+		if (is_array($cached)) {
+			$cached = $this->resolveStubFilename($cached);
+		}
 		if (is_array($cached)) {
 			if ($identifier->isConstant()) {
 				return ReflectionConstant::importFromCache($reflector, $cached);
@@ -77,10 +99,55 @@ final class CachedPhpInternalSourceLocator implements SourceLocator
 			|| $reflection instanceof ReflectionFunction
 			|| $reflection instanceof ReflectionConstant
 		) {
-			$this->cache->save($cacheKey, $variableCacheKey, $reflection->exportToCache());
+			$exported = $this->relativizeStubFilename($reflection->exportToCache());
+			if ($exported !== null) {
+				$this->cache->save($cacheKey, $variableCacheKey, $exported);
+			}
 		}
 
 		return $reflection;
+	}
+
+	/**
+	 * @param array<string, mixed> $exported
+	 * @return array<string, mixed>|null
+	 */
+	private function relativizeStubFilename(array $exported): ?array
+	{
+		$filename = $exported['locatedSource']['data']['filename'] ?? null;
+		if (!is_string($filename)) {
+			return null;
+		}
+
+		$markerPosition = strpos($filename, self::STUBS_DIR_MARKER);
+		if ($markerPosition === false) {
+			return null;
+		}
+
+		$exported['locatedSource']['data']['filename'] = self::RELATIVE_FILENAME_PREFIX . substr($filename, $markerPosition + strlen(self::STUBS_DIR_MARKER));
+
+		return $exported;
+	}
+
+	/**
+	 * @param array<string, mixed> $cached
+	 * @return array<string, mixed>|null
+	 */
+	private function resolveStubFilename(array $cached): ?array
+	{
+		$filename = $cached['locatedSource']['data']['filename'] ?? null;
+		if (!is_string($filename) || !str_starts_with($filename, self::RELATIVE_FILENAME_PREFIX)) {
+			return null;
+		}
+
+		$resolved = ($this->stubsRootDir ??= ComposerHelper::getPhpStormStubsDir()) . '/' . substr($filename, strlen(self::RELATIVE_FILENAME_PREFIX));
+		if (!is_file($resolved)) {
+			return null;
+		}
+
+		$cached['locatedSource']['data']['filename'] = $resolved;
+
+		return $cached;
 	}
 
 	/**
@@ -95,7 +162,7 @@ final class CachedPhpInternalSourceLocator implements SourceLocator
 	private function getVariableCacheKey(): string
 	{
 		return $this->variableCacheKey ??= sprintf(
-			'v1-%s-%s-%s',
+			'v2-%s-%s-%s',
 			ComposerHelper::getBetterReflectionVersion(),
 			ComposerHelper::getPhpStormStubsVersion(),
 			$this->phpVersion->getVersionString(),


### PR DESCRIPTION
Fixes the regression introduced in ae5fd3163f507b5091ff19c0e96d7ab3c8d3e4c0 (Cache reflections built from the PhpStorm stubs).

The mechanism:

- `CachedPhpInternalSourceLocator` keys the cache only by package versions (better-reflection, phpstorm-stubs, target PHP version) — no paths — so the entries are shared by every installation with the same versions, and survive the installation being moved.
- The cached `exportToCache()` blob however stored the absolute path of the stub file inside the installation that filled the cache (`.../vendor/jetbrains/phpstorm-stubs/...`; in the phar case the path embeds the phar's absolute location).
- `InternalLocatedSource::importFromCache()` eagerly runs `FileChecker::assertReadableFile()` + `file_get_contents()` on that path, so a warm run from a moved installation — or a different installation sharing `sys_get_temp_dir() . '/phpstan'`, like rotating Jenkins workspaces — crashed with `Internal error: "..." is not a file`. The entries also survive `clear-result-cache`, so there was no way to recover.

The first commit adds an e2e test: copy the checkout to `/tmp/phpstan-install-1`, analyse a small file using built-in symbols (fills the cache), move the installation to `/tmp/phpstan-install-2`, run the same analysis again. It failed with the internal error above before the fix.

The second commit fixes it: the stub path is stored relative to the phpstorm-stubs package root (`phpstorm-stubs:date/date_c.php`) and resolved against the current installation on import, so the entries stay shared across installations and moves. An `is_file()` guard turns any unresolvable path into a plain cache miss, making this class of crash impossible by construction. The variable-key version bump (`v1` → `v2`) invalidates existing poisoned entries with absolute paths, rescuing already-affected caches.

Verified locally besides the e2e: a warm in-place run rewrites 0 cache files (the relative entries really are imported), and a second installation at a different path shares the same warm entries. Keeping the cache (rather than reverting it) is backed by benchmarks: it saves ~1.5–3% CPU on runs with a cold result cache (ABBA pairs, paired t-test).

Closes https://github.com/phpstan/phpstan/issues/15023

🤖 Generated with [Claude Code](https://claude.com/claude-code)
