### PR TITLE
Enter closure and arrow function scopes without re-walking the body

### DIFF
--- a/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
+++ b/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
@@ -82,9 +82,26 @@ final class ClosureTypeResolver
 	public function getClosureType(
 		MutatingScope $scope,
 		Node\Expr\Closure|ArrowFunction $expr,
+		bool $shallow = false,
 	): ClosureType
 	{
 		[$parameters, $isVariadic, $callableParameters, $nativeCallableParameters] = $this->buildParametersAndAcceptors($scope, $expr);
+
+		// A shallow reflection is the closure/arrow function's signature without
+		// walking its body: parameters plus the DECLARED return type. Used at scope
+		// ENTRY (enterAnonymousFunction()/enterArrowFunction()) so entering a
+		// closure/arrow scope never re-walks the body - the refined return type is
+		// built afterwards from the single body walk's gathered returns and carried
+		// on the node/rule scope (see NodeScopeResolver::processClosureNode()
+		// and processArrowFunctionNode()).
+		if ($shallow) {
+			return new ClosureType(
+				$parameters,
+				$scope->getFunctionType($expr->returnType, false, false),
+				$isVariadic,
+				isStatic: TrinaryLogic::createFromBoolean($expr->static),
+			);
+		}
 
 		$cachedTypes = $expr->getAttribute('phpstanCachedTypes', []);
 		$cacheKey = $this->closureContextCacheKey($scope, $expr, $callableParameters, $parameters);
@@ -242,6 +259,7 @@ final class ClosureTypeResolver
 		array $impurePoints,
 		array $invalidateExpressions,
 		bool $native = false,
+		bool $writeCache = true,
 	): ClosureType
 	{
 		if ($this->bodyWalkHasOwnParameterTypes($expr)) {
@@ -271,6 +289,7 @@ final class ClosureTypeResolver
 				$parameters,
 			),
 			$native,
+			$writeCache,
 		);
 	}
 
@@ -292,6 +311,7 @@ final class ClosureTypeResolver
 		array $impurePoints,
 		array $invalidateExpressions,
 		bool $native = false,
+		bool $writeCache = true,
 	): ClosureType
 	{
 		if ($this->bodyWalkHasOwnParameterTypes($expr)) {
@@ -310,7 +330,7 @@ final class ClosureTypeResolver
 			$expr,
 			$native ? $nativeCallableParameters : $callableParameters,
 			$parameters,
-		));
+		), $writeCache);
 	}
 
 	/**
@@ -458,6 +478,7 @@ final class ClosureTypeResolver
 		array $invalidateExpressions,
 		?string $cacheKey = null,
 		bool $native = false,
+		bool $writeCache = true,
 	): ClosureType
 	{
 		$onlyNeverExecutionEnds = $this->deriveOnlyNeverExecutionEnds($executionEnds);
@@ -562,7 +583,7 @@ final class ClosureTypeResolver
 			break;
 		}
 
-		return $this->assembleClosureType($scope, $expr, $parameters, $isVariadic, $returnType, $throwPoints, $impurePoints, $invalidateExpressions, $usedVariables, $cacheKey);
+		return $this->assembleClosureType($scope, $expr, $parameters, $isVariadic, $returnType, $throwPoints, $impurePoints, $invalidateExpressions, $usedVariables, $cacheKey, $writeCache);
 	}
 
 	private function resolveArrowFunctionReturnType(
@@ -795,6 +816,7 @@ final class ClosureTypeResolver
 		array $invalidateExpressions,
 		array $usedVariables,
 		?string $cacheKey = null,
+		bool $writeCache = true,
 	): ClosureType
 	{
 		foreach ($parameters as $parameter) {
@@ -814,16 +836,18 @@ final class ClosureTypeResolver
 		$throwPointsForClosureType = array_map(static fn (ThrowPoint $throwPoint) => $throwPoint->isExplicit() ? SimpleThrowPoint::createExplicit($throwPoint->getType(), $throwPoint->canContainAnyThrowable()) : SimpleThrowPoint::createImplicit(), $throwPoints);
 		$impurePointsForClosureType = array_map(static fn (ImpurePoint $impurePoint) => new SimpleImpurePoint($impurePoint->getIdentifier(), $impurePoint->getDescription(), $impurePoint->isCertain()), $impurePoints);
 
-		$cachedTypes = $expr->getAttribute('phpstanCachedTypes', []);
-		$cacheKey ??= $this->closureContextCacheKey($scope, $expr, null, $parameters);
-		$cachedTypes[$cacheKey] = [
-			'returnType' => $returnType,
-			'throwPoints' => $throwPointsForClosureType,
-			'impurePoints' => $impurePointsForClosureType,
-			'invalidateExpressions' => $invalidateExpressions,
-			'usedVariables' => $usedVariables,
-		];
-		$expr->setAttribute('phpstanCachedTypes', $cachedTypes);
+		if ($writeCache) {
+			$cachedTypes = $expr->getAttribute('phpstanCachedTypes', []);
+			$cacheKey ??= $this->closureContextCacheKey($scope, $expr, null, $parameters);
+			$cachedTypes[$cacheKey] = [
+				'returnType' => $returnType,
+				'throwPoints' => $throwPointsForClosureType,
+				'impurePoints' => $impurePointsForClosureType,
+				'invalidateExpressions' => $invalidateExpressions,
+				'usedVariables' => $usedVariables,
+			];
+			$expr->setAttribute('phpstanCachedTypes', $cachedTypes);
+		}
 
 		$mustUseReturnValue = TrinaryLogic::createNo();
 		foreach ($expr->attrGroups as $attrGroup) {

--- a/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
+++ b/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\Expr\YieldFrom;
+use PhpParser\NodeFinder;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ImpurePoint;
@@ -49,10 +50,12 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
 use function array_key_exists;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function count;
 use function implode;
+use function in_array;
 use function is_string;
 
 #[AutowiredService]
@@ -438,7 +441,72 @@ final class ClosureTypeResolver
 		// when the seeding pin copies the phpdoc build to the promoted key
 		$flavour = $expr instanceof ArrowFunction ? ($scope->nativeTypesPromoted ? '/native' : '/phpdoc') : '';
 
-		return $scope->getClosureScopeCacheKey() . '/' . implode('|', $parts) . $flavour;
+		return $scope->getClosureScopeCacheKey($this->freeVariableRoots($expr)) . '/' . implode('|', $parts) . $flavour;
+	}
+
+	/**
+	 * The expression roots this closure's type can read from the enclosing
+	 * scope: '$this' and the use()d variables for closures, '$this' and
+	 * every body variable that is not a parameter for arrow functions. Null
+	 * when the body accesses variables dynamically ($$name, compact(),
+	 * get_defined_vars()) and the whole scope must key the cache.
+	 *
+	 * @return list<string>|null
+	 */
+	private function freeVariableRoots(Node\Expr\Closure|ArrowFunction $expr): ?array
+	{
+		/** @var list<string>|false|null $cached */
+		$cached = $expr->getAttribute('phpstanFreeVariableRoots', false);
+		if ($cached !== false) {
+			return $cached;
+		}
+
+		$roots = [];
+		if (!$expr->static) {
+			$roots['$this'] = true;
+		}
+
+		if ($expr instanceof Node\Expr\Closure) {
+			foreach ($expr->uses as $use) {
+				if (!is_string($use->var->name)) {
+					$expr->setAttribute('phpstanFreeVariableRoots', null);
+					return null;
+				}
+				$roots['$' . $use->var->name] = true;
+			}
+		} else {
+			$paramNames = [];
+			foreach ($expr->params as $param) {
+				if (!($param->var instanceof Node\Expr\Variable) || !is_string($param->var->name)) {
+					continue;
+				}
+
+				$paramNames['$' . $param->var->name] = true;
+			}
+			$finder = new NodeFinder();
+			foreach ($finder->findInstanceOf([$expr->expr], Node\Expr\Variable::class) as $variable) {
+				if (!is_string($variable->name)) {
+					$expr->setAttribute('phpstanFreeVariableRoots', null);
+					return null;
+				}
+				$name = '$' . $variable->name;
+				if (isset($paramNames[$name])) {
+					continue;
+				}
+				$roots[$name] = true;
+			}
+			foreach ($finder->findInstanceOf([$expr->expr], Node\Expr\FuncCall::class) as $call) {
+				if ($call->name instanceof Node\Name && in_array($call->name->toLowerString(), ['compact', 'extract', 'get_defined_vars'], true)) {
+					$expr->setAttribute('phpstanFreeVariableRoots', null);
+					return null;
+				}
+			}
+		}
+
+		$rootList = array_keys($roots);
+		$expr->setAttribute('phpstanFreeVariableRoots', $rootList);
+
+		return $rootList;
 	}
 
 	/**

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -21,9 +21,9 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\NodeFinder;
+use PHPStan\Analyser\ExprHandler\Helper\ClosureTypeResolver;
 use PHPStan\Analyser\Traverser\TransformStaticTypeTraverser;
 use PHPStan\Collectors\Collector;
-use PHPStan\Analyser\ExprHandler\Helper\ClosureTypeResolver;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\ExtensionsCollection;
 use PHPStan\Node\EmitCollectedDataNode;
@@ -119,6 +119,7 @@ use function array_unique;
 use function array_values;
 use function assert;
 use function count;
+use function ctype_alnum;
 use function explode;
 use function implode;
 use function in_array;
@@ -1093,11 +1094,23 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		);
 	}
 
-	public function getClosureScopeCacheKey(): string
+	/**
+	 * A cache key of the scope state a closure's type can depend on. With
+	 * $relevantRoots (the closure's free variables, '$this' included) only
+	 * the expression types rooted in them contribute - narrow enough that
+	 * loop-local churn does not invalidate the closure's cached type. Null
+	 * means everything contributes (dynamic variable access in the body).
+	 *
+	 * @param list<string>|null $relevantRoots
+	 */
+	public function getClosureScopeCacheKey(?array $relevantRoots = null): string
 	{
 		$parts = [];
 		foreach ($this->expressionTypes as $exprString => $expressionTypeHolder) {
 			if ($expressionTypeHolder->getExpr() instanceof VirtualNode) {
+				continue;
+			}
+			if ($relevantRoots !== null && !self::exprStringIsRootedIn($exprString, $relevantRoots)) {
 				continue;
 			}
 			$parts[] = sprintf('%s::%s', $exprString, $expressionTypeHolder->getType()->describe(VerbosityLevel::cache()));
@@ -1115,6 +1128,28 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		return md5(implode("\n", $parts));
+	}
+
+	/**
+	 * @param list<string> $roots
+	 */
+	private static function exprStringIsRootedIn(string $exprString, array $roots): bool
+	{
+		foreach ($roots as $root) {
+			if ($exprString === $root) {
+				return true;
+			}
+			if (!str_starts_with($exprString, $root)) {
+				continue;
+			}
+
+			$next = $exprString[strlen($root)];
+			if ($next !== '_' && !ctype_alnum($next)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private function resolveType(string $exprString, Expr $node): Type

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -23,6 +23,7 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Traverser\TransformStaticTypeTraverser;
 use PHPStan\Collectors\Collector;
+use PHPStan\Analyser\ExprHandler\Helper\ClosureTypeResolver;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\ExtensionsCollection;
 use PHPStan\Node\EmitCollectedDataNode;
@@ -975,6 +976,36 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	public function getAnonymousFunctionReflection(): ?ClosureType
 	{
 		return $this->anonymousFunctionReflection;
+	}
+
+	/**
+	 * A copy of this scope with only the anonymous-function
+	 * reflection replaced. The scope entered at a closure/arrow carries only a
+	 * shallow reflection (parameters + declared return); once the single body
+	 * walk has gathered the returns, the engine builds the refined ClosureType and
+	 * swaps it in here so the closure/arrow return-type node and its rules see the
+	 * refined expected return.
+	 */
+	public function withAnonymousFunctionReflection(ClosureType $anonymousFunctionReflection): self
+	{
+		return $this->scopeFactory->create(
+			$this->context,
+			$this->isDeclareStrictTypes(),
+			$this->getFunction(),
+			$this->getNamespace(),
+			$this->expressionTypes,
+			$this->nativeExpressionTypes,
+			$this->conditionalExpressions,
+			$this->inClosureBindScopeClasses,
+			$anonymousFunctionReflection,
+			$this->isInFirstLevelStatement(),
+			$this->currentlyAssignedExpressions,
+			$this->currentlyAllowedUndefinedExpressions,
+			$this->inFunctionCallsStack,
+			$this->afterExtractCall,
+			$this->parentScope,
+			$this->nativeTypesPromoted,
+		);
 	}
 
 	/** @api */
@@ -2129,10 +2160,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		?array $nativeCallableParameters = null,
 	): self
 	{
-		$anonymousFunctionReflection = $this->resolveType('__phpstanClosure', $closure);
-		if (!$anonymousFunctionReflection instanceof ClosureType) {
-			throw new ShouldNotHappenException();
-		}
+		$anonymousFunctionReflection = $this->container->getByType(ClosureTypeResolver::class)->getClosureType($this, $closure, true);
 
 		$scope = $this->enterAnonymousFunctionWithoutReflection($closure, $callableParameters, $nativeCallableParameters);
 
@@ -2352,10 +2380,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	 */
 	public function enterArrowFunction(Expr\ArrowFunction $arrowFunction, ?array $callableParameters, ?array $nativeCallableParameters = null): self
 	{
-		$anonymousFunctionReflection = $this->resolveType('__phpStanArrowFn', $arrowFunction);
-		if (!$anonymousFunctionReflection instanceof ClosureType) {
-			throw new ShouldNotHappenException();
-		}
+		$anonymousFunctionReflection = $this->container->getByType(ClosureTypeResolver::class)->getClosureType($this, $arrowFunction, true);
 
 		$scope = $this->enterArrowFunctionWithoutReflection($arrowFunction, $callableParameters, $nativeCallableParameters);
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3082,6 +3082,7 @@ class NodeScopeResolver
 		if (count($byRefUses) === 0) {
 			$statementResult = $this->processStmtNodesInternalWithoutFlushingPendingFibers($expr, $expr->stmts, $closureScope, $storage, $closureStmtsCallback, StatementContext::createTopLevel());
 			$publicStatementResult = $statementResult->toPublic();
+			$closureReturnStatementsNodeScope = $this->refineClosureNodeScope($closureScope, $scope, $expr, $gatheredReturnStatementsWithScope, $gatheredYieldStatementsWithScope, $executionEnds, $statementResult->getThrowPoints(), array_merge($closureImpurePoints, $statementResult->getImpurePoints()), $invalidateExpressions);
 			$this->callNodeCallback($nodeCallback, new ClosureReturnStatementsNode(
 				$expr,
 				$gatheredReturnStatements,
@@ -3089,7 +3090,7 @@ class NodeScopeResolver
 				$publicStatementResult,
 				$executionEnds,
 				array_merge($publicStatementResult->getImpurePoints(), $closureImpurePoints),
-			), $closureScope, $storage);
+			), $closureReturnStatementsNodeScope, $storage);
 
 			return new ProcessClosureResult(
 				$scope,
@@ -3145,6 +3146,7 @@ class NodeScopeResolver
 		$storage = $originalStorage;
 		$statementResult = $this->processStmtNodesInternalWithoutFlushingPendingFibers($expr, $expr->stmts, $closureScope, $storage, $closureStmtsCallback, StatementContext::createTopLevel());
 		$publicStatementResult = $statementResult->toPublic();
+		$closureReturnStatementsNodeScope = $this->refineClosureNodeScope($closureScope, $scope, $expr, $gatheredReturnStatementsWithScope, $gatheredYieldStatementsWithScope, $executionEnds, $statementResult->getThrowPoints(), array_merge($closureImpurePoints, $statementResult->getImpurePoints()), $invalidateExpressions);
 		$this->callNodeCallback($nodeCallback, new ClosureReturnStatementsNode(
 			$expr,
 			$gatheredReturnStatements,
@@ -3152,7 +3154,7 @@ class NodeScopeResolver
 			$publicStatementResult,
 			$executionEnds,
 			array_merge($publicStatementResult->getImpurePoints(), $closureImpurePoints),
-		), $closureScope, $storage);
+		), $closureReturnStatementsNodeScope, $storage);
 
 		return new ProcessClosureResult(
 			$scope,
@@ -3166,6 +3168,46 @@ class NodeScopeResolver
 			$closureResultScope,
 			$byRefUses,
 		);
+	}
+
+	/**
+	 * The refined closure type built from the single body walk, swapped onto the
+	 * closure scope so ClosureReturnStatementsNode's rules see the refined
+	 * expected return instead of the shallow entry reflection.
+	 *
+	 * @param list<array{Node\Stmt\Return_, Scope}> $gatheredReturnStatementsWithScope
+	 * @param list<array{Expr\Yield_|Expr\YieldFrom, Scope}> $gatheredYieldStatementsWithScope
+	 * @param list<ExecutionEndNode> $executionEnds
+	 * @param InternalThrowPoint[] $throwPoints
+	 * @param ImpurePoint[] $impurePoints
+	 * @param InvalidateExprNode[] $invalidateExpressions
+	 */
+	private function refineClosureNodeScope(
+		MutatingScope $closureScope,
+		MutatingScope $scope,
+		Expr\Closure $expr,
+		array $gatheredReturnStatementsWithScope,
+		array $gatheredYieldStatementsWithScope,
+		array $executionEnds,
+		array $throwPoints,
+		array $impurePoints,
+		array $invalidateExpressions,
+	): MutatingScope
+	{
+		$refinedClosureType = $this->container->getByType(ClosureTypeResolver::class)->buildClosureTypeForClosure(
+			$scope,
+			$expr,
+			$gatheredReturnStatementsWithScope,
+			$gatheredYieldStatementsWithScope,
+			$executionEnds,
+			$throwPoints,
+			$impurePoints,
+			$invalidateExpressions,
+			false,
+			false,
+		);
+
+		return $closureScope->withAnonymousFunctionReflection($refinedClosureType);
 	}
 
 	/**
@@ -3216,11 +3258,9 @@ class NodeScopeResolver
 		$callableParameters = $this->createCallableParameters($scope, $expr, $arrowFunctionCallArgs, $passedToType);
 		$nativeCallableParameters = $this->createNativeCallableParameters($scope, $expr, $arrowFunctionCallArgs, $nativePassedToType);
 		$arrowFunctionScope = $scope->enterArrowFunction($expr, $callableParameters, $nativeCallableParameters);
-		$arrowFunctionType = $arrowFunctionScope->getAnonymousFunctionReflection();
-		if ($arrowFunctionType === null) {
+		if ($arrowFunctionScope->getAnonymousFunctionReflection() === null) {
 			throw new ShouldNotHappenException();
 		}
-		$this->callNodeCallback($nodeCallback, new InArrowFunctionNode($arrowFunctionType, $expr), $arrowFunctionScope, $storage);
 
 		// Gather the property-assign impure points and invalidate expressions the
 		// arrow function type needs (mirroring ClosureTypeResolver::getClosureType()),
@@ -3256,6 +3296,27 @@ class NodeScopeResolver
 
 		$closureTypeThrowPoints = array_map(static fn (InternalThrowPoint $throwPoint) => $throwPoint->toPublic(), $exprResult->getThrowPoints());
 		$closureTypeImpurePoints = array_merge($arrowFunctionImpurePoints, $exprResult->getImpurePoints());
+
+		// The arrow scope was entered with a shallow reflection (parameters +
+		// declared return, no body walk). Now that the single body walk above has
+		// run, build the refined arrow function type from the walked body (no
+		// second walk) and fire InArrowFunctionNode with it, so the node and the
+		// return-type rules see the refined expected return. The build must not
+		// write the type cache: its values reflect this call's (possibly
+		// extension-overridden) parameter typing while its key would match a
+		// plain pricing ask.
+		$refinedArrowFunctionType = $this->container->getByType(ClosureTypeResolver::class)->buildClosureTypeForArrowFunction(
+			$scope,
+			$expr,
+			$arrowFunctionScope,
+			$closureTypeThrowPoints,
+			$closureTypeImpurePoints,
+			$invalidateExpressions,
+			false,
+			false,
+		);
+		$refinedArrowFunctionScope = $arrowFunctionScope->withAnonymousFunctionReflection($refinedArrowFunctionType);
+		$this->callNodeCallback($nodeCallback, new InArrowFunctionNode($refinedArrowFunctionType, $expr), $refinedArrowFunctionScope, $storage);
 
 		return new ProcessArrowFunctionResult(
 			$this->expressionResultFactory->create($scope, beforeScope: $scope, expr: $expr, hasYield: false, isAlwaysTerminating: $exprResult->isAlwaysTerminating(), throwPoints: $exprResult->getThrowPoints(), impurePoints: $exprResult->getImpurePoints()),

--- a/tests/PHPStan/Analyser/nsrt/closure-get-current.php
+++ b/tests/PHPStan/Analyser/nsrt/closure-get-current.php
@@ -10,7 +10,10 @@ function doFoo(): void {
 }
 
 function (int $i): string {
-	assertType("Closure(int): 'foo'", Closure::getCurrent());
+	// Closure::getCurrent() reads the closure scope's own reflection mid-body,
+	// which carries the declared return type - the body-inferred 'foo' is not yet
+	// available from the single body walk at this point.
+	assertType('Closure(int): string', Closure::getCurrent());
 
 	return 'foo';
 };

--- a/tests/PHPStan/Rules/Functions/ArrowFunctionReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrowFunctionReturnTypeRuleTest.php
@@ -77,4 +77,9 @@ class ArrowFunctionReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-anonymous-function-method-constant.php'], []);
 	}
 
+	public function testBug14914(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14914-arrow.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/ClosureReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ClosureReturnTypeRuleTest.php
@@ -149,4 +149,9 @@ class ClosureReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13964.php'], []);
 	}
 
+	public function testBug14914(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14914.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-14914-arrow.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14914-arrow.php
@@ -1,0 +1,15 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug14914Arrow;
+
+function doFoo(): void
+{
+	preg_replace_callback(
+		'/a|(?<b>b)/',
+		fn (array $match) => $match['b'] !== null ? 'aa' : 'possible?',
+		'abcd',
+		flags: PREG_UNMATCHED_AS_NULL,
+	);
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-14914.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14914.php
@@ -1,0 +1,20 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug14914;
+
+function doFoo(): void
+{
+	preg_replace_callback(
+		'/a|(?<b>b)/',
+		function (array $match): string {
+			if ($match['b'] !== null) {
+				return 'aa';
+			}
+			return 'possible?';
+		},
+		'abcd',
+		flags: PREG_UNMATCHED_AS_NULL,
+	);
+}


### PR DESCRIPTION
Follow-up to #6169, completing the closure single-walk story:

- **Shallow scope entry**: `enterAnonymousFunction()` and `enterArrowFunction()` resolved their reflection through the pricing walk — a whole body walk at scope entry, before the rule walk even started. They now enter with a shallow reflection (parameters plus the declared return type); once the single body walk has gathered the returns, the engine builds the refined `ClosureType` and swaps it onto the scope (`MutatingScope::withAnonymousFunctionReflection()`), so `ClosureReturnStatementsNode` and `InArrowFunctionNode` — and their return-type rules — see the refined expected return as before. `InArrowFunctionNode` consequently fires after the body walk. With this, one closure means one body walk.
- The refined builds must not write the closure type cache: their values reflect the call's (possibly extension-overridden) parameter typing while their key would match a plain pricing ask — the `preg_replace_callback` parameter-shape extensions surface this immediately. `assembleClosureType()` gains a `$writeCache` flag for them.
- **Input-keyed closure type cache**: `getClosureScopeCacheKey()` hashed every non-virtual expression type in the scope, so unrelated tracked-expression churn (loop-local above all) invalidated the closure's cached type and forced a re-walk — it also made #6169's seeds miss whenever anything changed between the walk and the ask. The key now hashes only the expression types rooted in the closure's free variables (`$this` and the `use()`d variables for closures; `$this` and every non-parameter body variable for arrow functions), memoized on the node; dynamic variable access (`$$name`, `compact()`, `extract()`, `get_defined_vars()`) keeps the whole-scope key.

One deliberate semantic change, pinned in the fixture: `Closure::getCurrent()` mid-body now reports the declared, not the inferred, return type — the refined type does not exist yet at that point.

Full test suite green in both turbo modes, self-analysis and CS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7


Closes https://github.com/phpstan/phpstan/issues/14914
