### PR TITLE
Faster `UnionType->isNull()`

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -83,6 +83,8 @@ class UnionType implements CompoundType
 	/** @var list<Type>|null */
 	private ?array $finiteTypes = null;
 
+	private ?TrinaryLogic $isNull = null;
+
 	/**
 	 * @api
 	 * @param list<Type> $types
@@ -1163,7 +1165,7 @@ class UnionType implements CompoundType
 
 	public function isNull(): TrinaryLogic
 	{
-		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isNull());
+		return $this->isNull ??= $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isNull());
 	}
 
 	public function isConstantValue(): TrinaryLogic


### PR DESCRIPTION
`Type->isNull()` is invoked in [`TypeSpecifier->createForExpr`](https://github.com/phpstan/phpstan-src/blob/380b5ba72fc6bd35fb4f8c27a306a16ea42f24c1/src/Analyser/TypeSpecifier.php#L552-L556) on most expressions.

its shows up in a blackfire profile of https://github.com/phpstan/phpstan-src/blob/380b5ba72fc6bd35fb4f8c27a306a16ea42f24c1/tests/bench/data/big-constant-int-union.php :
<img width="485" height="444" alt="grafik" src="https://github.com/user-attachments/assets/982686a2-3a8e-4ef7-a529-9bcf34715266" />

before this PR:
```
➜  phpstan-src git:(2.2.x) ✗ php bin/phpstan analyze big-constant-int-union.php --debug -vv
Note: Using configuration file /Users/staabm/workspace/phpstan-src/phpstan.neon.dist.
Result cache not used because of debug mode.
/Users/staabm/workspace/phpstan-src/big-constant-int-union.php
Result cache was not saved because only files were passed as analysed paths.

                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        

Elapsed time: 0.42 seconds
Used memory: 58.5 MB
```

after this PR:
```
➜  phpstan-src git:(isnull) ✗ php bin/phpstan analyze big-constant-int-union.php --debug -vv
Note: Using configuration file /Users/staabm/workspace/phpstan-src/phpstan.neon.dist.
Result cache not used because of debug mode.
/Users/staabm/workspace/phpstan-src/big-constant-int-union.php
Result cache was not saved because only files were passed as analysed paths.

                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        

Elapsed time: 0.38 seconds
Used memory: 58.5 MB
```

refs https://github.com/phpstan/phpstan/issues/15088