### PR TITLE
Reset NodeCallbackScope ask memos when cloning scopes natively

### DIFF
--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -22,7 +22,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = 'f529bad';
+	public const EXPECTED_EXTENSION_VERSION = 'dabbfe7';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/turbo-ext/src/ScopeOps.cpp
+++ b/turbo-ext/src/ScopeOps.cpp
@@ -38,8 +38,9 @@ typedef struct _pt_scope_offsets {
 	int32_t scope_out_of_first_level;
 	int32_t scope_with_promoted_native;
 	int32_t walk_scope;          /* NodeCallbackScope */
-	int32_t truthy_value_exprs;  /* NodeCallbackScope */
-	int32_t falsey_value_exprs;  /* NodeCallbackScope */
+	int32_t scope_ops;           /* NodeCallbackScope */
+	int32_t asked_types;         /* NodeCallbackScope */
+	int32_t asked_native_types;  /* NodeCallbackScope */
 } pt_scope_offsets;
 
 static HashTable pt_scope_offsets_cache;
@@ -79,8 +80,9 @@ static pt_scope_offsets *pt_scope_offsets_for(zend_class_entry *ce)
 	off->scope_out_of_first_level = pt_instance_prop_offset(ce, "scopeOutOfFirstLevelStatement", sizeof("scopeOutOfFirstLevelStatement") - 1);
 	off->scope_with_promoted_native = pt_instance_prop_offset(ce, "scopeWithPromotedNativeTypes", sizeof("scopeWithPromotedNativeTypes") - 1);
 	off->walk_scope = pt_instance_prop_offset(ce, "walkScope", sizeof("walkScope") - 1);
-	off->truthy_value_exprs = pt_instance_prop_offset(ce, "truthyValueExprs", sizeof("truthyValueExprs") - 1);
-	off->falsey_value_exprs = pt_instance_prop_offset(ce, "falseyValueExprs", sizeof("falseyValueExprs") - 1);
+	off->scope_ops = pt_instance_prop_offset(ce, "scopeOps", sizeof("scopeOps") - 1);
+	off->asked_types = pt_instance_prop_offset(ce, "askedTypes", sizeof("askedTypes") - 1);
+	off->asked_native_types = pt_instance_prop_offset(ce, "askedNativeTypes", sizeof("askedNativeTypes") - 1);
 
 	zend_hash_add_ptr(&pt_scope_offsets_cache, ce->name, off);
 	return off;
@@ -303,8 +305,9 @@ public:
 		resetToNull(cloneObj, off->scope_out_of_first_level);
 		resetToNull(cloneObj, off->scope_with_promoted_native);
 		resetToNull(cloneObj, off->walk_scope);
-		resetToEmptyArray(cloneObj, off->truthy_value_exprs);
-		resetToEmptyArray(cloneObj, off->falsey_value_exprs);
+		resetToEmptyArray(cloneObj, off->scope_ops);
+		resetToEmptyArray(cloneObj, off->asked_types);
+		resetToEmptyArray(cloneObj, off->asked_native_types);
 
 		zval out;
 		ZVAL_OBJ(&out, clone);


### PR DESCRIPTION
Fixes the turbo-suite failures on every "Run with Turbo Extension" job since 4db78841d4 (`NodeCallbackScopeDerivedOpsRuleTest::testDerivedOps` — the assigned type read back as the pre-assignment one).

The native `scopeWith()` derives scopes by **cloning** and resetting per-instance memo properties to fresh-constructor defaults; the PHP twin's `duplicateWith()` **constructs fresh** — so any memo missing from the native reset list survives derivation only under turbo. NodeCallbackScope's entries were stale twice over:

- `truthyValueExprs`/`falseyValueExprs` no longer exist (4db78841d4 replaced them with the ordered `scopeOps` list) — their resets became no-ops, and `scopeOps` was never reset;
- the `askedTypes`/`askedNativeTypes` ask memos (06ff8f02fd) were never listed at all.

The failing sequence: a rule asks a node's type (memoized), derives a scope (`assignExpression()`, `filterByTruthyValue()`, …), and asks again — the clone carries the memo, the second ask short-circuits on it, and the recorded ops never replay. The reset list now covers `scopeOps`, `askedTypes`, and `askedNativeTypes`.

Verified: `NodeCallbackScopeDerivedOpsRuleTest` red → green under the loaded extension on the same tree; smoke ALL OK; full suite green with turbo active (21144/95996).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnwgpaeUXRkgSDyg95tfK8
