### PR TITLE
Walk closure by-ref convergence passes in deep statement context

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3111,7 +3111,11 @@ class NodeScopeResolver
 			$prevScope = $closureScope;
 
 			$storage = $originalStorage->duplicate();
-			$intermediaryClosureScopeResult = $this->processStmtNodesInternalWithoutFlushingPendingFibers($expr, $expr->stmts, $closureScope, $storage, new NoopNodeCallback(), StatementContext::createTopLevel());
+			// deep context, like the loop handlers' own convergence passes: inner
+			// loops walk single-pass here and only the final walk below (top-level)
+			// runs their full convergence - otherwise every closure-convergence
+			// pass would re-converge every inner loop from scratch
+			$intermediaryClosureScopeResult = $this->processStmtNodesInternalWithoutFlushingPendingFibers($expr, $expr->stmts, $closureScope, $storage, new NoopNodeCallback(), StatementContext::createDeep());
 			$intermediaryClosureScope = $intermediaryClosureScopeResult->getScope();
 			foreach ($intermediaryClosureScopeResult->getExitPoints() as $exitPoint) {
 				$intermediaryClosureScope = $intermediaryClosureScope->mergeWith($exitPoint->getScope());


### PR DESCRIPTION
The closure by-ref fixpoint walked its intermediate passes with a top-level statement context, so every inner loop re-converged from scratch on every pass — convergence within convergence, which the loop handlers themselves avoid by walking their intermediate passes deep. A by-ref closure with nested loops re-created the innermost expressions' results many times over; deep-context passes bring it in line with the loop handlers' discipline, and the final top-level walk keeps full precision.

Zero expectation churn: full test suite green in both turbo modes, self-analysis and CS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7
