### PR TITLE
Decouple ImpossibleCheckTypeHelper from TypeSpecifier

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3437,6 +3437,17 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	}
 
 	/**
+	 * Asks the scope for a node's narrowing, so callers do not need to hold
+	 * a TypeSpecifier themselves.
+	 *
+	 * @internal
+	 */
+	public function specifyTypesOfNewWorldHandlerNode(Expr $node, TypeSpecifierContext $context): SpecifiedTypes
+	{
+		return $this->typeSpecifier->specifyTypesInCondition($this, $node, $context);
+	}
+
+	/**
 	 * @api
 	 */
 	public function filterByTruthyValue(Expr $expr): self

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
-use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -48,7 +47,6 @@ final class ImpossibleCheckTypeHelper
 
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
-		private TypeSpecifier $typeSpecifier,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 	)
@@ -315,7 +313,7 @@ final class ImpossibleCheckTypeHelper
 		}
 
 		$typeSpecifierScope = $this->treatPhpDocTypesAsCertain ? $scope : $scope->doNotTreatPhpDocTypesAsCertain();
-		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($typeSpecifierScope, $node, $this->determineContext($typeSpecifierScope, $node));
+		$specifiedTypes = $typeSpecifierScope->specifyTypesOfNewWorldHandlerNode($node, $this->determineContext($typeSpecifierScope, $node));
 
 		// don't validate types on overwrite
 		if ($specifiedTypes->shouldOverwrite()) {
@@ -505,7 +503,6 @@ final class ImpossibleCheckTypeHelper
 
 		return new self(
 			$this->reflectionProvider,
-			$this->typeSpecifier,
 			false,
 		);
 	}

--- a/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
@@ -4,8 +4,6 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Analyser\TypeSpecifier;
-use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
@@ -18,10 +16,8 @@ use function count;
 use function in_array;
 
 #[AutowiredService]
-final class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension, TypeSpecifierAwareExtension
+final class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
-
-	private TypeSpecifier $typeSpecifier;
 
 	private ?ImpossibleCheckTypeHelper $helper = null;
 
@@ -31,11 +27,6 @@ final class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements Dynamic
 		private bool $treatPhpDocTypesAsCertain,
 	)
 	{
-	}
-
-	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
-	{
-		$this->typeSpecifier = $typeSpecifier;
 	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
@@ -71,7 +62,7 @@ final class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements Dynamic
 
 	private function getHelper(): ImpossibleCheckTypeHelper
 	{
-		return $this->helper ??= new ImpossibleCheckTypeHelper($this->reflectionProvider, $this->typeSpecifier, $this->treatPhpDocTypesAsCertain);
+		return $this->helper ??= new ImpossibleCheckTypeHelper($this->reflectionProvider, $this->treatPhpDocTypesAsCertain);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
@@ -36,7 +36,6 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -49,7 +48,6 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -62,7 +60,6 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
@@ -35,7 +35,6 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -48,7 +47,6 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -61,7 +59,6 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -36,7 +36,6 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -49,7 +48,6 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -62,7 +60,6 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
@@ -30,7 +30,6 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -43,7 +42,6 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -56,7 +54,6 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -36,7 +36,6 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -49,7 +48,6 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -62,7 +60,6 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -32,7 +32,6 @@ class IfConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -45,7 +44,6 @@ class IfConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -58,7 +56,6 @@ class IfConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -29,7 +29,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
@@ -16,7 +16,6 @@ class ImpossibleCheckTypeGenericOverwriteRuleTest extends RuleTestCase
 		return new ImpossibleCheckTypeMethodCallRule(
 			new ImpossibleCheckTypeHelper(
 				self::createReflectionProvider(),
-				$this->getTypeSpecifier(),
 				true,
 			),
 			new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
@@ -16,7 +16,6 @@ class ImpossibleCheckTypeMethodCallRuleEqualsTest extends RuleTestCase
 		return new ImpossibleCheckTypeMethodCallRule(
 			new ImpossibleCheckTypeHelper(
 				self::createReflectionProvider(),
-				$this->getTypeSpecifier(),
 				true,
 			),
 			new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -25,7 +25,6 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
@@ -25,7 +25,6 @@ class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
@@ -31,7 +31,6 @@ class LogicalXorConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -44,7 +43,6 @@ class LogicalXorConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -57,7 +55,6 @@ class LogicalXorConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -31,7 +31,6 @@ class MatchExpressionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -44,7 +43,6 @@ class MatchExpressionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -57,7 +55,6 @@ class MatchExpressionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -32,7 +32,6 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -45,7 +44,6 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),
@@ -58,7 +56,6 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->treatPhpDocTypesAsCertain,
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
@@ -30,7 +30,6 @@ class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -43,7 +42,6 @@ class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -56,7 +54,6 @@ class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysTrueConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysTrueConditionRuleTest.php
@@ -30,7 +30,6 @@ class WhileLoopAlwaysTrueConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeFunctionCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -43,7 +42,6 @@ class WhileLoopAlwaysTrueConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),
@@ -56,7 +54,6 @@ class WhileLoopAlwaysTrueConditionRuleTest extends RuleTestCase
 			new ImpossibleCheckTypeStaticMethodCallRule(
 				new ImpossibleCheckTypeHelper(
 					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
 				new PossiblyImpureTipHelper(true),


### PR DESCRIPTION
Extracted from the resolve-type-rewrite branch (its TypeSpecifier↔extension decoupling, re-expressed for 2.2.x).

`ImpossibleCheckTypeHelper` held an injected `TypeSpecifier` only to ask it to specify types in the checked call's condition — and `TypeSpecifyingFunctionsDynamicReturnTypeExtension` had to implement `TypeSpecifierAwareExtension` (the setter dance) purely to construct the helper. The new `@internal` `MutatingScope::specifyTypesOfNewWorldHandlerNode()` asks the scope for the narrowing instead — on 2.2.x it is a thin wrapper over the scope's own `TypeSpecifier`; the name matches the rewrite branch's counterpart (there it reads the narrowing from the node's already-computed ExpressionResult) so the helper converges at the eventual merge.

- `ImpossibleCheckTypeHelper` loses the `TypeSpecifier` constructor dependency (DI callers unaffected; the 16 rule-test construction sites drop the argument)
- `TypeSpecifyingFunctionsDynamicReturnTypeExtension` no longer implements `TypeSpecifierAwareExtension`

Both test suites pass in both turbo modes (21319 tests), self-analysis clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7