### PR TITLE
Compare the element type of a variadic by-ref parameter against its out type

### DIFF
--- a/src/Rules/TooWideTypehints/TooWideParameterOutTypeCheck.php
+++ b/src/Rules/TooWideTypehints/TooWideParameterOutTypeCheck.php
@@ -9,6 +9,7 @@ use PHPStan\Node\ExecutionEndNode;
 use PHPStan\Node\ReturnStatement;
 use PHPStan\Reflection\ExtendedParameterReflection;
 use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\VariadicByRefParameterOutType;
 use function lcfirst;
 use function sprintf;
 
@@ -93,6 +94,13 @@ final class TooWideParameterOutTypeCheck
 
 		$variableExpr = new Variable($parameter->getName());
 		$variableType = $scope->getType($variableExpr);
+
+		if ($parameter->isVariadic()) {
+			$variableType = VariadicByRefParameterOutType::elementType($variableType);
+			if ($variableType === null) {
+				return [];
+			}
+		}
 
 		return $this->tooWideTypeCheck->checkParameterOutType(
 			$outType,

--- a/src/Rules/Variables/ParameterOutTypeCheck.php
+++ b/src/Rules/Variables/ParameterOutTypeCheck.php
@@ -57,16 +57,7 @@ final class ParameterOutTypeCheck
 			$scope,
 			$checkedExpr,
 			'',
-			static function (Type $type) use ($outType, $isVariadic): bool {
-				if ($isVariadic) {
-					$type = VariadicByRefParameterOutType::elementType($type);
-					if ($type === null) {
-						return false;
-					}
-				}
-
-				return $outType->isSuperTypeOf($type)->yes();
-			},
+			static fn (Type $type): bool => $outType->isSuperTypeOf($type)->yes(),
 		);
 		if ($typeResult->getType() instanceof ErrorType) {
 			return $typeResult->getUnknownClassErrors();

--- a/src/Rules/Variables/ParameterOutTypeCheck.php
+++ b/src/Rules/Variables/ParameterOutTypeCheck.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Rules\VariadicByRefParameterOutType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -21,6 +22,9 @@ use function sprintf;
  *
  * The promise is either an explicit `@param-out` or, in its absence, the parameter's own type.
  * Which one it is only shows in the error message, so callers report it via $isParamOutType.
+ *
+ * For a variadic parameter the promise describes a single argument while the variable holds the
+ * packed array of them, so the two sides are reconciled through VariadicByRefParameterOutType.
  *
  * @internal
  */
@@ -47,17 +51,35 @@ final class ParameterOutTypeCheck
 		bool $isParamOutType,
 	): array
 	{
+		$isVariadic = $parameter->isVariadic();
+
 		$typeResult = $this->ruleLevelHelper->findTypeToCheck(
 			$scope,
 			$checkedExpr,
 			'',
-			static fn (Type $type): bool => $outType->isSuperTypeOf($type)->yes(),
+			static function (Type $type) use ($outType, $isVariadic): bool {
+				if ($isVariadic) {
+					$type = VariadicByRefParameterOutType::elementType($type);
+					if ($type === null) {
+						return false;
+					}
+				}
+
+				return $outType->isSuperTypeOf($type)->yes();
+			},
 		);
 		if ($typeResult->getType() instanceof ErrorType) {
 			return $typeResult->getUnknownClassErrors();
 		}
 
 		$assignedExprType = $scope->getType($checkedExpr);
+		if ($isVariadic) {
+			$assignedExprType = VariadicByRefParameterOutType::elementType($assignedExprType);
+			if ($assignedExprType === null) {
+				return [];
+			}
+		}
+
 		if ($outType->isSuperTypeOf($assignedExprType)->yes()) {
 			return [];
 		}

--- a/src/Rules/VariadicByRefParameterOutType.php
+++ b/src/Rules/VariadicByRefParameterOutType.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules;
+
+use PHPStan\Type\Type;
+
+/**
+ * The out type of a variadic by-ref parameter describes a single argument: that is how it is applied
+ * at the call site, where NodeScopeResolver writes the out type - or the declared type when there is
+ * no @param-out - back to each argument individually. Inside the body the variable holds the packed
+ * array of those arguments instead, so the element type is the side to compare against the out type.
+ *
+ * @internal
+ */
+final class VariadicByRefParameterOutType
+{
+
+	/**
+	 * Returns the type to compare against the out type, or null when there is nothing to compare.
+	 *
+	 * Null means the variable no longer holds an array. Rebinding the packed variable discards the
+	 * references it held, so PHP writes nothing back to any caller and no out value is left to check.
+	 * An array is still compared, because a write through an offset - `$refs[0] = ...`, which does
+	 * reach the caller - leaves the variable as an array too, and the two are indistinguishable here.
+	 */
+	public static function elementType(Type $packedType): ?Type
+	{
+		if (!$packedType->isArray()->yes()) {
+			return null;
+		}
+
+		return $packedType->getIterableValueType();
+	}
+
+}

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideFunctionParameterOutTypeRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideFunctionParameterOutTypeRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\TooWideTypehints;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Rules\Rule as TRule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<TooWideFunctionParameterOutTypeRule>
@@ -46,6 +47,24 @@ class TooWideFunctionParameterOutTypeRuleTest extends RuleTestCase
 				'PHPDoc tag @param-out type array<array{int, bool}> of function NestedTooWideFunctionParameterOutType\doFoo() can be narrowed to array<array{int, false}>.',
 				9,
 				'Offset 1 (false) does not accept type bool.',
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug15066(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-15066.php'], [
+			[
+				'Function Bug15066\\variadicNeverNull() never assigns null to &$refs so it can be removed from the by-ref type.',
+				24,
+				'You can narrow the parameter out type with @param-out PHPDoc tag.',
+			],
+			// rebinding the packed variable to a non-array is silent, to an array is not - see the fixture
+			[
+				'Function Bug15066\\variadicRebindOnlyString() never assigns null to &$refs so it can be removed from the by-ref type.',
+				62,
+				'You can narrow the parameter out type with @param-out PHPDoc tag.',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodParameterOutTypeRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodParameterOutTypeRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\TooWideTypehints;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Rules\Rule as TRule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<TooWideMethodParameterOutTypeRule>
@@ -140,6 +141,18 @@ class TooWideMethodParameterOutTypeRuleTest extends RuleTestCase
 				'PHPDoc tag @param-out type array<array{int, bool}> of method NestedTooWideMethodParameterOutType\Foo::doFoo() can be narrowed to array<array{int, false}>.',
 				12,
 				'Offset 1 (false) does not accept type bool.',
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug15066(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-15066.php'], [
+			[
+				'Method Bug15066\\Foo::variadicNeverNull() never assigns null to &$refs so it can be removed from the by-ref type.',
+				45,
+				'You can narrow the parameter out type with @param-out PHPDoc tag.',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/TooWideTypehints/data/bug-15066.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/data/bug-15066.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace Bug15066;
+
+function variadicByRef(string|null &...$refs): void
+{
+	foreach ($refs as &$ref) {
+		$ref = $ref === null ? null : trim($ref);
+	}
+}
+
+function singleByRef(string|null &$ref): void
+{
+	$ref = $ref === null ? null : trim($ref);
+}
+
+function variadicByIndex(string|null &...$refs): void
+{
+	foreach ($refs as $key => $value) {
+		$refs[$key] = $value === null ? null : trim($value);
+	}
+}
+
+function variadicNeverNull(string|null &...$refs): void
+{
+	foreach ($refs as $key => $value) {
+		$refs[$key] = 'foo';
+	}
+}
+
+function variadicNeverWritten(string|null &...$refs): void
+{
+}
+
+class Foo
+{
+
+	public function variadicByIndex(string|null &...$refs): void
+	{
+		foreach ($refs as $key => $value) {
+			$refs[$key] = $value === null ? null : trim($value);
+		}
+	}
+
+	public function variadicNeverNull(string|null &...$refs): void
+	{
+		foreach ($refs as $key => $value) {
+			$refs[$key] = 'foo';
+		}
+	}
+
+}
+
+// Rebinding the packed variable discards the references it held, so PHP writes nothing back and
+// there is no out value left to check. An array is still compared, because a write through an
+// offset reaches the caller and leaves the variable as an array too.
+function variadicRebindNonArray(string|null &...$refs): void
+{
+	$refs = 42;
+}
+
+function variadicRebindOnlyString(string|null &...$refs): void
+{
+	$refs = ['ok'];
+}

--- a/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
@@ -117,4 +117,27 @@ class ParameterOutAssignedTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug15066(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-15066.php'], [
+			[
+				'Parameter &$refs by-ref type of function Bug15066Variables\\variadicWrongType() expects string|null, int|string|null given.',
+				22,
+				'You can change the parameter out type with @param-out PHPDoc tag.',
+			],
+			[
+				'Parameter &$refs by-ref type of method Bug15066Variables\\Foo::variadicWrongType() expects string|null, int|string|null given.',
+				52,
+				'You can change the parameter out type with @param-out PHPDoc tag.',
+			],
+			// rebinding the packed variable to a non-array is silent, to an array is not - see the fixture
+			[
+				'Parameter &$refs by-ref type of function Bug15066Variables\\variadicRebindWrongArray() expects string|null, int given.',
+				69,
+				'You can change the parameter out type with @param-out PHPDoc tag.',
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/ParameterOutExecutionEndTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/ParameterOutExecutionEndTypeRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Variables;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<ParameterOutExecutionEndTypeRule>
@@ -72,6 +73,17 @@ class ParameterOutExecutionEndTypeRuleTest extends RuleTestCase
 	public function testBug12330(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-12330.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug15066(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-15066.php'], [
+			[
+				'Parameter &$refs @param-out type of function Bug15066Variables\\variadicParamOutNeverWritten() expects string, string|null given.',
+				35,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-15066.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-15066.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace Bug15066Variables;
+
+function variadicByRef(string|null &...$refs): void
+{
+	foreach ($refs as &$ref) {
+		$ref = $ref === null ? null : trim($ref);
+	}
+}
+
+function variadicByIndex(string|null &...$refs): void
+{
+	foreach ($refs as $key => $value) {
+		$refs[$key] = $value === null ? null : trim($value);
+	}
+}
+
+function variadicWrongType(string|null &...$refs): void
+{
+	foreach ($refs as $key => $value) {
+		$refs[$key] = 42;
+	}
+}
+
+/** @param-out string|null $refs */
+function variadicParamOut(string|null &...$refs): void
+{
+	foreach ($refs as $key => $value) {
+		$refs[$key] = $value === null ? null : trim($value);
+	}
+}
+
+/** @param-out string $refs */
+function variadicParamOutNeverWritten(string|null &...$refs): void
+{
+}
+
+class Foo
+{
+
+	public function variadicByIndex(string|null &...$refs): void
+	{
+		foreach ($refs as $key => $value) {
+			$refs[$key] = $value === null ? null : trim($value);
+		}
+	}
+
+	public function variadicWrongType(string|null &...$refs): void
+	{
+		foreach ($refs as $key => $value) {
+			$refs[$key] = 42;
+		}
+	}
+
+}
+
+// Rebinding the packed variable discards the references it held, so PHP writes nothing back to any
+// caller. Nothing is reported for a non-array, because no out value is left to check. An array is
+// still reported: a write through an offset reaches the caller and leaves the variable as an array
+// too, so the two cannot be told apart here, and the offset write is the case that matters.
+function variadicRebindNonArray(string|null &...$refs): void
+{
+	$refs = 42;
+}
+
+function variadicRebindWrongArray(string|null &...$refs): void
+{
+	$refs = [42];
+}
+
+function variadicRebindOkArray(string|null &...$refs): void
+{
+	$refs = ['ok'];
+}
+
+// The packed variable may end up only maybe holding an array. There is then no element type to
+// speak of, so the comparison is skipped rather than run against a nonexistent one.
+function variadicRebindMaybeArray(string|null &...$refs): void
+{
+	$refs = rand(0, 1) === 1 ? [42] : null;
+}
+


### PR DESCRIPTION
Rebased onto #6238, so this is now only the functional change: one commit, and the two Variables rules are untouched because the comparison they share already lives in `ParameterOutTypeCheck`.

The out type of a variadic by-ref parameter describes a single argument. That is how it is applied at the call site: `NodeScopeResolver` writes `getOutType()`, or the declared type when there is no `@param-out`, back to each argument individually. `tests/PHPStan/Analyser/data/param-out.php` already asserts it, for `noParamOutVariadic(string &...$s)` called with two arguments.

Inside the body, though, the variable holds the packed array of those arguments. Four rules compare the two directly, so they were reading a packed array as if it were one argument - through the two checks they share:

* `TooWideParameterOutTypeCheck`, behind `TooWideFunctionParameterOutTypeRule` and `TooWideMethodParameterOutTypeRule`
* `ParameterOutTypeCheck`, behind `ParameterOutAssignedTypeRule` and `ParameterOutExecutionEndTypeRule`

Nothing could satisfy that comparison, so every variadic by-ref parameter with a union type was reported, whatever the body did with it:

```php
function variadicByRef(string|null &...$refs): void
{
	foreach ($refs as &$ref) {
		$ref = $ref === null ? null : trim($ref);
	}
}
```

```
Function variadicByRef() never assigns null to &$refs so it can be removed from the by-ref type.
Function variadicByRef() never assigns string to &$refs so it can be removed from the by-ref type.
```

The same function without the `...` is silent, which is what localises it. An empty body was reported too, so the body never mattered.

Neither spelling of `@param-out` was a way out. `@param-out string|null` hits the same mismatch, and `@param-out array<int, string|null>` fails on the key type, because the packed array is `array<int<0, max>|string, ...>` and no hand written `array<int, ...>` accepts that.

## The change

Compare the element type when the parameter is variadic.

The `RuleLevelHelper::findTypeToCheck()` callback deliberately does **not** get the same treatment. It only decides which members of the observed type are kept, and these checks use that result for nothing but its `ErrorType` test, which the callback cannot influence - filtering everything out falls back to the unfiltered type. An earlier revision unpacked the element type in the callback too; it changed no output at levels 3, 5, 7, 8 or 9 on nullable, union, mixed and object-typed variadics, so it is gone.

Genuinely too wide variadics are still reported, and errors that used to name the packed array now name the element. On `tests/PHPStan/Analyser/data/param-out.php` the same 14 errors are reported before and after, four of them changing from `expects int, array<int|string, mixed> given` to `expects int, mixed given`.

## One behaviour change worth flagging

Rebinding the variable itself to something that is not an array, as in `$refs = 42;`, is now silent where it previously produced three errors on that function. Rebinding to an array of the wrong element type, `$refs = [42];`, is still reported, with the message naming the element.

That asymmetry is deliberate but it is not a difference in what PHP does. Rebinding the packed variable discards the references it held, so nothing is written back to any caller in either case - checked against PHP, where none of `$refs = 42`, `$refs = []`, `$refs = [42]` or even `$refs = $refs` updates any argument, while `$refs[0] = 42` and a by-ref `foreach` do. The reason arrays stay reported is that a write through an offset also leaves the variable holding an array, so by type alone the two are indistinguishable here, and the offset write is the case worth reporting. Bailing out on a non-array is the part that is unambiguous.

## Verification

* A regression test per rule: `TooWideFunctionParameterOutTypeRuleTest`, `TooWideMethodParameterOutTypeRuleTest`, `ParameterOutAssignedTypeRuleTest`, `ParameterOutExecutionEndTypeRuleTest`. Each fails without the change, each with the symptom from the issue, and each fixture also carries a true positive so the tests cannot be satisfied by skipping variadics.
* Both fixtures also carry the three rebinding shapes, so the behaviour described above is pinned rather than only documented: the non-array rebinding stays silent and the array one stays reported.
* The element-type unpacking lives in one place, `VariadicByRefParameterOutType::elementType()`, and with #6238 in it is applied in two checks rather than at each of the five comparison sites it started at.
* Full suite green, self analysis clean, `phpcs` clean on the touched files.
* Analysing `vendor/symfony`, `vendor/nikic` and `vendor/react` gives an identical set of findings before and after. That is a no regression signal only, since these rules produce no by-ref findings on that code at all. `param-out.php` above is the run that actually exercises the change.

Performance: one `isVariadic()` check per by-ref parameter in level 3 rules, so nothing on a hot path.

One CI note: Mutation Testing flags an escaped `IsSuperTypeOfCalleeAndArgumentMutator` on the `findTypeToCheck()` callback line, and I do not think it is killable. `ParameterOutTypeCheck` uses the result of `findTypeToCheck()` only as `instanceof ErrorType`, and the callback cannot influence that - it is consulted only to strip null (`!checkNullables`) or to filter union members (`!checkUnionTypes`), and neither can turn the result into an `ErrorType`. Swapping the operands leaves the whole suite green (21329 tests) and produces byte-identical output on a probe of nullable, union, benevolent-union and object out types at levels 3, 5, 7 and 8. The same escape applies to the callback as it stood before this PR; it only surfaced now because the line is part of a diff. Happy to follow up if you would rather these rules compared the filtered type instead - that would make the callback meaningful, but it changes what is reported below level 8.

Closes https://github.com/phpstan/phpstan/issues/15066



