### PR TITLE
Do not report a private method overriding a private trait method as unused

### DIFF
--- a/src/Rules/DeadCode/UnusedPrivateMethodRule.php
+++ b/src/Rules/DeadCode/UnusedPrivateMethodRule.php
@@ -9,6 +9,7 @@ use PHPStan\DependencyInjection\AutowiredExtensions;
 use PHPStan\DependencyInjection\ExtensionsCollection;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Node\ClassMethodsNode;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Methods\AlwaysUsedMethodExtension;
 use PHPStan\Rules\Rule;
@@ -67,6 +68,10 @@ final class UnusedPrivateMethodRule implements Rule
 				continue;
 			}
 			if (strtolower($methodName) === '__clone') {
+				continue;
+			}
+
+			if ($this->isOverridingPrivateTraitMethod($classReflection, $methodName)) {
 				continue;
 			}
 
@@ -201,6 +206,28 @@ final class UnusedPrivateMethodRule implements Rule
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * A private method overriding a private method of a used trait is called from
+	 * the trait's own methods. Those call sites are invisible when the trait is not
+	 * part of the analysed files.
+	 */
+	private function isOverridingPrivateTraitMethod(ClassReflection $classReflection, string $methodName): bool
+	{
+		foreach ($classReflection->getTraits() as $trait) {
+			if (!$trait->hasNativeMethod($methodName)) {
+				continue;
+			}
+
+			if (!$trait->getNativeMethod($methodName)->isPrivate()) {
+				continue;
+			}
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
@@ -134,6 +134,16 @@ class UnusedPrivateMethodRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12201(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12201.php'], [
+			[
+				'Method Bug12201\AnotherKernel::doNothing() is unused.',
+				24,
+			],
+		]);
+	}
+
 	public function testBug14880(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-14880.php'], []);

--- a/tests/PHPStan/Rules/DeadCode/data/bug-12201-traits.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-12201-traits.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12201;
+
+trait KernelTrait
+{
+	/**
+	 * @return string[]
+	 */
+	private function getAllowedEnvs(): array
+	{
+		return [];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function getKernelParameters(): array
+	{
+		return $this->getAllowedEnvs();
+	}
+}
+
+trait MicroKernelTrait
+{
+	use KernelTrait;
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-12201.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-12201.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12201;
+
+// The traits live in bug-12201-traits.php which is not analysed on purpose:
+// it stands for a dependency living outside of the analysed paths.
+class AppKernel
+{
+	use MicroKernelTrait;
+
+	/**
+	 * @return list<string>
+	 */
+	private function getAllowedEnvs(): array
+	{
+		return ['prod', 'dev', 'test'];
+	}
+}
+
+class AnotherKernel
+{
+	use MicroKernelTrait;
+
+	private function doNothing(): void
+	{
+	}
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#12201

## Why

A class member takes precedence over the member of the same name coming from a used trait. So a private method redeclared in the class is the one the trait's own methods call.

`UnusedPrivateMethodRule` sees those call sites only when the trait is part of the analysed files. In a project whose `paths` exclude its dependencies, `ClassMethodsNode::getMethodCalls()` collects no call at all. The class method is then reported as unused.

The canonical case is a Symfony application. The recipe generates a `Kernel` that redeclares `KernelTrait::getAllowedEnvs()`, and the trait lives in `vendor/`.

```php
// vendor/symfony/dependency-injection/Kernel/KernelTrait.php, not analysed
trait KernelTrait
{
	private function getAllowedEnvs(): array
	{
		return [];
	}

	protected function getKernelParameters(): array
	{
		// ...
		if (!$knownEnvs = array_flip($this->getAllowedEnvs())) {
		// ...
	}
}
```

```php
// src/Kernel.php, analysed
class Kernel extends BaseKernel
{
	use MicroKernelTrait; // uses KernelTrait

	/**
	 * @return list<string>
	 */
	private function getAllowedEnvs(): array // reported as unused
	{
		return ['prod', 'dev', 'test'];
	}
}
```

Every new Symfony 8.1 project hits this from level 4 up. `ignoreErrors` is the only way out.

## What

A private method is skipped when a used trait declares a private method of the same name.

`getTraits()` is enough without recursion. PHP flattens trait composition. `getAllowedEnvs()` comes from the nested `KernelTrait`, and the reflection of `MicroKernelTrait` already reports it.