### PR TITLE
Pin the iteratee's entry types in the by-ref foreach intertwined expression

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2650,7 +2650,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		if ($valueByRef && $iterateeType->isArray()->yes() && $iterateeType->isConstantArray()->no()) {
 			$scope = $scope->assignExpression(
 				new IntertwinedVariableByReferenceWithExpr($valueName, $iteratee, new SetExistingOffsetValueTypeExpr(
-					$iteratee,
+					new NativeTypeExpr($iterateeType, $nativeIterateeType),
 					new NativeTypeExpr(
 						$originalScope->getIterableKeyType($iterateeType),
 						$originalScope->getIterableKeyType($nativeIterateeType),


### PR DESCRIPTION
Extracted from the resolve-type-rewrite branch. The `SetExistingOffsetValueTypeExpr` subject inside the by-ref foreach `IntertwinedVariableByReferenceWithExpr` re-priced the raw iteratee through `Scope::getType()` on every ask of the intertwined node. The iteratee's phpdoc and native types at loop entry are already threaded into `enterForeach()` (#6162), and the sibling key expression already pins them the same way.

The outer `IntertwinedVariableByReferenceWithExpr` keeps carrying the raw iteratee, so invalidation on reassignment is unchanged. Both test suites pass with zero expectation churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7