### PR TITLE
Collapse ObjectShapeType against HasPropertyType regardless of member order

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -1735,11 +1735,16 @@ final class TypeCombinator
 		$hasOffsetValueTypeCount = 0;
 		$typesCount = count($types);
 		$typesNeedSorting = false;
+		$hasPropertyType = false;
 		for ($i = 0; $i < $typesCount; $i++) {
 			$type = $types[$i];
 
 			if ($type instanceof SubtractableType || $type instanceof ConstantArrayType) {
 				$typesNeedSorting = true;
+			}
+
+			if ($type instanceof HasPropertyType) {
+				$hasPropertyType = true;
 			}
 
 			if ($type instanceof IntersectionType && !$type instanceof TemplateType) {
@@ -1778,6 +1783,41 @@ final class TypeCombinator
 
 				return 0;
 			});
+		}
+
+		// Resolve object-shape optional keys that a HasPropertyType asserts are present before the
+		// reduction loop below. In that loop the generic supertype dedup can drop a HasPropertyType
+		// as redundant against a dynamic-property class such as stdClass (which reports every
+		// property as present) before it is ever paired with the object shape. Which of the two
+		// fires first depends on the member order, so the collapse runs here, where order does not
+		// change the result of what is meant to be an order-independent value. Gated on the presence
+		// of a HasPropertyType so the common intersection pays only the flag check set above.
+		if ($hasPropertyType) {
+			for ($i = 0; $i < $typesCount; $i++) {
+				for ($j = $i + 1; $j < $typesCount; $j++) {
+					if (
+						$types[$i] instanceof ObjectShapeType
+						&& $types[$j] instanceof HasPropertyType
+						&& !$types[$i]->hasInstanceProperty($types[$j]->getPropertyName())->no()
+					) {
+						$types[$i] = $types[$i]->makePropertyRequired($types[$j]->getPropertyName());
+						array_splice($types, $j--, 1);
+						$typesCount--;
+						continue;
+					}
+
+					if (
+						$types[$j] instanceof ObjectShapeType
+						&& $types[$i] instanceof HasPropertyType
+						&& !$types[$j]->hasInstanceProperty($types[$i]->getPropertyName())->no()
+					) {
+						$types[$j] = $types[$j]->makePropertyRequired($types[$i]->getPropertyName());
+						array_splice($types, $i--, 1);
+						$typesCount--;
+						continue 2;
+					}
+				}
+			}
 		}
 
 		// transform IntegerType & ConstantIntegerType to ConstantIntegerType
@@ -1939,20 +1979,6 @@ final class TypeCombinator
 					}
 
 					if ($types[$j] instanceof OversizedArrayType && $types[$i] instanceof HasOffsetValueType) {
-						array_splice($types, $i--, 1);
-						$typesCount--;
-						continue 2;
-					}
-
-					if ($types[$i] instanceof ObjectShapeType && $types[$j] instanceof HasPropertyType) {
-						$types[$i] = $types[$i]->makePropertyRequired($types[$j]->getPropertyName());
-						array_splice($types, $j--, 1);
-						$typesCount--;
-						continue;
-					}
-
-					if ($types[$j] instanceof ObjectShapeType && $types[$i] instanceof HasPropertyType) {
-						$types[$j] = $types[$j]->makePropertyRequired($types[$i]->getPropertyName());
 						array_splice($types, $i--, 1);
 						$typesCount--;
 						continue 2;

--- a/tests/PHPStan/Analyser/nsrt/bug-15047.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-15047.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Bug15047;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+abstract class AbstractJsonRepresentation
+{
+
+	/**
+	 * @param stdClass $data
+	 */
+	abstract protected static function fromObjectInternal(stdClass $data): self;
+
+}
+
+final class MissalYearLimits extends AbstractJsonRepresentation
+{
+
+	private ?int $untilYear;
+
+	private function __construct(?int $untilYear)
+	{
+		$this->untilYear = $untilYear;
+	}
+
+	/**
+	 * @param stdClass&object{since_year:int,until_year?:int} $data
+	 */
+	protected static function fromObjectInternal(stdClass $data): self
+	{
+		assertType('object{since_year: int, until_year?: int}&stdClass', $data);
+		assertType('int|null', $data->until_year ?? null);
+		assertType('int', $data->since_year);
+
+		if (isset($data->until_year)) {
+			assertType('object{since_year: int, until_year: int}&stdClass', $data);
+			assertType('int', $data->until_year);
+		}
+
+		return new self($data->until_year ?? null);
+	}
+
+}
+
+/**
+ * The member order of the intersection must not change the result: whether the object shape or
+ * stdClass is written first, isset()/?? narrowing resolves the optional key to its declared type.
+ *
+ * @param stdClass&object{u?:int} $stdFirst
+ * @param object{u?:int}&stdClass $shapeFirst
+ */
+function orderIndependent($stdFirst, $shapeFirst): void
+{
+	assertType('int|null', $stdFirst->u ?? null);
+	assertType('int|null', $shapeFirst->u ?? null);
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-15047.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-15047.php
@@ -1,28 +1,18 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace Bug15047;
 
 use stdClass;
 use function PHPStan\Testing\assertType;
 
-abstract class AbstractJsonRepresentation
+final class MissalYearLimits
 {
 
-	/**
-	 * @param stdClass $data
-	 */
-	abstract protected static function fromObjectInternal(stdClass $data): self;
+	private ?int $until_year;
 
-}
-
-final class MissalYearLimits extends AbstractJsonRepresentation
-{
-
-	private ?int $untilYear;
-
-	private function __construct(?int $untilYear)
+	private function __construct(?int $until_year)
 	{
-		$this->untilYear = $untilYear;
+		$this->until_year = $until_year;
 	}
 
 	/**
@@ -31,28 +21,19 @@ final class MissalYearLimits extends AbstractJsonRepresentation
 	protected static function fromObjectInternal(stdClass $data): self
 	{
 		assertType('object{since_year: int, until_year?: int}&stdClass', $data);
-		assertType('int|null', $data->until_year ?? null);
 		assertType('int', $data->since_year);
+		assertType('int|null', isset($data->until_year) ? $data->until_year : null);
+		assertType('int|null', $data->until_year ?? null);
 
+		// isset() adds a hasProperty() member to the intersection, and resolving the
+		// optional key against it must not depend on where that member lands in the
+		// member list - which is what this used to be sensitive to.
 		if (isset($data->until_year)) {
 			assertType('object{since_year: int, until_year: int}&stdClass', $data);
 			assertType('int', $data->until_year);
 		}
 
-		return new self($data->until_year ?? null);
+		return new self(isset($data->until_year) ? $data->until_year : null);
 	}
 
-}
-
-/**
- * The member order of the intersection must not change the result: whether the object shape or
- * stdClass is written first, isset()/?? narrowing resolves the optional key to its declared type.
- *
- * @param stdClass&object{u?:int} $stdFirst
- * @param object{u?:int}&stdClass $shapeFirst
- */
-function orderIndependent($stdFirst, $shapeFirst): void
-{
-	assertType('int|null', $stdFirst->u ?? null);
-	assertType('int|null', $shapeFirst->u ?? null);
 }

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -25,6 +25,8 @@ class InstantiationRuleTest extends RuleTestCase
 
 	private bool $checkExplicitMixed = false;
 
+	private bool $checkImplicitMixed = false;
+
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
@@ -35,7 +37,7 @@ class InstantiationRuleTest extends RuleTestCase
 			checkThisOnly: false,
 			checkUnionTypes: true,
 			checkExplicitMixed: $this->checkExplicitMixed,
-			checkImplicitMixed: false,
+			checkImplicitMixed: $this->checkImplicitMixed,
 			checkBenevolentUnionTypes: false,
 			discoveringSymbolsTip: true,
 		);
@@ -729,6 +731,12 @@ class InstantiationRuleTest extends RuleTestCase
 				50,
 			],
 		]);
+	}
+
+	public function testBug15047(): void
+	{
+		$this->checkImplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-15047.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-15047.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-15047.php
@@ -4,29 +4,14 @@ namespace Bug15047Instantiation;
 
 use stdClass;
 
-abstract class AbstractJsonRepresentation
+final class MissalYearLimits
 {
 
-	/**
-	 * @param stdClass $data
-	 */
-	abstract protected static function fromObjectInternal(stdClass $data): self;
+	private ?int $until_year;
 
-}
-
-final class MissalYearLimits extends AbstractJsonRepresentation
-{
-
-	private ?int $untilYear;
-
-	private function __construct(?int $untilYear)
+	private function __construct(?int $until_year)
 	{
-		$this->untilYear = $untilYear;
-	}
-
-	public function getUntilYear(): ?int
-	{
-		return $this->untilYear;
+		$this->until_year = $until_year;
 	}
 
 	/**
@@ -34,9 +19,14 @@ final class MissalYearLimits extends AbstractJsonRepresentation
 	 */
 	protected static function fromObjectInternal(stdClass $data): self
 	{
-		// the optional key must keep its declared type through the ?? narrowing,
+		// the optional key must keep its declared type through the isset() narrowing,
 		// otherwise this reports "expects int|null, mixed given"
-		return new self($data->until_year ?? null);
+		return new self(isset($data->until_year) ? $data->until_year : null);
+	}
+
+	public function getUntilYear(): ?int
+	{
+		return $this->until_year;
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-15047.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-15047.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15047Instantiation;
+
+use stdClass;
+
+abstract class AbstractJsonRepresentation
+{
+
+	/**
+	 * @param stdClass $data
+	 */
+	abstract protected static function fromObjectInternal(stdClass $data): self;
+
+}
+
+final class MissalYearLimits extends AbstractJsonRepresentation
+{
+
+	private ?int $untilYear;
+
+	private function __construct(?int $untilYear)
+	{
+		$this->untilYear = $untilYear;
+	}
+
+	public function getUntilYear(): ?int
+	{
+		return $this->untilYear;
+	}
+
+	/**
+	 * @param stdClass&object{since_year:int,until_year?:int} $data
+	 */
+	protected static function fromObjectInternal(stdClass $data): self
+	{
+		// the optional key must keep its declared type through the ?? narrowing,
+		// otherwise this reports "expects int|null, mixed given"
+		return new self($data->until_year ?? null);
+	}
+
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -4965,6 +4965,26 @@ class TypeCombinatorTest extends PHPStanTestCase
 			ObjectShapeType::class,
 			'object{foo: int}',
 		];
+		// A third member the generic supertype dedup can weigh the HasPropertyType against must
+		// not change whether the optional key is resolved - the member order used to decide it.
+		yield [
+			[
+				new ObjectType('stdClass'),
+				new ObjectShapeType(['foo' => new IntegerType()], ['foo']),
+				new HasPropertyType('foo'),
+			],
+			IntersectionType::class,
+			'object{foo: int}&stdClass',
+		];
+		yield [
+			[
+				new ObjectShapeType(['foo' => new IntegerType()], ['foo']),
+				new ObjectType('Traversable'),
+				new HasPropertyType('foo'),
+			],
+			IntersectionType::class,
+			'object{foo: int}&Traversable',
+		];
 		yield [
 			[
 				new ObjectShapeType(['foo' => new IntegerType()], []),


### PR DESCRIPTION
When a parameter is typed `\stdClass&object{u?:int}` and its value goes through `isset()`/`??` narrowing, PHPStan should resolve the optional key to its declared type. Since 2.2.6 it fell back to `mixed` instead:

```php
abstract class AbstractJsonRepresentation
{
    /** @param \stdClass $data */
    abstract protected static function fromObjectInternal(\stdClass $data): self;
}

final class MissalYearLimits extends AbstractJsonRepresentation
{
    private ?int $until_year;

    /** @param \stdClass&object{since_year:int,until_year?:int} $data */
    protected static function fromObjectInternal(\stdClass $data): self
    {
        // 2.2.5: int|null   2.2.6+: mixed  -> "argument.type" false positive at level 10
        return new self($data->until_year ?? null);
    }
}
```

## Root cause

`isset($data->until_year)` narrows `$data` by intersecting it with a `HasPropertyType` for the key, and `TypeCombinator::intersect()` is supposed to collapse `object{until_year?:int} & hasProperty(until_year)` into `object{until_year:int}`, so the read is `int`.

That collapse lived in the pairwise reduction loop, reached only after the generic supertype dedup. The parameter also carries `stdClass`, a dynamic-property class that reports every property as present, so `hasProperty(until_year)` is a supertype of it and the dedup removes the `HasPropertyType` as redundant against `stdClass`. Whether the dedup drops it first or the object shape collapses it first depends on the order of the members in the intersection.

While intersection members were still sorted in place, describing the type happened to reorder them so the object shape came first and won the race. Once that in-place mutation was removed (correctly, so a type's value no longer depends on what has been called on it) the construction order took over, `stdClass` came first, and its `mixed` dominated.

Note the bare read `$data->until_year` without `isset`/`??` was already `mixed` before and after 2.2.6. That is a separate, pre-existing gap and not what this fixes; this change is about the `isset`/`??` narrowing path only.

## Fix

Move the object-shape / `HasPropertyType` collapse into its own pass before the reduction loop, so member order no longer decides the outcome. Two details keep it behaviour-preserving otherwise:

- It only fires when the shape has, or may have, the key (`hasInstanceProperty(...)` is not `no`). A sealed shape intersected with a `HasPropertyType` for a key it cannot have is left alone, so it still reduces to `never` in the loop below, as it did before.
- The pass is gated on a `HasPropertyType` being present in the intersection, a flag computed in the existing flatten loop, so an intersection without one pays only that flag check and never enters the extra loop.

The array analogue (`ConstantArrayType & HasOffsetType`) is not affected: there is no universal-offset type that reports every offset as present, so nothing absorbs the `HasOffsetType` before the offset is made required. Verified against real 2.2.5/2.2.6 builds.

Closes https://github.com/phpstan/phpstan/issues/15047
