### PR TITLE
Restore @param ErrorIdentifier phpdoc on IssetCheck::checkUndefinedInner()

### DIFF
--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -240,6 +240,9 @@ final class IssetCheck
 		return null;
 	}
 
+	/**
+	 * @param ErrorIdentifier $identifier
+	 */
 	private function checkUndefinedInner(?IssetabilityResolution $resolution, MutatingScope $scope, string $operatorDescription, string $identifier): ?IdentifierRuleError
 	{
 		if ($resolution === null) {


### PR DESCRIPTION
The extract-identifiers job in phpstan/phpstan is failing with "Internal error: Unknown identifier while analysing file .../src/Rules/IssetCheck.php" (https://github.com/phpstan/phpstan/actions/runs/30953518153/job/92141072720).

In ac92f19c80 the old checkUndefined() was replaced by checkUndefinedInner() and lost its @param ErrorIdentifier phpdoc. Without it $identifier is plain string, so sprintf('%s.variable', $identifier) no longer resolves to constant strings and the identifier extractor throws. The other methods in the class kept the annotation.