### PR TITLE
uniqid: Tighten return type to non-falsy-string

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11282,7 +11282,7 @@ return [
 'UnexpectedValueException::getPrevious' => ['Throwable|UnexpectedValueException|null'],
 'UnexpectedValueException::getTrace' => ['list<array{function:string,line?:int,file?:string,class?:class-string,type?:\'::\'|\'->\',args?:list<mixed>,object?:object}>'],
 'UnexpectedValueException::getTraceAsString' => ['string'],
-'uniqid' => ['non-empty-string', 'prefix='=>'string', 'more_entropy='=>'bool'],
+'uniqid' => ['non-falsy-string', 'prefix='=>'string', 'more_entropy='=>'bool'],
 'unixtojd' => ['int|false', 'timestamp='=>'int'],
 'unlink' => ['bool', 'filename'=>'string', 'context='=>'resource'],
 'unpack' => ['array|false', 'format'=>'string', 'data'=>'string', 'offset='=>'int'],


### PR DESCRIPTION
This PR tightens the return type of the 'uniqid' function from non-empty-string to non-falsy-string.  The official documentation [1] of the uniqid function says:

> With an empty prefix, the returned string will be 13 characters long. If more_entropy is true, it will be 23 characters.

This implies that the returned string will be of length `strlen(prefix) + (more_entropy ? 23 : 13)`.
In either case, it will be of at least length 13. But the only falsy strings are `'0'` and `''` (both of length less than 13) [2]. Hence the return value will always be a non-falsy-string.

[1] https://www.php.net/manual/en/function.uniqid.php
[2] https://www.php.net/manual/en/language.types.boolean.php