### PR TITLE
` src/Rules/Api/*Rule`: cheap checks first

### DIFF
--- a/src/Rules/Api/NodeConnectingVisitorAttributesRule.php
+++ b/src/Rules/Api/NodeConnectingVisitorAttributesRule.php
@@ -34,12 +34,14 @@ final class NodeConnectingVisitorAttributesRule implements Rule
 		if ($node->name->toLowerString() !== 'getattribute') {
 			return [];
 		}
-		$calledOnType = $scope->getType($node->var);
-		if (!(new ObjectType(Node::class))->isSuperTypeOf($calledOnType)->yes()) {
-			return [];
-		}
+
 		$args = $node->getArgs();
 		if (!isset($args[0])) {
+			return [];
+		}
+
+		$calledOnType = $scope->getType($node->var);
+		if (!(new ObjectType(Node::class))->isSuperTypeOf($calledOnType)->yes()) {
 			return [];
 		}
 

--- a/src/Rules/Api/OldPhpParser4ClassRule.php
+++ b/src/Rules/Api/OldPhpParser4ClassRule.php
@@ -42,6 +42,10 @@ final class OldPhpParser4ClassRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if (!$scope->isInClass()) {
+			return [];
+		}
+
 		$nameMapping = array_change_key_case(self::NAME_MAPPING);
 		$lowerName = $node->toLowerString();
 		if (!array_key_exists($lowerName, $nameMapping)) {
@@ -49,10 +53,6 @@ final class OldPhpParser4ClassRule implements Rule
 		}
 
 		$newName = $nameMapping[$lowerName];
-
-		if (!$scope->isInClass()) {
-			return [];
-		}
 
 		$classReflection = $scope->getClassReflection();
 		$hasPhpStanInterface = false;

--- a/src/Rules/Api/RuntimeReflectionFunctionRule.php
+++ b/src/Rules/Api/RuntimeReflectionFunctionRule.php
@@ -35,6 +35,10 @@ final class RuntimeReflectionFunctionRule implements Rule
 			return [];
 		}
 
+		if (!$scope->isInClass()) {
+			return [];
+		}
+
 		if (!$this->reflectionProvider->hasFunction($node->name, $scope)) {
 			return [];
 		}
@@ -47,10 +51,6 @@ final class RuntimeReflectionFunctionRule implements Rule
 			'class_implements',
 			'class_uses',
 		], true)) {
-			return [];
-		}
-
-		if (!$scope->isInClass()) {
 			return [];
 		}
 

--- a/src/Rules/Api/RuntimeReflectionInstantiationRule.php
+++ b/src/Rules/Api/RuntimeReflectionInstantiationRule.php
@@ -45,6 +45,10 @@ final class RuntimeReflectionInstantiationRule implements Rule
 			return [];
 		}
 
+		if (!$scope->isInClass()) {
+			return [];
+		}
+
 		$className = $scope->resolveName($node->class);
 		if (!$this->reflectionProvider->hasClass($className)) {
 			return [];
@@ -66,10 +70,6 @@ final class RuntimeReflectionInstantiationRule implements Rule
 			ReflectionGenerator::class,
 			'ReflectionFiber',
 		], true)) {
-			return [];
-		}
-
-		if (!$scope->isInClass()) {
 			return [];
 		}
 


### PR DESCRIPTION
defer function reflection after the cheaper is-in-scope check