### PR TITLE
Return the operand from union() for equal array operands, not just identical ones

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -232,8 +232,22 @@ final class TypeCombinator
 				return $b;
 			}
 
-			// union(X, X) = X (same object identity)
-			if ($a === $b) {
+			// union(X, X) = X — for equal array operands, not just identical
+			// ones. For arrays the general path below is not a no-op on a pair
+			// that already denotes a single type: it rebuilds them from
+			// ArrayType::getIterableKeyType(), which coerces a subtracted key
+			// type down to the plain array-key union, so `array<mixed~'User',
+			// mixed>` unioned with an equal instance came back as plain
+			// `array`. Whether the two operands happen to be the same object
+			// must not decide the result.
+			//
+			// Non-array operands keep taking the general path. It is lossless
+			// for them, and it has to stay in charge because `equals()` is
+			// weaker than interchangeability for some types: a benevolent
+			// `(int|string)` equals a plain `int|string` and `Foo=final` equals
+			// `Foo`, and there the general path deliberately yields the wider
+			// operand rather than whichever one was passed first.
+			if ($a === $b || ($a->equals($b) && $a->isArray()->yes())) {
 				return $a;
 			}
 		}

--- a/tests/PHPStan/Rules/Variables/data/bug-8113.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-8113.php
@@ -44,5 +44,5 @@ function () {
 		unset($review['Review']['User']);
 		assertType("non-empty-array&hasOffsetValue('Review', array<mixed~'User', mixed>)&hasOffsetValue('User', mixed)", $review);
 	}
-	assertType("non-empty-array&hasOffsetValue('Review', array)", $review);
+	assertType("non-empty-array&hasOffsetValue('Review', array<mixed~'User', mixed>)", $review);
 };

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -937,6 +937,18 @@ class TypeCombinatorTest extends PHPStanTestCase
 				IntersectionType::class,
 				'list{object, \'foo\'}&callable(): mixed',
 			],
+			// Equal-but-distinct array operands must union to the same type as
+			// identical ones. Reconstructing the pair through
+			// ArrayType::getIterableKeyType() would coerce the subtracted key
+			// away and yield plain 'array'.
+			[
+				[
+					new ArrayType(new MixedType(subtractedType: new ConstantStringType('User')), new MixedType()),
+					new ArrayType(new MixedType(subtractedType: new ConstantStringType('User')), new MixedType()),
+				],
+				ArrayType::class,
+				'array<mixed~\'User\', mixed>',
+			],
 			[
 				[
 					new IntersectionType([new ArrayType(new MixedType(), new MixedType()), new NonEmptyArrayType()]),


### PR DESCRIPTION
This bug fix blocks some of the performance work I'm currently doing since it causes inconsistent type identity results.

TypeCombinator::doUnion()'s two-operand fast path returned `$a` when `$a === $b`, so whether the two operands happened to be the same object decided the result. For equal-but-distinct array operands the general path ran instead, and it is not a no-op on a pair that already denotes a single type: processArrayTypes() rebuilds two-or-more array operands from ArrayType::getIterableKeyType(), which coerces a `mixed` key down to the plain array-key union and drops its subtraction along the way. So

    $mk = fn () => new ArrayType(new MixedType(subtractedType: new ConstantStringType('User')), new MixedType());
    union($mk(), $mk());   // array
    union($one, $one);     // array<mixed~'User', mixed>

Extend the fast path to equal array operands. Arrays only: for everything else the general path is lossless, and it has to stay in charge because equals() is weaker than interchangeability for some types — a benevolent `(int|string)` equals a plain `int|string`, and `Foo=final` equals `Foo` — where the general path deliberately yields the wider of the two rather than whichever one was passed first. Both cases are covered by existing TypeCombinatorTest data sets.

The bug-8113 expectation moves with it, and is a genuine precision gain: at that join `array_key_exists('User', $review['Review'])` leaves `$review['Review']` as `array<mixed~'User', mixed>` in *both* branches, so the union is of a type with an equal type and must keep the subtraction.

Serial self-analysis of src, order-rotated: no detectable cost from the added equals() call (before 97-123 s, after 101-116 s user CPU).