### PR TITLE
Require array_search()'s haystack argument before reading it

### DIFF
--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -1912,7 +1912,7 @@ final class AssignHandler implements ExprHandler
 			$arrayDimFetch->dim instanceof Expr\FuncCall
 			&& $arrayDimFetch->dim->name instanceof Name
 			&& $arrayDimFetch->dim->name->toLowerString() === 'array_search'
-			&& count($arrayDimFetch->dim->getArgs()) >= 1
+			&& count($arrayDimFetch->dim->getArgs()) >= 2 // the haystack is the second argument
 			&& $this->isSameVariable($arrayDimFetch->var, $arrayDimFetch->dim->getArgs()[1]->value)
 		) {
 			return true;

--- a/tests/PHPStan/Analyser/nsrt/array-search-offset-argument-count.php
+++ b/tests/PHPStan/Analyser/nsrt/array-search-offset-argument-count.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace ArraySearchOffsetArgumentCount;
+
+use function PHPStan\Testing\assertType;
+
+function singleArgument(): void
+{
+	$list = [1, 2, 3];
+	// the haystack is array_search()'s second argument, so a call without one cannot be the
+	// list-preserving idiom - the call itself is reported as invalid
+	$list[array_search($list)] = 4;
+	assertType('array{1|4, 2|4, 3|4, ...<int<min, -1>|int<3, max>|string, 4>}', $list);
+}
+
+/**
+ * @param array{int, list<int>} $args
+ */
+function unpackedArguments(array $args): void
+{
+	$list = [1, 2, 3];
+	$list[array_search(...$args)] = 4;
+	assertType('array{1|4, 2|4, 3|4, ...<int<min, -1>|int<3, max>|string, 4>}', $list);
+}


### PR DESCRIPTION
Split out of #6226 as requested in https://github.com/phpstan/phpstan-src/pull/6226#issuecomment-5324758422.

`AssignHandler::shouldKeepList()` recognizes `$list[array_search($needle, $list)]` as an offset that keeps an array a list. The branch accepted a call with one argument and then read the second one, so this aborts the analysis on current 2.2.x:

```php
$list = [1, 2, 3];
$list[array_search($list)] = 4;
```

```
Internal error: PHPStan\Analyser\ExprHandler\AssignHandler::isSameVariable():
Argument #2 ($b) must be of type PhpParser\Node\Expr, null given,
called in src/Analyser/ExprHandler/AssignHandler.php on line 1916
```

The haystack is `array_search()`'s second argument, so requiring two is what the branch already assumed. The call stays malformed - it is now reported as `Function array_search invoked with 1 parameter, 2-3 required.` instead of ending the run.

A single unpacked argument counts as one argument too, so `$list[array_search(...$args)] = 4;` reached the same read and is covered as well.

I checked the neighbouring heuristics for the same off-by-one: every other `getArgs()[N]` in the file is guarded by a count of at least `N + 1`, and a sweep over `src/` for an argument index accessed under a weaker count guard turned up no other case that can be reached (the `count()` ones bail out on an empty argument list before getting there).

`tests/PHPStan/Analyser/nsrt/array-search-offset-argument-count.php` holds both cases; with the guard reverted the test errors with the TypeError above. Full suite, self-analysis and phpcs are green.
