### PR TITLE
Faster `UnionType->getFiniteTypes()`

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -80,6 +80,8 @@ class UnionType implements CompoundType
 	 */
 	private FiniteTypeSet|false|null $finiteTypeSet = null;
 
+	private ?array $finiteTypes = null;
+
 	/**
 	 * @api
 	 * @param list<Type> $types
@@ -1552,6 +1554,10 @@ class UnionType implements CompoundType
 
 	public function getFiniteTypes(): array
 	{
+		if ($this->finiteTypes !== null) {
+			return $this->finiteTypes;
+		}
+
 		$types = $this->notBenevolentPickFromTypes(static fn (Type $type) => $type->getFiniteTypes());
 		$uniquedTypes = [];
 		foreach ($types as $type) {
@@ -1559,10 +1565,11 @@ class UnionType implements CompoundType
 		}
 
 		if (count($uniquedTypes) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
-			return [];
+			return $this->finiteTypes = [];
 		}
 
-		return array_values($uniquedTypes);
+		$this->finiteTypes = array_values($uniquedTypes);
+		return $this->finiteTypes;
 	}
 
 	/**

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -80,6 +80,7 @@ class UnionType implements CompoundType
 	 */
 	private FiniteTypeSet|false|null $finiteTypeSet = null;
 
+	/** @var list<Type>|null */
 	private ?array $finiteTypes = null;
 
 	/**

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1568,8 +1568,7 @@ class UnionType implements CompoundType
 			return $this->finiteTypes = [];
 		}
 
-		$this->finiteTypes = array_values($uniquedTypes);
-		return $this->finiteTypes;
+		return $this->finiteTypes = array_values($uniquedTypes);
 	}
 
 	/**


### PR DESCRIPTION
repro from https://github.com/phpstan/phpstan/issues/15004 

| n | before PR | after PR |
| - | ----------- | -------- |
| 250 | 6,92s | 4,15s |
| 400 | 26,1s | 14,5s |

---

PHPBench CI:

<img width="914" height="343" alt="grafik" src="https://github.com/user-attachments/assets/e70bb20a-1f9f-426c-98d2-e20f495c838f" />
