### PR TITLE
Release each file's resolved closure types when its analysis ends

### DIFF
--- a/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
+++ b/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
@@ -15,6 +15,7 @@ use PHPStan\Analyser\ImpurePoint;
 use PHPStan\Analyser\InternalThrowPoint;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\PerFileAnalysisResettable;
 use PHPStan\Analyser\ProcessArrowFunctionResult;
 use PHPStan\Analyser\ProcessClosureResult;
 use PHPStan\Analyser\Scope;
@@ -57,18 +58,39 @@ use function count;
 use function implode;
 use function in_array;
 use function is_string;
+use function spl_object_id;
 
 #[AutowiredService]
-final class ClosureTypeResolver
+final class ClosureTypeResolver implements PerFileAnalysisResettable
 {
 
 	private static int $resolveClosureTypeDepth = 0;
+
+	/**
+	 * Per-context resolved closure types, keyed by the closure node. Node
+	 * attributes would persist on the parser cache's retained ASTs after the
+	 * file's analysis ends - the per-file reset releases the Types and
+	 * throw/impure points with the rest of the file's result graph.
+	 *
+	 * Keyed by the closure node's spl_object_id(). The keys are AST nodes that
+	 * live for the whole file's analysis (the parser cache retains them), so
+	 * ids of live entries never collide; the per-file reset empties the map
+	 * before another file could reuse them.
+	 *
+	 * @var array<int, array<string, array{returnType: Type, throwPoints: SimpleThrowPoint[], impurePoints: SimpleImpurePoint[], invalidateExpressions: InvalidateExprNode[], usedVariables: string[]}>>
+	 */
+	private array $cachedTypes = [];
 
 	public function __construct(
 		private NodeScopeResolver $nodeScopeResolver,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
+	}
+
+	public function resetFileAnalysisState(): void
+	{
+		$this->cachedTypes = [];
 	}
 
 	/**
@@ -106,7 +128,7 @@ final class ClosureTypeResolver
 			);
 		}
 
-		$cachedTypes = $expr->getAttribute('phpstanCachedTypes', []);
+		$cachedTypes = $this->cachedTypes[spl_object_id($expr)] ?? [];
 		$cacheKey = $this->closureContextCacheKey($scope, $expr, $callableParameters, $parameters);
 		if (array_key_exists($cacheKey, $cachedTypes)) {
 			return $this->createClosureTypeFromCache($expr, $parameters, $isVariadic, $cachedTypes[$cacheKey]);
@@ -375,7 +397,7 @@ final class ClosureTypeResolver
 
 		[$parameters, , $callableParameters] = $this->buildParametersAndAcceptors($scope, $expr);
 		$phpdocKey = $this->closureContextCacheKey($scope, $expr, $callableParameters, $parameters);
-		$cachedTypes = $expr->getAttribute('phpstanCachedTypes', []);
+		$cachedTypes = $this->cachedTypes[spl_object_id($expr)] ?? [];
 		if (!array_key_exists($phpdocKey, $cachedTypes)) {
 			return;
 		}
@@ -383,7 +405,7 @@ final class ClosureTypeResolver
 		$promotedScope = $scope->doNotTreatPhpDocTypesAsCertain();
 		[$promotedParameters, , $promotedCallableParameters] = $this->buildParametersAndAcceptors($promotedScope, $expr);
 		$cachedTypes[$this->closureContextCacheKey($promotedScope, $expr, $promotedCallableParameters, $promotedParameters)] = $cachedTypes[$phpdocKey];
-		$expr->setAttribute('phpstanCachedTypes', $cachedTypes);
+		$this->cachedTypes[spl_object_id($expr)] = $cachedTypes;
 	}
 
 	/**
@@ -905,7 +927,7 @@ final class ClosureTypeResolver
 		$impurePointsForClosureType = array_map(static fn (ImpurePoint $impurePoint) => new SimpleImpurePoint($impurePoint->getIdentifier(), $impurePoint->getDescription(), $impurePoint->isCertain()), $impurePoints);
 
 		if ($writeCache) {
-			$cachedTypes = $expr->getAttribute('phpstanCachedTypes', []);
+			$cachedTypes = $this->cachedTypes[spl_object_id($expr)] ?? [];
 			$cacheKey ??= $this->closureContextCacheKey($scope, $expr, null, $parameters);
 			$cachedTypes[$cacheKey] = [
 				'returnType' => $returnType,
@@ -914,7 +936,7 @@ final class ClosureTypeResolver
 				'invalidateExpressions' => $invalidateExpressions,
 				'usedVariables' => $usedVariables,
 			];
-			$expr->setAttribute('phpstanCachedTypes', $cachedTypes);
+			$this->cachedTypes[spl_object_id($expr)] = $cachedTypes;
 		}
 
 		$mustUseReturnValue = TrinaryLogic::createNo();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -226,6 +226,7 @@ class NodeScopeResolver
 	 * @param ExtensionsCollection<FunctionParameterClosureTypeExtension> $functionParameterClosureTypeExtensions
 	 * @param ExtensionsCollection<MethodParameterClosureTypeExtension> $methodParameterClosureTypeExtensions
 	 * @param ExtensionsCollection<StaticMethodParameterClosureTypeExtension> $staticMethodParameterClosureTypeExtensions
+	 * @param ExtensionsCollection<PerFileAnalysisResettable> $perFileAnalysisResettables
 	 */
 	public function __construct(
 		private readonly Container $container,
@@ -259,6 +260,8 @@ class NodeScopeResolver
 		private readonly ExtensionsCollection $methodParameterClosureTypeExtensions,
 		#[AutowiredExtensions(of: StaticMethodParameterClosureTypeExtension::class)]
 		private readonly ExtensionsCollection $staticMethodParameterClosureTypeExtensions,
+		#[AutowiredExtensions(of: PerFileAnalysisResettable::class)]
+		private readonly ExtensionsCollection $perFileAnalysisResettables,
 		private readonly ScopeFactory $scopeFactory,
 		#[AutowiredParameter]
 		private readonly bool $polluteScopeWithLoopInitialAssignments,
@@ -286,6 +289,18 @@ class NodeScopeResolver
 	}
 
 	/**
+	 * Releases the previous file's node-keyed captures: the parser cache
+	 * retains ASTs, so node-keyed cache entries never die on
+	 * their own and would hold that file's whole result graph alive.
+	 */
+	public function resetPerFileAnalysisState(): void
+	{
+		foreach ($this->perFileAnalysisResettables->getAll() as $resettableService) {
+			$resettableService->resetFileAnalysisState();
+		}
+	}
+
+	/**
 	 * @api
 	 * @param Node[] $nodes
 	 * @param callable(Node $node, Scope $scope): void $nodeCallback
@@ -296,6 +311,8 @@ class NodeScopeResolver
 		callable $nodeCallback,
 	): void
 	{
+		$this->resetPerFileAnalysisState();
+
 		$expressionResultStorage = new ExpressionResultStorage();
 		$alreadyTerminated = false;
 		$exitPoints = [];

--- a/src/Analyser/PerFileAnalysisResettable.php
+++ b/src/Analyser/PerFileAnalysisResettable.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\DependencyInjection\ExtensionInterface;
+
+/**
+ * A service holding per-file analysis state keyed by AST nodes. The parser
+ * cache retains ASTs across files, so node-keyed caches never release their
+ * entries on their own - NodeScopeResolver resets these services at the start
+ * of each file's analysis, releasing the previous file's captured results and
+ * everything they transitively hold (callbacks, scopes).
+ */
+#[ExtensionInterface(tag: self::TAG)]
+interface PerFileAnalysisResettable
+{
+
+	public const TAG = 'phpstan.perFileAnalysisResettable';
+
+	public function resetFileAnalysisState(): void;
+
+}

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\IgnoreErrorExtension;
 use PHPStan\Analyser\InternalError;
 use PHPStan\Analyser\LocalIgnoresProcessor;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\PerFileAnalysisResettable;
 use PHPStan\Analyser\RuleErrorTransformer;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Collectors\Collector;
@@ -120,6 +121,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 			self::getContainer()->getExtensionsCollection(FunctionParameterClosureTypeExtension::class),
 			self::getContainer()->getExtensionsCollection(MethodParameterClosureTypeExtension::class),
 			self::getContainer()->getExtensionsCollection(StaticMethodParameterClosureTypeExtension::class),
+			self::getContainer()->getExtensionsCollection(PerFileAnalysisResettable::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -11,6 +11,7 @@ use PHPStan\Analyser\ExprHandler\Helper\ImplicitToStringCallHelper;
 use PHPStan\Analyser\Fiber\FiberNodeScopeResolver;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\PerFileAnalysisResettable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\File\FileHelper;
@@ -95,6 +96,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			$container->getExtensionsCollection(FunctionParameterClosureTypeExtension::class),
 			$container->getExtensionsCollection(MethodParameterClosureTypeExtension::class),
 			$container->getExtensionsCollection(StaticMethodParameterClosureTypeExtension::class),
+			$container->getExtensionsCollection(PerFileAnalysisResettable::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -172,8 +172,9 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 				[$argType],
 				isList: TrinaryLogic::createYes(),
 			);
+			// the resolved-closure-type cache is keyed by node identity
+			// (ClosureTypeResolver::$cachedTypes), so the clone starts uncached
 			$clone->setAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME, [new Node\Arg(new TypeExpr($wrappedType))]);
-			$clone->setAttribute('phpstanCachedTypes', []);
 
 			return $scope->getType($clone)->getCallableParametersAcceptors($scope)[0]->getReturnType();
 		}

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -836,6 +836,7 @@ class AnalyserTest extends PHPStanTestCase
 			$container->getExtensionsCollection(FunctionParameterClosureTypeExtension::class),
 			$container->getExtensionsCollection(MethodParameterClosureTypeExtension::class),
 			$container->getExtensionsCollection(StaticMethodParameterClosureTypeExtension::class),
+			$container->getExtensionsCollection(PerFileAnalysisResettable::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			false,
 			true,

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExprHandler\Helper\ImplicitToStringCallHelper;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\PerFileAnalysisResettable;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\DirectExtensionsCollection;
 use PHPStan\File\FileHelper;
@@ -140,6 +141,7 @@ class FiberNodeScopeResolverRuleTest extends RuleTestCase
 			self::getContainer()->getExtensionsCollection(FunctionParameterClosureTypeExtension::class),
 			self::getContainer()->getExtensionsCollection(MethodParameterClosureTypeExtension::class),
 			self::getContainer()->getExtensionsCollection(StaticMethodParameterClosureTypeExtension::class),
+			self::getContainer()->getExtensionsCollection(PerFileAnalysisResettable::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser\Fiber;
 use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExprHandler\Helper\ImplicitToStringCallHelper;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\PerFileAnalysisResettable;
 use PHPStan\File\FileHelper;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\Reflection\ClassReflectionFactory;
@@ -73,6 +74,7 @@ class FiberNodeScopeResolverTest extends TypeInferenceTestCase
 			$container->getExtensionsCollection(FunctionParameterClosureTypeExtension::class),
 			$container->getExtensionsCollection(MethodParameterClosureTypeExtension::class),
 			$container->getExtensionsCollection(StaticMethodParameterClosureTypeExtension::class),
+			$container->getExtensionsCollection(PerFileAnalysisResettable::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),


### PR DESCRIPTION
PHPStan runs with `gc_disable()`, and the parser cache retains ASTs across files — so anything keyed by an AST node outlives the file it belongs to. Since #6169 the resolved-closure-type cache lives in `phpstanCachedTypes` node attributes: every retained AST pins its file's resolved closure types (return `Type`s, throw/impure points, invalidation expressions) until the process ends.

This PR moves that cache off the nodes and introduces the release point:

- **`PerFileAnalysisResettable`** — a tagged interface for services holding per-file analysis state keyed by AST nodes.
- **`NodeScopeResolver::resetPerFileAnalysisState()`** — called at the start of each `processNodes()` (both callers, `FileAnalyser` and `TypeInferenceTestCase`, are file boundaries; there is no internal recursion), it resets every tagged service, releasing the previous file's captures and everything they transitively hold.
- **`ClosureTypeResolver`** now keeps the cache in an instance map keyed by the closure node's `spl_object_id()`. Ids of live entries can't collide — the keys are AST nodes that live for the whole file's analysis — and the per-file reset empties the map before another file could reuse them.
- **`ArrayMapFunctionReturnTypeExtension`** no longer needs to blank the clone's cache attribute — an identity-keyed cache starts empty for a fresh clone.

Retention now scales with the largest single file instead of accumulating over the whole run. Measured on self-analysis the standalone effect is modest — single-process `src` analysis peak RSS 736 → 725 MB, parallel `make phpstan` used memory 2.29 → 2.27 GB — because the parser cache's byte cap already bounds the retained-AST set here; closure-heavy codebases with large hot sets pin proportionally more. The interface is also the release point further node-keyed caches will hook into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7
