### PR TITLE
End-to-End tests: Support different php versions per case

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -531,6 +531,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        php-version: ["8.2"]
         include:
           - script: "bin/phpstan analyse -l 8 -a tests/e2e/data/timecop.php -c tests/e2e/data/empty.neon tests/e2e/data/timecop.php"
             tools: "pecl"
@@ -616,6 +617,7 @@ jobs:
           - script: |
               cd e2e/bug13425
               timeout 15 ../bashunit -a exit_code "1" "../../bin/phpstan analyze src/ plugins/"
+            php-version: "8.3"
           - script: |
               cd e2e/bug-14036
               composer install
@@ -660,7 +662,7 @@ jobs:
         uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           coverage: "none"
-          php-version: "8.2"
+          php-version: ${{ matrix.php-version }}
           tools: ${{ matrix.tools }}
           extensions: ${{ matrix.extensions }}
 


### PR DESCRIPTION
e2e test summary currently contain a long list of phpstan errors, most of them for the bug13425 case:

<img width="1483" height="847" alt="grafik" src="https://github.com/user-attachments/assets/92cb6cdf-d447-4130-a6a0-82c3a1f0b288" />

the test was added in https://github.com/phpstan/phpstan-src/pull/4268 and is only about detecting a perf regression. therefore I think its fine to upgrade to php 8.3 and by that getting most of the summary errors fixed.