### PR TITLE
Renamed trait constructor promotes properties when called

### DIFF
--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -31,6 +31,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Expr\PossiblyImpureCallExpr;
 use PHPStan\Node\InvalidateExprNode;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ExtendedParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
@@ -43,6 +44,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function count;
@@ -55,6 +57,9 @@ use function strtolower;
 #[AutowiredService]
 final class MethodCallHandler implements ExprHandler
 {
+
+	/** @var array<string, list<string>> */
+	private array $promotedParameterNamesCache = [];
 
 	public function __construct(
 		private EarlyTerminatingCallHelper $earlyTerminatingCallHelper,
@@ -200,6 +205,17 @@ final class MethodCallHandler implements ExprHandler
 						),
 						$scope->getNativeType($normalizedExpr->var),
 					);
+				}
+			}
+
+			if (
+				!$methodReflection->isStatic()
+				&& $scope->isInClass()
+				&& $scope->getClassReflection()->getName() === $methodReflection->getDeclaringClass()->getName()
+			) {
+				$calledOnType = $scope->getType($normalizedExpr->var);
+				foreach ($this->getPromotedParameterNames($methodReflection) as $propertyName) {
+					$scope = $scope->assignInitializedProperty($calledOnType, $propertyName);
 				}
 			}
 
@@ -373,6 +389,36 @@ final class MethodCallHandler implements ExprHandler
 		}
 
 		return $typeSpecifier->handleDefaultTruthyOrFalseyContext($context, $expr, $scope);
+	}
+
+	/**
+	 * Constructor promotion is not limited to methods called __construct: a trait
+	 * constructor imported under a different name (use T { __construct as init; })
+	 * keeps promoting its parameters, so calling it initializes those properties.
+	 *
+	 * @return list<string>
+	 */
+	private function getPromotedParameterNames(ExtendedMethodReflection $methodReflection): array
+	{
+		$declaringClass = $methodReflection->getDeclaringClass();
+		$cacheKey = sprintf('%s::%s', $declaringClass->getName(), $methodReflection->getName());
+		if (array_key_exists($cacheKey, $this->promotedParameterNamesCache)) {
+			return $this->promotedParameterNamesCache[$cacheKey];
+		}
+
+		$names = [];
+		$nativeClassReflection = $declaringClass->getNativeReflection();
+		if ($nativeClassReflection->hasMethod($methodReflection->getName())) {
+			foreach ($nativeClassReflection->getMethod($methodReflection->getName())->getParameters() as $parameter) {
+				if (!$parameter->isPromoted()) {
+					continue;
+				}
+
+				$names[] = $parameter->getName();
+			}
+		}
+
+		return $this->promotedParameterNamesCache[$cacheKey] = $names;
 	}
 
 }

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -213,7 +213,9 @@ final class MethodCallHandler implements ExprHandler
 				&& $scope->isInClass()
 				&& $scope->getClassReflection()->getName() === $methodReflection->getDeclaringClass()->getName()
 			) {
-				$calledOnType = $scope->getType($normalizedExpr->var);
+				// $calledOnType is the receiver before the arguments were evaluated, which is
+				// the object the call goes to: an argument reassigning the receiver variable
+				// does not change who gets called.
 				foreach ($this->getPromotedParameterNames($methodReflection) as $propertyName) {
 					$scope = $scope->assignInitializedProperty($calledOnType, $propertyName);
 				}

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -32,6 +32,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Expr\PossiblyImpureCallExpr;
 use PHPStan\Node\InvalidateExprNode;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ExtendedParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
@@ -44,6 +45,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function count;
@@ -56,6 +58,9 @@ use function strtolower;
 #[AutowiredService]
 final class MethodCallHandler implements ExprHandler
 {
+
+	/** @var array<string, list<string>> */
+	private array $promotedParameterNamesCache = [];
 
 	public function __construct(
 		private CalledMethodProcessor $calledMethodProcessor,
@@ -202,6 +207,17 @@ final class MethodCallHandler implements ExprHandler
 						),
 						$scope->getNativeType($normalizedExpr->var),
 					);
+				}
+			}
+
+			if (
+				!$methodReflection->isStatic()
+				&& $scope->isInClass()
+				&& $scope->getClassReflection()->getName() === $methodReflection->getDeclaringClass()->getName()
+			) {
+				$calledOnType = $scope->getType($normalizedExpr->var);
+				foreach ($this->getPromotedParameterNames($methodReflection) as $propertyName) {
+					$scope = $scope->assignInitializedProperty($calledOnType, $propertyName);
 				}
 			}
 
@@ -375,6 +391,36 @@ final class MethodCallHandler implements ExprHandler
 		}
 
 		return $typeSpecifier->handleDefaultTruthyOrFalseyContext($context, $expr, $scope);
+	}
+
+	/**
+	 * Constructor promotion is not limited to methods called __construct: a trait
+	 * constructor imported under a different name (use T { __construct as init; })
+	 * keeps promoting its parameters, so calling it initializes those properties.
+	 *
+	 * @return list<string>
+	 */
+	private function getPromotedParameterNames(ExtendedMethodReflection $methodReflection): array
+	{
+		$declaringClass = $methodReflection->getDeclaringClass();
+		$cacheKey = sprintf('%s::%s', $declaringClass->getName(), $methodReflection->getName());
+		if (array_key_exists($cacheKey, $this->promotedParameterNamesCache)) {
+			return $this->promotedParameterNamesCache[$cacheKey];
+		}
+
+		$names = [];
+		$nativeClassReflection = $declaringClass->getNativeReflection();
+		if ($nativeClassReflection->hasMethod($methodReflection->getName())) {
+			foreach ($nativeClassReflection->getMethod($methodReflection->getName())->getParameters() as $parameter) {
+				if (!$parameter->isPromoted()) {
+					continue;
+				}
+
+				$names[] = $parameter->getName();
+			}
+		}
+
+		return $this->promotedParameterNamesCache[$cacheKey] = $names;
 	}
 
 }

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -215,7 +215,9 @@ final class MethodCallHandler implements ExprHandler
 				&& $scope->isInClass()
 				&& $scope->getClassReflection()->getName() === $methodReflection->getDeclaringClass()->getName()
 			) {
-				$calledOnType = $scope->getType($normalizedExpr->var);
+				// $calledOnType is the receiver before the arguments were evaluated, which is
+				// the object the call goes to: an argument reassigning the receiver variable
+				// does not change who gets called.
 				foreach ($this->getPromotedParameterNames($methodReflection) as $propertyName) {
 					$scope = $scope->assignInitializedProperty($calledOnType, $propertyName);
 				}

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -28,6 +28,7 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 					'Bug10523\\MultipleWrites::init',
 					'Bug10523\\SingleWriteInConstructorCalledMethod::init',
 					'Bug12253\\PayloadWithAdditionalConstructor::setUp',
+					'Bug9789\\WithAdditionalConstructor::setUp',
 				],
 			),
 		);

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -223,6 +223,33 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 	}
 
 	#[RequiresPhp('>= 8.1.0')]
+	public function testBug9789(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9789.php'], [
+			[
+				'Class Bug9789\InitNeverCalled has an uninitialized readonly property $value. Assign it in the constructor.',
+				6,
+			],
+			[
+				'Class Bug9789\InitOnAnotherObject has an uninitialized readonly property $value. Assign it in the constructor.',
+				6,
+			],
+			[
+				'Access to an uninitialized readonly property Bug9789\ReadBeforeInit::$value.',
+				51,
+			],
+			[
+				'Access to an uninitialized readonly property Bug9789\ConditionalInit::$value.',
+				69,
+			],
+			[
+				'Access to an uninitialized readonly property Bug9789\InitOnAnotherObject::$value.',
+				97,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
 	public function testBug9577(): void
 	{
 		$this->analyse([__DIR__ . '/../Classes/data/bug-9577.php'], [

--- a/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
@@ -240,4 +240,15 @@ class UninitializedPropertyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14983-uninitialized.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.1.0')]
+	public function testBug9789(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9789.php'], [
+			[
+				'Access to an uninitialized property Bug9789\NotReadOnlyReadBeforeInit::$value.',
+				130,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-9789.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-9789.php
@@ -132,3 +132,23 @@ class NotReadOnlyReadBeforeInit
 	}
 
 }
+
+class WithAdditionalConstructor
+{
+
+	use T {
+		__construct as protected init;
+	}
+
+	protected function setUp(): void
+	{
+		$this->init('x');
+		echo $this->readValue();
+	}
+
+	private function readValue(): string
+	{
+		return $this->value;
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-9789.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-9789.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug9789;
+
+trait T {
+	public function __construct(public readonly string $value) {}
+}
+
+class C {
+
+	use T {
+		__construct as protected init;
+	}
+
+	public function __construct(string $value) {
+		$this->init($value);
+		if (!$this->isValid()) {
+			throw new \Exception();
+		}
+	}
+
+	private function isValid(): bool {
+		return !empty($this->value);
+	}
+}
+
+class ReadInConstructor
+{
+
+	use T {
+		__construct as protected init;
+	}
+
+	public function __construct(string $value)
+	{
+		$this->init($value);
+		echo $this->value;
+	}
+
+}
+
+class ReadBeforeInit
+{
+
+	use T {
+		__construct as protected init;
+	}
+
+	public function __construct(string $value)
+	{
+		echo $this->value;
+		$this->init($value);
+	}
+
+}
+
+class ConditionalInit
+{
+
+	use T {
+		__construct as protected init;
+	}
+
+	public function __construct(string $value, bool $condition)
+	{
+		if ($condition) {
+			$this->init($value);
+		}
+		echo $this->value;
+	}
+
+}
+
+class InitNeverCalled
+{
+
+	use T {
+		__construct as protected init;
+	}
+
+	public function __construct(public int $code)
+	{
+	}
+
+}
+
+class InitOnAnotherObject
+{
+
+	use T {
+		__construct as public init;
+	}
+
+	public function __construct(string $value, self $other)
+	{
+		$other->init($value);
+		echo $this->value;
+	}
+
+}
+
+trait NotReadOnlyT {
+	public function __construct(public string $value) {}
+}
+
+class NotReadOnly
+{
+
+	use NotReadOnlyT {
+		__construct as protected init;
+	}
+
+	public function __construct(string $value)
+	{
+		$this->init($value);
+		echo $this->value;
+	}
+
+}
+
+class NotReadOnlyReadBeforeInit
+{
+
+	use NotReadOnlyT {
+		__construct as protected init;
+	}
+
+	public function __construct(string $value)
+	{
+		echo $this->value;
+		$this->init($value);
+	}
+
+}


### PR DESCRIPTION
Constructor property promotion is not limited to methods *named* `__construct`. A trait constructor imported under a different name keeps promoting its parameters:

```php
trait T {
      public function __construct(public readonly string $value) {}
}

class C {
      use T { __construct as protected init; }

      public function __construct(string $value) {
              $this->init($value);          // really does initialize $this->value
              if (!$this->isValid()) { throw new \Exception(); }
      }

      private function isValid(): bool {
              return !empty($this->value);  // reported: access to an uninitialized readonly property
      }
}
```

`StaticCallHandler` already marks a parent's promoted properties as initialized after `parent::__construct()`, but `MethodCallHandler` had no counterpart, so the scope after `$this->init($value)` still considered `$value` uninitialized. `ClassPropertiesNode::getUninitializedProperties()` derives the initialized-property map for each method called from the constructor from that caller scope, so `isValid()` inherited the stale state and the read was reported as premature access — as was a direct `echo $this->value` in the constructor itself.

`MethodCallHandler` now mirrors the `parent::__construct()` handling for `$this->method()` calls whose callee is declared in the current class. Detection is by parameter promotion rather than by method name, so no trait-specific special case is needed, and a per-method cache keeps the native-reflection lookup off the hot path.

Still reported, and pinned in the new test data: reading the property *before* the alias call, calling the alias conditionally, never calling it at all (`Class … has an uninitialized readonly property`), and calling it on a different instance. The same fix also clears the identical false positive for non-readonly promoted properties (`property.uninitialized`).

One knock-on: `isset($this->value)` after the alias call now reports `isset.initializedProperty` ("not nullable nor uninitialized") where it previously reported `isset.property` ("not nullable") — the property is genuinely initialized at that point, so the new message is the accurate one.

Not covered here: a trait constructor that assigns a **non-promoted** readonly property in its body still reports `property.readOnlyAssignNotInConstructor`. That needs `ConstructorsHelper` to treat renamed trait constructors as constructors as well, which is a separate change.

Closes https://github.com/phpstan/phpstan/issues/9789