### PR TITLE
Use LruCache for the other three least-recently-used caches

### DIFF
--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -59,12 +59,12 @@ final class CachedParser implements Parser
 	public function __construct(
 		private Parser $originalParser,
 		private int $cachedNodesByStringCountMax,
-		private int $cachedSourceBytesMax = self::CACHED_SOURCE_BYTES_DEFAULT_LIMIT,
+		int $cachedSourceBytesMax = self::CACHED_SOURCE_BYTES_DEFAULT_LIMIT,
 	)
 	{
 		$this->cachedNodesByString = new LruCache(
 			$this->cachedNodesByStringCountMax,
-			$this->cachedSourceBytesMax,
+			$cachedSourceBytesMax,
 			self::SIZE_EVICTION_FLOOR_LIMIT,
 		);
 		$this->cachedSourceByFile = new LruCache(maxWeight: self::MEMOIZED_SOURCE_BYTES_LIMIT);

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -16,6 +16,7 @@ use PHPStan\BetterReflection\Reflection\Adapter\ReflectionParameter;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionProperty;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Internal\LruCache;
 use PHPStan\Parser\Parser;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
@@ -62,7 +63,6 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypehintHelper;
 use PHPStan\Type\UnionType;
 use function array_key_exists;
-use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_slice;
@@ -77,8 +77,8 @@ use function strtolower;
 final class PhpClassReflectionExtension
 {
 
-	/** @var array<string, true> shared LRU over the member cache keys below; first entry = least recently used */
-	private array $memberCacheOrder = [];
+	/** @var LruCache<true> shared LRU over the member cache keys below */
+	private LruCache $memberCacheOrder;
 
 	/** @var PhpPropertyReflection[][] */
 	private array $propertiesIncludingAnnotations = [];
@@ -121,6 +121,7 @@ final class PhpClassReflectionExtension
 		private int $memberCacheKeysMax,
 	)
 	{
+		$this->memberCacheOrder = new LruCache($this->memberCacheKeysMax);
 	}
 
 	/**
@@ -135,25 +136,18 @@ final class PhpClassReflectionExtension
 	 */
 	private function touchMemberCacheKey(string $cacheKey): void
 	{
-		if (isset($this->memberCacheOrder[$cacheKey])) {
-			unset($this->memberCacheOrder[$cacheKey]);
-			$this->memberCacheOrder[$cacheKey] = true;
+		if ($this->memberCacheOrder->get($cacheKey) !== null) {
 			return;
 		}
 
-		$this->memberCacheOrder[$cacheKey] = true;
-		if ($this->memberCacheKeysMax === 0 || count($this->memberCacheOrder) <= $this->memberCacheKeysMax) {
-			return;
+		foreach ($this->memberCacheOrder->set($cacheKey, true, 0) as $evictKey) {
+			unset(
+				$this->methodsIncludingAnnotations[$evictKey],
+				$this->nativeMethods[$evictKey],
+				$this->propertiesIncludingAnnotations[$evictKey],
+				$this->nativeProperties[$evictKey],
+			);
 		}
-
-		$evictKey = array_key_first($this->memberCacheOrder);
-		unset(
-			$this->memberCacheOrder[$evictKey],
-			$this->methodsIncludingAnnotations[$evictKey],
-			$this->nativeMethods[$evictKey],
-			$this->propertiesIncludingAnnotations[$evictKey],
-			$this->nativeProperties[$evictKey],
-		);
 	}
 
 	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -118,10 +118,10 @@ final class PhpClassReflectionExtension
 		private bool $inferPrivatePropertyTypeFromConstructor,
 		private PhpVersion $phpVersion,
 		#[AutowiredParameter(ref: '%cache.memberCacheKeysMax%')]
-		private int $memberCacheKeysMax,
+		int $memberCacheKeysMax,
 	)
 	{
-		$this->memberCacheOrder = new LruCache($this->memberCacheKeysMax);
+		$this->memberCacheOrder = new LruCache($memberCacheKeysMax);
 	}
 
 	/**

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -86,13 +86,13 @@ final class FileTypeMapper
 		#[AutowiredParameter(ref: '%cache.resolvedPhpDocBlockCacheCountMax%')]
 		private int $resolvedPhpDocBlockCacheCountMax,
 		#[AutowiredParameter(ref: '%cache.nameScopeMapMemoryCacheCountMax%')]
-		private int $nameScopeMapMemoryCacheCountMax,
+		int $nameScopeMapMemoryCacheCountMax,
 	)
 	{
 		// 0 kept one entry here rather than meaning "no limit" as it does for the other bounded
 		// caches: the eviction loop ran before the insertion, emptying the cache and then putting
 		// a single entry back. Preserved rather than normalised - see the PR description.
-		$this->memoryCache = new LruCache($this->nameScopeMapMemoryCacheCountMax === 0 ? 1 : $this->nameScopeMapMemoryCacheCountMax);
+		$this->memoryCache = new LruCache($nameScopeMapMemoryCacheCountMax === 0 ? 1 : $nameScopeMapMemoryCacheCountMax);
 	}
 
 	/** @api */

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -15,6 +15,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\File\FileContentHasher;
 use PHPStan\File\FileHelper;
 use PHPStan\Internal\ComposerHelper;
+use PHPStan\Internal\LruCache;
 use PHPStan\Parser\Parser;
 use PHPStan\PhpDoc\NameScopeAlreadyBeingCreatedException;
 use PHPStan\PhpDoc\PhpDocNodeResolver;
@@ -58,10 +59,8 @@ final class FileTypeMapper
 	private const SKIP_NODE = 1;
 	private const POP_TYPE_MAP_STACK = 2;
 
-	/** @var array<string, array{array<string, IntermediaryNameScope>}> */
-	private array $memoryCache = [];
-
-	private int $memoryCacheCount = 0;
+	/** @var LruCache<array{array<string, IntermediaryNameScope>}> */
+	private LruCache $memoryCache;
 
 	/** @var array<string, true> */
 	private array $inProcess = [];
@@ -90,6 +89,10 @@ final class FileTypeMapper
 		private int $nameScopeMapMemoryCacheCountMax,
 	)
 	{
+		// 0 kept one entry here rather than meaning "no limit" as it does for the other bounded
+		// caches: the eviction loop ran before the insertion, emptying the cache and then putting
+		// a single entry back. Preserved rather than normalised - see the PR description.
+		$this->memoryCache = new LruCache($this->nameScopeMapMemoryCacheCountMax === 0 ? 1 : $this->nameScopeMapMemoryCacheCountMax);
 	}
 
 	/** @api */
@@ -336,13 +339,8 @@ final class FileTypeMapper
 	 */
 	private function getNameScopeMap(string $fileName): array
 	{
-		if (isset($this->memoryCache[$fileName])) {
-			// LRU: move the freshly-accessed entry to the end so eviction drops
-			// genuinely cold files, not hot dependencies inserted early on.
-			$cachedEntry = $this->memoryCache[$fileName];
-			unset($this->memoryCache[$fileName]);
-			$this->memoryCache[$fileName] = $cachedEntry;
-
+		$cachedEntry = $this->memoryCache->get($fileName);
+		if ($cachedEntry !== null) {
 			return $cachedEntry;
 		}
 
@@ -364,19 +362,10 @@ final class FileTypeMapper
 		} else {
 			[$nameScopeMap] = $cached;
 		}
-		while ($this->memoryCacheCount >= $this->nameScopeMapMemoryCacheCountMax) {
-			$oldestKey = array_key_first($this->memoryCache);
-			if ($oldestKey === null) {
-				break;
-			}
-			unset($this->memoryCache[$oldestKey]);
-			$this->memoryCacheCount--;
-		}
+		$entry = [$nameScopeMap];
+		$this->memoryCache->set($fileName, $entry, 0);
 
-		$this->memoryCache[$fileName] = [$nameScopeMap];
-		$this->memoryCacheCount++;
-
-		return $this->memoryCache[$fileName];
+		return $entry;
 	}
 
 	/**

--- a/src/Type/UsefulTypeAliasResolver.php
+++ b/src/Type/UsefulTypeAliasResolver.php
@@ -5,13 +5,12 @@ namespace PHPStan\Type;
 use PHPStan\Analyser\NameScope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Internal\LruCache;
 use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use function array_key_exists;
-use function array_key_first;
-use function count;
 use function sprintf;
 
 #[AutowiredService(as: TypeAliasResolver::class)]
@@ -21,8 +20,8 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 	/** @var array<string, Type> */
 	private array $resolvedGlobalTypeAliases = [];
 
-	/** @var array<string, Type> LRU; first entry = least recently used */
-	private array $resolvedLocalTypeAliases = [];
+	/** @var LruCache<Type> */
+	private LruCache $resolvedLocalTypeAliases;
 
 	/** @var array<string, true> */
 	private array $resolvingClassTypeAliases = [];
@@ -43,6 +42,7 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 		private int $resolvedLocalTypeAliasesCountMax,
 	)
 	{
+		$this->resolvedLocalTypeAliases = new LruCache($this->resolvedLocalTypeAliasesCountMax);
 	}
 
 	public function hasTypeAlias(string $aliasName, ?string $classNameScope): bool
@@ -84,12 +84,9 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 
 		$aliasNameInClassScope = $className . '::' . $aliasName;
 
-		if (array_key_exists($aliasNameInClassScope, $this->resolvedLocalTypeAliases)) {
-			// LRU: move to the most-recently-used position
-			$resolvedAliasType = $this->resolvedLocalTypeAliases[$aliasNameInClassScope];
-			unset($this->resolvedLocalTypeAliases[$aliasNameInClassScope]);
-
-			return $this->resolvedLocalTypeAliases[$aliasNameInClassScope] = $resolvedAliasType;
+		$resolvedAliasType = $this->resolvedLocalTypeAliases->get($aliasNameInClassScope);
+		if ($resolvedAliasType !== null) {
+			return $resolvedAliasType;
 		}
 
 		// prevent infinite recursion
@@ -127,12 +124,9 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 			$resolvedAliasType = new CircularTypeAliasErrorType();
 		}
 
-		$this->resolvedLocalTypeAliases[$aliasNameInClassScope] = $resolvedAliasType;
-		if ($this->resolvedLocalTypeAliasesCountMax !== 0 && count($this->resolvedLocalTypeAliases) > $this->resolvedLocalTypeAliasesCountMax) {
-			// resolved alias types transitively pin ClassReflections and their whole
-			// reflection trees — evict the least recently used
-			unset($this->resolvedLocalTypeAliases[array_key_first($this->resolvedLocalTypeAliases)]);
-		}
+		// resolved alias types transitively pin ClassReflections and their whole
+		// reflection trees, so the cache is bounded and evicts the least recently used
+		$this->resolvedLocalTypeAliases->set($aliasNameInClassScope, $resolvedAliasType, 0);
 		unset($this->inProcess[$aliasNameInClassScope]);
 
 		return $resolvedAliasType;

--- a/src/Type/UsefulTypeAliasResolver.php
+++ b/src/Type/UsefulTypeAliasResolver.php
@@ -39,10 +39,10 @@ final class UsefulTypeAliasResolver implements TypeAliasResolver
 		private TypeNodeResolver $typeNodeResolver,
 		private ReflectionProvider $reflectionProvider,
 		#[AutowiredParameter(ref: '%cache.resolvedLocalTypeAliasesCountMax%')]
-		private int $resolvedLocalTypeAliasesCountMax,
+		int $resolvedLocalTypeAliasesCountMax,
 	)
 	{
-		$this->resolvedLocalTypeAliases = new LruCache($this->resolvedLocalTypeAliasesCountMax);
+		$this->resolvedLocalTypeAliases = new LruCache($resolvedLocalTypeAliasesCountMax);
 	}
 
 	public function hasTypeAlias(string $aliasName, ?string $classNameScope): bool


### PR DESCRIPTION
Follow-up to #5928, which introduced `LruCache` for the parser's file-contents memo. staabm asked in https://github.com/phpstan/phpstan-src/pull/5928#discussion_r3812265166 whether other places could use it - three could, and here they are.

| site | what it was doing |
| --- | --- |
| `PhpClassReflectionExtension::touchMemberCacheKey()` | an order map over four member caches; `set()` returning the evicted keys is what lets all four drop the same key |
| `FileTypeMapper::$memoryCache` | touch-on-hit plus a count-bounded eviction loop and a manual `$memoryCacheCount`, which `count()` replaces |
| `UsefulTypeAliasResolver::$resolvedLocalTypeAliases` | the same touch-on-hit and count bound |

Two deliberate non-changes:

- **`FileTypeMapper::$resolvedPhpDocBlockCache` is left alone.** It does not touch entries on a hit, so despite sitting next to an LRU it evicts in insertion order. Moving it would change its eviction policy, which wants measuring on its own rather than riding along in a refactor.
- **`nameScopeMapMemoryCacheCountMax: 0` keeps its odd meaning.** In the other three caches 0 means "no limit"; here the eviction loop ran *before* the insertion, so 0 emptied the cache and put a single entry back - a one-entry cache. The constructor maps it to `new LruCache(1)` so nobody who set that parameter to 0 gets an unbounded cache instead. Happy to normalise it to "no limit" in a separate PR if you would rather the four behaved alike; it is a behaviour change, so I did not fold it in.

Verification:

- Full suite 21334 tests, self-analysis clean, phpcs clean.
- Same errors reported before and after on an identical analysis (102 error lines over `src/Rules` + `src/Type/Php`, sorted diff clean).
- Same cache footprint, which is the part output equality cannot show: **1168** name-scope map misses, **2** local type alias misses and **910** member-cache evictions, identical on both sides, counted with probes at the miss and eviction sites.

No new tests: these are behaviour-preserving conversions of existing caches, and `LruCache` itself has `LruCacheTest` from #5928.
