### PR TITLE
Do not restrict `@internal` usages of anonymous class members

### DIFF
--- a/src/Rules/InternalTag/RestrictedInternalUsageHelper.php
+++ b/src/Rules/InternalTag/RestrictedInternalUsageHelper.php
@@ -16,6 +16,10 @@ final class RestrictedInternalUsageHelper
 
 	public function shouldClassBeReported(Scope $scope, ClassReflection $classReflection): bool
 	{
+		if ($classReflection->isAnonymous()) {
+			return false;
+		}
+
 		return $this->shouldBeReported($scope, $classReflection->getName());
 	}
 

--- a/tests/PHPStan/Rules/InternalTag/RestrictedInternalClassConstantUsageExtensionTest.php
+++ b/tests/PHPStan/Rules/InternalTag/RestrictedInternalClassConstantUsageExtensionTest.php
@@ -87,4 +87,14 @@ class RestrictedInternalClassConstantUsageExtensionTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug13042(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13042.php'], [
+			[
+				'Access to internal constant Bug13042\Foo::INTERNAL from outside its root namespace Bug13042.',
+				143,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/InternalTag/RestrictedInternalMethodUsageExtensionTest.php
+++ b/tests/PHPStan/Rules/InternalTag/RestrictedInternalMethodUsageExtensionTest.php
@@ -77,6 +77,10 @@ class RestrictedInternalMethodUsageExtensionTest extends RuleTestCase
 				'Call to internal method Bug13042\Foo::doInternal() from outside its root namespace Bug13042.',
 				163,
 			],
+			[
+				'Call to internal method Bug13042\Foo::doInternal() from outside its root namespace Bug13042.',
+				182,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/InternalTag/RestrictedInternalMethodUsageExtensionTest.php
+++ b/tests/PHPStan/Rules/InternalTag/RestrictedInternalMethodUsageExtensionTest.php
@@ -66,4 +66,18 @@ class RestrictedInternalMethodUsageExtensionTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug13042(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13042.php'], [
+			[
+				'Call to internal method Bug13042\Foo::doInternal() from outside its root namespace Bug13042.',
+				144,
+			],
+			[
+				'Call to internal method Bug13042\Foo::doInternal() from outside its root namespace Bug13042.',
+				163,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/InternalTag/RestrictedInternalPropertyUsageExtensionTest.php
+++ b/tests/PHPStan/Rules/InternalTag/RestrictedInternalPropertyUsageExtensionTest.php
@@ -56,4 +56,18 @@ class RestrictedInternalPropertyUsageExtensionTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug13042(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13042.php'], [
+			[
+				'Access to internal property Bug13042\Foo::$internal from outside its root namespace Bug13042.',
+				141,
+			],
+			[
+				'Access to internal property Bug13042\Foo::$internal from outside its root namespace Bug13042.',
+				160,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/InternalTag/RestrictedInternalPropertyUsageExtensionTest.php
+++ b/tests/PHPStan/Rules/InternalTag/RestrictedInternalPropertyUsageExtensionTest.php
@@ -67,6 +67,10 @@ class RestrictedInternalPropertyUsageExtensionTest extends RuleTestCase
 				'Access to internal property Bug13042\Foo::$internal from outside its root namespace Bug13042.',
 				160,
 			],
+			[
+				'Access to internal property Bug13042\Foo::$internal from outside its root namespace Bug13042.',
+				179,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/InternalTag/RestrictedInternalStaticMethodUsageExtensionTest.php
+++ b/tests/PHPStan/Rules/InternalTag/RestrictedInternalStaticMethodUsageExtensionTest.php
@@ -81,4 +81,14 @@ class RestrictedInternalStaticMethodUsageExtensionTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13210.php'], []);
 	}
 
+	public function testBug13042(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13042.php'], [
+			[
+				'Call to internal static method Bug13042\Foo::doInternalStatic() from outside its root namespace Bug13042.',
+				145,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/InternalTag/RestrictedInternalStaticPropertyUsageExtensionTest.php
+++ b/tests/PHPStan/Rules/InternalTag/RestrictedInternalStaticPropertyUsageExtensionTest.php
@@ -66,4 +66,14 @@ class RestrictedInternalStaticPropertyUsageExtensionTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug13042(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13042.php'], [
+			[
+				'Access to internal static property Bug13042\Foo::$internalStatic from outside its root namespace Bug13042.',
+				142,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/InternalTag/data/bug-13042.php
+++ b/tests/PHPStan/Rules/InternalTag/data/bug-13042.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Bug13042 {
+
+	trait SomeTrait
+	{
+
+		/** @internal don't use it directly */
+		private ?string $text = null;
+
+		/** @internal */
+		private static ?string $staticText = null;
+
+		/** @internal */
+		private function internalMethod(): void
+		{
+		}
+
+		/** @internal */
+		private static function internalStaticMethod(): void
+		{
+		}
+
+		public function setText(string $text): void
+		{
+			$this->text = $text;
+			self::$staticText = $text;
+			$this->internalMethod();
+			self::internalStaticMethod();
+		}
+
+	}
+
+	class HelloWorld
+	{
+
+		public function sayHello(): object
+		{
+			return new class {
+
+				use SomeTrait;
+
+				/** @internal */
+				public $ownProperty;
+
+				/** @internal */
+				public static $ownStaticProperty;
+
+				/** @internal */
+				public const OWN_CONSTANT = 'x';
+
+				/** @internal */
+				public function ownMethod(): void
+				{
+				}
+
+				/** @internal */
+				public static function ownStaticMethod(): void
+				{
+				}
+
+				public function doFoo(): void
+				{
+					$this->ownProperty;
+					self::$ownStaticProperty;
+					self::OWN_CONSTANT;
+					$this->ownMethod();
+					self::ownStaticMethod();
+				}
+
+			};
+		}
+
+		public function fromTheOutside(): void
+		{
+			$foo = new class {
+
+				/** @internal */
+				public $internal;
+
+				/** @internal */
+				public static $internalStatic;
+
+				/** @internal */
+				const INTERNAL = 'x';
+
+				/** @internal */
+				public function doInternal(): void
+				{
+				}
+
+				/** @internal */
+				public static function doInternalStatic(): void
+				{
+				}
+
+			};
+
+			$foo->internal;
+			$foo::$internalStatic;
+			$foo::INTERNAL;
+			$foo->doInternal();
+			$foo::doInternalStatic();
+		}
+
+	}
+
+	class Foo
+	{
+
+		/** @internal */
+		public $internal;
+
+		/** @internal */
+		public static $internalStatic;
+
+		/** @internal */
+		const INTERNAL = 'x';
+
+		/** @internal */
+		public function doInternal(): void
+		{
+		}
+
+		/** @internal */
+		public static function doInternalStatic(): void
+		{
+		}
+
+	}
+
+}
+
+namespace Bug13042Other {
+
+	function (): object {
+		return new class {
+
+			public function doFoo(\Bug13042\Foo $foo): void
+			{
+				$foo->internal;
+				$foo::$internalStatic;
+				$foo::INTERNAL;
+				$foo->doInternal();
+				$foo::doInternalStatic();
+			}
+
+		};
+	};
+
+}
+
+namespace Bug13042Inheritance {
+
+	function (): object {
+		return new class extends \Bug13042\Foo {
+
+			public function doFoo(): void
+			{
+				$this->internal;
+				self::$internalStatic;
+				self::INTERNAL;
+				$this->doInternal();
+				self::doInternalStatic();
+			}
+
+		};
+	};
+
+}

--- a/tests/PHPStan/Rules/InternalTag/data/bug-13042.php
+++ b/tests/PHPStan/Rules/InternalTag/data/bug-13042.php
@@ -167,4 +167,22 @@ namespace Bug13042Inheritance {
 		};
 	};
 
+	// A named subclass gets the very same exemptions: the static access rules re-ask
+	// the extension with the referenced class instead of the declaring one, so only
+	// the instance accesses below are reported. The anonymous subclass above must not
+	// be reported any more strictly than this one.
+	class NamedSubclass extends \Bug13042\Foo
+	{
+
+		public function doFoo(): void
+		{
+			$this->internal;
+			self::$internalStatic;
+			self::INTERNAL;
+			$this->doInternal();
+			self::doInternalStatic();
+		}
+
+	}
+
 }


### PR DESCRIPTION
Anonymous classes are not part of any namespace, so the root-namespace comparison in RestrictedInternalUsageHelper always reported their members as used from outside their namespace.

Fixes https://github.com/phpstan/phpstan/issues/13042#issuecomment-2889085217

https://phpstan.org/r/3b58b0a4-f740-4941-a7b3-d74e3564876f

**Edit:** the early return also fires when the anonymous class is the *referenced* class rather than the declaring one, which is a second, deliberate behaviour change worth recording.

The four static-access rules re-ask the extension with a rewritten declaring class and drop the error when that second answer is `null` (`RestrictedStaticPropertyUsageRule.php:95-101`, and the same block in `RestrictedStaticMethodUsageRule`, `RestrictedStaticMethodCallableUsageRule`, `RestrictedClassConstantUsageRule`). So an `@internal` member inherited from a **named** class is no longer reported when accessed statically through an anonymous subclass:

```php
namespace Other;

function anonSubclass(): object
{
      return new class extends \Vendor\Library\Base {
              public function f(): void
              {
                      echo self::$internalStatic;   // was reported, now silent
                      echo self::INTERNAL;          // was reported, now silent
                      self::internalStaticMethod(); // was reported, now silent
                      $this->internalMethod();      // reported, before and after
              }
      };
}
```

This is the exemption a **named** subclass already gets — it is what the `Rewritten*` machinery is for, access through your own subclass — so the change makes anonymous subclasses consistent with named ones rather than newly permissive. In effect `shouldClassBeReported()` now models "an anonymous class belongs to the current namespace", and the current namespace is the only place its type is reachable: `getNativeReflection()->getNamespaceName()` is `''` for anonymous classes, so there is nothing to gate on the declaration namespace instead, and the type cannot escape to another namespace (PHP rejects `const FOO = new class {};` outright).

`bug-13042.php` now carries both halves side by side in `Bug13042Inheritance` — the anonymous subclass and a named `NamedSubclass` over the same base — so the silence on the `self::` lines reads as a matched exemption rather than an accident. Reverting only `RestrictedInternalUsageHelper.php` brings back the anonymous subclass's errors on lines 161, 162 and 164 while leaving the named subclass's output untouched.

Not addressed here: the fixture makes a pre-existing inconsistency visible — `$this->doInternal()` is reported while `self::doInternalStatic()` is not, because only the static rules have the rewrite gate.