### PR TITLE
Isolate intersection test toggle state

### DIFF
--- a/tests/PHPStan/Type/IntersectionTypeTest.php
+++ b/tests/PHPStan/Type/IntersectionTypeTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use DoctrineIntersectionTypeIsSupertypeOf\Collection;
 use Iterator;
 use ObjectTypeEnums\FooEnum;
+use PHPStan\DependencyInjection\BleedingEdgeToggle;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -132,20 +133,20 @@ class IntersectionTypeTest extends PHPStanTestCase
 		// array&callable isAcceptedBy constantArray{stdClass, string} - maybe
 		yield [
 			new IntersectionType([new ArrayType(new MixedType(), new MixedType()), new CallableType()]),
-			new ConstantArrayType(
+			BleedingEdgeToggle::withBleedingEdge(false, static fn (): ConstantArrayType => new ConstantArrayType(
 				[new ConstantIntegerType(0), new ConstantIntegerType(1)],
 				[new UnionType([new ObjectType('stdClass'), new StringType()]), new StringType()],
-			),
+			)),
 			TrinaryLogic::createMaybe(),
 		];
 
 		// array&callable isAcceptedBy constantArray{string, string} - maybe
 		yield [
 			new IntersectionType([new ArrayType(new MixedType(), new MixedType()), new CallableType()]),
-			new ConstantArrayType(
+			BleedingEdgeToggle::withBleedingEdge(false, static fn (): ConstantArrayType => new ConstantArrayType(
 				[new ConstantIntegerType(0), new ConstantIntegerType(1)],
 				[new StringType(), new StringType()],
-			),
+			)),
 			TrinaryLogic::createMaybe(),
 		];
 
@@ -189,10 +190,10 @@ class IntersectionTypeTest extends PHPStanTestCase
 				new NonEmptyArrayType(),
 				new HasOffsetValueType(new ConstantIntegerType(0), new IntegerType()),
 			]),
-			new ConstantArrayType(
+			BleedingEdgeToggle::withBleedingEdge(false, static fn (): ConstantArrayType => new ConstantArrayType(
 				[new ConstantIntegerType(0), new ConstantIntegerType(1)],
 				[new IntegerType(), new IntegerType()],
-			),
+			)),
 			TrinaryLogic::createMaybe(),
 		];
 
@@ -203,10 +204,10 @@ class IntersectionTypeTest extends PHPStanTestCase
 				new NonEmptyArrayType(),
 				new HasOffsetValueType(new ConstantIntegerType(0), new IntegerType()),
 			]),
-			new ConstantArrayType(
+			BleedingEdgeToggle::withBleedingEdge(false, static fn (): ConstantArrayType => new ConstantArrayType(
 				[new ConstantIntegerType(0), new ConstantIntegerType(1)],
 				[new StringType(), new StringType()],
-			),
+			)),
 			TrinaryLogic::createNo(),
 		];
 


### PR DESCRIPTION
Reused ParaTest workers can leave the global bleeding-edge toggle enabled. This changes the array shapes constructed by toggle-sensitive IntersectionType test fixtures and makes their expected trinary results depend on test order.

Construct those fixtures with bleeding edge disabled so they retain their intended unsealed-array semantics without changing the surrounding test state.

Failure in PR #6254: [Tests with old PHPUnit (7.4, windows-latest)](https://github.com/phpstan/phpstan-src/actions/runs/32731324024/job/97443980399).