### PR TITLE
Reset expression analysis state in ExpressionResultTest

### DIFF
--- a/tests/PHPStan/Analyser/ExpressionResultTest.php
+++ b/tests/PHPStan/Analyser/ExpressionResultTest.php
@@ -204,6 +204,7 @@ class ExpressionResultTest extends PHPStanTestCase
 			->assignVariable('x', new IntegerType(), new IntegerType(), TrinaryLogic::createYes())
 			->assignVariable('arr', new ArrayType(new MixedType(), new MixedType()), new ArrayType(new MixedType(), new MixedType()), TrinaryLogic::createYes());
 
+		$nodeScopeResolver->resetPerFileAnalysisState();
 		$result = $nodeScopeResolver->processExprNode(
 			$stmt,
 			$expr,


### PR DESCRIPTION
 `ExpressionResultTest` calls `NodeScopeResolver::processExprNode()` directly for multiple data-provider cases. Unlike normal file analysis, this path did not reset per-file resolver state first.

Cached closure types can therefore survive between cases and be read again when PHP reuses a `spl_object_id()`. Reset the resolver before each direct expression analysis so the test follows the normal per-file lifecycle and does not depend on test order.