### PR TITLE
Replay the recorded fixpoint pass instead of repeating the final loop walk

### DIFF
--- a/src/Analyser/ExpressionResultStorage.php
+++ b/src/Analyser/ExpressionResultStorage.php
@@ -41,4 +41,17 @@ final class ExpressionResultStorage
 		return $this->scopesById[spl_object_id($expr)] ?? null;
 	}
 
+	/**
+	 * Adopts every before-scope the other storage stored - a finished
+	 * convergence pass's stores answer for the final walk its replay
+	 * replaces.
+	 */
+	public function mergeResults(self $other): void
+	{
+		foreach ($other->exprsById as $id => $expr) {
+			$this->exprsById[$id] = $expr;
+			$this->scopesById[$id] = $other->scopesById[$id];
+		}
+	}
+
 }

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -106,6 +106,7 @@ use function array_slice;
 use function array_values;
 use function count;
 use function in_array;
+use function is_array;
 use function is_int;
 use function is_string;
 use function max;
@@ -913,6 +914,91 @@ class NodeScopeResolver
 		return [];
 	}
 
+	private const REPLAYABLE_BODY_ATTRIBUTE = 'convergenceReplayableBody';
+
+	/**
+	 * Whether a recorded convergence pass over the loop body can replace the
+	 * final walk. A pass runs at deep statement context, the final walk at top
+	 * level - constructs that analyse differently between the two (nested
+	 * loop/label fixpoints run only at top level, statement-level classes are
+	 * skipped at deep context) disqualify the body. Closure bodies process
+	 * context-independently and are not traversed.
+	 *
+	 * @param Node\Stmt[] $bodyStmts
+	 */
+	public function isReplayableConvergenceBody(Node $loopNode, array $bodyStmts): bool
+	{
+		$cached = $loopNode->getAttribute(self::REPLAYABLE_BODY_ATTRIBUTE);
+		if ($cached !== null) {
+			return $cached;
+		}
+
+		$replayable = true;
+		foreach ($bodyStmts as $bodyStmt) {
+			if ($this->hasContextSensitiveConstruct($bodyStmt)) {
+				$replayable = false;
+				break;
+			}
+		}
+		$loopNode->setAttribute(self::REPLAYABLE_BODY_ATTRIBUTE, $replayable);
+
+		return $replayable;
+	}
+
+	private function hasContextSensitiveConstruct(Node $node): bool
+	{
+		if ($node instanceof Expr\Closure) {
+			return false;
+		}
+		if (
+			$node instanceof Node\Stmt\While_
+			|| $node instanceof Node\Stmt\Do_
+			|| $node instanceof Node\Stmt\For_
+			|| $node instanceof Foreach_
+			|| $node instanceof Node\Stmt\Label
+			|| $node instanceof Node\Stmt\ClassLike
+		) {
+			return true;
+		}
+
+		foreach ($node->getSubNodeNames() as $subNodeName) {
+			$subNode = $node->$subNodeName;
+			if ($subNode instanceof Node) {
+				if ($this->hasContextSensitiveConstruct($subNode)) {
+					return true;
+				}
+			} elseif (is_array($subNode)) {
+				foreach ($subNode as $item) {
+					if ($item instanceof Node && $this->hasContextSensitiveConstruct($item)) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Replays a recorded convergence pass's emissions through the real node
+	 * callback in place of the final loop walk. The pass's storage was merged
+	 * into $storage by the caller; binding it for the whole replay lets the
+	 * recorded scopes answer rule asks from the stored before-scopes, the
+	 * same way the repeated walk's per-emission binding would.
+	 *
+	 * @param callable(Node $node, Scope $scope): void $nodeCallback
+	 */
+	public function replayRecording(RecordingNodeCallback $recording, callable $nodeCallback, ExpressionResultStorage $storage): void
+	{
+		$stack = $this->getExpressionResultStorageStack();
+		$stack->push($storage);
+		try {
+			$recording->replayThrough($nodeCallback);
+		} finally {
+			$stack->pop();
+		}
+	}
+
 	/**
 	 * @param callable(Node $node, Scope $scope): void $nodeCallback
 	 */
@@ -952,6 +1038,13 @@ class NodeScopeResolver
 		}
 
 		if ($nodeCallback instanceof NoopNodeCallback) {
+			return;
+		}
+
+		if ($nodeCallback instanceof RecordingNodeCallback) {
+			// recording never asks about types - the pairs are wrapped and
+			// bound to the storage at replay time instead
+			$nodeCallback($node, $scope);
 			return;
 		}
 
@@ -1126,15 +1219,29 @@ class NodeScopeResolver
 
 		$count = 0;
 		$closureResultScope = null;
+		$replayBodyRecording = null;
+		$replayPassStorage = null;
+		$replayPassResult = null;
+		$replayEntryScope = null;
+		$bodyIsReplayable = $this->isReplayableConvergenceBody($expr, $expr->stmts);
 		do {
 			$prevScope = $closureScope;
 
 			$storage = $originalStorage->duplicate();
+			$bodyRecording = $bodyIsReplayable ? new RecordingNodeCallback() : new NoopNodeCallback();
 			// deep context, like the loop handlers' own convergence passes: inner
 			// loops walk single-pass here and only the final walk below (top-level)
 			// runs their full convergence - otherwise every closure-convergence
 			// pass would re-converge every inner loop from scratch
-			$intermediaryClosureScopeResult = $this->processStmtNodesInternal($expr, $expr->stmts, $closureScope, $storage, new NoopNodeCallback(), StatementContext::createDeep());
+			$intermediaryClosureScopeResult = $this->processStmtNodesInternal($expr, $expr->stmts, $closureScope, $storage, $bodyRecording, StatementContext::createDeep());
+			// the candidate to replace the final walk when this pass's entry
+			// turns out to be the fixpoint
+			if ($bodyRecording instanceof RecordingNodeCallback) {
+				$replayBodyRecording = $bodyRecording;
+				$replayPassStorage = $storage;
+				$replayPassResult = $intermediaryClosureScopeResult;
+				$replayEntryScope = $prevScope;
+			}
 			$intermediaryClosureScope = $intermediaryClosureScopeResult->getScope();
 			foreach ($intermediaryClosureScopeResult->getExitPoints() as $exitPoint) {
 				$intermediaryClosureScope = $intermediaryClosureScope->mergeWith($exitPoint->getScope());
@@ -1162,7 +1269,24 @@ class NodeScopeResolver
 		}
 
 		$storage = $originalStorage;
-		$statementResult = $this->processStmtNodesInternal($expr, $expr->stmts, $closureScope, $storage, $closureStmtsCallback, StatementContext::createTopLevel());
+		if (
+			$replayBodyRecording !== null && $replayPassStorage !== null
+			&& $replayPassResult !== null && $replayEntryScope !== null
+			&& $closureScope->equals($replayEntryScope)
+		) {
+			// the final walk would repeat the recorded fixpoint pass exactly
+			// (same entry scope, deterministic walk) - adopt the pass's result
+			// and replay its emissions through the gathering callback instead.
+			// The pass's own entry scope takes over: the recorded pairs carry
+			// its anonymous-function reflection, which the gathering filter
+			// compares by identity (the state is equals-identical anyway).
+			$closureScope = $replayEntryScope;
+			$originalStorage->mergeResults($replayPassStorage);
+			$this->replayRecording($replayBodyRecording, $closureStmtsCallback, $originalStorage);
+			$statementResult = $replayPassResult;
+		} else {
+			$statementResult = $this->processStmtNodesInternal($expr, $expr->stmts, $closureScope, $storage, $closureStmtsCallback, StatementContext::createTopLevel());
+		}
 		$publicStatementResult = $statementResult->toPublic();
 		$closureReturnStatementsNodeScope = $this->refineClosureNodeScope($closureScope, $scope, $expr, $gatheredReturnStatementsWithScope, $gatheredYieldStatementsWithScope, $executionEnds, $statementResult->getThrowPoints(), array_merge($closureImpurePoints, $statementResult->getImpurePoints()), $invalidateExpressions);
 		$this->callNodeCallback($nodeCallback, new ClosureReturnStatementsNode(

--- a/src/Analyser/RecordingNodeCallback.php
+++ b/src/Analyser/RecordingNodeCallback.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Records every (node, scope) emission of a convergence pass in order. When
+ * the pass turns out to be the fixpoint (the final walk's entry scope equals
+ * the pass's entry), the final walk is replaced by replaying the recording
+ * through the real node callback - the scopes are state-equal to what the
+ * repeated walk would emit.
+ *
+ * Recording appends the raw walk scope - nothing asks about types until a
+ * replay happens, so the pass pays no callback-scope construction and no
+ * storage binding. replayThrough() wraps each pair the way
+ * NodeScopeResolver::callNodeCallback() would have.
+ */
+final class RecordingNodeCallback
+{
+
+	/** @var list<array{Node, Scope}> */
+	private array $pairs = [];
+
+	public function __invoke(Node $node, Scope $scope): void
+	{
+		$this->pairs[] = [$node, $scope];
+	}
+
+	/**
+	 * @param callable(Node $node, Scope $scope): void $nodeCallback
+	 */
+	public function replayThrough(callable $nodeCallback): void
+	{
+		foreach ($this->pairs as [$node, $scope]) {
+			if (!$scope instanceof MutatingScope) {
+				throw new ShouldNotHappenException();
+			}
+			$nodeCallback($node, $scope->toNodeCallbackScope());
+		}
+	}
+
+}

--- a/src/Analyser/StmtHandler/DoWhileHandler.php
+++ b/src/Analyser/StmtHandler/DoWhileHandler.php
@@ -12,6 +12,7 @@ use PHPStan\Analyser\InternalStatementResult;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\NoopNodeCallback;
+use PHPStan\Analyser\RecordingNodeCallback;
 use PHPStan\Analyser\StatementContext;
 use PHPStan\Analyser\StmtHandler;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -48,8 +49,12 @@ final class DoWhileHandler implements StmtHandler
 		$impurePoints = [];
 		$originalStorage = $storage;
 
+		$replayBodyRecording = null;
+		$replayPassStorage = null;
+		$replayPassResult = null;
+		$prevEntryScope = null;
 		if ($context->isTopLevel()) {
-			$prevEntryScope = null;
+			$bodyIsReplayable = $nodeScopeResolver->isReplayableConvergenceBody($stmt, $stmt->stmts);
 			do {
 				$prevScope = $bodyScope;
 				$bodyScope = $bodyScope->mergeWith($scope);
@@ -62,7 +67,8 @@ final class DoWhileHandler implements StmtHandler
 				}
 				$prevEntryScope = $bodyScope;
 				$storage = $originalStorage->duplicate();
-				$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, new NoopNodeCallback(), $context->enterDeep())->filterOutLoopExitPoints();
+				$bodyRecording = $bodyIsReplayable ? new RecordingNodeCallback() : new NoopNodeCallback();
+				$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $bodyRecording, $context->enterDeep())->filterOutLoopExitPoints();
 				$alwaysTerminating = $bodyScopeResult->isAlwaysTerminating();
 				$bodyScope = $bodyScopeResult->getScope();
 				foreach ($bodyScopeResult->getExitPointsByType(Continue_::class) as $continueExitPoint) {
@@ -71,6 +77,13 @@ final class DoWhileHandler implements StmtHandler
 				$finalScope = $alwaysTerminating ? $finalScope : $bodyScope->mergeWith($finalScope);
 				foreach ($bodyScopeResult->getExitPointsByType(Break_::class) as $breakExitPoint) {
 					$finalScope = $breakExitPoint->getScope()->mergeWith($finalScope);
+				}
+				// the candidate to replace the final body walk when this pass's
+				// entry turns out to be the fixpoint
+				if ($bodyRecording instanceof RecordingNodeCallback) {
+					$replayBodyRecording = $bodyRecording;
+					$replayPassStorage = $storage;
+					$replayPassResult = $bodyScopeResult;
 				}
 				$bodyScope = $nodeScopeResolver->processExprNode($stmt, $stmt->cond, $bodyScope, $storage, new NoopNodeCallback(), ExpressionContext::createDeep())->getTruthyScope();
 				if ($bodyScope->equals($prevScope)) {
@@ -87,7 +100,20 @@ final class DoWhileHandler implements StmtHandler
 		}
 
 		$storage = $originalStorage;
-		$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $nodeCallback, $context)->filterOutLoopExitPoints();
+		if (
+			$replayBodyRecording !== null && $replayPassStorage !== null && $replayPassResult !== null
+			&& $prevEntryScope !== null && $bodyScope->equals($prevEntryScope)
+		) {
+			// the final body walk would repeat the recorded fixpoint pass exactly
+			// (same entry scope, deterministic walk) - adopt the pass's results
+			// and replay its emissions through the real callback instead; the
+			// condition walks below stay real
+			$originalStorage->mergeResults($replayPassStorage);
+			$nodeScopeResolver->replayRecording($replayBodyRecording, $nodeCallback, $originalStorage);
+			$bodyScopeResult = $replayPassResult;
+		} else {
+			$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $nodeCallback, $context)->filterOutLoopExitPoints();
+		}
 		$bodyScope = $bodyScopeResult->getScope();
 		foreach ($bodyScopeResult->getExitPointsByType(Continue_::class) as $continueExitPoint) {
 			$bodyScope = $bodyScope->mergeWith($continueExitPoint->getScope());

--- a/src/Analyser/StmtHandler/ForeachHandler.php
+++ b/src/Analyser/StmtHandler/ForeachHandler.php
@@ -28,6 +28,7 @@ use PHPStan\Analyser\InternalThrowPoint;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\NoopNodeCallback;
+use PHPStan\Analyser\RecordingNodeCallback;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\StatementContext;
 use PHPStan\Analyser\StmtHandler;
@@ -135,6 +136,10 @@ final class ForeachHandler implements StmtHandler
 		$iterateeScope = $nodeScopeResolver->shouldPolluteScopeWithAlwaysIterableForeach() ? $scope->filterByTruthyValue($arrayComparisonExpr) : $scope;
 
 		$originalStorage = $storage;
+		$replayBodyRecording = null;
+		$replayPassStorage = null;
+		$replayPassResult = null;
+		$replayEntryScope = null;
 		$unrolledEndScope = null;
 		$unrolledTotalKeys = null;
 		if ($context->isTopLevel()) {
@@ -152,6 +157,7 @@ final class ForeachHandler implements StmtHandler
 				$bodyScope = $this->enterForeach($nodeScopeResolver, $originalScope, $storage, $originalScope, $stmt, $foreachIterateeType, $foreachNativeIterateeType, $nodeCallback);
 				$count = 0;
 				$prevEntryScope = null;
+				$bodyIsReplayable = $nodeScopeResolver->isReplayableConvergenceBody($stmt, $stmt->stmts);
 				do {
 					$prevScope = $bodyScope;
 					$bodyScope = $bodyScope->mergeWith($iterateeScope);
@@ -164,10 +170,19 @@ final class ForeachHandler implements StmtHandler
 					$prevEntryScope = $bodyScope;
 					$storage = $originalStorage->duplicate();
 					$bodyScope = $this->enterForeach($nodeScopeResolver, $bodyScope, $storage, $originalScope, $stmt, $foreachIterateeType, $foreachNativeIterateeType, $nodeCallback);
-					$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, new NoopNodeCallback(), $context->enterDeep())->filterOutLoopExitPoints();
+					$bodyRecording = $bodyIsReplayable ? new RecordingNodeCallback() : new NoopNodeCallback();
+					$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $bodyRecording, $context->enterDeep())->filterOutLoopExitPoints();
 					$bodyScope = $bodyScopeResult->getScope();
 					foreach ($bodyScopeResult->getExitPointsByType(Continue_::class) as $continueExitPoint) {
 						$bodyScope = $bodyScope->mergeWith($continueExitPoint->getScope());
+					}
+					// the candidate to replace the final walk when this pass's
+					// entry turns out to be the fixpoint
+					if ($bodyRecording instanceof RecordingNodeCallback) {
+						$replayBodyRecording = $bodyRecording;
+						$replayPassStorage = $storage;
+						$replayPassResult = $bodyScopeResult;
+						$replayEntryScope = $prevEntryScope;
 					}
 					if ($bodyScope->equals($prevScope)) {
 						break;
@@ -182,10 +197,24 @@ final class ForeachHandler implements StmtHandler
 		}
 
 		$bodyScope = $bodyScope->mergeWith($iterateeScope);
+		$finalEntryScope = $bodyScope;
 		$storage = $originalStorage;
 		$bodyScope = $this->enterForeach($nodeScopeResolver, $bodyScope, $storage, $originalScope, $stmt, $foreachIterateeType, $foreachNativeIterateeType, $nodeCallback);
-		$finalPassContext = $unrolledTotalKeys !== null ? $context->enterUnrolledForeach($unrolledTotalKeys) : $context;
-		$finalScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $nodeCallback, $finalPassContext)->filterOutLoopExitPoints();
+		if (
+			$replayBodyRecording !== null && $replayPassStorage !== null
+			&& $replayPassResult !== null && $replayEntryScope !== null
+			&& $unrolledTotalKeys === null && $finalEntryScope->equals($replayEntryScope)
+		) {
+			// the final walk would repeat the recorded fixpoint pass exactly
+			// (same entry scope, deterministic walk) - adopt the pass's results
+			// and replay its emissions through the real callback instead
+			$originalStorage->mergeResults($replayPassStorage);
+			$nodeScopeResolver->replayRecording($replayBodyRecording, $nodeCallback, $originalStorage);
+			$finalScopeResult = $replayPassResult;
+		} else {
+			$finalPassContext = $unrolledTotalKeys !== null ? $context->enterUnrolledForeach($unrolledTotalKeys) : $context;
+			$finalScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $nodeCallback, $finalPassContext)->filterOutLoopExitPoints();
+		}
 		$finalScope = $finalScopeResult->getScope();
 		$scopesWithIterableValueType = [];
 

--- a/src/Analyser/StmtHandler/WhileHandler.php
+++ b/src/Analyser/StmtHandler/WhileHandler.php
@@ -12,6 +12,7 @@ use PHPStan\Analyser\InternalStatementResult;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\NoopNodeCallback;
+use PHPStan\Analyser\RecordingNodeCallback;
 use PHPStan\Analyser\StatementContext;
 use PHPStan\Analyser\StmtHandler;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -61,9 +62,14 @@ final class WhileHandler implements StmtHandler
 		}
 		$bodyScope = $condResult->getTruthyScope();
 
+		$replayCondRecording = null;
+		$replayBodyRecording = null;
+		$replayPassStorage = null;
+		$replayPassResult = null;
+		$prevEntryScope = null;
 		if ($context->isTopLevel()) {
 			$count = 0;
-			$prevEntryScope = null;
+			$bodyIsReplayable = $nodeScopeResolver->isReplayableConvergenceBody($stmt, $stmt->stmts);
 			do {
 				$prevScope = $bodyScope;
 				$bodyScope = $bodyScope->mergeWith($scope);
@@ -75,11 +81,21 @@ final class WhileHandler implements StmtHandler
 				}
 				$prevEntryScope = $bodyScope;
 				$storage = $originalStorage->duplicate();
-				$bodyScope = $nodeScopeResolver->processExprNode($stmt, $stmt->cond, $bodyScope, $storage, new NoopNodeCallback(), ExpressionContext::createDeep())->getTruthyScope();
-				$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, new NoopNodeCallback(), $context->enterDeep())->filterOutLoopExitPoints();
+				$condRecording = $bodyIsReplayable ? new RecordingNodeCallback() : new NoopNodeCallback();
+				$bodyRecording = $bodyIsReplayable ? new RecordingNodeCallback() : new NoopNodeCallback();
+				$bodyScope = $nodeScopeResolver->processExprNode($stmt, $stmt->cond, $bodyScope, $storage, $condRecording, ExpressionContext::createDeep())->getTruthyScope();
+				$bodyScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $bodyRecording, $context->enterDeep())->filterOutLoopExitPoints();
 				$bodyScope = $bodyScopeResult->getScope();
 				foreach ($bodyScopeResult->getExitPointsByType(Continue_::class) as $continueExitPoint) {
 					$bodyScope = $bodyScope->mergeWith($continueExitPoint->getScope());
+				}
+				// the candidate to replace the final walk when this pass's
+				// entry turns out to be the fixpoint
+				if ($condRecording instanceof RecordingNodeCallback && $bodyRecording instanceof RecordingNodeCallback) {
+					$replayCondRecording = $condRecording;
+					$replayBodyRecording = $bodyRecording;
+					$replayPassStorage = $storage;
+					$replayPassResult = $bodyScopeResult;
 				}
 				if ($bodyScope->equals($prevScope)) {
 					break;
@@ -95,8 +111,22 @@ final class WhileHandler implements StmtHandler
 		$bodyScope = $bodyScope->mergeWith($scope);
 		$bodyScopeMaybeRan = $bodyScope;
 		$storage = $originalStorage;
-		$bodyScope = $nodeScopeResolver->processExprNode($stmt, $stmt->cond, $bodyScope, $storage, $nodeCallback, ExpressionContext::createDeep())->getTruthyScope();
-		$finalScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $nodeCallback, $context)->filterOutLoopExitPoints();
+		if (
+			$replayCondRecording !== null && $replayBodyRecording !== null
+			&& $replayPassStorage !== null && $replayPassResult !== null
+			&& $prevEntryScope !== null && $bodyScope->equals($prevEntryScope)
+		) {
+			// the final walk would repeat the recorded fixpoint pass exactly
+			// (same entry scope, deterministic walk) - adopt the pass's results
+			// and replay its emissions through the real callback instead
+			$originalStorage->mergeResults($replayPassStorage);
+			$nodeScopeResolver->replayRecording($replayCondRecording, $nodeCallback, $originalStorage);
+			$nodeScopeResolver->replayRecording($replayBodyRecording, $nodeCallback, $originalStorage);
+			$finalScopeResult = $replayPassResult;
+		} else {
+			$bodyScope = $nodeScopeResolver->processExprNode($stmt, $stmt->cond, $bodyScope, $storage, $nodeCallback, ExpressionContext::createDeep())->getTruthyScope();
+			$finalScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $nodeCallback, $context)->filterOutLoopExitPoints();
+		}
 		$finalScope = $finalScopeResult->getScope()->filterByFalseyValue($stmt->cond);
 
 		$alwaysIterates = false;

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -20,7 +20,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '4cc5e5e';
+	public const EXPECTED_EXTENSION_VERSION = '83f3b7a';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/turbo-ext/src/ExpressionResultStorage.cpp
+++ b/turbo-ext/src/ExpressionResultStorage.cpp
@@ -58,6 +58,24 @@ public:
 		return zv::Val::copyOf(found);
 	}
 
+	void mergeResults(zval *other)
+	{
+		zv::ObjRef dst(self);
+		zv::ObjRef src(other);
+		zv::ArrRef dstExprs(dst.propAt(PT_ERS_PROP_EXPRS).raw());
+		zv::ArrRef dstScopes(dst.propAt(PT_ERS_PROP_SCOPES).raw());
+		zv::ArrRef srcScopes(src.propAt(PT_ERS_PROP_SCOPES).raw());
+		zend_ulong id;
+		zval *exprZv;
+		ZEND_HASH_FOREACH_NUM_KEY_VAL(Z_ARRVAL_P(src.propAt(PT_ERS_PROP_EXPRS).raw()), id, exprZv) {
+			dstExprs.setIndex(id, zv::Ref(exprZv));
+			zv::Ref scopeRef = srcScopes.findIndex(id);
+			if (scopeRef.raw() != NULL) {
+				dstScopes.setIndex(id, scopeRef);
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
+
 private:
 	zval *self;
 };
@@ -102,6 +120,14 @@ void pt_register_expression_result_storage()
 			Z_PARAM_OBJECT(expr)
 		ZEND_PARSE_PARAMETERS_END();
 		ExpressionResultStorage(ZEND_THIS).findBeforeScope(expr).intoReturnValue(return_value);
+	});
+
+	cls.method("mergeResults", reg::Public, 1, { reg::any("other") }, [](INTERNAL_FUNCTION_PARAMETERS) {
+		zval *other;
+		ZEND_PARSE_PARAMETERS_START(1, 1)
+			Z_PARAM_OBJECT(other)
+		ZEND_PARSE_PARAMETERS_END();
+		ExpressionResultStorage(ZEND_THIS).mergeResults(other);
 	});
 
 	cls.register_();

--- a/turbo-ext/tests/smoke.php
+++ b/turbo-ext/tests/smoke.php
@@ -327,6 +327,12 @@ foreach (['php' => \PHPStan\Analyser\ExpressionResultStorage::class, 'native' =>
 	$storage->storeBeforeScope($exprB, $scopeB);
 	check($duplicate->findBeforeScope($exprB) === $scopeA, "ERS $label: original stores do not leak into the duplicate");
 
+	$exprC = new \PhpParser\Node\Expr\Variable('c');
+	$duplicate->storeBeforeScope($exprC, $scopeB);
+	$storage->mergeResults($duplicate);
+	check($storage->findBeforeScope($exprB) === $scopeA, "ERS $label: mergeResults overwrites with the other storage's entry");
+	check($storage->findBeforeScope($exprC) === $scopeB, "ERS $label: mergeResults adopts new entries");
+	check($duplicate->findBeforeScope($exprA) === $scopeB, "ERS $label: mergeResults leaves the source untouched");
 }
 
 // ---- ScopeOps::mergeVariableHolders differingKeys ----


### PR DESCRIPTION
Second extraction chunk from the single-pass analyser branch (follow-up to #6248).

Loop convergence walks the body repeatedly until the entry scope reaches a fixpoint, then walks it once more with the real node callback. When the final walk's entry scope equals the last pass's entry, that final walk reproduces the pass exactly — walking is deterministic in the entry scope. This PR records the last pass's `(node, scope)` emissions and its expression-result storage, and when the equality holds, replays the recording through the real callback instead of walking again.

- `RecordingNodeCallback` records raw walk scopes — recording pays no callback-scope construction and no storage binding (short-circuited in `callNodeCallback`); pairs are wrapped via `toNodeCallbackScope()` only at replay time.
- Replay sites: `while` (cond + body), `do-while` (body only — its condition walks stay real), non-unrolled `foreach`, and closure by-ref convergence.
- `isReplayableConvergenceBody()` excludes bodies with context-sensitive constructs (nested loops, labels, class-likes) where deep vs top-level analysis differs.
- `ExpressionResultStorage::mergeResults()` adopts the recorded pass's stored results into the surrounding storage (PHP twin + turbo mirror, smoke-covered).

Benchmarks (user CPU, 3+3 interleaved legs, toggled within one checkout):

| corpus | before | after | Δ |
|---|---|---|---|
| self-analysis (`--debug src`) | 77.99s | 75.63s | **−3.0%** |
| WordPress core (e2e corpus, level 0) | 173.47s | 167.97s | **−3.2%** |

Analysis output is unchanged (full test suite; turbo on/off self-analysis output byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnwgpaeUXRkgSDyg95tfK8
