### PR TITLE
Extract the shared parameter-out type comparison into ParameterOutTypeCheck

### DIFF
--- a/src/Rules/Variables/ParameterOutAssignedTypeRule.php
+++ b/src/Rules/Variables/ParameterOutAssignedTypeRule.php
@@ -6,16 +6,9 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Node\VariableAssignNode;
-use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Rules\RuleLevelHelper;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
-use PHPStan\Type\VerbosityLevel;
 use function is_string;
-use function sprintf;
 
 /**
  * @implements Rule<VariableAssignNode>
@@ -25,7 +18,7 @@ final class ParameterOutAssignedTypeRule implements Rule
 {
 
 	public function __construct(
-		private RuleLevelHelper $ruleLevelHelper,
+		private ParameterOutTypeCheck $parameterOutTypeCheck,
 	)
 	{
 	}
@@ -78,45 +71,14 @@ final class ParameterOutAssignedTypeRule implements Rule
 
 		$outType = TypeUtils::resolveLateResolvableTypes($outType);
 
-		$typeResult = $this->ruleLevelHelper->findTypeToCheck(
+		return $this->parameterOutTypeCheck->check(
 			$scope,
+			$inFunction,
+			$foundParameter,
 			$node->getAssignedExpr(),
-			'',
-			static fn (Type $type): bool => $outType->isSuperTypeOf($type)->yes(),
+			$outType,
+			$isParamOutType,
 		);
-		$type = $typeResult->getType();
-		if ($type instanceof ErrorType) {
-			return $typeResult->getUnknownClassErrors();
-		}
-
-		$assignedExprType = $scope->getType($node->getAssignedExpr());
-		if ($outType->isSuperTypeOf($assignedExprType)->yes()) {
-			return [];
-		}
-
-		if ($inFunction instanceof ExtendedMethodReflection) {
-			$functionDescription = sprintf('method %s::%s()', $inFunction->getDeclaringClass()->getDisplayName(), $inFunction->getName());
-		} else {
-			$functionDescription = sprintf('function %s()', $inFunction->getName());
-		}
-
-		$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($outType, $assignedExprType);
-		$errorBuilder = RuleErrorBuilder::message(sprintf(
-			'Parameter &$%s %s of %s expects %s, %s given.',
-			$foundParameter->getName(),
-			$isParamOutType ? '@param-out type' : 'by-ref type',
-			$functionDescription,
-			$outType->describe($verbosityLevel),
-			$assignedExprType->describe($verbosityLevel),
-		))->identifier(sprintf('%s.type', $isParamOutType ? 'paramOut' : 'parameterByRef'));
-
-		if (!$isParamOutType) {
-			$errorBuilder->tip('You can change the parameter out type with @param-out PHPDoc tag.');
-		}
-
-		return [
-			$errorBuilder->build(),
-		];
 	}
 
 }

--- a/src/Rules/Variables/ParameterOutExecutionEndTypeRule.php
+++ b/src/Rules/Variables/ParameterOutExecutionEndTypeRule.php
@@ -12,14 +12,8 @@ use PHPStan\Reflection\ExtendedParameterReflection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Rules\RuleLevelHelper;
-use PHPStan\Type\ErrorType;
 use PHPStan\Type\NeverType;
-use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
-use PHPStan\Type\VerbosityLevel;
-use function sprintf;
 
 /**
  * @implements Rule<ExecutionEndNode>
@@ -29,7 +23,7 @@ final class ParameterOutExecutionEndTypeRule implements Rule
 {
 
 	public function __construct(
-		private RuleLevelHelper $ruleLevelHelper,
+		private ParameterOutTypeCheck $parameterOutTypeCheck,
 	)
 	{
 	}
@@ -94,41 +88,14 @@ final class ParameterOutExecutionEndTypeRule implements Rule
 
 		$outType = TypeUtils::resolveLateResolvableTypes($outType);
 
-		$variableExpr = new Node\Expr\Variable($parameter->getName());
-		$typeResult = $this->ruleLevelHelper->findTypeToCheck(
+		return $this->parameterOutTypeCheck->check(
 			$scope,
-			$variableExpr,
-			'',
-			static fn (Type $type): bool => $outType->isSuperTypeOf($type)->yes(),
+			$inFunction,
+			$parameter,
+			new Node\Expr\Variable($parameter->getName()),
+			$outType,
+			true, // this rule only runs when @param-out is present
 		);
-		$type = $typeResult->getType();
-		if ($type instanceof ErrorType) {
-			return $typeResult->getUnknownClassErrors();
-		}
-
-		$assignedExprType = $scope->getType($variableExpr);
-		if ($outType->isSuperTypeOf($assignedExprType)->yes()) {
-			return [];
-		}
-
-		if ($inFunction instanceof ExtendedMethodReflection) {
-			$functionDescription = sprintf('method %s::%s()', $inFunction->getDeclaringClass()->getDisplayName(), $inFunction->getName());
-		} else {
-			$functionDescription = sprintf('function %s()', $inFunction->getName());
-		}
-
-		$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($outType, $assignedExprType);
-		$errorBuilder = RuleErrorBuilder::message(sprintf(
-			'Parameter &$%s @param-out type of %s expects %s, %s given.',
-			$parameter->getName(),
-			$functionDescription,
-			$outType->describe($verbosityLevel),
-			$assignedExprType->describe($verbosityLevel),
-		))->identifier(sprintf('paramOut.type'));
-
-		return [
-			$errorBuilder->build(),
-		];
 	}
 
 }

--- a/src/Rules/Variables/ParameterOutTypeCheck.php
+++ b/src/Rules/Variables/ParameterOutTypeCheck.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Variables;
+
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * Compares what a by-ref parameter is left holding against the type its callers are promised.
+ *
+ * The promise is either an explicit `@param-out` or, in its absence, the parameter's own type.
+ * Which one it is only shows in the error message, so callers report it via $isParamOutType.
+ *
+ * @internal
+ */
+#[AutowiredService]
+final class ParameterOutTypeCheck
+{
+
+	public function __construct(
+		private RuleLevelHelper $ruleLevelHelper,
+	)
+	{
+	}
+
+	/**
+	 * @param Type $outType Already passed through TypeUtils::resolveLateResolvableTypes()
+	 * @return list<IdentifierRuleError>
+	 */
+	public function check(
+		Scope $scope,
+		FunctionReflection|ExtendedMethodReflection $inFunction,
+		ParameterReflection $parameter,
+		Expr $checkedExpr,
+		Type $outType,
+		bool $isParamOutType,
+	): array
+	{
+		$typeResult = $this->ruleLevelHelper->findTypeToCheck(
+			$scope,
+			$checkedExpr,
+			'',
+			static fn (Type $type): bool => $outType->isSuperTypeOf($type)->yes(),
+		);
+		if ($typeResult->getType() instanceof ErrorType) {
+			return $typeResult->getUnknownClassErrors();
+		}
+
+		$assignedExprType = $scope->getType($checkedExpr);
+		if ($outType->isSuperTypeOf($assignedExprType)->yes()) {
+			return [];
+		}
+
+		if ($inFunction instanceof ExtendedMethodReflection) {
+			$functionDescription = sprintf('method %s::%s()', $inFunction->getDeclaringClass()->getDisplayName(), $inFunction->getName());
+		} else {
+			$functionDescription = sprintf('function %s()', $inFunction->getName());
+		}
+
+		$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($outType, $assignedExprType);
+		$errorBuilder = RuleErrorBuilder::message(sprintf(
+			'Parameter &$%s %s of %s expects %s, %s given.',
+			$parameter->getName(),
+			$isParamOutType ? '@param-out type' : 'by-ref type',
+			$functionDescription,
+			$outType->describe($verbosityLevel),
+			$assignedExprType->describe($verbosityLevel),
+		))->identifier(sprintf('%s.type', $isParamOutType ? 'paramOut' : 'parameterByRef'));
+
+		if (!$isParamOutType) {
+			$errorBuilder->tip('You can change the parameter out type with @param-out PHPDoc tag.');
+		}
+
+		return [
+			$errorBuilder->build(),
+		];
+	}
+
+}

--- a/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
@@ -16,15 +16,17 @@ class ParameterOutAssignedTypeRuleTest extends RuleTestCase
 	protected function getRule(): TRule
 	{
 		return new ParameterOutAssignedTypeRule(
-			new RuleLevelHelper(
-				self::createReflectionProvider(),
-				checkNullables: true,
-				checkThisOnly: false,
-				checkUnionTypes: true,
-				checkExplicitMixed: true,
-				checkImplicitMixed: false,
-				checkBenevolentUnionTypes: false,
-				discoveringSymbolsTip: true,
+			new ParameterOutTypeCheck(
+				new RuleLevelHelper(
+					self::createReflectionProvider(),
+					checkNullables: true,
+					checkThisOnly: false,
+					checkUnionTypes: true,
+					checkExplicitMixed: true,
+					checkImplicitMixed: false,
+					checkBenevolentUnionTypes: false,
+					discoveringSymbolsTip: true,
+				),
 			),
 		);
 	}

--- a/tests/PHPStan/Rules/Variables/ParameterOutExecutionEndTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/ParameterOutExecutionEndTypeRuleTest.php
@@ -15,15 +15,17 @@ class ParameterOutExecutionEndTypeRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ParameterOutExecutionEndTypeRule(
-			new RuleLevelHelper(
-				self::createReflectionProvider(),
-				checkNullables: true,
-				checkThisOnly: false,
-				checkUnionTypes: true,
-				checkExplicitMixed: true,
-				checkImplicitMixed: false,
-				checkBenevolentUnionTypes: false,
-				discoveringSymbolsTip: true,
+			new ParameterOutTypeCheck(
+				new RuleLevelHelper(
+					self::createReflectionProvider(),
+					checkNullables: true,
+					checkThisOnly: false,
+					checkUnionTypes: true,
+					checkExplicitMixed: true,
+					checkImplicitMixed: false,
+					checkBenevolentUnionTypes: false,
+					discoveringSymbolsTip: true,
+				),
 			),
 		);
 	}


### PR DESCRIPTION
Split out of https://github.com/phpstan/phpstan-src/pull/6227 as requested in https://github.com/phpstan/phpstan-src/pull/6227#discussion_r3802057854. Pure refactoring, no functional change.

`ParameterOutAssignedTypeRule` and `ParameterOutExecutionEndTypeRule` both compare what a by-ref parameter is left holding against the type its callers are promised, and both build the same message out of it. The execution-end rule is the assigned-value rule with `@param-out` known to be present, so its message is what the other one produces when `$isParamOutType` is true - identical string, identical `paramOut.type` identifier, and no tip either way.

The comparison, the level-dependent `findTypeToCheck()` filtering, the function description and the message now live in `ParameterOutTypeCheck`. Each rule keeps only what is its own: finding the parameter that the assignment writes to, and walking the parameters at an execution end.

Evidence that nothing changed:

* Both rule tests keep their expectations untouched - the only diff in `tests/` is `new ParameterOutTypeCheck(...)` wrapping the `RuleLevelHelper`.
* Full suite: 21325 tests, 96906 assertions, green.
* Self-analysis (`build/phpstan.neon`) reports no errors, phpcs is clean on the five touched files.

Once this is in I will rebase #6227 on top of it, so that PR is left with just the variadic element-type comparison.
