### PR TITLE
Accept the shared data provider's third argument in testOverridingFinalMethod

### DIFF
--- a/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
@@ -56,7 +56,7 @@ class OverridingMethodRuleTest extends RuleTestCase
 	}
 
 	#[DataProvider('dataOverridingFinalMethod')]
-	public function testOverridingFinalMethod(int $phpVersion, string $contravariantMessage): void
+	public function testOverridingFinalMethod(int $phpVersion, string $contravariantMessage, string $covariantMessage): void
 	{
 		$errors = [
 			[


### PR DESCRIPTION
`dataOverridingFinalMethod()` yields three values per set (`phpVersion`, a parameter-contravariance message, and a return-type-covariance message) and is shared by two tests. `testParle()` declares and uses all three; `testOverridingFinalMethod()` declared only two, so the third value went unused.

Older PHPUnit tolerated the extra data-set value, but PHPUnit 12 treats it as an error:

```
Data set #0 provided by ...::dataOverridingFinalMethod has more arguments (3) than the test method accepts (2)
```

It started failing on the `Tests PHPUnit 12.x` matrix once it picked up a stricter PHPUnit 12 release, which is why the base was green earlier. This declares the third parameter on `testOverridingFinalMethod()` so its arity matches the shared provider. The method has no covariance assertion, so it does not use the value, but declaring it keeps the data set valid under PHPUnit 12.

Verified locally on PHPUnit 11.5 (the test still passes) and via self-analysis and the coding standard. I could not run PHPUnit 12 locally, but the fix makes the data-set arity equal the parameter count, which is what PHPUnit 12 requires.
