### PR TITLE
Do not remember conditional expressions about precisely resolved class constants

### DIFF
--- a/src/Analyser/ConstantResolver.php
+++ b/src/Analyser/ConstantResolver.php
@@ -396,6 +396,22 @@ final class ConstantResolver
 		return $result;
 	}
 
+	/**
+	 * Whether the constant is configured as dynamic, so that resolveClassConstantType()
+	 * may widen it beyond the declared value.
+	 */
+	public function isDynamicClassConstant(string $className, string $constantName): bool
+	{
+		if ($this->dynamicConstantNames === []) {
+			return false;
+		}
+
+		$lookupConstantName = sprintf('%s::%s', $className, $constantName);
+
+		return array_key_exists($lookupConstantName, $this->dynamicConstantNames)
+			|| in_array($lookupConstantName, $this->dynamicConstantNames, true);
+	}
+
 	public function getConfiguredClassConstantType(string $className, string $constantName): ?Type
 	{
 		$lookupConstantName = sprintf('%s::%s', $className, $constantName);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
@@ -3797,6 +3798,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 
 		$differingExpressionKeys = [];
 		$mergedExpressionTypes = ScopeOps::mergeVariableHolders($ourExpressionTypes, $theirExpressionTypes, $differingExpressionKeys);
+		$differingExpressionKeys = $this->withoutPreciseClassConstantFetches($differingExpressionKeys, $ourExpressionTypes, $theirExpressionTypes);
 		$conditionalExpressions = ScopeOps::intersectConditionalExpressions($this->conditionalExpressions, $otherScope->conditionalExpressions);
 		if ($preserveVacuousConditionals) {
 			$conditionalExpressions = $this->preserveVacuousConditionalExpressions(
@@ -3845,6 +3847,60 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->inFirstLevelStatement,
 			$this->afterExtractCall && $otherScope->afterExtractCall,
 		);
+	}
+
+	/**
+	 * Drops the keys of class-constant fetches that resolve to their declared value.
+	 *
+	 * A conditional expression records "when the guard holds, this expression had
+	 * that type in the branch the guard selects". Such a record can only ever pay
+	 * off when the expression resolves to something less precise on its own - and
+	 * a class-constant fetch with a statically known class resolves to the exact
+	 * declared value, unless the constant is configured as dynamic. So the record
+	 * is bookkeeping that can never narrow anything, and an expensive one: creating
+	 * it compares the guard against every member of the (potentially very wide)
+	 * merged guard type.
+	 *
+	 * @param array<string, true> $differingExpressionKeys
+	 * @param array<string, ExpressionTypeHolder> $ourExpressionTypes
+	 * @param array<string, ExpressionTypeHolder> $theirExpressionTypes
+	 * @return array<string, true>
+	 */
+	private function withoutPreciseClassConstantFetches(
+		array $differingExpressionKeys,
+		array $ourExpressionTypes,
+		array $theirExpressionTypes,
+	): array
+	{
+		foreach (array_keys($differingExpressionKeys) as $exprString) {
+			$holder = $ourExpressionTypes[$exprString] ?? $theirExpressionTypes[$exprString] ?? null;
+			if ($holder === null) {
+				continue;
+			}
+
+			$expr = $holder->getExpr();
+			if (
+				!$expr instanceof ClassConstFetch
+				|| !$expr->class instanceof Name
+				|| !$expr->name instanceof Identifier
+			) {
+				continue;
+			}
+
+			// static::CONST is late-bound, so which class - and therefore which
+			// declared value - it resolves to is not known here.
+			if ($expr->class->toLowerString() === 'static') {
+				continue;
+			}
+
+			if ($this->constantResolver->isDynamicClassConstant($this->resolveName($expr->class), $expr->name->toString())) {
+				continue;
+			}
+
+			unset($differingExpressionKeys[$exprString]);
+		}
+
+		return $differingExpressionKeys;
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/dynamic-constant.php
+++ b/tests/PHPStan/Analyser/data/dynamic-constant.php
@@ -49,4 +49,33 @@ class NoDynamicConstantClass
 		assertType('array', GLOBAL_DYNAMIC_EMPTY_ARRAY);
 		assertType('array{}', GLOBAL_NON_DYNAMIC_EMPTY_ARRAY);
 	}
+
+	private function conditionallyNarrowedDynamicConstant(bool $b): void
+	{
+		if ($b) {
+			if (!is_string(DynamicConstantClass::DYNAMIC_NULL_WITH_PHPDOC_CONSTANT)) {
+				return;
+			}
+		}
+
+		if ($b) {
+			// re-narrowed through the conditional expression remembered for the merge above
+			assertType('string', DynamicConstantClass::DYNAMIC_NULL_WITH_PHPDOC_CONSTANT);
+		}
+
+		assertType('string|null', DynamicConstantClass::DYNAMIC_NULL_WITH_PHPDOC_CONSTANT);
+	}
+
+	private function conditionallyNarrowedPureConstant(bool $b): void
+	{
+		if ($b) {
+			if (!is_string(DynamicConstantClass::PURE_CONSTANT_IN_CLASS)) {
+				return;
+			}
+		}
+
+		if ($b) {
+			assertType("'abc123def'", DynamicConstantClass::PURE_CONSTANT_IN_CLASS);
+		}
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-14478.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14478.php
@@ -1,0 +1,53 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace Bug14478;
+
+use function PHPStan\Testing\assertType;
+
+enum SomeEnum: string
+{
+
+	case A = 'a';
+	case B = 'b';
+	case C = 'c';
+
+	public function toInt(): int
+	{
+		return match ($this) {
+			self::A => 1,
+			self::B => 2,
+			self::C => 3,
+		};
+	}
+
+	public function narrowedInArm(): int
+	{
+		return match ($this) {
+			self::A => (function (): int {
+				assertType('$this(Bug14478\SomeEnum)&Bug14478\SomeEnum::A', $this);
+				assertType('Bug14478\SomeEnum::A', self::A);
+
+				return 1;
+			})(),
+			self::B, self::C => 2,
+		};
+	}
+
+	public function afterMatch(): void
+	{
+		$i = match ($this) {
+			self::A => 1,
+			self::B => 2,
+			self::C => 3,
+		};
+
+		assertType('1|2|3', $i);
+		// the union of per-arm narrowings the arm scopes are merged into - it is this
+		// union that the conditional-expression guard checks used to walk once per arm
+		assertType('($this(Bug14478\SomeEnum)&Bug14478\SomeEnum::C)|($this(Bug14478\SomeEnum)&Bug14478\SomeEnum::B)|($this(Bug14478\SomeEnum)&Bug14478\SomeEnum::A)', $this);
+		assertType('Bug14478\SomeEnum::A', self::A);
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/14478

An exhaustive `match` over a large enum scales quadratically. On `2.2.x` a 1600-case enum takes 17.9s of CPU for one method; with this change it takes 2.0s.

## Where the time goes

Every scope merge in the match arm loop hands `ScopeOps::createConditionalExpressions()` two differing expression keys: the match subject `$this`, and the arm's own `self::Ck` fetch. `$this` is selected as the type guard, `self::Ck` becomes the conditional target, and deciding whether that pair is worth recording runs `isSuperTypeOf()` between the guard and the merged guard type. The merged type of `$this` grows by one enum case per arm, so those checks walk an N-member union once per arm.

Measured on the generated reproducer (level 8, single file, cold cache, CPU as user+sys, PHP 8.5.8), the union members visited by those checks come to 79,801 at N=400 and 319,601 at N=800 — i.e. N²/2. Two subtractive probes bound what removing that work can buy: stubbing `createConditionalExpressions()` entirely gives 1.93s at N=1600, and stubbing just its two `isSuperTypeOf()` calls gives 3.78s, so the guard checks alone are 78% of the run and the whole function is 89%.

## The change

For a class-constant fetch with a statically known class, a conditional expression can never narrow anything: the fetch already resolves to the exact declared value, so the recorded type can only repeat what the expression resolves to on its own. Such keys are dropped before conditional expressions are created.

The exception is `dynamicConstantNames`, which is precisely the case where the resolved type is *wider* than the declared value and the record does pay off — those are kept, as are `static::CONST` (late-bound), `$object::CONST` and `Foo::{$name}` (both depend on an inner expression's type). Enum cases can never be affected by `dynamicConstantNames` because `InitializerExprTypeResolver` returns an `EnumCaseObjectType` before `resolveClassConstantType()` is consulted.

The filtering happens on the differing-key set, which also feeds type-guard selection — but that side is a no-op: a type guard has to have a type that differs from the merged type, and an expression whose type is identical in both branches never does. Instrumenting guard selection on `2.2.x` confirms it: across the whole test suite, a class-constant fetch is selected as a type guard zero times.

## Numbers

Interleaved base/PR per N, 3 rounds, medians, same machine:

| N | `match ($this)` base | PR | speedup | `match ($param)` base | PR | speedup |
|---|---|---|---|---|---|---|
| 100 | 0.60s | 0.53s | 1.12x | | | |
| 200 | 0.83s | 0.58s | 1.44x | 0.60s | 0.55s | 1.09x |
| 400 | 1.74s | 0.68s | 2.53x | 0.86s | 0.64s | 1.35x |
| 800 | 5.35s | 0.97s | 5.53x | 1.87s | 0.89s | 2.10x |
| 1600 | 17.87s | 1.96s | 9.10x | 3.90s | 1.76s | 2.21x |

Growth per doubling of N, `match ($this)`: **x3.08, x3.34 on base, x1.41, x2.03 with this change** — the quadratic term is gone, and 1.96s at N=1600 matches the 1.93s ceiling of stubbing the whole function, so nothing quadratic is left in it on this shape. The `param` shape was not quadratic to begin with and gains a constant factor.

## No regression

- Full test suite green (21307 tests). Self-analysis clean.
- On a real-world Doctrine/Symfony application reporting 3267 errors over 1144 files, the JSON output is **byte-identical** to `2.2.x`, and CPU is flat: medians over 3 interleaved rounds 129.2s base vs 129.7s (+0.4%, inside the 125.1–131.8s spread).
- The new check is two `instanceof` plus a name comparison per differing key, and only reaches the `dynamicConstantNames` lookup for keys that are class-constant fetches.

## Tests

`dynamic-constant.php` gains the case this fix has to keep working — a dynamic constant narrowed inside one branch and re-narrowed after the merge (`string`, not `string|null`). That assertion fails if the skip is applied to dynamic constants too, which is how the exception above was found; it was previously uncovered, so the whole suite passed the unsound version.

`nsrt/bug-14478.php` pins inference on the affected construct (arm-local narrowing of `$this` and `self::CASE`, and the merged union after the match). It passes on `2.2.x` as well — it is a characterisation test, not a failing-first one, since this change is meant to leave inference untouched.

## Scope

This is not the batch scope merge sketched in the issue. It removes the quadratic that the const-fetch targets cause; the guard `isSuperTypeOf()` checks are still paid once per merge for other targets, so a match whose arms narrow variables can still get expensive. `ScopeOps::createConditionalExpressions()` itself is unchanged, so its `turbo-ext` mirror needs no counterpart change — the filtering happens in `MutatingScope::mergeWith()` before the call.
