### PR TITLE
Minor: Fix incorrect casing

### DIFF
--- a/src/Testing/PHPUnit/InitContainerBeforeDataProviderSubscriber.php
+++ b/src/Testing/PHPUnit/InitContainerBeforeDataProviderSubscriber.php
@@ -16,7 +16,7 @@ final class InitContainerBeforeDataProviderSubscriber implements DataProviderMet
 	{
 		$testClassName = $event->testMethod()->className();
 
-		if (!is_a($testClassName, PhpStanTestCase::class, true)) {
+		if (!is_a($testClassName, PHPStanTestCase::class, true)) {
 			return;
 		}
 

--- a/src/Testing/PHPUnit/InitContainerBeforeTestSubscriber.php
+++ b/src/Testing/PHPUnit/InitContainerBeforeTestSubscriber.php
@@ -22,7 +22,7 @@ final class InitContainerBeforeTestSubscriber implements PreparationStartedSubsc
 
 		$testClassName = $test->className();
 
-		if (!is_a($testClassName, PhpStanTestCase::class, true)) {
+		if (!is_a($testClassName, PHPStanTestCase::class, true)) {
 			return;
 		}
 


### PR DESCRIPTION
Just a couple of classes being used with the wrong name casing