### PR TITLE
Avoid dead catch false positive for inconsistently overridden trait methods

### DIFF
--- a/src/Analyser/StmtHandler/TryCatchHandler.php
+++ b/src/Analyser/StmtHandler/TryCatchHandler.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\StatementContext;
 use PHPStan\Analyser\StmtHandler;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Node\CatchWithThrownExceptionInTraitNode;
 use PHPStan\Node\CatchWithUnthrownExceptionNode;
 use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Node\FinallyExitPointsNode;
@@ -169,6 +170,13 @@ final class TryCatchHandler implements StmtHandler
 			// emit error
 			foreach ($matchingCatchTypes as $catchTypeIndex => $matched) {
 				if ($matched) {
+					// A trait's catch can be dead in the context of one class using the
+					// trait and alive in the context of another, so the alive ones have
+					// to be reported there as well for the disagreement to be noticed.
+					if ($scope->isInTrait()) {
+						$nodeScopeResolver->callNodeCallback($nodeCallback, new CatchWithThrownExceptionInTraitNode($catchNode, $originalCatchTypes[$catchTypeIndex]), $scope, $storage);
+					}
+
 					continue;
 				}
 				$nodeScopeResolver->callNodeCallback($nodeCallback, new CatchWithUnthrownExceptionNode($catchNode, $catchTypes[$catchTypeIndex], $originalCatchTypes[$catchTypeIndex]), $scope, $storage);

--- a/src/Analyser/StmtHandler/TryCatchHandler.php
+++ b/src/Analyser/StmtHandler/TryCatchHandler.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\StatementContext;
 use PHPStan\Analyser\StmtHandler;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Node\CatchWithThrownExceptionInTraitNode;
 use PHPStan\Node\CatchWithUnthrownExceptionNode;
 use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Node\FinallyExitPointsNode;
@@ -171,6 +172,13 @@ final class TryCatchHandler implements StmtHandler
 			// emit error
 			foreach ($matchingCatchTypes as $catchTypeIndex => $matched) {
 				if ($matched) {
+					// A trait's catch can be dead in the context of one class using the
+					// trait and alive in the context of another, so the alive ones have
+					// to be reported there as well for the disagreement to be noticed.
+					if ($scope->isInTrait()) {
+						$nodeScopeResolver->callNodeCallback($nodeCallback, new CatchWithThrownExceptionInTraitNode($catchNode, $originalCatchTypes[$catchTypeIndex]), $scope, $storage);
+					}
+
 					continue;
 				}
 				$nodeScopeResolver->callNodeCallback($nodeCallback, new CatchWithUnthrownExceptionNode($catchNode, $catchTypes[$catchTypeIndex], $originalCatchTypes[$catchTypeIndex]), $scope, $storage);

--- a/src/Node/CatchWithThrownExceptionInTraitNode.php
+++ b/src/Node/CatchWithThrownExceptionInTraitNode.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Node;
+
+use Override;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\NodeAbstract;
+use PHPStan\Type\Type;
+
+/**
+ * A catch clause inside a trait whose caught type _is_ thrown in the try block.
+ *
+ * Emitted only in traits. A trait's catch can be dead in the context of one class using
+ * the trait and alive in the context of another, so CatchWithUnthrownExceptionRule has to
+ * learn about the alive ones as well to notice the disagreement. Dead catches keep being
+ * reported through CatchWithUnthrownExceptionNode.
+ */
+final class CatchWithThrownExceptionInTraitNode extends NodeAbstract implements VirtualNode
+{
+
+	public function __construct(private Catch_ $originalNode, private Type $originalCaughtType)
+	{
+		parent::__construct($originalNode->getAttributes());
+	}
+
+	public function getOriginalNode(): Catch_
+	{
+		return $this->originalNode;
+	}
+
+	public function getOriginalCaughtType(): Type
+	{
+		return $this->originalCaughtType;
+	}
+
+	#[Override]
+	public function getType(): string
+	{
+		return 'PHPStan_Node_CatchWithThrownExceptionInTraitNode';
+	}
+
+	/**
+	 * @return string[]
+	 */
+	#[Override]
+	public function getSubNodeNames(): array
+	{
+		return [];
+	}
+
+}

--- a/src/Rules/Comparison/ConstantConditionInTraitHelper.php
+++ b/src/Rules/Comparison/ConstantConditionInTraitHelper.php
@@ -41,16 +41,7 @@ final class ConstantConditionInTraitHelper
 		Expr $expr,
 	): void
 	{
-		if (!$scope->isInTrait()) {
-			return;
-		}
-
-		$scope->emitCollectedData(ConstantConditionInTraitCollector::class, [
-			$ruleName,
-			$scope->getTraitReflection()->getName(),
-			$this->exprString($expr),
-			null,
-		]);
+		$this->emitNoErrorForKey($ruleName, $scope, $this->exprString($expr));
 	}
 
 	/**
@@ -60,6 +51,48 @@ final class ConstantConditionInTraitHelper
 		string $ruleName,
 		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 		Expr $expr,
+		bool $value,
+		RuleError $ruleError,
+	): void
+	{
+		$this->emitErrorForKey($ruleName, $scope, $expr, $this->exprString($expr), $value, $ruleError);
+	}
+
+	/**
+	 * Like emitNoError(), but for callers that cannot key their check by a single Expr
+	 * (e.g. one Rule node covering several distinct checks at the same location).
+	 *
+	 * @param class-string<Rule<covariant Node>> $ruleName
+	 */
+	public function emitNoErrorForKey(
+		string $ruleName,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		string $key,
+	): void
+	{
+		if (!$scope->isInTrait()) {
+			return;
+		}
+
+		$scope->emitCollectedData(ConstantConditionInTraitCollector::class, [
+			$ruleName,
+			$scope->getTraitReflection()->getName(),
+			$key,
+			null,
+		]);
+	}
+
+	/**
+	 * Like emitError(), but for callers that cannot key their check by a single Expr
+	 * (e.g. one Rule node covering several distinct checks at the same location).
+	 *
+	 * @param class-string<Rule<covariant Node>> $ruleName
+	 */
+	public function emitErrorForKey(
+		string $ruleName,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Node $node,
+		string $key,
 		bool $value,
 		RuleError $ruleError,
 	): void
@@ -75,9 +108,9 @@ final class ConstantConditionInTraitHelper
 		$scope->emitCollectedData(ConstantConditionInTraitCollector::class, [
 			$ruleName,
 			$scope->getTraitReflection()->getName(),
-			$this->exprString($expr),
+			$key,
 			$value,
-			$this->ruleErrorTransformer->transform($ruleError, $scope, [], $expr),
+			$this->ruleErrorTransformer->transform($ruleError, $scope, [], $node),
 		]);
 	}
 

--- a/src/Rules/Exceptions/CatchWithThrownExceptionInTraitRule.php
+++ b/src/Rules/Exceptions/CatchWithThrownExceptionInTraitRule.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Exceptions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Node\CatchWithThrownExceptionInTraitNode;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
+use PHPStan\Rules\Rule;
+
+/**
+ * Records that a catch clause in a trait is alive in the context of the current class,
+ * so that CatchWithUnthrownExceptionRule does not report it as dead based only on the
+ * classes using the trait where it happens to be unreachable.
+ *
+ * @implements Rule<CatchWithThrownExceptionInTraitNode>
+ */
+#[RegisteredRule(level: 4)]
+final class CatchWithThrownExceptionInTraitRule implements Rule
+{
+
+	public function __construct(private ConstantConditionInTraitHelper $constantConditionInTraitHelper)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return CatchWithThrownExceptionInTraitNode::class;
+	}
+
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
+	{
+		$this->constantConditionInTraitHelper->emitNoErrorForKey(
+			CatchWithUnthrownExceptionRule::class,
+			$scope,
+			DeadCatchInTraitKey::create($node->getOriginalNode(), $node->getOriginalCaughtType()),
+		);
+
+		return [];
+	}
+
+}

--- a/src/Rules/Exceptions/CatchWithUnthrownExceptionRule.php
+++ b/src/Rules/Exceptions/CatchWithUnthrownExceptionRule.php
@@ -3,10 +3,13 @@
 namespace PHPStan\Rules\Exceptions;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Node\CatchWithUnthrownExceptionNode;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\NeverType;
@@ -25,6 +28,7 @@ final class CatchWithUnthrownExceptionRule implements Rule
 		private ExceptionTypeResolver $exceptionTypeResolver,
 		#[AutowiredParameter(ref: '%exceptions.reportUncheckedExceptionDeadCatch%')]
 		private bool $reportUncheckedExceptionDeadCatch,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 	)
 	{
 	}
@@ -34,41 +38,56 @@ final class CatchWithUnthrownExceptionRule implements Rule
 		return CatchWithUnthrownExceptionNode::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if ($node->getCaughtType() instanceof NeverType) {
-			return [
-				RuleErrorBuilder::message(
-					sprintf('Dead catch - %s is already caught above.', $node->getOriginalCaughtType()->describe(VerbosityLevel::typeOnly())),
-				)
-					->line($node->getStartLine())
-					->identifier('catch.alreadyCaught')
-					->build(),
-			];
-		}
+			$error = RuleErrorBuilder::message(
+				sprintf('Dead catch - %s is already caught above.', $node->getOriginalCaughtType()->describe(VerbosityLevel::typeOnly())),
+			)
+				->line($node->getStartLine())
+				->identifier('catch.alreadyCaught')
+				->build();
+		} else {
+			if (!$this->reportUncheckedExceptionDeadCatch) {
+				$isCheckedException = false;
+				foreach ($node->getCaughtType()->getObjectClassNames() as $objectClassName) {
+					if ($this->exceptionTypeResolver->isCheckedException($objectClassName, $scope)) {
+						$isCheckedException = true;
+						break;
+					}
+				}
 
-		if (!$this->reportUncheckedExceptionDeadCatch) {
-			$isCheckedException = false;
-			foreach ($node->getCaughtType()->getObjectClassNames() as $objectClassName) {
-				if ($this->exceptionTypeResolver->isCheckedException($objectClassName, $scope)) {
-					$isCheckedException = true;
-					break;
+				if (!$isCheckedException) {
+					return [];
 				}
 			}
 
-			if (!$isCheckedException) {
-				return [];
-			}
-		}
-
-		return [
-			RuleErrorBuilder::message(
+			$error = RuleErrorBuilder::message(
 				sprintf('Dead catch - %s is never thrown in the try block.', $node->getCaughtType()->describe(VerbosityLevel::typeOnly())),
 			)
 				->line($node->getStartLine())
 				->identifier('catch.neverThrown')
-				->build(),
-		];
+				->build();
+		}
+
+		if ($scope->isInTrait()) {
+			// A trait's catch can be dead in the context of one class using the trait and
+			// alive in the context of another, e.g. when it depends on whether an abstract
+			// method gets overridden. Let the collector compare the verdicts of all the
+			// classes using the trait instead of reporting right away; the alive ones are
+			// recorded by CatchWithThrownExceptionInTraitRule under the same key.
+			$this->constantConditionInTraitHelper->emitErrorForKey(
+				self::class,
+				$scope,
+				$node->getOriginalNode(),
+				DeadCatchInTraitKey::create($node->getOriginalNode(), $node->getOriginalCaughtType()),
+				true,
+				$error,
+			);
+			return [];
+		}
+
+		return [$error];
 	}
 
 }

--- a/src/Rules/Exceptions/DeadCatchInTraitKey.php
+++ b/src/Rules/Exceptions/DeadCatchInTraitKey.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Exceptions;
+
+use PhpParser\Node\Stmt\Catch_;
+use PHPStan\Type\Type;
+use function implode;
+use function sprintf;
+
+/**
+ * Identifies one caught type of one catch clause in a trait, so that the dead-catch
+ * verdicts collected from every class using the trait can be compared.
+ *
+ * The trait is parsed from the same file for every using class, so the caught type
+ * together with the line pins down the occurrence: `catch (A|B)` yields two keys,
+ * one per caught type.
+ */
+final class DeadCatchInTraitKey
+{
+
+	public static function create(Catch_ $catchNode, Type $originalCaughtType): string
+	{
+		return sprintf('%s:%d', implode('|', $originalCaughtType->getObjectClassNames()), $catchNode->getStartLine());
+	}
+
+}

--- a/tests/PHPStan/Rules/Exceptions/AbilityToDisableImplicitThrowsTest.php
+++ b/tests/PHPStan/Rules/Exceptions/AbilityToDisableImplicitThrowsTest.php
@@ -2,26 +2,40 @@
 
 namespace PHPStan\Rules\Exceptions;
 
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitRule;
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function array_merge;
 
 /**
- * @extends RuleTestCase<CatchWithUnthrownExceptionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class AbilityToDisableImplicitThrowsTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule
 	{
-		return new CatchWithUnthrownExceptionRule(new DefaultExceptionTypeResolver(
-			self::createReflectionProvider(),
-			[],
-			[],
-			[],
-			[],
-		), true);
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new CatchWithUnthrownExceptionRule(
+				new DefaultExceptionTypeResolver(
+					self::createReflectionProvider(),
+					[],
+					[],
+					[],
+					[],
+				),
+				true,
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+			),
+			new CatchWithThrownExceptionInTraitRule(
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+			),
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testRule(): void
@@ -93,6 +107,28 @@ class AbilityToDisableImplicitThrowsTest extends RuleTestCase
 			[
 				'Dead catch - Exception is never thrown in the try block.',
 				19,
+			],
+		]);
+	}
+
+	public function testBug10315(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10315.php'], []);
+	}
+
+	public function testDeadCatchInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/dead-catch-in-trait.php'], [
+			[
+				// dead in both FirstUser and SecondUser: reported once, on the trait
+				'Dead catch - DeadCatchInTrait\AlphaException is never thrown in the try block.',
+				36,
+			],
+			[
+				// same catch as AlphaException on line 67, which is dead in ThrowsNeither
+				// but alive in ThrowsAlphaOnly and therefore not reported
+				'Dead catch - DeadCatchInTrait\BetaException is never thrown in the try block.',
+				67,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleStubsTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleStubsTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Exceptions;
 
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -19,7 +20,7 @@ class CatchWithUnthrownExceptionRuleStubsTest extends RuleTestCase
 			[],
 			[],
 			[],
-		), true);
+		), true, self::getContainer()->getByType(ConstantConditionInTraitHelper::class));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -4,12 +4,15 @@ namespace PHPStan\Rules\Exceptions;
 
 use Error;
 use InvalidArgumentException;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitRule;
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<CatchWithUnthrownExceptionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 {
@@ -21,13 +24,24 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new CatchWithUnthrownExceptionRule(new DefaultExceptionTypeResolver(
-			self::createReflectionProvider(),
-			[],
-			$this->uncheckedExceptionClasses,
-			[],
-			[],
-		), $this->reportUncheckedExceptionDeadCatch);
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new CatchWithUnthrownExceptionRule(
+				new DefaultExceptionTypeResolver(
+					self::createReflectionProvider(),
+					[],
+					$this->uncheckedExceptionClasses,
+					[],
+					[],
+				),
+				$this->reportUncheckedExceptionDeadCatch,
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+			),
+			new CatchWithThrownExceptionInTraitRule(
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+			),
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testRule(): void
@@ -840,6 +854,16 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 	public function testBug9826(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-9826.php'], []);
+	}
+
+	public function testBug10315(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10315.php'], []);
+	}
+
+	public function testDeadCatchInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/dead-catch-in-trait.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Exceptions/data/bug-10315.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-10315.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10315;
+
+class PhpfastcacheUnsupportedMethodException extends \Exception
+{
+
+}
+
+trait DriverPoolAbstractTrait
+{
+
+	/**
+	 * @throws PhpfastcacheUnsupportedMethodException
+	 */
+	protected function driverReadMultiple(): array
+	{
+		throw new PhpfastcacheUnsupportedMethodException();
+	}
+
+}
+
+trait CacheItemPoolTrait
+{
+
+	public function getItems(): array
+	{
+		try {
+			return $this->driverReadMultiple();
+		} catch (PhpfastcacheUnsupportedMethodException $e) {
+			return [];
+		}
+	}
+
+}
+
+class Redis
+{
+
+	use DriverPoolAbstractTrait, CacheItemPoolTrait;
+
+	protected function driverReadMultiple(): array
+	{
+		return [];
+	}
+
+}
+
+class Memcached
+{
+
+	use DriverPoolAbstractTrait, CacheItemPoolTrait;
+
+}

--- a/tests/PHPStan/Rules/Exceptions/data/dead-catch-in-trait.php
+++ b/tests/PHPStan/Rules/Exceptions/data/dead-catch-in-trait.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types = 1);
+
+namespace DeadCatchInTrait;
+
+class AlphaException extends \Exception
+{
+
+}
+
+class BetaException extends \Exception
+{
+
+}
+
+trait ThrowingTrait
+{
+
+	/**
+	 * @throws AlphaException
+	 * @throws BetaException
+	 */
+	protected function work(): void
+	{
+		throw new AlphaException();
+	}
+
+}
+
+trait DeadInEveryUsingClassTrait
+{
+
+	public function run(): void
+	{
+		try {
+			$this->nothingThrown();
+		} catch (AlphaException $e) {
+		}
+	}
+
+	protected function nothingThrown(): void
+	{
+	}
+
+}
+
+class FirstUser
+{
+
+	use DeadInEveryUsingClassTrait;
+
+}
+
+class SecondUser
+{
+
+	use DeadInEveryUsingClassTrait;
+
+}
+
+trait UnionCatchTrait
+{
+
+	public function run(): void
+	{
+		try {
+			$this->work();
+		} catch (AlphaException | BetaException $e) {
+		}
+	}
+
+}
+
+class ThrowsNeither
+{
+
+	use ThrowingTrait, UnionCatchTrait;
+
+	protected function work(): void
+	{
+	}
+
+}
+
+class ThrowsAlphaOnly
+{
+
+	use ThrowingTrait, UnionCatchTrait;
+
+	/**
+	 * @throws AlphaException
+	 */
+	protected function work(): void
+	{
+		throw new AlphaException();
+	}
+
+}


### PR DESCRIPTION
A trait's try/catch can be dead in the context of one class using the trait and alive in another, e.g. when it depends on whether an abstract method gets overridden without throwing. Apply the same ConstantConditionInTraitHelper mechanism already used for isset/empty/?? to CatchWithUnthrownExceptionRule, so disagreeing verdicts across classes using the trait suppress the error instead of reporting it.

Closes https://github.com/phpstan/phpstan/issues/10315

**Edit:** routing trait catches through the collector changes where they are reported. A dead catch inside a trait used to be reported once per class using the trait, decorated with `(in context of class …)`; it is now reported once on the trait itself:

**before**

```
probe.php (in context of class P6199\OnlyUser):97:Dead catch - P6199\MyException is never thrown in the try block.
```

**after**

```
probe.php:97:Dead catch - P6199\MyException is never thrown in the try block.
```

This matches how isset/empty/`??` in traits already behave and removes the duplication for a trait used by many classes, but it is user-visible: baseline entries carrying `(in context of class …)` for `catch.neverThrown` will stop matching and need regenerating. Worth a release-notes line.