### PR TITLE
Skip fiber machinery for noop node callbacks

### DIFF
--- a/src/Analyser/Fiber/FiberNodeScopeResolver.php
+++ b/src/Analyser/Fiber/FiberNodeScopeResolver.php
@@ -10,6 +10,7 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\GatheringNodeCallback;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\ShouldNotHappenException;
@@ -39,6 +40,12 @@ final class FiberNodeScopeResolver extends NodeScopeResolver
 		while ($nodeCallback instanceof GatheringNodeCallback) {
 			($nodeCallback->getGatherer())($node, $scope);
 			$nodeCallback = $nodeCallback->getInner();
+		}
+
+		if ($nodeCallback instanceof NoopNodeCallback) {
+			// fibers exist solely to let node callbacks ask about types,
+			// a noop callback does not need one
+			return;
 		}
 
 		if (Fiber::getCurrent() !== null) {


### PR DESCRIPTION
Extracted from the resolve-type-rewrite branch. `FiberNodeScopeResolver::callNodeCallback()` created or resumed a worker fiber even when the effective callback (after unwrapping gatherers) is the noop used by scope-effect-only walks — loop convergence passes, closure pre-walks. Fibers exist solely to let node callbacks ask about types, so a noop callback returns before any fiber is touched. Parked fibers are idle workers, not pending work — skipping their no-op fuel starves nothing.

Note: the branch's sibling change (passing `toFiberScope()` to gatherers) is deliberately **not** included — on 2.2.x gatherers run synchronously outside any fiber, so a FiberScope's unsettled-type ask would hit `Fiber::suspend` with no fiber to suspend (confirmed by self-analysis). That half only works under the branch's single-pass ordering.

Both test suites pass in both turbo modes (21319 tests), self-analysis clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7