### PR TITLE
Add regression tests for #13789 and #13802

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-13789.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13789.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bug13789;
+
+use function PHPStan\Testing\assertType;
+
+/** @return list<non-empty-array<mixed>> */
+function get_list_of_non_empty_array(): array
+{
+	return [['a' => 1]];
+}
+
+/** @param array<mixed> $row */
+function sanitize(array &$row): void
+{
+}
+
+function (): void {
+	$foo = get_list_of_non_empty_array();
+	assertType('list<non-empty-array<mixed>>', $foo);
+
+	foreach ($foo as &$row) {
+		sanitize($row); // $row might be empty after that line
+		assertType('array<mixed>', $row);
+		$row[random_bytes(2)] = random_bytes(2); // $row is definitely non-empty after that line
+		assertType('non-empty-array<mixed>', $row);
+	}
+	unset($row);
+
+	assertType('list<non-empty-array<mixed>>', $foo);
+};

--- a/tests/PHPStan/Analyser/nsrt/bug-13802.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13802.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13802;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @return array<string, string>
+ */
+function createArray(): array {
+	return ['arr' => 'key'];
+}
+
+function (): void {
+	$arr = createArray();
+
+	assertType('array<string, string>', $arr);
+
+	foreach ($arr as &$val) {
+		assertType('string', $val);
+		$val = preg_replace('/[^\x20-\x7E]/', '', $val);
+		assertType('string|null', $val);
+		$val = str_replace(' ', '', $val ?? '');
+		assertType('string', $val);
+	}
+
+	assertType('array<string, string>', $arr);
+};


### PR DESCRIPTION
Both issues were fixed by #6217 (the by-ref foreach iteratee pinning). The tests are the OP playground snippets pinned with `assertType()`; with 90514d9235 reverted, each fails with exactly the wrong type the issue reports (`list<array<mixed>>` / `array<string, string|null>`).

Closes https://github.com/phpstan/phpstan/issues/13789
Closes https://github.com/phpstan/phpstan/issues/13802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaBZjgksga4c5s6Q9FniY7