### PR TITLE
Decline a bootstrap autoloader only when it would re-include a loaded file

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -141,6 +141,9 @@ jobs:
               composer install
               ../../bin/phpstan analyze
           - script: |
+              cd e2e/bug-15102b
+              ../../bin/phpstan analyze
+          - script: |
               cd e2e/bug-14724
               composer install
               ../../bin/phpstan analyze app/

--- a/e2e/bug-15102b/bootstrap.php
+++ b/e2e/bug-15102b/bootstrap.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+// The shape Illuminate\Foundation\AliasLoader creates: a prepended autoloader that
+// resolves a short alias to a real class with class_alias(), reading no file. The alias
+// names collide with global functions - Laravel's Cache, File, Str, Hash all do.
+require_once __DIR__ . '/src/Real.php';
+
+spl_autoload_register(static function (string $class): void {
+	if ($class !== 'File') {
+		return;
+	}
+
+	class_alias(E2eFacadeAlias\Real::class, 'File');
+}, true, true);

--- a/e2e/bug-15102b/phpstan.dist.neon
+++ b/e2e/bug-15102b/phpstan.dist.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: 8
+	bootstrapFiles:
+		- bootstrap.php
+	paths:
+		- test.php

--- a/e2e/bug-15102b/src/Real.php
+++ b/e2e/bug-15102b/src/Real.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace E2eFacadeAlias;
+
+class Real
+{
+
+	public function doFoo(): void
+	{
+	}
+
+}

--- a/e2e/bug-15102b/test.php
+++ b/e2e/bug-15102b/test.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types = 1);
+
+function (File $file): void {
+	$file->doFoo();
+};

--- a/src/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocator.php
@@ -10,9 +10,13 @@ use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use function class_exists;
 use function function_exists;
+use function get_included_files;
+use function in_array;
 use function interface_exists;
 use function PHPStan\autoloadFunctions;
 use function PHPStan\autoloadFunctionsPrependedToComposer;
+use function restore_error_handler;
+use function set_error_handler;
 use function trait_exists;
 
 final class AutoloadFunctionsSourceLocator implements SourceLocator
@@ -43,35 +47,110 @@ final class AutoloadFunctionsSourceLocator implements SourceLocator
 			return null;
 		}
 
-		// If the name is already a defined function, this locator must not run the bootstrap
-		// autoloaders for it: a catch-all autoloader (e.g. PHP_CodeSniffer's, which falls back to
-		// Composer's findFile()) would resolve the name to the function's own file and plain-include
-		// it a second time - it was loaded once already, e.g. by a package that ships one function
-		// per PSR-4 path and requires it from its bootstrap - fatally redeclaring the function.
-		// Returning null only declines this locator; a class and a function may share a name in PHP,
-		// and a class that genuinely exists under this name in another file is still located by the
-		// later source locators in the chain. See https://github.com/phpstan/phpstan/issues/14988
-		if (function_exists($className)) {
-			return null;
-		}
-
 		$autoloadFunctions = $this->prependedToComposer
 			? autoloadFunctionsPrependedToComposer()
 			: autoloadFunctions();
-		foreach ($autoloadFunctions as $autoloadFunction) {
-			$autoloadFunction($className);
-			$reflection = $this->autoloadSourceLocator->locateIdentifier($reflector, $identifier);
-			if ($reflection !== null) {
-				return $reflection;
+
+		if ($autoloadFunctions === []) {
+			return null;
+		}
+
+		if (function_exists($className)) {
+			if ($this->wouldReIncludeALoadedFile($autoloadFunctions, $className)) {
+				return null;
 			}
 
-			$reflection = $this->reflectionClassSourceLocator->locateIdentifier($reflector, $identifier);
+			// The trap intercepts file reads, not execution, so the probe ran the autoloaders for
+			// real. One that defines the class without reading a file - class_alias(), eval() -
+			// has already done its work, and calling it again would redeclare what it defined.
+			if (class_exists($className, false) || interface_exists($className, false) || trait_exists($className, false)) {
+				return $this->locateWithoutAutoloading($reflector, $identifier);
+			}
+		}
+
+		foreach ($autoloadFunctions as $autoloadFunction) {
+			$autoloadFunction($className);
+
+			$reflection = $this->locateWithoutAutoloading($reflector, $identifier);
 			if ($reflection !== null) {
 				return $reflection;
 			}
 		}
 
 		return null;
+	}
+
+	private function locateWithoutAutoloading(Reflector $reflector, Identifier $identifier): ?Reflection
+	{
+		$reflection = $this->autoloadSourceLocator->locateIdentifier($reflector, $identifier);
+		if ($reflection !== null) {
+			return $reflection;
+		}
+
+		return $this->reflectionClassSourceLocator->locateIdentifier($reflector, $identifier);
+	}
+
+	/**
+	 * Whether running these autoloaders for $className would include a file that is loaded already.
+	 *
+	 * A function of this name exists, so an autoloader that maps names to paths - a catch-all one
+	 * like PHP_CodeSniffer's, falling back to Composer's findFile() - can resolve this *class* name
+	 * to the *function's* own file. Including that file a second time fatally redeclares the
+	 * function, which is what https://github.com/phpstan/phpstan/issues/14988 reported.
+	 *
+	 * Probing under the file-read trap answers which file the autoloaders would read without
+	 * executing it, so only that case is declined. Declining on the name alone would also block
+	 * class names that merely coincide with a function - classes and functions live in separate
+	 * symbol spaces, and Laravel's facade aliases (Cache, File, Str, ...) collide with the global
+	 * helpers cache(), file() and str(). See https://github.com/phpstan/phpstan/issues/15102
+	 *
+	 * @param array<int, callable(string): void> $autoloadFunctions
+	 */
+	private function wouldReIncludeALoadedFile(array $autoloadFunctions, string $className): bool
+	{
+		set_error_handler(static fn (): bool => true);
+
+		try {
+			$locatedFiles = FileReadTrapStreamWrapper::withStreamWrapperOverride(
+				static function () use ($autoloadFunctions, $className): array {
+					foreach ($autoloadFunctions as $autoloadFunction) {
+						$autoloadFunction($className);
+
+						// Stop as soon as the name is defined, the way spl_autoload_call() does:
+						// a later autoloader must not get the chance to resolve a name that is
+						// already taken care of. Under the trap a file read cannot define
+						// anything, so this means the autoloader defined it by itself.
+						if (class_exists($className, false) || interface_exists($className, false) || trait_exists($className, false)) {
+							return [];
+						}
+
+						if (FileReadTrapStreamWrapper::$autoloadLocatedFiles !== []) {
+							return FileReadTrapStreamWrapper::$autoloadLocatedFiles;
+						}
+					}
+
+					return [];
+				},
+			);
+		} finally {
+			restore_error_handler();
+		}
+
+		if ($locatedFiles === []) {
+			return false;
+		}
+
+		// PHP canonicalises the path before it reaches a stream wrapper - a `/./` segment, a
+		// symlinked directory or an include-path-relative name all arrive resolved - so the
+		// trapped paths compare directly against get_included_files().
+		$includedFiles = get_included_files();
+		foreach ($locatedFiles as $locatedFile) {
+			if (in_array($locatedFile, $includedFiles, true)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	#[Override]

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocatorTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\BetterReflection\SourceLocator;
+
+use PhpParser\PrettyPrinter\Standard;
+use PHPStan\BetterReflection\Identifier\Identifier;
+use PHPStan\BetterReflection\Identifier\IdentifierType;
+use PHPStan\BetterReflection\Reflector\DefaultReflector;
+use PHPStan\BetterReflection\SourceLocator\Ast\Locator;
+use PHPStan\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber;
+use PHPStan\Testing\PHPStanTestCase;
+use TestSingleFileSourceLocator\AFoo;
+use function class_alias;
+use function class_exists;
+use function function_exists;
+
+class AutoloadFunctionsSourceLocatorTest extends PHPStanTestCase
+{
+
+	/**
+	 * A class alias created by a bootstrap-registered autoloader must be located even when a
+	 * *function* of the same name exists - classes and functions live in separate symbol
+	 * spaces, and Laravel's facade aliases (Cache, File, Str, ...) collide with global
+	 * helpers like cache(), file() and str().
+	 *
+	 * @see https://github.com/phpstan/phpstan/issues/15102
+	 */
+	public function testLocatesAliasWhoseNameCollidesWithAFunction(): void
+	{
+		require_once __DIR__ . '/data/a.php';
+		$this->assertTrue(function_exists('file'), 'precondition: file() is a built-in function');
+		$this->assertFalse(class_exists('File', false), 'precondition: no File class yet');
+
+		$invocations = 0;
+		$GLOBALS['__phpstanAutoloadFunctions'] = [
+			static function (string $class) use (&$invocations): void {
+				if ($class !== 'File') {
+					return;
+				}
+
+				$invocations++;
+				class_alias(AFoo::class, 'File');
+			},
+		];
+
+		try {
+			$locator = $this->createLocator();
+			$reflection = $locator->locateIdentifier(
+				new DefaultReflector($locator),
+				new Identifier('File', new IdentifierType(IdentifierType::IDENTIFIER_CLASS)),
+			);
+
+			// Non-null is the point: before the fix this locator declined outright because a
+			// function named file() exists. The reflection carries the alias *target*'s name -
+			// rewriting it to the alias is RewriteClassAliasSourceLocator's job, further up the chain.
+			$this->assertNotNull($reflection, 'the aliased class should be located');
+			$this->assertSame(AFoo::class, $reflection->getName());
+
+			// An autoloader that defines the class itself must not be called a second time:
+			// class_alias() would then warn that the name is already in use.
+			$this->assertSame(1, $invocations, 'the autoloader should run exactly once');
+		} finally {
+			unset($GLOBALS['__phpstanAutoloadFunctions']);
+		}
+	}
+
+	/**
+	 * A defining autoloader must win over a later catch-all one that would resolve the same name to
+	 * an already-loaded file: the name is taken care of by the time the catch-all runs, exactly as
+	 * spl_autoload_call() would stop there.
+	 */
+	public function testDefiningAutoloaderWinsOverALaterCatchAllOne(): void
+	{
+		require_once __DIR__ . '/data/a.php';
+		$this->assertTrue(function_exists('hash'), 'precondition: hash() is a built-in function');
+		$this->assertFalse(class_exists('Hash', false), 'precondition: no Hash class yet');
+
+		$GLOBALS['__phpstanAutoloadFunctions'] = [
+			static function (string $class): void {
+				if ($class !== 'Hash') {
+					return;
+				}
+
+				class_alias(AFoo::class, 'Hash');
+			},
+			static function (string $class): void {
+				if ($class !== 'Hash') {
+					return;
+				}
+
+				// A catch-all autoloader mapping names to paths - PHP_CodeSniffer's shape - landing
+				// on a file that is loaded already.
+				require __DIR__ . '/data/a.php';
+			},
+		];
+
+		try {
+			$locator = $this->createLocator();
+			$reflection = $locator->locateIdentifier(
+				new DefaultReflector($locator),
+				new Identifier('Hash', new IdentifierType(IdentifierType::IDENTIFIER_CLASS)),
+			);
+
+			$this->assertNotNull($reflection, 'the aliased class should be located');
+			$this->assertSame(AFoo::class, $reflection->getName());
+		} finally {
+			unset($GLOBALS['__phpstanAutoloadFunctions']);
+		}
+	}
+
+	private function createLocator(): AutoloadFunctionsSourceLocator
+	{
+		$container = self::getContainer();
+
+		return new AutoloadFunctionsSourceLocator(
+			new AutoloadSourceLocator($container->getByType(FileNodesFetcher::class), false),
+			new ReflectionClassSourceLocator(
+				new Locator($container->getService('phpParserDecorator')),
+				new ReflectionSourceStubber(new Standard()),
+			),
+			false,
+		);
+	}
+
+}


### PR DESCRIPTION
Fixes the second regression reported in phpstan/phpstan#15102 - the one @hoetaek reduced to a portable repro. This is not the ordering issue that opened that ticket; that one is #6069's heuristic and needs its own change.

## What was wrong

#6185 added this to `AutoloadFunctionsSourceLocator`:

```php
if (function_exists($className)) {
    return null;
}
```

Classes and functions occupy separate symbol spaces, so a class name coinciding with a function name is legal and common. Laravel is the worst case: the facade aliases `Cache`, `File`, `Str`, `Hash` coincide with the global helpers `cache()`, `str()` and with PHP's own `file()`, `hash()`. `Illuminate\Foundation\AliasLoader` creates those aliases lazily from a prepended autoloader, so with the guard in place `use Cache;` reports `class.notFound` for every larastan user. Verified against the release phars on @hoetaek's repro:

| | `File` (collides with `file()`) | `Alias` (no such function) |
| --- | --- | --- |
| 2.2.8 | resolved | resolved |
| 2.2.9 | **class.notFound** | resolved |

## What the hazard actually was

phpstan/phpstan#14988 was not about the name. A catch-all autoloader - PHP_CodeSniffer's, falling back to Composer's `findFile()` - resolved a *class* name to a *function's* file and plain-included it a second time, fatally redeclaring the function.

So the check now asks that question instead of guessing from the name: probe the autoloaders under `FileReadTrapStreamWrapper`, which reports which file they would read *without executing it*, and decline only when that file is already in `get_included_files()`. An autoloader that defines the class without reading a file - `class_alias()`, `eval()` - runs exactly as it did in 2.2.8. The probe only runs for names that actually collide with a function, and not at all when the bucket holds no autoloaders - so a project without bootstrap autoloaders never reaches it: analysing `src/Rules` triggers 0 probes. Where it does run, `get_included_files()` held ~35 entries, so the scan is nothing.

One subtlety the trap forces: it intercepts file *reads*, not execution, so the probe really does run the autoloaders. An autoloader that defines the class without reading a file has therefore already done its work by the time the probe returns, and calling it again would redeclare what it defined - `class_alias()` warns that the name is already in use. So when the class exists after the probe, the locator reflects it directly instead of looping over the autoloaders again; the test asserts the autoloader runs exactly once. For the same reason the probe stops at the first autoloader that defines the name, the way `spl_autoload_call()` does - otherwise a later catch-all autoloader in the same bucket could still resolve that name to a loaded file and veto a class the first one had already defined.

## Verification

- New `AutoloadFunctionsSourceLocatorTest` pins two cases, both verified failing without the change: the alias case (on `2.2.x` the locator declines and returns null), and a defining autoloader followed by a catch-all one in the same bucket. It also asserts the autoloader is invoked exactly once - the outcome assertion alone passes either way, only the count (2 vs 1) separates them.
- `e2e/bug-14988` still exits 0 - the redeclare fatal does not come back, it is prevented by the trap rather than by the name.
- `e2e/bug-12972b`, `e2e/bug-12972c` (#6069) and `CollectNewAutoloadFunctionsTest` unchanged and green.
- Full suite 21157 green, self-analysis clean, phpcs clean, rebased on current `2.2.x`.
- Any red checks are base breakage rather than this branch - at the time of writing that was `Result cache E2E bug-11826`, the `phpstan-doctrine` lane (phpstan/phpstan-doctrine#789 fixes it once 2.2.10 is out) and the integration tests, all red on every PR.

**Coverage:** `e2e/bug-15102b` covers it - red without the fix (2x `class.notFound`), green with it. An earlier version of this description claimed only a phar exhibits this; that was wrong, and came from a result cache shared between source states (same `2.2.x-dev` cache key). Each measurement now uses a fresh `tmpDir`.








