### PR TITLE
Fork parallel workers whenever the turbo extension is active

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -10,6 +10,7 @@ use PHPStan\Command\FixerWorkerCommand;
 use PHPStan\Command\WorkerCommand;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Turbo\TurboExtensionEnabler;
+use PHPStan\Turbo\TurboProcessRestarter;
 use Symfony\Component\Console\Helper\ProgressBar;
 
 (function () {
@@ -24,6 +25,9 @@ use Symfony\Component\Console\Helper\ProgressBar;
 	define('__PHPSTAN_RUNNING__', true);
 
 	require_once __DIR__ . '/../src/Turbo/TurboExtensionEnabler.php';
+	require_once __DIR__ . '/../src/Turbo/TurboExtensionSelector.php';
+	require_once __DIR__ . '/../src/Turbo/TurboProcessRestarter.php';
+	TurboProcessRestarter::restartIfSuitable($_SERVER['argv']);
 	TurboExtensionEnabler::enableIfLoaded();
 
 	$analysisStartTime = microtime(true);

--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -150,6 +150,11 @@ parameters:
 			path: PHPStan/Build/TurboAttributeCollector.php
 			reportUnmatched: false
 		-
+			# called from bin/phpstan before the autoloader, outside the analysed paths
+			identifier: shipmonk.deadMethod
+			message: '#^Unused PHPStan\\Turbo\\TurboProcessRestarter::restartIfSuitable#'
+			reportUnmatched: false
+		-
 			# the turbo extension shadows this seam class; the nullable returns
 			# are the contract of the pair, the PHP twin honestly never hits
 			message: '#^Method PHPStan\\Cache\\ArenaCache\:\:(?:create|lookupHashAll)\(\) never returns .+ so it can be removed from the return type\.$#'

--- a/src/Parallel/ForkParallelChecker.php
+++ b/src/Parallel/ForkParallelChecker.php
@@ -5,8 +5,8 @@ namespace PHPStan\Parallel;
 use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Diagnose\DiagnoseExtension;
+use PHPStan\Turbo\TurboExtensionEnabler;
 use function function_exists;
-use function getenv;
 use function opcache_get_status;
 use function sprintf;
 
@@ -14,10 +14,22 @@ use function sprintf;
  * Decides whether parallel analysis should fork workers via pcntl_fork()
  * (see ForkedProcess) instead of spawning fresh PHP processes (see SpawnedProcess).
  *
- * Experimental and opt-in: enabled only when PHPSTAN_PARALLEL_FORK=1 is set,
- * the pcntl/posix functions exist, and OPcache + JIT are both off — their
- * shared memory is not safe to populate concurrently from forked children and
- * doing so corrupts analysis results.
+ * Fork is used whenever possible — a forked worker inherits the booted
+ * process and skips the application re-boot a spawned one pays. It requires:
+ *
+ * - pcntl/posix functions (not available on Windows — always spawn there)
+ * - the turbo extension, active with the expected version. A forked worker
+ *   inherits the parent's extensions, so the spawn-time `-d extension=`
+ *   injection cannot reach it — TurboProcessRestarter re-executes the main
+ *   process with the distributed binary loaded when needed. The extension
+ *   also arms the phar-fork-guard: libphar serves phar:// reads through one
+ *   shared per-archive fd whose seek cursor forked processes race on,
+ *   corrupting reads — the guard gives each forked child a private cursor.
+ *   Without it, running from a phar would corrupt analysis, so no turbo
+ *   means spawn.
+ * - OPcache + JIT off — their shared memory is not safe to populate
+ *   concurrently from forked children and doing so corrupts analysis
+ *   results.
  */
 #[AutowiredService]
 final class ForkParallelChecker implements DiagnoseExtension
@@ -34,15 +46,13 @@ final class ForkParallelChecker implements DiagnoseExtension
 
 		$reason = $this->getDisabledReason();
 		if ($reason === null) {
-			$output->writeLineFormatted('Mechanism:                 fork (pcntl_fork — experimental)');
+			$output->writeLineFormatted('Mechanism:                 fork (pcntl_fork)');
 			$output->writeLineFormatted('');
 			return;
 		}
 
 		$output->writeLineFormatted('Mechanism:                 spawn (react/child-process)');
-		if (getenv('PHPSTAN_PARALLEL_FORK') === '1') {
-			$output->writeLineFormatted(sprintf('Reason fork not used:      %s', $reason));
-		}
+		$output->writeLineFormatted(sprintf('Reason fork not used:      %s', $reason));
 		$output->writeLineFormatted('');
 	}
 
@@ -58,8 +68,8 @@ final class ForkParallelChecker implements DiagnoseExtension
 			return 'pcntl/posix functions are not available';
 		}
 
-		if (getenv('PHPSTAN_PARALLEL_FORK') !== '1') {
-			return 'PHPSTAN_PARALLEL_FORK environment variable is not set to "1"';
+		if (!TurboExtensionEnabler::isActive()) {
+			return 'the turbo extension is not active (see the Turbo extension section)';
 		}
 
 		if ($this->isOpcacheOrJitEnabled()) {

--- a/src/Turbo/TurboDiagnoseExtension.php
+++ b/src/Turbo/TurboDiagnoseExtension.php
@@ -43,7 +43,12 @@ final class TurboDiagnoseExtension implements DiagnoseExtension
 		));
 
 		if (TurboExtensionEnabler::isLoaded()) {
-			$workerBinaryLine = 'loaded via php.ini, workers inherit it';
+			$restartPath = TurboProcessRestarter::getRestartExtensionPath();
+			if ($restartPath !== null) {
+				$workerBinaryLine = sprintf('%s (loaded via process restart)', $restartPath);
+			} else {
+				$workerBinaryLine = 'loaded via php.ini, workers inherit it';
+			}
 		} else {
 			$workerBinaryLine = $workerBinary ?? 'none found';
 		}

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -22,7 +22,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '83f3b7a';
+	public const EXPECTED_EXTENSION_VERSION = 'f529bad';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -2,7 +2,9 @@
 
 namespace PHPStan\Turbo;
 
+use Phar;
 use PHPStanTurbo\Runtime;
+use function class_exists;
 use function dirname;
 use function extension_loaded;
 use function file_get_contents;
@@ -149,6 +151,18 @@ final class TurboExtensionEnabler
 		// autoloader registers, so later references to the original names
 		// resolve to them.
 		require_once $stubsFile;
+
+		// When running from a phar, arm the pthread_atfork hooks that keep
+		// phar:// reads safe in pcntl_fork()ed workers — libphar serves them
+		// through one shared archive fd whose seek cursor forked processes
+		// would otherwise race on. Fork mode requires the guard, and
+		// ForkParallelChecker only allows fork with the extension active.
+		if (class_exists('Phar', false)) {
+			$pharPath = Phar::running(false);
+			if ($pharPath !== '') {
+				Runtime::enablePharForkGuard($pharPath);
+			}
+		}
 
 		self::$typeCombinatorCacheEnabled = true;
 		self::$enabled = true;

--- a/src/Turbo/TurboExtensionSelector.php
+++ b/src/Turbo/TurboExtensionSelector.php
@@ -18,7 +18,9 @@ use const PHP_ZTS;
 
 /**
  * Locates the distributed turbo extension binary matching the current runtime
- * so worker processes can load it via `-d extension=`.
+ * so it can be loaded via `-d extension=` — into spawned worker processes
+ * (ProcessHelper), or into the restarted main process (TurboProcessRestarter)
+ * whose pcntl_fork()ed workers then inherit it.
  *
  * The binaries are committed to the phpstan/phpstan repository next to
  * phpstan.phar (turbo-ext/<platform>/phpstan_turbo-<minor>.so, .dll on
@@ -37,12 +39,30 @@ final class TurboExtensionSelector
 	public static function findExtensionForWorkers(): ?string
 	{
 		if (TurboExtensionEnabler::isLoaded()) {
+			$restartPath = TurboProcessRestarter::getRestartExtensionPath();
+			if ($restartPath !== null) {
+				// loaded through the restart's own -d flag (see
+				// TurboProcessRestarter) — spawned workers do not inherit
+				// command-line -d flags, so they need it passed explicitly
+				return $restartPath;
+			}
+
 			// loaded through php.ini — workers inherit the ini file
 			return null;
 		}
 		if (getenv('PHPSTAN_TURBO') === '0') {
 			return null;
 		}
+
+		return self::findExtension();
+	}
+
+	/**
+	 * Locates the distributed extension binary for the current platform —
+	 * present only next to a phar-based installation.
+	 */
+	public static function findExtension(): ?string
+	{
 		if ((bool) PHP_DEBUG) {
 			return null;
 		}

--- a/src/Turbo/TurboProcessRestarter.php
+++ b/src/Turbo/TurboProcessRestarter.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Turbo;
+
+use function extension_loaded;
+use function function_exists;
+use function get_cfg_var;
+use function getenv;
+use function ini_get;
+use function is_string;
+use function pcntl_exec;
+use function php_ini_loaded_file;
+use const PHP_BINARY;
+
+/**
+ * Restarts the main PHPStan process via pcntl_exec() with the distributed
+ * turbo extension loaded through -d extension=.
+ *
+ * Parallel analysis prefers pcntl_fork()ed workers over spawned ones (see
+ * ForkParallelChecker) — a forked worker inherits the booted process instead
+ * of paying a full re-boot. But a forked worker also inherits the parent's
+ * loaded extensions: the spawn-time `-d extension=` injection
+ * (ProcessHelper) cannot reach it, and dl() cannot load a binary from next
+ * to the phar. So when the extension binary is available but not loaded,
+ * the whole process is re-executed with it before anything else runs —
+ * forked workers then inherit the extension, its stub shadowing, and (when
+ * running from a phar) the phar-fork-guard that keeps phar:// reads safe
+ * across fork.
+ *
+ * The restart carries a marker ini entry with the extension path. It doubles
+ * as the retry stop (a binary that failed to load leaves the extension
+ * unloaded — without the marker the restart would loop) and tells
+ * TurboExtensionSelector that spawned workers still need the -d flag
+ * (command-line -d flags, unlike php.ini, are not inherited).
+ */
+final class TurboProcessRestarter
+{
+
+	public const EXTENSION_PATH_INI = 'phpstan.turboExtensionPath';
+
+	/**
+	 * The extension path this process was restarted with, null when the
+	 * process was not restarted.
+	 */
+	public static function getRestartExtensionPath(): ?string
+	{
+		$path = get_cfg_var(self::EXTENSION_PATH_INI);
+		if (!is_string($path) || $path === '') {
+			return null;
+		}
+
+		return $path;
+	}
+
+	/**
+	 * On success the call never returns — the process image is replaced.
+	 *
+	 * @param list<string> $argv
+	 */
+	public static function restartIfSuitable(array $argv): void
+	{
+		if (extension_loaded('phpstan_turbo')) {
+			return;
+		}
+		if (getenv('PHPSTAN_TURBO') === '0') {
+			return;
+		}
+		if (self::getRestartExtensionPath() !== null) {
+			// already restarted and the extension still did not load
+			return;
+		}
+		if (
+			!function_exists('pcntl_exec')
+			|| !function_exists('pcntl_fork')
+			|| !function_exists('pcntl_waitpid')
+			|| !function_exists('pcntl_wifexited')
+			|| !function_exists('pcntl_wexitstatus')
+			|| !function_exists('posix_kill')
+		) {
+			// fork mode is impossible here (see ForkParallelChecker) and
+			// spawned workers get the extension from ProcessHelper already
+			return;
+		}
+
+		$extensionPath = TurboExtensionSelector::findExtension();
+		if ($extensionPath === null) {
+			return;
+		}
+
+		$args = [];
+		$phpIni = php_ini_loaded_file();
+		if ($phpIni !== false) {
+			$args[] = '-c';
+			$args[] = $phpIni;
+		}
+		$args[] = '-d';
+		$args[] = 'memory_limit=' . ini_get('memory_limit');
+		$args[] = '-d';
+		$args[] = 'extension=' . $extensionPath;
+		$args[] = '-d';
+		$args[] = self::EXTENSION_PATH_INI . '=' . $extensionPath;
+		foreach ($argv as $arg) {
+			$args[] = $arg;
+		}
+
+		pcntl_exec(PHP_BINARY, $args);
+		// pcntl_exec() returns only on failure — continue without the extension
+	}
+
+}

--- a/turbo-ext/analysis-stub.php
+++ b/turbo-ext/analysis-stub.php
@@ -19,4 +19,8 @@ final class Runtime
 	{
 	}
 
+	public static function enablePharForkGuard(string $pharPath): void
+	{
+	}
+
 }

--- a/turbo-ext/config.w32
+++ b/turbo-ext/config.w32
@@ -29,7 +29,7 @@ if (PHP_PHPSTAN_TURBO != "no") {
 	// directory by splitting on backslashes only — with forward slashes the
 	// objects compile flat while the link list expects the subpath
 	EXTENSION("phpstan_turbo",
-		"src\\main.cpp src\\support.cpp src\\ArenaCache.cpp src\\CombinationsHelper.cpp src\\ConditionalExpressionHolder.cpp src\\ExpressionResultStorage.cpp src\\ExpressionTypeHolder.cpp src\\NodeScanner.cpp src\\NodeTraverser.cpp src\\ScopeOps.cpp src\\TrinaryLogic.cpp src\\TypeCombinatorCache.cpp",
+		"src\\main.cpp src\\support.cpp src\\ArenaCache.cpp src\\CombinationsHelper.cpp src\\ConditionalExpressionHolder.cpp src\\ExpressionResultStorage.cpp src\\ExpressionTypeHolder.cpp src\\NodeScanner.cpp src\\NodeTraverser.cpp src\\PharForkGuard.cpp src\\ScopeOps.cpp src\\TrinaryLogic.cpp src\\TypeCombinatorCache.cpp",
 		true,
 		flags);
 	ADD_SOURCES(configure_module_dirname + "/src/parser",

--- a/turbo-ext/src/PharForkGuard.cpp
+++ b/turbo-ext/src/PharForkGuard.cpp
@@ -1,0 +1,166 @@
+/*
+ * PharForkGuard — makes phar:// reads safe across pcntl_fork().
+ *
+ * libphar keeps one open handle per archive per process and serves every
+ * phar:// entry read as a seek-then-read pair on it (a "stream position
+ * proxy" over phar->fp). After fork() the parent and every child share the
+ * same open file description — one kernel seek cursor — so concurrent reads
+ * across the processes interleave and return bytes from wrong offsets,
+ * surfacing as parse errors in phar-internal files. php-src has no fix
+ * (the running phar's fp is hidden extension state userland cannot reopen).
+ *
+ * The guard privatizes the cursor without touching phar internals, at the
+ * fd level via pthread_atfork():
+ *
+ *   prepare (parent, pre-fork): find every read-only fd whose backing file
+ *   is the registered phar (dev/inode match) and record its cursor. Nothing
+ *   runs between prepare and fork, so the recorded cursors are exactly the
+ *   fork-time state the child's copied php_stream buffers assume.
+ *
+ *   child (post-fork): open the phar fresh — a private open file
+ *   description — restore the recorded cursor, and dup2 it onto the old fd
+ *   number. The php_stream structs are untouched (they hold only the fd
+ *   number); the inherited read buffer, stream position and now-private
+ *   cursor are exactly as consistent as the parent's were at fork.
+ *
+ * The parent keeps its own description and is unaffected; each forked child
+ * privatizes its own, so no two processes share a cursor. The child hook
+ * uses only async-signal-safe calls (open/lseek/dup2/close/fcntl/write) and
+ * static storage — it also runs in fork-and-exec children (proc_open),
+ * where the swap is harmless because FD_CLOEXEC state is preserved.
+ */
+
+#include "support.h"
+
+#ifndef PHP_WIN32
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* More than one fd on the archive would mean phar opened it twice; libphar
+ * holds exactly one (phar->fp), so the table is generous already. */
+#define PT_PFG_MAX_FDS 8
+
+typedef struct _pt_pfg_entry {
+	int fd;
+	off_t cursor;
+	int fd_flags; /* F_GETFD result, preserves FD_CLOEXEC across the dup2 */
+} pt_pfg_entry;
+
+static char pt_pfg_path[PATH_MAX];
+static bool pt_pfg_registered = false;
+static bool pt_pfg_atfork_installed = false;
+static pt_pfg_entry pt_pfg_table[PT_PFG_MAX_FDS];
+static int pt_pfg_count = 0;
+
+static void pt_pfg_prepare(void)
+{
+	pt_pfg_count = 0;
+	if (!pt_pfg_registered) {
+		return;
+	}
+
+	struct stat target;
+	if (stat(pt_pfg_path, &target) != 0) {
+		return;
+	}
+
+	/* /dev/fd is a symlink to /proc/self/fd on Linux and native on the BSDs
+	 * and macOS; listing it beats fstat()ing every fd up to the rlimit. */
+	DIR *dir = opendir("/dev/fd");
+	if (dir == NULL) {
+		return;
+	}
+	int dir_fd = dirfd(dir);
+
+	struct dirent *entry;
+	while ((entry = readdir(dir)) != NULL && pt_pfg_count < PT_PFG_MAX_FDS) {
+		char *end = NULL;
+		long fd = strtol(entry->d_name, &end, 10);
+		if (end == entry->d_name || *end != '\0' || fd < 0 || fd == dir_fd) {
+			continue;
+		}
+
+		struct stat st;
+		if (fstat((int) fd, &st) != 0
+			|| !S_ISREG(st.st_mode)
+			|| st.st_dev != target.st_dev
+			|| st.st_ino != target.st_ino) {
+			continue;
+		}
+
+		/* A write-mode fd would mean someone is rebuilding the archive —
+		 * swapping its description out from under them is not ours to do. */
+		int fl_flags = fcntl((int) fd, F_GETFL);
+		if (fl_flags == -1 || (fl_flags & O_ACCMODE) != O_RDONLY) {
+			continue;
+		}
+
+		off_t cursor = lseek((int) fd, 0, SEEK_CUR);
+		if (cursor == (off_t) -1) {
+			continue;
+		}
+
+		pt_pfg_table[pt_pfg_count].fd = (int) fd;
+		pt_pfg_table[pt_pfg_count].cursor = cursor;
+		pt_pfg_table[pt_pfg_count].fd_flags = fcntl((int) fd, F_GETFD);
+		pt_pfg_count++;
+	}
+
+	closedir(dir);
+}
+
+static void pt_pfg_child(void)
+{
+	for (int i = 0; i < pt_pfg_count; i++) {
+		int new_fd = open(pt_pfg_path, O_RDONLY);
+		if (new_fd < 0) {
+			/* Continuing would corrupt phar reads through the still-shared
+			 * cursor; the archive vanishing mid-run is fatal anyway. */
+			static const char message[] = "phpstan_turbo: cannot reopen the phar archive in the forked child\n";
+			ssize_t ignored = write(2, message, sizeof(message) - 1);
+			(void) ignored;
+			_exit(70);
+		}
+
+		lseek(new_fd, pt_pfg_table[i].cursor, SEEK_SET);
+		dup2(new_fd, pt_pfg_table[i].fd);
+		close(new_fd);
+		if (pt_pfg_table[i].fd_flags != -1) {
+			fcntl(pt_pfg_table[i].fd, F_SETFD, pt_pfg_table[i].fd_flags);
+		}
+	}
+	pt_pfg_count = 0;
+}
+
+void pt_phar_fork_guard_register(zend_string *path)
+{
+	if (ZSTR_LEN(path) == 0 || ZSTR_LEN(path) >= sizeof(pt_pfg_path)) {
+		return;
+	}
+
+	memcpy(pt_pfg_path, ZSTR_VAL(path), ZSTR_LEN(path) + 1);
+	pt_pfg_registered = true;
+
+	/* pthread_atfork() registrations cannot be removed, so install once and
+	 * gate the hooks on pt_pfg_registered instead. */
+	if (!pt_pfg_atfork_installed) {
+		pthread_atfork(pt_pfg_prepare, NULL, pt_pfg_child);
+		pt_pfg_atfork_installed = true;
+	}
+}
+
+#else /* PHP_WIN32 */
+
+/* No fork() on Windows — parallel workers are always spawned there. */
+void pt_phar_fork_guard_register(zend_string *path)
+{
+	(void) path;
+}
+
+#endif

--- a/turbo-ext/src/main.cpp
+++ b/turbo-ext/src/main.cpp
@@ -60,6 +60,20 @@ static void ZEND_FASTCALL runtimeClassRefs(INTERNAL_FUNCTION_PARAMETERS)
 	pt_class_refs_dump(return_value);
 }
 
+/* PHPStanTurbo\Runtime::enablePharForkGuard() — TurboExtensionEnabler passes
+ * Phar::running(false) when PHPStan runs from a phar, arming the
+ * pthread_atfork hooks that keep phar:// reads safe in pcntl_fork()ed
+ * workers (see PharForkGuard.cpp). */
+static void ZEND_FASTCALL runtimeEnablePharForkGuard(INTERNAL_FUNCTION_PARAMETERS)
+{
+	zend_string *path;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(path)
+	ZEND_PARSE_PARAMETERS_END();
+
+	pt_phar_fork_guard_register(path);
+}
+
 static PHP_MINIT_FUNCTION(phpstan_turbo)
 {
 #ifdef ZTS
@@ -69,6 +83,7 @@ static PHP_MINIT_FUNCTION(phpstan_turbo)
 	reg::Class runtime("PHPStanTurbo\\Runtime");
 	runtime.method("configure", reg::PublicStatic, 1, { reg::arrayArg("classMap") }, runtimeConfigure);
 	runtime.method("classRefs", reg::PublicStatic, 0, {}, runtimeClassRefs);
+	runtime.method("enablePharForkGuard", reg::PublicStatic, 1, { reg::stringArg("pharPath") }, runtimeEnablePharForkGuard);
 	runtime.register_();
 
 	pt_register_trinary_logic();

--- a/turbo-ext/src/support.h
+++ b/turbo-ext/src/support.h
@@ -161,6 +161,11 @@ void pt_type_combinator_cache_rshutdown();
  * ArenaCache::destroy() on a graceful exit */
 void pt_arena_mshutdown();
 
+/* Runtime::enablePharForkGuard() — privatizes the phar archive's fd cursor
+ * in pcntl_fork()ed children via pthread_atfork (see PharForkGuard.cpp);
+ * a no-op on Windows */
+void pt_phar_fork_guard_register(zend_string *path);
+
 /* }}} */
 
 /* {{{ TrinaryLogic values and singletons */

--- a/turbo-ext/tests/phar-fork-guard.php
+++ b/turbo-ext/tests/phar-fork-guard.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+/**
+ * Differential test for Runtime::enablePharForkGuard().
+ *
+ * libphar serves every phar:// read as a seek-then-read pair on one shared
+ * per-archive fd; after pcntl_fork() all processes share that fd's kernel
+ * cursor, so concurrent reads race and return bytes from wrong offsets.
+ * The guard privatizes the cursor per forked child via pthread_atfork.
+ *
+ * Two passes over the same workload (parent + 8 forked children hammering
+ * randomized verified reads):
+ *   1. control, guard not armed — must corrupt (proves the workload races)
+ *   2. guard armed — must be error-free everywhere
+ *
+ * The control pass runs first because pthread_atfork registrations cannot
+ * be removed. Run: php -d extension=$PWD/phpstan_turbo.so tests/phar-fork-guard.php
+ */
+
+const WORKERS = 8;
+const ROUNDS = 12;
+const ENTRIES = 200;
+
+if (in_array('--build', $argv, true)) {
+	[, , $pharPath, $manifestPath] = $argv;
+	$phar = new Phar($pharPath);
+	$phar->startBuffering();
+	$manifest = [];
+	mt_srand(42);
+	for ($i = 0; $i < ENTRIES; $i++) {
+		$name = sprintf('files/entry-%03d.txt', $i);
+		// sizes up to ~40KB so many entries span several 8KB stream-buffer refills
+		$size = 1024 + ($i * 199) % (40 * 1024);
+		$content = '';
+		while (strlen($content) < $size) {
+			$content .= md5((string) mt_rand(), true);
+		}
+		$manifest[$name] = md5(substr($content, 0, $size));
+		$phar->addFromString($name, substr($content, 0, $size));
+	}
+	$phar->setStub('<?php __HALT_COMPILER();');
+	$phar->stopBuffering();
+	file_put_contents($manifestPath, serialize($manifest));
+	exit(0);
+}
+
+if (!extension_loaded('phpstan_turbo')) {
+	fwrite(STDERR, "phpstan_turbo extension is not loaded\n");
+	exit(1);
+}
+if (!function_exists('pcntl_fork')) {
+	echo "SKIP: pcntl is not available\n";
+	exit(0);
+}
+
+/** @param array<string, string> $manifest */
+function hammer(string $pharUrl, array $manifest, int $seed): int
+{
+	$errors = 0;
+	mt_srand($seed);
+	$names = array_keys($manifest);
+	for ($round = 0; $round < ROUNDS; $round++) {
+		shuffle($names);
+		foreach ($names as $name) {
+			$content = @file_get_contents($pharUrl . $name);
+			if ($content === false || md5($content) !== $manifest[$name]) {
+				$errors++;
+			}
+		}
+	}
+	return $errors;
+}
+
+/**
+ * @param array<string, string> $manifest
+ * @return array{int, int} parent errors, corrupt children
+ */
+function forkAndHammer(string $pharUrl, array $manifest, int $seedBase): array
+{
+	$children = [];
+	for ($i = 0; $i < WORKERS; $i++) {
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			fwrite(STDERR, "fork failed\n");
+			exit(1);
+		}
+		if ($pid === 0) {
+			exit(hammer($pharUrl, $manifest, $seedBase + $i) > 0 ? 1 : 0);
+		}
+		$children[] = $pid;
+	}
+
+	$parentErrors = hammer($pharUrl, $manifest, $seedBase + 999);
+
+	$corruptChildren = 0;
+	foreach ($children as $pid) {
+		pcntl_waitpid($pid, $status);
+		if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
+			$corruptChildren++;
+		}
+	}
+
+	return [$parentErrors, $corruptChildren];
+}
+
+$pharPath = tempnam(sys_get_temp_dir(), 'ptpfg') . '.phar';
+$manifestPath = $pharPath . '.manifest';
+
+exec(implode(' ', array_map('escapeshellarg', [
+	PHP_BINARY, '-d', 'phar.readonly=0', __FILE__, '--build', $pharPath, $manifestPath,
+])), $output, $exitCode);
+if ($exitCode !== 0) {
+	fwrite(STDERR, "building the test phar failed\n");
+	exit(1);
+}
+
+/** @var array<string, string> $manifest */
+$manifest = unserialize(file_get_contents($manifestPath));
+$pharUrl = 'phar://' . $pharPath . '/';
+
+// Pin the archive like the running phar is pinned in the real case — without
+// a live reference libphar closes the fd at refcount 0 and nothing is shared.
+$pin = new Phar($pharPath);
+
+// warm reads so the shared fd is open with a buffered window, as after boot
+foreach (array_slice(array_keys($manifest), 0, 20) as $name) {
+	if (md5((string) file_get_contents($pharUrl . $name)) !== $manifest[$name]) {
+		fwrite(STDERR, "pre-fork sanity read failed\n");
+		exit(1);
+	}
+}
+
+[$controlParentErrors, $controlCorruptChildren] = forkAndHammer($pharUrl, $manifest, 1000);
+printf("control (no guard):  parent errors %d, corrupt children %d/%d\n", $controlParentErrors, $controlCorruptChildren, WORKERS);
+
+PHPStanTurbo\Runtime::enablePharForkGuard($pharPath);
+
+[$guardedParentErrors, $guardedCorruptChildren] = forkAndHammer($pharUrl, $manifest, 2000);
+printf("guarded:             parent errors %d, corrupt children %d/%d\n", $guardedParentErrors, $guardedCorruptChildren, WORKERS);
+
+unset($pin);
+@unlink($pharPath);
+@unlink($manifestPath);
+
+if ($controlParentErrors === 0 && $controlCorruptChildren === 0) {
+	fwrite(STDERR, "FAIL: the control pass did not corrupt — the workload no longer exercises the race\n");
+	exit(1);
+}
+if ($guardedParentErrors > 0 || $guardedCorruptChildren > 0) {
+	fwrite(STDERR, "FAIL: corruption with the guard armed\n");
+	exit(1);
+}
+
+echo "ALL OK\n";


### PR DESCRIPTION
Fork mode stops being opt-in via `PHPSTAN_PARALLEL_FORK` and becomes the default whenever it can work:

- **spawn** on Windows (no pcntl), and when the turbo extension is neither loaded nor distributed next to the phar
- **fork** when the turbo extension is active with the expected version (and OPcache + JIT are off)

### Why fork needs turbo

Running from a phar, forked workers corrupt `phar://` reads: libphar keeps one open handle per archive per process and serves every entry read as a seek-then-read pair on it (a stream position proxy over `phar->fp`). After `fork()` all processes share that fd's open file description — one kernel seek cursor — so concurrent reads interleave and return bytes from wrong offsets, surfacing as parse errors in phar-internal `.php` and stub files. php-src has no fix; the handle is hidden extension state userland cannot reopen (and `dl()` cannot load a binary from next to the phar).

The turbo extension now arms `pthread_atfork()` hooks (`Runtime::enablePharForkGuard()`) that privatize the cursor at the fd level, without touching phar internals: the prepare hook records the cursor of every read-only fd backed by the phar, and the child hook reopens the archive, restores the cursor, and `dup2()`s the private description onto the old fd number. `turbo-ext/tests/phar-fork-guard.php` proves both directions — the unguarded control pass corrupts (parent + all 8 forked children), the guarded pass is error-free on the same workload.

### Loading turbo into the main process

A forked worker inherits the parent's extensions, so the spawn-time `-d extension=` injection cannot reach it. `TurboProcessRestarter` re-executes the main process via `pcntl_exec()` with the distributed binary loaded before anything else runs; forked workers then inherit the extension, its stub shadowing, and the phar-fork-guard. The restart carries a marker ini entry that stops a retry when the binary failed to load and tells `TurboExtensionSelector` that spawned workers still need the `-d` flag. Outside a phar nothing changes: there is no distributed binary to find, so no restart — fork is used when turbo is loaded via php.ini, spawn otherwise.

As a side effect the main process is turbo-accelerated too — it never was for phar installations.

### Benchmarks

Full cold-cache analyses of two large real-world codebases, phar built from this branch (fork) vs phar built from 2.2.x (spawn), same turbo `.so` next to both so spawned workers keep their turbo acceleration; ABBA interleaved, `/usr/bin/time` including children. Error output is byte-identical in all runs.

| project | metric | spawn (2.2.x) | fork (this PR) | Δ |
|---|---|---|---|---|
| slevomat (n=3) | wall | 105.5 s | 94.0 s | **−10.9 %** |
| slevomat (n=3) | user CPU | 714.4 s | 652.6 s | **−8.7 %** |
| shipmonk (n=2) | user CPU | 1772.4 s | 1631.2 s | **−8.0 %** |
| shipmonk (n=2) | wall | 282.1 s | 317.6 s | (machine was busy; wall noisy) |

The wall-clock inversion on the shipmonk pair coincided with other load on the machine; user CPU — the stable metric — improved consistently on both projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2oPPwjrXy88MUsYekCFQ6