### PR TITLE
Faster `UnionType->isCallable()`

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -85,6 +85,8 @@ class UnionType implements CompoundType
 
 	private ?TrinaryLogic $isNull = null;
 
+	private ?TrinaryLogic $isCallable = null;
+
 	/**
 	 * @api
 	 * @param list<Type> $types
@@ -1126,7 +1128,7 @@ class UnionType implements CompoundType
 
 	public function isCallable(): TrinaryLogic
 	{
-		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isCallable());
+		return $this->isCallable ??= $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isCallable());
 	}
 
 	public function getCallableParametersAcceptors(ClassMemberAccessAnswerer $scope): array


### PR DESCRIPTION
before this PR
```
➜  phpstan-src git:(2.2.x) ✗ hyperfine 'php bin/phpstan analyze big-constant-string-union.php --debug -vv'
Benchmark 1: php bin/phpstan analyze big-constant-string-union.php --debug -vv
  Time (mean ± σ):     842.5 ms ±   2.8 ms    [User: 646.9 ms, System: 192.9 ms]
  Range (min … max):   839.2 ms … 848.4 ms    10 runs
```

after this PR
```
➜  phpstan-src git:(2.2.x) ✗ hyperfine 'php bin/phpstan analyze big-constant-string-union.php --debug -vv'
Benchmark 1: php bin/phpstan analyze big-constant-string-union.php --debug -vv
  Time (mean ± σ):     810.6 ms ±   2.5 ms    [User: 613.7 ms, System: 194.4 ms]
  Range (min … max):   807.8 ms … 814.3 ms    10 runs
```

refs https://github.com/phpstan/phpstan/issues/15088