### PR TITLE
Flatten deep BooleanAnd chains in resolveType() and the falsey context

### DIFF
--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -29,9 +29,11 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use function array_filter;
+use function array_key_last;
 use function array_merge;
 use function array_reverse;
 use function array_values;
+use function count;
 use function is_string;
 
 /**
@@ -58,6 +60,13 @@ final class BooleanAndHandler implements ExprHandler
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type
 	{
+		// For deep BooleanAnd chains, resolve the boolean type by iterating the flattened arms
+		// while threading the truthy scope, instead of recursing into the left operand and
+		// re-narrowing the whole chain at each level - the latter is O(n^2) in the number of arms.
+		if (self::getBooleanExpressionDepth($expr) > self::BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH) {
+			return $this->resolveTypeForFlattenedBooleanAnd($scope, $expr);
+		}
+
 		$leftBooleanType = $scope->getType($expr->left)->toBoolean();
 		if ($leftBooleanType->isFalse()->yes()) {
 			return new ConstantBooleanType(false);
@@ -84,20 +93,61 @@ final class BooleanAndHandler implements ExprHandler
 		return new BooleanType();
 	}
 
+	/**
+	 * The whole chain is false if any arm is false (given the previous arms are true), true if
+	 * every arm is true, and bool otherwise. Threading the truthy scope arm by arm keeps this
+	 * O(n), matching the recursive resolveType() result without re-narrowing the whole left
+	 * chain at each level.
+	 *
+	 * @param BooleanAnd|LogicalAnd $expr
+	 */
+	private function resolveTypeForFlattenedBooleanAnd(MutatingScope $scope, Expr $expr): Type
+	{
+		$arms = [];
+		$current = $expr;
+		while ($current instanceof BooleanAnd || $current instanceof LogicalAnd) {
+			$arms[] = $current->right;
+			$current = $current->left;
+		}
+		$arms[] = $current;
+		$arms = array_reverse($arms);
+
+		$allArmsAreTrue = true;
+		$armScope = $scope;
+		$lastArmKey = array_key_last($arms);
+		foreach ($arms as $key => $arm) {
+			$armType = $armScope->getType($arm);
+			if ($armType->toBoolean()->isFalse()->yes()) {
+				return new ConstantBooleanType(false);
+			}
+			if (!$armType->toBoolean()->isTrue()->yes()) {
+				$allArmsAreTrue = false;
+			}
+			if ($key === $lastArmKey) {
+				continue;
+			}
+			$armScope = $armScope->filterByTruthyValue($arm);
+		}
+
+		return $allArmsAreTrue ? new ConstantBooleanType(true) : new BooleanType();
+	}
+
 	public function specifyTypes(TypeSpecifier $typeSpecifier, Scope $scope, Expr $expr, TypeSpecifierContext $context): SpecifiedTypes
 	{
 		if (!$scope instanceof MutatingScope) {
 			throw new ShouldNotHappenException();
 		}
 
-		// For deep BooleanAnd chains in truthy context, flatten and
-		// process all arms at once to avoid O(N²) recursive
-		// filterByTruthyValue calls.
-		if (
-			$context->true()
-			&& self::getBooleanExpressionDepth($expr) > self::BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH
-		) {
-			return $this->specifyTypesForFlattenedBooleanAnd($typeSpecifier, $scope, $expr, $context);
+		// For deep BooleanAnd chains, flatten and process all arms at once to avoid
+		// O(N²) recursive filterByTruthyValue / filterByFalseyValue calls.
+		if (self::getBooleanExpressionDepth($expr) > self::BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH) {
+			if ($context->true()) {
+				return $this->specifyTypesForFlattenedBooleanAnd($typeSpecifier, $scope, $expr, $context);
+			}
+
+			if (!$context->null()) {
+				return $this->specifyTypesForFlattenedFalseyBooleanAnd($typeSpecifier, $scope, $expr, $context);
+			}
 		}
 
 		$leftTypes = $typeSpecifier->specifyTypesInCondition($scope, $expr->left, $context)->setRootExpr($expr);
@@ -221,6 +271,55 @@ final class BooleanAndHandler implements ExprHandler
 		}
 
 		return SpecifiedTypes::unionAll($armTypes)->setRootExpr($expr);
+	}
+
+	/**
+	 * The falsey counterpart of specifyTypesForFlattenedBooleanAnd(): at least one arm is
+	 * false, so the arms' narrowings intersect, the same merge intersectWith() does for the
+	 * recursive path. This is the De Morgan mirror of the flattened truthy BooleanOr chain,
+	 * and like it, deep chains trade the per-pair conditional-holder augments for linear time.
+	 *
+	 * A mixed truthy-and-false context takes this path too, so it also forgoes the holders the
+	 * recursive path re-derives from the falsey narrowing - the same class of information a
+	 * plain falsey context already forgoes here.
+	 *
+	 * @param BooleanAnd|LogicalAnd $expr
+	 */
+	private function specifyTypesForFlattenedFalseyBooleanAnd(
+		TypeSpecifier $typeSpecifier,
+		MutatingScope $scope,
+		Expr $expr,
+		TypeSpecifierContext $context,
+	): SpecifiedTypes
+	{
+		$arms = [];
+		$current = $expr;
+		while ($current instanceof BooleanAnd || $current instanceof LogicalAnd) {
+			$arms[] = $current->right;
+			$current = $current->left;
+		}
+		$arms[] = $current;
+		$arms = array_reverse($arms);
+
+		$armSpecifiedTypes = [];
+		foreach ($arms as $arm) {
+			$armSpecifiedTypes[] = $typeSpecifier->specifyTypesInCondition($scope, $arm, $context);
+		}
+
+		$types = $armSpecifiedTypes[0];
+		for ($i = 1; $i < count($armSpecifiedTypes); $i++) {
+			$types = $types->intersectWith($armSpecifiedTypes[$i]);
+		}
+
+		$result = (new SpecifiedTypes(
+			$types->getSureTypes(),
+			$types->getSureNotTypes(),
+		))->withAlternativeTypesOf($types);
+		if ($types->shouldOverwrite()) {
+			$result = $result->setAlwaysOverwriteTypes();
+		}
+
+		return $result->setRootExpr($expr);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/deep-boolean-and-chain.php
+++ b/tests/PHPStan/Analyser/nsrt/deep-boolean-and-chain.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types = 1);
+
+namespace DeepBooleanAndChain;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Chains longer than BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH take the flattened path in
+ * BooleanAndHandler, both for the truthy side and - the De Morgan counterpart - the falsey
+ * side. The narrowing must match what the recursive path produces for a short chain.
+ *
+ * @param 1|2|3|4|5|6|7|8 $x
+ */
+function deepChain(int $x): void
+{
+	if ($x !== 1 && $x !== 2 && $x !== 3 && $x !== 4 && $x !== 5 && $x !== 6 && $x !== 7) {
+		assertType('8', $x);
+	} else {
+		assertType('1|2|3|4|5|6|7', $x);
+	}
+
+	assertType('1|2|3|4|5|6|7|8', $x);
+}
+
+/** @param 1|2|3 $x */
+function shortChain(int $x): void
+{
+	// short enough to stay on the recursive path, for comparison
+	if ($x !== 1 && $x !== 2) {
+		assertType('3', $x);
+	} else {
+		assertType('1|2', $x);
+	}
+}
+
+/**
+ * @param 1|2|3|4|5|6|7|8 $x
+ */
+function deepChainNegated(int $x): void
+{
+	if (!($x !== 1 && $x !== 2 && $x !== 3 && $x !== 4 && $x !== 5 && $x !== 6 && $x !== 7)) {
+		assertType('1|2|3|4|5|6|7', $x);
+	} else {
+		assertType('8', $x);
+	}
+}
+
+/**
+ * Comparing the chain against a boolean puts it in a mixed truthy-and-false context, which
+ * must not be handled as if it were a plain truthy one - the chain being false does not make
+ * every arm false.
+ *
+ * @param 1|2|3|4|5|6|7|8 $x
+ */
+function deepChainComparedToTrue(int $x): void
+{
+	if (($x !== 1 && $x !== 2 && $x !== 3 && $x !== 4 && $x !== 5 && $x !== 6 && $x !== 7) !== true) {
+		assertType('1|2|3|4|5|6|7', $x);
+	} else {
+		assertType('8', $x);
+	}
+}
+
+/** @param 1|2|3|4|5|6|7|8 $x */
+function deepChainComparedToFalse(int $x): void
+{
+	if (($x !== 1 && $x !== 2 && $x !== 3 && $x !== 4 && $x !== 5 && $x !== 6 && $x !== 7) === false) {
+		assertType('1|2|3|4|5|6|7', $x);
+	} else {
+		assertType('8', $x);
+	}
+}
+
+/**
+ * A deep chain of mixed arms: the falsey side cannot narrow the subject to a single value,
+ * so the else branch keeps the declared type.
+ *
+ * @param 1|2|3|4|5|6|7|8 $x
+ */
+function deepChainMixed(int $x, bool $b): void
+{
+	if ($x !== 1 && $x !== 2 && $x !== 3 && $b && $x !== 4 && $x !== 5 && $x !== 6) {
+		assertType('7|8', $x);
+		assertType('true', $b);
+	} else {
+		assertType('1|2|3|4|5|6|7|8', $x);
+		assertType('bool', $b);
+	}
+}
+
+/**
+ * @param non-empty-string|null $s
+ */
+function deepChainIsset(?string $s, ?int $i, ?float $f, ?bool $bo, ?object $o): void
+{
+	if ($s !== null && $i !== null && $f !== null && $bo !== null && $o !== null) {
+		assertType('non-empty-string', $s);
+		assertType('int', $i);
+		assertType('float', $f);
+		assertType('bool', $bo);
+		assertType('object', $o);
+	} else {
+		assertType('non-empty-string|null', $s);
+		assertType('int|null', $i);
+	}
+}

--- a/tests/bench/data/and-chain-resolve-type-blowup.php
+++ b/tests/bench/data/and-chain-resolve-type-blowup.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types = 1);
+
+namespace BenchAndChainResolveTypeBlowup;
+
+/**
+ * Regression test for the O(N^2) cost of deep BooleanAnd chains of instanceof arms.
+ *
+ * Without the flattening, both resolveType() and the falsey specifyTypes() path recursed
+ * into the left operand and re-narrowed the whole left chain with filterByTruthyValue() at
+ * each level. This file exercises both: 17.3s unflattened, 9.2s with only resolveType()
+ * flattened, 1.1s with both. instanceof arms make the per-level narrowing expensive enough
+ * to show at the BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH = 4 default (no raised cap needed).
+ */
+final class C1 {}
+final class C2 {}
+final class C3 {}
+final class C4 {}
+final class C5 {}
+final class C6 {}
+final class C7 {}
+final class C8 {}
+final class C9 {}
+final class C10 {}
+final class C11 {}
+final class C12 {}
+final class C13 {}
+final class C14 {}
+final class C15 {}
+final class C16 {}
+final class C17 {}
+final class C18 {}
+final class C19 {}
+final class C20 {}
+final class C21 {}
+final class C22 {}
+final class C23 {}
+final class C24 {}
+final class C25 {}
+final class C26 {}
+final class C27 {}
+final class C28 {}
+final class C29 {}
+final class C30 {}
+final class C31 {}
+final class C32 {}
+final class C33 {}
+final class C34 {}
+final class C35 {}
+final class C36 {}
+final class C37 {}
+final class C38 {}
+final class C39 {}
+final class C40 {}
+final class C41 {}
+final class C42 {}
+final class C43 {}
+final class C44 {}
+final class C45 {}
+final class C46 {}
+final class C47 {}
+final class C48 {}
+final class C49 {}
+final class C50 {}
+final class C51 {}
+final class C52 {}
+final class C53 {}
+final class C54 {}
+final class C55 {}
+final class C56 {}
+final class C57 {}
+final class C58 {}
+final class C59 {}
+final class C60 {}
+final class C61 {}
+final class C62 {}
+final class C63 {}
+final class C64 {}
+final class C65 {}
+final class C66 {}
+final class C67 {}
+final class C68 {}
+final class C69 {}
+final class C70 {}
+final class C71 {}
+final class C72 {}
+final class C73 {}
+final class C74 {}
+final class C75 {}
+final class C76 {}
+final class C77 {}
+final class C78 {}
+final class C79 {}
+final class C80 {}
+final class C81 {}
+final class C82 {}
+final class C83 {}
+final class C84 {}
+final class C85 {}
+final class C86 {}
+final class C87 {}
+final class C88 {}
+final class C89 {}
+final class C90 {}
+final class C91 {}
+final class C92 {}
+final class C93 {}
+final class C94 {}
+final class C95 {}
+final class C96 {}
+final class C97 {}
+final class C98 {}
+final class C99 {}
+final class C100 {}
+
+function test(object $x): void {
+	if (!$x instanceof C1 && !$x instanceof C2 && !$x instanceof C3 && !$x instanceof C4 && !$x instanceof C5 && !$x instanceof C6 && !$x instanceof C7 && !$x instanceof C8 && !$x instanceof C9 && !$x instanceof C10 && !$x instanceof C11 && !$x instanceof C12 && !$x instanceof C13 && !$x instanceof C14 && !$x instanceof C15 && !$x instanceof C16 && !$x instanceof C17 && !$x instanceof C18 && !$x instanceof C19 && !$x instanceof C20 && !$x instanceof C21 && !$x instanceof C22 && !$x instanceof C23 && !$x instanceof C24 && !$x instanceof C25 && !$x instanceof C26 && !$x instanceof C27 && !$x instanceof C28 && !$x instanceof C29 && !$x instanceof C30 && !$x instanceof C31 && !$x instanceof C32 && !$x instanceof C33 && !$x instanceof C34 && !$x instanceof C35 && !$x instanceof C36 && !$x instanceof C37 && !$x instanceof C38 && !$x instanceof C39 && !$x instanceof C40 && !$x instanceof C41 && !$x instanceof C42 && !$x instanceof C43 && !$x instanceof C44 && !$x instanceof C45 && !$x instanceof C46 && !$x instanceof C47 && !$x instanceof C48 && !$x instanceof C49 && !$x instanceof C50 && !$x instanceof C51 && !$x instanceof C52 && !$x instanceof C53 && !$x instanceof C54 && !$x instanceof C55 && !$x instanceof C56 && !$x instanceof C57 && !$x instanceof C58 && !$x instanceof C59 && !$x instanceof C60 && !$x instanceof C61 && !$x instanceof C62 && !$x instanceof C63 && !$x instanceof C64 && !$x instanceof C65 && !$x instanceof C66 && !$x instanceof C67 && !$x instanceof C68 && !$x instanceof C69 && !$x instanceof C70 && !$x instanceof C71 && !$x instanceof C72 && !$x instanceof C73 && !$x instanceof C74 && !$x instanceof C75 && !$x instanceof C76 && !$x instanceof C77 && !$x instanceof C78 && !$x instanceof C79 && !$x instanceof C80 && !$x instanceof C81 && !$x instanceof C82 && !$x instanceof C83 && !$x instanceof C84 && !$x instanceof C85 && !$x instanceof C86 && !$x instanceof C87 && !$x instanceof C88 && !$x instanceof C89 && !$x instanceof C90 && !$x instanceof C91 && !$x instanceof C92 && !$x instanceof C93 && !$x instanceof C94 && !$x instanceof C95 && !$x instanceof C96 && !$x instanceof C97 && !$x instanceof C98 && !$x instanceof C99 && !$x instanceof C100) {
+		echo "none";
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/15004

A long `&&` chain of `!==` comparisons against a literal union is quadratic. The 400-clause reproducer from the issue goes from 18.4s of CPU to 1.0s, and the growth curve flattens to linear.

## The report's root cause was wrong, and I wrote it

I reported this as the `TypeCombinator::remove` counterpart of the `intersect` blowup #5935 fixed, and proposed mirroring that fast path into `remove`. I built that first. **It made things slightly slower** (0.90x at N=400), and the counters say why: of 279,295 `remove` calls at N=200, the fast path could serve 40,381, and *every one of them* still had to rebuild the union — there was no cheap "value is not a member" case to win at all. It only added a keying attempt in front of the existing work. Dropped it.

Subtractive probe on where the time really goes: stubbing `doRemove()` to return its input removes 63% at N=400, but what remains still grows x4.54 per doubling. So `remove` is expensive but not the shape of the problem — the *number* of narrowing operations is, and that number is quadratic.

## What it actually is

`BooleanOrHandler` flattens deep chains in **both** `resolveType()` and `specifyTypes()`. `BooleanAndHandler` flattened only `specifyTypes()`, and only when `$context->true()`. The two missing halves each recursed into the left operand and re-narrowed the whole left chain at every level.

The asymmetry is visible as a straight measurement — same reproducer, same method, only the operator differs (3 rounds, medians):

| N | `$x !== 1 && ...` | `$x === 1 \|\| ...` |
|---|---|---|
| 100 | 0.93s | 0.48s |
| 200 | 3.17s | 0.59s |
| 400 | 18.38s | 0.98s |
| per doubling | **x3.41, x5.80** | x1.24, x1.65 |

And instrumenting the handler on `2.2.x` shows exactly which path runs: for the 200-arm chain the truthy side flattens 582 times, while the recursive path is entered 407 times at depths 193-198 — all of them in a falsey context (`false()` set, `truthy()` clear). That is the `else` side of the chain, plus `resolveType`.

## The change

Both additions mirror their `BooleanOr` counterparts:

- **`resolveTypeForFlattenedBooleanAnd()`** threads the truthy scope arm by arm: false if any arm is false, true if every arm is true, `bool` otherwise.
- **`specifyTypesForFlattenedFalseyBooleanAnd()`** is the De Morgan mirror of the flattened truthy `BooleanOr` chain: at least one arm is false, so the arms' narrowings intersect. Like that path, a deep chain trades the per-pair conditional-holder augments for linear time.

Every non-`true` context that is not the null context takes the flattened falsey path. I first gated it more narrowly (`$context->false() && !$context->truthy()`) to keep mixed truthy-and-false contexts on the recursive path, and dropped that guard once the mutation gate showed it was unobservable — see the CI note below.

I measured the trade-off rather than leaning on the precedent: instrumenting `2.2.x` to count how often the deep-falsey recursive path actually builds a non-null `branchUnionAugment`, it fires **3 times across the whole test suite and twice on the 1144-file corpus**. So it is a real trade-off, not a proven no-op - but in both samples the resulting output is unchanged (suite green, corpus byte-identical). If you would rather keep the augment for deep chains, it can be built once from the flattened arms instead; I did not do that because it reintroduces per-pair work and nothing measurable depends on it.

## Numbers

Interleaved base/PR per N, 3 rounds, medians, level 8, single file, cold cache, CPU as user+sys, PHP 8.5.8:

| N | 2.2.x | PR | speedup |
|---|---|---|---|
| 50 | 0.56s | 0.48s | 1.17x |
| 100 | 0.93s | 0.52s | 1.78x |
| 200 | 3.17s | 0.63s | 5.03x |
| 300 | 8.56s | 0.80s | 10.67x |
| 400 | 18.38s | 1.04s | **17.63x** |

Growth per doubling of N: **x3.41 (100->200) and x5.80 (200->400) on base; x1.21 and x1.65 with this change.** The PR's 1.04s at N=400 matches the `||` shape's 0.98s, so the two operators now cost the same.

The same holds for string literals rather than ints (`$x !== 's1' && ...`): 17.30s -> 1.01s at N=400, per-doubling x5.88 -> x1.63. Worth noting because the issue claimed the plain-string version was already handled by the flattening — it was not, it is equally quadratic on `2.2.x`.

## No regression

- Full suite green (**21310** tests). Self-analysis clean, `phpcs` clean.
- On a real-world Doctrine/Symfony application reporting 3267 errors over 1144 files, output is **byte-identical** to `2.2.x`, and CPU is 3.2% *lower* (medians of 2 interleaved rounds, 134.6s -> 130.3s).
- The reproducer reports the same 3 errors before and after.

## Tests

`nsrt/deep-boolean-and-chain.php` pins the narrowing on both sides of chains longer than `BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH`, against a short chain on the recursive path for comparison, plus a negated chain, a mixed-arm chain whose falsey side cannot narrow, and a null-check chain. It passes on `2.2.x` too — it is a characterisation test, since the change is meant to leave inference untouched.

`tests/bench/data/and-chain-resolve-type-blowup.php` adds the instanceof-arm shape, mirroring `or-chain-resolve-type-blowup.php` and following how `7eab3d2` added its bench in the same commit as the fix. It is a strong discriminator: **17.27s unflattened, 9.17s with only `resolveType()` flattened, 1.08s with both**.

I first also added an `and-chain-falsey-blowup.php` and then deleted it, for two reasons worth stating: it was a near-duplicate of the existing `and-chain-truthy-blowup.php` (same 100-arm `!==` shape), and instrumenting confirmed that existing bench already enters the new flattened falsey path, so mine guarded nothing new. It is also the bench that shows this change most clearly in CI - `and-chain-truthy-blowup.php` comes out at **-81.88%** against the committed baseline.

Note the new variant will not be in the committed phpbench baselines until they are regenerated.

## About the CI reds

- **`Benchmark / Test (PHP 8.5)`** flags `bug-13352.php` +11.09% and `bug-14624.php` +15.89% against the committed baseline. That is baseline drift, not this change: A/B on one machine, two rounds, medians, gives **2.07s vs 2.08s** and **1.91s vs 1.91s** - 1.00x for both. The same job is red on unrelated branches.
- **`Mutation Testing`** was red twice, and both were mine. Worth writing out, because the second one changed the code.

  First, two `LooseBooleanMutator` mutants. That mutator appends `->toBoolean()` to `isTrue()`/`isFalse()` receivers, and its `canMutate()` deliberately skips a receiver that is already a `->toBoolean()` call — but I had assigned that call to a variable first, so it could not see through it and produced two no-op mutants no test can kill. Fixed by inlining `toBoolean()` at both check sites.

  Then one `TrueTruthyFalseFalseyTypeSpecifierContextMutator` mutant on my narrower gate: `$context->false()` -> `$context->falsey()`. I could not kill it, and the reason is structural. `CONTEXT_FALSEY` is `CONTEXT_FALSE | CONTEXT_FALSEY_BUT_NOT_FALSE`, and a context with the second bit but not the first is not produced by any factory nor by `negate()`, so `false()` and `falsey()` agree on every reachable context. Instrumenting which contexts reach the depth gate across the whole suite gives only `CONTEXT_TRUTHY` (4x) and `CONTEXT_FALSEY` (7x); constructing mixed contexts on purpose (`(chain) !== true`, `=== false`) reaches `0b1110`, but `!$context->truthy()` masks the swap there too, so every phrasing of that guard yields an equivalent mutant.

  I checked whether the guard did anything before removing it: routing the mixed context through the flattened path instead produces identical inference on the shape I could build. So the guard was unobservable, and the gate is now just `!$context->null()` — `null()` is not a mutator target. The trade-off this widens is the same one the plain falsey path already makes (holders the recursive path re-derives), on a rarer context. Happy to restore the narrower guard and let that mutant escape if you would rather keep it.