### PR TITLE
DynamicReturnTypeExtensionRegistry: Cache extension-class-names

### DIFF
--- a/src/Analyser/ExprHandler/Helper/EarlyTerminatingCallHelper.php
+++ b/src/Analyser/ExprHandler/Helper/EarlyTerminatingCallHelper.php
@@ -5,9 +5,9 @@ namespace PHPStan\Analyser\ExprHandler\Helper;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ExtensionClassHelper;
 use PHPStan\Type\Type;
 use function array_key_exists;
-use function array_merge;
 use function in_array;
 use function strtolower;
 
@@ -57,8 +57,8 @@ final class EarlyTerminatingCallHelper
 				continue;
 			}
 
-			$classReflection = $this->reflectionProvider->getClass($referencedClass);
-			foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
+			$extensionClassNames = ExtensionClassHelper::getExtensionClassNames($this->reflectionProvider, $referencedClass);
+			foreach ($extensionClassNames as $className) {
 				if (!isset($this->earlyTerminatingMethodCalls[$className])) {
 					continue;
 				}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -27,6 +27,7 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\ExtensionClassHelper;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\IntegerRangeType;
@@ -791,8 +792,8 @@ final class TypeSpecifier
 	private function getTypeSpecifyingExtensionsForType(array $extensions, string $className): array
 	{
 		$extensionsForClass = [[]];
-		$class = $this->reflectionProvider->getClass($className);
-		foreach (array_merge([$className], $class->getParentClassesNames(), $class->getNativeReflection()->getInterfaceNames()) as $extensionClassName) {
+		$extensionClassNames = ExtensionClassHelper::getExtensionClassNames($this->reflectionProvider, $className);
+		foreach ($extensionClassNames as $extensionClassName) {
 			if (!isset($extensions[$extensionClassName])) {
 				continue;
 			}

--- a/src/Type/DynamicReturnTypeExtensionRegistry.php
+++ b/src/Type/DynamicReturnTypeExtensionRegistry.php
@@ -7,6 +7,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\DependencyInjection\ExtensionsCollection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use function array_key_exists;
 use function array_merge;
 use function strtolower;
 
@@ -22,6 +23,9 @@ final class DynamicReturnTypeExtensionRegistry
 
 	/** @var array<string, list<DynamicFunctionReturnTypeExtension>> */
 	private array $dynamicReturnTypeExtensionsByFunction = [];
+
+	/** @var array<string, array<string>> */
+	private static array $extensionClassNames = [];
 
 	/**
 	 * @param ExtensionsCollection<DynamicMethodReturnTypeExtension> $dynamicMethodReturnTypeExtensions
@@ -83,8 +87,11 @@ final class DynamicReturnTypeExtensionRegistry
 		}
 
 		$extensionsForClass = [[]];
-		$class = $this->reflectionProvider->getClass($className);
-		foreach (array_merge([$className], $class->getParentClassesNames(), $class->getNativeReflection()->getInterfaceNames()) as $extensionClassName) {
+		if (!array_key_exists($className, self::$extensionClassNames)) {
+			$class = $this->reflectionProvider->getClass($className);
+			self::$extensionClassNames[$className] = array_merge([$className], $class->getParentClassesNames(), $class->getNativeReflection()->getInterfaceNames());
+		}
+		foreach (self::$extensionClassNames[$className] as $extensionClassName) {
 			$extensionClassName = strtolower($extensionClassName);
 			if (!isset($extensions[$extensionClassName])) {
 				continue;

--- a/src/Type/DynamicReturnTypeExtensionRegistry.php
+++ b/src/Type/DynamicReturnTypeExtensionRegistry.php
@@ -7,7 +7,6 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\DependencyInjection\ExtensionsCollection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
-use function array_key_exists;
 use function array_merge;
 use function strtolower;
 
@@ -23,9 +22,6 @@ final class DynamicReturnTypeExtensionRegistry
 
 	/** @var array<string, list<DynamicFunctionReturnTypeExtension>> */
 	private array $dynamicReturnTypeExtensionsByFunction = [];
-
-	/** @var array<string, array<string>> */
-	private static array $extensionClassNames = [];
 
 	/**
 	 * @param ExtensionsCollection<DynamicMethodReturnTypeExtension> $dynamicMethodReturnTypeExtensions
@@ -87,11 +83,8 @@ final class DynamicReturnTypeExtensionRegistry
 		}
 
 		$extensionsForClass = [[]];
-		if (!array_key_exists($className, self::$extensionClassNames)) {
-			$class = $this->reflectionProvider->getClass($className);
-			self::$extensionClassNames[$className] = array_merge([$className], $class->getParentClassesNames(), $class->getNativeReflection()->getInterfaceNames());
-		}
-		foreach (self::$extensionClassNames[$className] as $extensionClassName) {
+		$extensionClassNames = ExtensionClassHelper::getExtensionClassNames($this->reflectionProvider, $className);
+		foreach ($extensionClassNames as $extensionClassName) {
 			$extensionClassName = strtolower($extensionClassName);
 			if (!isset($extensions[$extensionClassName])) {
 				continue;

--- a/src/Type/ExtensionClassHelper.php
+++ b/src/Type/ExtensionClassHelper.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\Reflection\ReflectionProvider;
+use function array_key_exists;
+use function array_merge;
+
+final class ExtensionClassHelper
+{
+
+	/** @var array<string, array<string>> */
+	private static array $extensionClassNames = [];
+
+	/**
+	 * @return string[]
+	 */
+	public static function getExtensionClassNames(ReflectionProvider $reflectionProvider, string $className): array
+	{
+		if (!array_key_exists($className, self::$extensionClassNames)) {
+			$class = $reflectionProvider->getClass($className);
+			self::$extensionClassNames[$className] = array_merge([$className], $class->getParentClassesNames(), $class->getNativeReflection()->getInterfaceNames());
+		}
+
+		return self::$extensionClassNames[$className];
+	}
+
+}


### PR DESCRIPTION
`/Users/staabm/workspace/phpstan-src/bin/phpstan analyze -vvv --debug /Users/staabm/workspace/shopware/src/Core/Framework/DependencyInjection/Configuration.php` on https://github.com/shopware/shopware/commit/5010d1c151b4cd29aa028c653bd10939609d3b0c

before this PR:
3,5s 190.5 MB

after this PR:
2,7s 188.5 MB

---

prevents expensive repetetive calls to `getParentClass()`/`getParentClassNames()`

<img width="490" height="232" alt="grafik" src="https://github.com/user-attachments/assets/01577f72-337b-49dd-825c-acfcf11edd75" />
