### PR TITLE
Register services from DI attributes found in configured directories

### DIFF
--- a/build/baseline-pre-8.0.neon
+++ b/build/baseline-pre-8.0.neon
@@ -25,6 +25,18 @@ parameters:
 			path: PHPStan/Build/TurboAttributeCollector.php
 
 		-
+			rawMessage: 'Call to an undefined method ReflectionClass<object>::getAttributes().'
+			identifier: method.notFound
+			count: 1
+			path: ../src/DependencyInjection/AutowiredServiceDiscoverer.php
+
+		-
+			rawMessage: 'Call to an undefined method ReflectionParameter::getAttributes().'
+			identifier: method.notFound
+			count: 1
+			path: ../src/DependencyInjection/AutowiredServiceDiscoverer.php
+
+		-
 			rawMessage: 'Call to an undefined method ReflectionClass::isReadOnly().'
 			identifier: method.notFound
 			count: 1

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -103,6 +103,7 @@ parameters:
 	mixinExcludeClasses: []
 	scanFiles: []
 	scanDirectories: []
+	autowiredServiceDirectories: []
 	parallel:
 		jobSize: 20
 		processTimeout: 600.0

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -177,6 +177,7 @@ parametersSchema:
 	mixinExcludeClasses: listOf(string())
 	scanFiles: listOf(string())
 	scanDirectories: listOf(string())
+	autowiredServiceDirectories: listOf(string())
 	editorUrl: schema(string(), nullable())
 	editorUrlTitle: schema(string(), nullable())
 	errorFormat: schema(string(), nullable())
@@ -224,6 +225,7 @@ expandRelativePaths:
 	- '[parameters][bootstrapFiles][]'
 	- '[parameters][scanFiles][]'
 	- '[parameters][scanDirectories][]'
+	- '[parameters][autowiredServiceDirectories][]'
 	- '[parameters][tmpDir]'
 	- '[parameters][pro][tmpDir]'
 	- '[parameters][memoryLimitFile]'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -213,7 +213,7 @@ parameters:
 		-
 			rawMessage: 'Call to static method expand() of internal class Nette\DI\Helpers from outside its root namespace Nette.'
 			identifier: staticMethod.internalClass
-			count: 1
+			count: 2
 			path: src/DependencyInjection/ContainerFactory.php
 
 		-

--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -22,6 +22,7 @@ use PHPStan\ShouldNotHappenException;
 use ReflectionClass;
 use stdClass;
 use function array_key_exists;
+use function array_merge;
 use function array_slice;
 use function count;
 use function explode;
@@ -51,8 +52,12 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 	{
 		require_once __DIR__ . '/../../vendor/attributes.php';
 		$builder = $this->getContainerBuilder();
+		$discoverer = AutowiredServiceDiscoverer::createFromContainerBuilder($builder);
 
-		$autowiredParameters = Attributes::findTargetMethodParameters(AutowiredParameter::class);
+		$autowiredParameters = array_merge(
+			Attributes::findTargetMethodParameters(AutowiredParameter::class),
+			$discoverer->findTargetMethodParameters(AutowiredParameter::class),
+		);
 		$constructorParameters = [];
 		foreach ($autowiredParameters as $parameter) {
 			if (strcasecmp($parameter->method, '__construct') !== 0) {
@@ -63,7 +68,9 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			$constructorParameters[$lowerClass][] = $parameter;
 		}
 
-		foreach (Attributes::findTargetClasses(AutowiredService::class) as $class) {
+		$interfaceTagMapping = ValidateServiceTagsExtension::getInterfaceTagMapping($builder);
+
+		foreach (array_merge(Attributes::findTargetClasses(AutowiredService::class), $discoverer->findTargetClasses(AutowiredService::class)) as $class) {
 			$reflection = new ReflectionClass($class->name);
 			$attribute = $class->attribute;
 
@@ -82,7 +89,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				continue;
 			}
 
-			foreach (ValidateServiceTagsExtension::getInterfaceTagMapping() as $interface => $tag) {
+			foreach ($interfaceTagMapping as $interface => $tag) {
 				if (!$reflection->implementsInterface($interface)) {
 					continue;
 				}
@@ -91,7 +98,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			}
 		}
 
-		foreach (Attributes::findTargetClasses(NonAutowiredService::class) as $class) {
+		foreach (array_merge(Attributes::findTargetClasses(NonAutowiredService::class), $discoverer->findTargetClasses(NonAutowiredService::class)) as $class) {
 			$attribute = $class->attribute;
 
 			$definition = $builder->addDefinition($attribute->name)
@@ -106,7 +113,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			self::processConstructorParameters($builder, $class->name, $definition, $constructorParameters);
 		}
 
-		foreach (Attributes::findTargetClasses(GenerateFactory::class) as $class) {
+		foreach (array_merge(Attributes::findTargetClasses(GenerateFactory::class), $discoverer->findTargetClasses(GenerateFactory::class)) as $class) {
 			$attribute = $class->attribute;
 			$definition = $builder->addFactoryDefinition(null)
 				->setImplement($attribute->interface);
@@ -125,7 +132,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			return;
 		}
 
-		foreach (Attributes::findTargetClasses(RegisteredRule::class) as $class) {
+		foreach (array_merge(Attributes::findTargetClasses(RegisteredRule::class), $discoverer->findTargetClasses(RegisteredRule::class)) as $class) {
 			$attribute = $class->attribute;
 			if ($attribute->level > $config->level) {
 				continue;
@@ -139,7 +146,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			self::processConstructorParameters($builder, $class->name, $definition, $constructorParameters);
 		}
 
-		foreach (Attributes::findTargetClasses(RegisteredCollector::class) as $class) {
+		foreach (array_merge(Attributes::findTargetClasses(RegisteredCollector::class), $discoverer->findTargetClasses(RegisteredCollector::class)) as $class) {
 			$attribute = $class->attribute;
 			if ($attribute->level > $config->level) {
 				continue;

--- a/src/DependencyInjection/AutowiredExtensions.php
+++ b/src/DependencyInjection/AutowiredExtensions.php
@@ -12,6 +12,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredExtensionsExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_PARAMETER)]
 final class AutowiredExtensions

--- a/src/DependencyInjection/AutowiredExtensionsExtension.php
+++ b/src/DependencyInjection/AutowiredExtensionsExtension.php
@@ -12,6 +12,7 @@ use PHPStan\ShouldNotHappenException;
 use ReflectionMethod;
 use ReflectionNamedType;
 use function array_key_exists;
+use function array_merge;
 use function is_string;
 use function sprintf;
 use function str_replace;
@@ -40,7 +41,7 @@ final class AutowiredExtensionsExtension extends CompilerExtension
 	public function loadConfiguration(): void
 	{
 		$builder = $this->getContainerBuilder();
-		foreach (ValidateServiceTagsExtension::getInterfaceTagMapping() as $interface => $tag) {
+		foreach (ValidateServiceTagsExtension::getInterfaceTagMapping($builder) as $interface => $tag) {
 			$builder->addDefinition(self::getCollectionServiceName($interface))
 				->setType(LazyExtensionsCollection::class)
 				->setArgument('tagName', $tag)
@@ -53,10 +54,14 @@ final class AutowiredExtensionsExtension extends CompilerExtension
 	{
 		require_once __DIR__ . '/../../vendor/attributes.php';
 		$builder = $this->getContainerBuilder();
-		$mapping = ValidateServiceTagsExtension::getInterfaceTagMapping();
+		$mapping = ValidateServiceTagsExtension::getInterfaceTagMapping($builder);
 
 		$parametersByClass = [];
-		foreach (Attributes::findTargetMethodParameters(AutowiredExtensions::class) as $parameter) {
+		$autowiredExtensions = array_merge(
+			Attributes::findTargetMethodParameters(AutowiredExtensions::class),
+			AutowiredServiceDiscoverer::createFromContainerBuilder($builder)->findTargetMethodParameters(AutowiredExtensions::class),
+		);
+		foreach ($autowiredExtensions as $parameter) {
 			if (strcasecmp($parameter->method, '__construct') !== 0) {
 				throw new ShouldNotHappenException(sprintf('Attribute #[AutowiredExtensions] is only supported on constructor parameters, found on %s::%s() $%s.', $parameter->class, $parameter->method, $parameter->name));
 			}

--- a/src/DependencyInjection/AutowiredParameter.php
+++ b/src/DependencyInjection/AutowiredParameter.php
@@ -12,6 +12,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredAttributeServicesExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_PARAMETER)]
 final class AutowiredParameter

--- a/src/DependencyInjection/AutowiredService.php
+++ b/src/DependencyInjection/AutowiredService.php
@@ -13,6 +13,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredAttributeServicesExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_CLASS)]
 final class AutowiredService

--- a/src/DependencyInjection/AutowiredServiceDiscoverer.php
+++ b/src/DependencyInjection/AutowiredServiceDiscoverer.php
@@ -1,0 +1,417 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+use Nette\DI\ContainerBuilder;
+use olvlvl\ComposerAttributeCollector\TargetClass;
+use olvlvl\ComposerAttributeCollector\TargetMethodParameter;
+use PhpParser\Error;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PHPStan\File\FileReader;
+use PHPStan\ShouldNotHappenException;
+use ReflectionClass;
+use Symfony\Component\Finder\Finder;
+use function array_key_exists;
+use function array_keys;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function class_exists;
+use function count;
+use function implode;
+use function in_array;
+use function interface_exists;
+use function is_dir;
+use function sort;
+use function sprintf;
+use function str_contains;
+use function strrpos;
+use function substr;
+
+/**
+ * Finds classes marked with PHPStan's dependency injection attributes in the directories
+ * listed in the `autowiredServiceDirectories` parameter.
+ *
+ * PHPStan's own services are collected at composer install time by
+ * ondrejmirtes/composer-attribute-collector into vendor/attributes.php. That file only ever
+ * covers phpstan-src's own `src` directory and is bundled into the PHAR, where the collector
+ * lives under a build-specific namespace prefix---extensions distributed as separate packages
+ * cannot contribute to it. They point this class at their source directories instead, and the
+ * results are merged with vendor/attributes.php by the compiler extensions consuming them.
+ *
+ * Each configuration file contributes its own directories to the parameter, so extensions
+ * never see each other's classes---because the parameter is a list, one extension adding
+ * to it cannot overwrite another's.
+ *
+ * @internal
+ */
+final class AutowiredServiceDiscoverer
+{
+
+	private const CLASS_ATTRIBUTES = [
+		AutowiredService::class,
+		NonAutowiredService::class,
+		RegisteredRule::class,
+		RegisteredCollector::class,
+		GenerateFactory::class,
+		ExtensionInterface::class,
+		ValidatesStubFiles::class,
+	];
+
+	private const CONSTRUCTOR_PARAMETER_ATTRIBUTES = [
+		AutowiredParameter::class,
+		AutowiredExtensions::class,
+	];
+
+	/**
+	 * Compiler extensions have to be registered before the compiler snapshots its extension list,
+	 * which is earlier than anything here runs. The `extensions:` section of a configuration file
+	 * does the same job for classes outside phpstan-src.
+	 *
+	 */
+	private const UNSUPPORTED_ATTRIBUTES = [
+		ContainerExtension::class,
+	];
+
+	/** @var array<string, self> */
+	private static array $instances = [];
+
+	/** @var array<string, list<string>> */
+	private static array $files = [];
+
+	/** @var list<string>|null */
+	private static ?array $attributeNamespaces = null;
+
+	private bool $collected = false;
+
+	/** @var array<class-string, list<TargetClass<object>>> */
+	private array $targetClasses = [];
+
+	/** @var array<class-string, list<TargetMethodParameter<object>>> */
+	private array $targetMethodParameters = [];
+
+	/**
+	 * @param list<string> $directories
+	 */
+	private function __construct(private string $key, private array $directories)
+	{
+	}
+
+	/**
+	 * @param list<string> $directories
+	 */
+	public static function create(array $directories): self
+	{
+		$directories = self::normalizeDirectories($directories);
+		$key = implode("\n", $directories);
+
+		return self::$instances[$key] ??= new self($key, $directories);
+	}
+
+	/**
+	 * Identifies the scanned set of directories. Callers memoizing anything derived from a
+	 * discoverer key their caches on it, because two containers compiled in the same process
+	 * can be configured with different directories.
+	 */
+	public function getKey(): string
+	{
+		return $this->key;
+	}
+
+	public static function createFromContainerBuilder(ContainerBuilder $builder): self
+	{
+		/** @var list<string> $directories */
+		$directories = $builder->parameters['autowiredServiceDirectories'];
+
+		return self::create($directories);
+	}
+
+	/**
+	 * Lists the files `create()` reads, without parsing any of them. ContainerFactory hashes them
+	 * into the container cache key, so that editing a discovered class rebuilds the container.
+	 *
+	 * @param list<string> $directories
+	 * @return list<string>
+	 */
+	public static function findFiles(array $directories): array
+	{
+		$directories = self::normalizeDirectories($directories);
+		$key = implode("\n", $directories);
+		if (array_key_exists($key, self::$files)) {
+			return self::$files[$key];
+		}
+
+		$files = [];
+		foreach ($directories as $directory) {
+			if (!is_dir($directory)) {
+				throw new ShouldNotHappenException(sprintf('Directory %s from the autowiredServiceDirectories parameter does not exist.', $directory));
+			}
+
+			$finder = new Finder();
+			$finder->followLinks()->files()->name('*.php')->in($directory);
+			foreach ($finder as $fileInfo) {
+				$files[] = $fileInfo->getPathname();
+			}
+		}
+
+		$files = array_values(array_unique($files));
+		sort($files);
+
+		return self::$files[$key] = $files;
+	}
+
+	/**
+	 * @template T of object
+	 * @param class-string<T> $attribute
+	 * @return list<TargetClass<T>>
+	 */
+	public function findTargetClasses(string $attribute): array
+	{
+		$this->collect();
+
+		/** @var list<TargetClass<T>> */
+		return $this->targetClasses[$attribute] ?? [];
+	}
+
+	/**
+	 * @template T of object
+	 * @param class-string<T> $attribute
+	 * @return list<TargetMethodParameter<T>>
+	 */
+	public function findTargetMethodParameters(string $attribute): array
+	{
+		$this->collect();
+
+		/** @var list<TargetMethodParameter<T>> */
+		return $this->targetMethodParameters[$attribute] ?? [];
+	}
+
+	/**
+	 * Reads and parses the discovered files on the first lookup. Compiler extensions ask for
+	 * attributes they do not always use - a container compiled without any of them never
+	 * touches the filesystem beyond the file list ContainerFactory needs anyway.
+	 */
+	private function collect(): void
+	{
+		if ($this->collected) {
+			return;
+		}
+
+		$this->collected = true;
+
+		$parser = (new ParserFactory())->createForNewestSupportedVersion();
+		$nodeFinder = new NodeFinder();
+		$discoveredClasses = [];
+
+		foreach (self::findFiles($this->directories) as $file) {
+			$contents = FileReader::read($file);
+			if (!self::mayContainAttributes($contents)) {
+				continue;
+			}
+
+			try {
+				$stmts = $parser->parse($contents);
+			} catch (Error $e) {
+				throw new ShouldNotHappenException(sprintf('Cannot parse %s: %s', $file, $e->getMessage()));
+			}
+			if ($stmts === null) {
+				continue;
+			}
+
+			$traverser = new NodeTraverser(new NameResolver());
+			$stmts = $traverser->traverse($stmts);
+
+			foreach ($nodeFinder->findInstanceOf($stmts, ClassLike::class) as $class) {
+				if ($class->namespacedName === null) {
+					// anonymous class
+					continue;
+				}
+
+				$attributeNames = self::findAttributeNames($class);
+				if (count($attributeNames) === 0) {
+					continue;
+				}
+
+				/** @var class-string $className */
+				$className = $class->namespacedName->toString();
+				foreach ($attributeNames as $attributeName) {
+					if (!in_array($attributeName, self::UNSUPPORTED_ATTRIBUTES, true)) {
+						continue;
+					}
+
+					throw new ShouldNotHappenException(sprintf(
+						'Attribute #[%s] on class %s is only supported for classes shipped with PHPStan itself, not for classes discovered through the autowiredServiceDirectories parameter.',
+						self::shortName($attributeName),
+						$className,
+					));
+				}
+
+				if (array_key_exists($className, $discoveredClasses)) {
+					// the same file can be reachable through two overlapping directories
+					continue;
+				}
+				$discoveredClasses[$className] = true;
+
+				$this->collectClass($className, $file);
+			}
+		}
+	}
+
+	/**
+	 * @param class-string $className
+	 */
+	private function collectClass(string $className, string $file): void
+	{
+		if (!class_exists($className) && !interface_exists($className)) {
+			throw new ShouldNotHappenException(sprintf(
+				'Class %s declared in %s has a PHPStan dependency injection attribute but cannot be autoloaded.',
+				$className,
+				$file,
+			));
+		}
+
+		$reflection = new ReflectionClass($className);
+		foreach (self::CLASS_ATTRIBUTES as $attributeClass) {
+			foreach ($reflection->getAttributes($attributeClass) as $attribute) {
+				$this->addTargetClass($attributeClass, $className, $attribute->newInstance());
+			}
+		}
+
+		$constructor = $reflection->getConstructor();
+		if ($constructor === null) {
+			return;
+		}
+
+		foreach ($constructor->getParameters() as $parameter) {
+			foreach (self::CONSTRUCTOR_PARAMETER_ATTRIBUTES as $attributeClass) {
+				foreach ($parameter->getAttributes($attributeClass) as $attribute) {
+					$this->addTargetMethodParameter($attributeClass, $className, $parameter->getName(), $attribute->newInstance());
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param class-string $attributeClass
+	 * @param class-string $className
+	 */
+	private function addTargetClass(string $attributeClass, string $className, object $attribute): void
+	{
+		$this->targetClasses[$attributeClass][] = new TargetClass($attribute, $className);
+	}
+
+	/**
+	 * @param class-string $attributeClass
+	 * @param class-string $className
+	 * @param non-empty-string $parameterName
+	 */
+	private function addTargetMethodParameter(string $attributeClass, string $className, string $parameterName, object $attribute): void
+	{
+		$this->targetMethodParameters[$attributeClass][] = new TargetMethodParameter($attribute, $className, $parameterName, '__construct');
+	}
+
+	/**
+	 * Names of PHPStan's dependency injection attributes on the class itself and on its
+	 * constructor parameters. Everything else in the scanned directories is left alone.
+	 *
+	 * @return list<string>
+	 */
+	private static function findAttributeNames(ClassLike $class): array
+	{
+		$known = array_merge(self::CLASS_ATTRIBUTES, self::CONSTRUCTOR_PARAMETER_ATTRIBUTES, self::UNSUPPORTED_ATTRIBUTES);
+		$attrGroups = $class->attrGroups;
+		$constructor = $class->getMethod('__construct');
+		if ($constructor !== null) {
+			foreach ($constructor->params as $param) {
+				$attrGroups = array_merge($attrGroups, $param->attrGroups);
+			}
+		}
+
+		$names = [];
+		foreach ($attrGroups as $attrGroup) {
+			foreach ($attrGroup->attrs as $attr) {
+				$name = $attr->name->toString();
+				if (!in_array($name, $known, true)) {
+					continue;
+				}
+
+				$names[] = $name;
+			}
+		}
+
+		return array_values(array_unique($names));
+	}
+
+	/**
+	 * Cheap pre-filter so that files without any of PHPStan's attributes are never parsed.
+	 *
+	 * Looking for the namespace the attributes live in rather than for each of their names keeps
+	 * this down to a single needle per file, and covers every way of referring to them: a plain,
+	 * grouped or aliased `use` line, a fully qualified name written in place, and - because the
+	 * `namespace` declaration matches too - an unqualified name in a file that already sits in
+	 * that namespace.
+	 */
+	private static function mayContainAttributes(string $contents): bool
+	{
+		if (!str_contains($contents, '#[')) {
+			return false;
+		}
+
+		foreach (self::getAttributeNamespaces() as $namespace) {
+			if (str_contains($contents, $namespace)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private static function getAttributeNamespaces(): array
+	{
+		if (self::$attributeNamespaces !== null) {
+			return self::$attributeNamespaces;
+		}
+
+		$namespaces = [];
+		foreach (array_merge(self::CLASS_ATTRIBUTES, self::CONSTRUCTOR_PARAMETER_ATTRIBUTES, self::UNSUPPORTED_ATTRIBUTES) as $attributeClass) {
+			$position = strrpos($attributeClass, '\\');
+			if ($position === false) {
+				continue;
+			}
+
+			$namespaces[substr($attributeClass, 0, $position)] = true;
+		}
+
+		return self::$attributeNamespaces = array_keys($namespaces);
+	}
+
+	private static function shortName(string $className): string
+	{
+		$position = strrpos($className, '\\');
+		if ($position === false) {
+			return $className;
+		}
+
+		return substr($className, $position + 1);
+	}
+
+	/**
+	 * @param list<string> $directories
+	 * @return list<string>
+	 */
+	private static function normalizeDirectories(array $directories): array
+	{
+		$directories = array_values(array_unique($directories));
+		sort($directories);
+
+		return $directories;
+	}
+
+}

--- a/src/DependencyInjection/ConditionalTagsExtension.php
+++ b/src/DependencyInjection/ConditionalTagsExtension.php
@@ -23,7 +23,7 @@ final class ConditionalTagsExtension extends CompilerExtension
 	#[Override]
 	public function getConfigSchema(): Nette\Schema\Schema
 	{
-		$tags = array_values(ValidateServiceTagsExtension::getInterfaceTagMapping());
+		$tags = array_values(ValidateServiceTagsExtension::getInterfaceTagMapping($this->getContainerBuilder()));
 
 		return Expect::arrayOf(Expect::structure(
 			array_fill_keys($tags, Expect::anyOf(

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -39,6 +39,9 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 	/** @var string[] */
 	private array $allConfigFiles = [];
 
+	/** @var string[] */
+	private array $autowiredServiceFiles = [];
+
 	public function __construct(private LoaderFactory $loaderFactory, private bool $journalContainer)
 	{
 		parent::__construct();
@@ -56,6 +59,14 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 	public function setAllConfigFiles(array $allConfigFiles): void
 	{
 		$this->allConfigFiles = $allConfigFiles;
+	}
+
+	/**
+	 * @param string[] $autowiredServiceFiles
+	 */
+	public function setAutowiredServiceFiles(array $autowiredServiceFiles): void
+	{
+		$this->autowiredServiceFiles = $autowiredServiceFiles;
 	}
 
 	/**
@@ -103,6 +114,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 			is_file($attributesPhp) ? hash_file('sha256', $attributesPhp) : 'attributes-missing',
 			NeonAdapter::CACHE_KEY,
 			$this->getAllConfigFilesHashes(),
+			self::hashFiles($this->autowiredServiceFiles),
 		];
 
 		$className = $loader->load(
@@ -233,8 +245,17 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 	 */
 	private function getAllConfigFilesHashes(): array
 	{
+		return self::hashFiles($this->allConfigFiles);
+	}
+
+	/**
+	 * @param string[] $files
+	 * @return string[]
+	 */
+	private static function hashFiles(array $files): array
+	{
 		$hashes = [];
-		foreach ($this->allConfigFiles as $file) {
+		foreach ($files as $file) {
 			$hash = hash_file('sha256', $file);
 
 			if ($hash === false) {

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -113,14 +113,14 @@ final class ContainerFactory
 		array $additionalParameters = [],
 	): Container
 	{
-		[$allConfigFiles, $projectConfig] = $this->detectDuplicateIncludedFiles(
-			array_merge([__DIR__ . '/../../conf/parametersSchema.neon'], $additionalConfigFiles),
-			[
-				'rootDir' => $this->rootDirectory,
-				'currentWorkingDirectory' => $this->currentWorkingDirectory,
-				'env' => Environment::getCleanedArray(),
-			],
-		);
+		$loaderParameters = [
+			'rootDir' => $this->rootDirectory,
+			'currentWorkingDirectory' => $this->currentWorkingDirectory,
+			'env' => Environment::getCleanedArray(),
+		];
+		$configFiles = array_merge([__DIR__ . '/../../conf/parametersSchema.neon'], $additionalConfigFiles);
+
+		[$allConfigFiles, $projectConfig] = $this->detectDuplicateIncludedFiles($configFiles, $loaderParameters, []);
 
 		$configurator = new Configurator(new LoaderFactory(
 			$this->fileHelper,
@@ -161,6 +161,7 @@ final class ContainerFactory
 		}
 
 		$configurator->setAllConfigFiles($allConfigFiles);
+		$configurator->setAutowiredServiceFiles($this->findAutowiredServiceFiles($configFiles, $loaderParameters, $projectConfig));
 
 		$container = $configurator->createContainer()->getByType(Container::class);
 		$this->validateParameters($container->getParameters(), $projectConfig['parametersSchema']);
@@ -230,17 +231,45 @@ final class ContainerFactory
 	}
 
 	/**
+	 * Files with classes registered through PHPStan's dependency injection attributes.
+	 * The container is cached under a key derived from their contents, so that editing
+	 * one of them rebuilds the container the same way editing a config file does.
+	 *
 	 * @param string[] $configFiles
 	 * @param array<string, mixed> $loaderParameters
+	 * @param array<mixed> $projectConfig
+	 * @return list<string>
+	 */
+	private function findAutowiredServiceFiles(array $configFiles, array $loaderParameters, array $projectConfig): array
+	{
+		if (count($projectConfig['parameters']['autowiredServiceDirectories'] ?? []) === 0) {
+			return [];
+		}
+
+		// the first config pass runs without expandRelativePaths - the list is read from the very
+		// same config - so directories relative to the file declaring them are not absolutized yet
+		[, $expandedConfig] = $this->detectDuplicateIncludedFiles($configFiles, $loaderParameters, $projectConfig['expandRelativePaths']);
+
+		/** @var list<string> $directories */
+		$directories = Helpers::expand($expandedConfig['parameters']['autowiredServiceDirectories'], $loaderParameters, true);
+
+		return AutowiredServiceDiscoverer::findFiles($directories);
+	}
+
+	/**
+	 * @param string[] $configFiles
+	 * @param array<string, mixed> $loaderParameters
+	 * @param list<string> $expandRelativePaths
 	 * @return array{list<string>, array<mixed>}
 	 * @throws DuplicateIncludedFilesException
 	 */
 	private function detectDuplicateIncludedFiles(
 		array $configFiles,
 		array $loaderParameters,
+		array $expandRelativePaths,
 	): array
 	{
-		$neonAdapter = new NeonCachedFileReader([]);
+		$neonAdapter = new NeonCachedFileReader($expandRelativePaths);
 		$phpAdapter = new PhpAdapter();
 		$allConfigFiles = [];
 		$configArray = [];

--- a/src/DependencyInjection/ExtensionInterface.php
+++ b/src/DependencyInjection/ExtensionInterface.php
@@ -13,6 +13,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredAttributeServicesExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_CLASS)]
 final class ExtensionInterface

--- a/src/DependencyInjection/ExtensionsCollection.php
+++ b/src/DependencyInjection/ExtensionsCollection.php
@@ -15,6 +15,7 @@ namespace PHPStan\DependencyInjection;
  * )
  * ```
  *
+ * @api
  * @template-covariant T of object
  */
 interface ExtensionsCollection

--- a/src/DependencyInjection/GenerateFactory.php
+++ b/src/DependencyInjection/GenerateFactory.php
@@ -15,6 +15,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredAttributeServicesExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_CLASS)]
 final class GenerateFactory

--- a/src/DependencyInjection/NonAutowiredService.php
+++ b/src/DependencyInjection/NonAutowiredService.php
@@ -9,6 +9,11 @@ use Attribute;
 
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredAttributeServicesExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_CLASS)]
 final class NonAutowiredService

--- a/src/DependencyInjection/RegisteredCollector.php
+++ b/src/DependencyInjection/RegisteredCollector.php
@@ -9,6 +9,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredAttributeServicesExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_CLASS)]
 final class RegisteredCollector

--- a/src/DependencyInjection/RegisteredRule.php
+++ b/src/DependencyInjection/RegisteredRule.php
@@ -9,6 +9,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and AutowiredAttributeServicesExtension.
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_CLASS)]
 final class RegisteredRule

--- a/src/DependencyInjection/StubValidatorRuleServicesExtension.php
+++ b/src/DependencyInjection/StubValidatorRuleServicesExtension.php
@@ -6,6 +6,7 @@ use Nette\DI\CompilerExtension;
 use olvlvl\ComposerAttributeCollector\Attributes;
 use Override;
 use PHPStan\PhpDoc\StubValidator;
+use function array_merge;
 use function strcasecmp;
 use function strtolower;
 
@@ -17,8 +18,12 @@ final class StubValidatorRuleServicesExtension extends CompilerExtension
 	{
 		require_once __DIR__ . '/../../vendor/attributes.php';
 		$builder = $this->getContainerBuilder();
+		$discoverer = AutowiredServiceDiscoverer::createFromContainerBuilder($builder);
 
-		$autowiredParameters = Attributes::findTargetMethodParameters(AutowiredParameter::class);
+		$autowiredParameters = array_merge(
+			Attributes::findTargetMethodParameters(AutowiredParameter::class),
+			$discoverer->findTargetMethodParameters(AutowiredParameter::class),
+		);
 		$constructorParameters = [];
 		foreach ($autowiredParameters as $parameter) {
 			if (strcasecmp($parameter->method, '__construct') !== 0) {
@@ -29,7 +34,7 @@ final class StubValidatorRuleServicesExtension extends CompilerExtension
 			$constructorParameters[$lowerClass][] = $parameter;
 		}
 
-		foreach (Attributes::findTargetClasses(ValidatesStubFiles::class) as $class) {
+		foreach (array_merge(Attributes::findTargetClasses(ValidatesStubFiles::class), $discoverer->findTargetClasses(ValidatesStubFiles::class)) as $class) {
 			$definition = $builder->addDefinition(null)
 				->setFactory($class->name)
 				->setAutowired(false)

--- a/src/DependencyInjection/ValidateServiceTagsExtension.php
+++ b/src/DependencyInjection/ValidateServiceTagsExtension.php
@@ -3,6 +3,7 @@
 namespace PHPStan\DependencyInjection;
 
 use Nette\DI\CompilerExtension;
+use Nette\DI\ContainerBuilder;
 use Nette\PhpGenerator\ClassType;
 use olvlvl\ComposerAttributeCollector\Attributes;
 use Override;
@@ -13,6 +14,7 @@ use ReflectionClass;
 use function array_flip;
 use function array_key_exists;
 use function array_keys;
+use function array_merge;
 use function count;
 use function sprintf;
 
@@ -20,27 +22,34 @@ use function sprintf;
 final class ValidateServiceTagsExtension extends CompilerExtension
 {
 
-	/** @var array<class-string, string>|null */
-	private static ?array $interfaceTagMapping = null;
+	/** @var array<string, array<class-string, string>> */
+	private static array $interfaceTagMapping = [];
 
 	/**
-	 * Derived from the #[ExtensionInterface] attribute above each extension interface.
+	 * Derived from the #[ExtensionInterface] attribute above each extension interface,
+	 * both PHPStan's own ones and those found in the autowiredServiceDirectories.
 	 *
 	 * @return array<class-string, string>
 	 */
-	public static function getInterfaceTagMapping(): array
+	public static function getInterfaceTagMapping(ContainerBuilder $builder): array
 	{
-		if (self::$interfaceTagMapping !== null) {
-			return self::$interfaceTagMapping;
-		}
-
 		require_once __DIR__ . '/../../vendor/attributes.php';
+
+		$discoverer = AutowiredServiceDiscoverer::createFromContainerBuilder($builder);
+		$cacheKey = $discoverer->getKey();
+		if (array_key_exists($cacheKey, self::$interfaceTagMapping)) {
+			return self::$interfaceTagMapping[$cacheKey];
+		}
 
 		$mapping = [
 			// vendor interface - cannot carry the #[ExtensionInterface] attribute
 			NodeVisitor::class => RichParser::VISITOR_SERVICE_TAG,
 		];
-		foreach (Attributes::findTargetClasses(ExtensionInterface::class) as $class) {
+		$classes = array_merge(
+			Attributes::findTargetClasses(ExtensionInterface::class),
+			$discoverer->findTargetClasses(ExtensionInterface::class),
+		);
+		foreach ($classes as $class) {
 			// the attribute is not repeatable but the collector does not validate that
 			if (array_key_exists($class->name, $mapping)) {
 				throw new ShouldNotHappenException(sprintf('Interface %s claims multiple tags', $class->name));
@@ -48,7 +57,7 @@ final class ValidateServiceTagsExtension extends CompilerExtension
 			$mapping[$class->name] = $class->attribute->tag;
 		}
 
-		return self::$interfaceTagMapping = $mapping;
+		return self::$interfaceTagMapping[$cacheKey] = $mapping;
 	}
 
 	/**
@@ -65,7 +74,7 @@ final class ValidateServiceTagsExtension extends CompilerExtension
 	public function afterCompile(ClassType $class): void
 	{
 		$builder = $this->getContainerBuilder();
-		$mapping = self::getInterfaceTagMapping();
+		$mapping = self::getInterfaceTagMapping($builder);
 		$mappingCount = count($mapping);
 		$flippedMapping = array_flip($mapping);
 

--- a/src/DependencyInjection/ValidatesStubFiles.php
+++ b/src/DependencyInjection/ValidatesStubFiles.php
@@ -11,6 +11,11 @@ use Attribute;
  *
  * Works thanks to https://github.com/ondrejmirtes/composer-attribute-collector
  * and StubValidatorRuleServicesExtension (similar to AutowiredAttributeServicesExtension).
+ *
+ * Extensions distributed outside phpstan-src list the directories to look for
+ * this attribute in through the `autowiredServiceDirectories` parameter.
+ *
+ * @api
  */
 #[Attribute(flags: Attribute::TARGET_CLASS)]
 final class ValidatesStubFiles

--- a/tests/PHPStan/DependencyInjection/AutowiredServiceDiscovererTest.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServiceDiscovererTest.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+use PHPStan\Collectors\RegistryFactory;
+use PHPStan\DependencyInjection\AutowiredServices\DiscoveredExtension;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredAliasedService;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredCollector;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredExtension;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredHighLevelRule;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredNonAutowiredService;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredReadWritePropertiesExtension;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredRule;
+use PHPStan\DependencyInjection\AutowiredServices\TestedDiscoveredService;
+use PHPStan\File\FileReader;
+use PHPStan\File\FileWriter;
+use PHPStan\Rules\LazyRegistry;
+use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
+use PHPUnit\Framework\TestCase;
+use function array_filter;
+use function glob;
+use function md5;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+class AutowiredServiceDiscovererTest extends TestCase
+{
+
+	private static ?Container $container = null;
+
+	private static string $tmpDir;
+
+	private static function createContainer(): Container
+	{
+		if (self::$container !== null) {
+			return self::$container;
+		}
+
+		self::$tmpDir = sys_get_temp_dir() . '/phpstan-autowired-services-' . md5(uniqid(more_entropy: true));
+		mkdir(self::$tmpDir, 0777, true);
+
+		$containerFactory = new ContainerFactory(__DIR__);
+
+		return self::$container = $containerFactory->create(self::$tmpDir, [__DIR__ . '/autowiredServices.neon'], []);
+	}
+
+	public function testAutowiredService(): void
+	{
+		$service = self::createContainer()->getByType(TestedDiscoveredService::class);
+		$this->assertSame(self::$tmpDir, $service->getTmpDir());
+		$this->assertFalse($service->isBleedingEdge());
+	}
+
+	public function testNonAutowiredService(): void
+	{
+		$container = self::createContainer();
+		$this->assertInstanceOf(
+			TestedDiscoveredNonAutowiredService::class,
+			$container->getService('testedDiscoveredNonAutowiredService'),
+		);
+	}
+
+	/**
+	 * The pre-filter deciding which files are worth parsing must not assume the attribute is
+	 * referred to by name - an aliased namespace import spells out neither.
+	 */
+	public function testServiceUsingAnAliasedNamespaceImport(): void
+	{
+		$container = self::createContainer();
+		$this->assertInstanceOf(
+			TestedDiscoveredAliasedService::class,
+			$container->getService('testedDiscoveredAliasedService'),
+		);
+	}
+
+	public function testNonAutowiredServiceCannotBeAutowired(): void
+	{
+		$container = self::createContainer();
+		$this->expectException(MissingServiceException::class);
+		$container->getByType(TestedDiscoveredNonAutowiredService::class);
+	}
+
+	public function testRegisteredRuleOnCurrentLevel(): void
+	{
+		$rules = self::createContainer()->getServicesByTag(LazyRegistry::RULE_TAG);
+		$this->assertCount(1, array_filter($rules, static fn ($rule): bool => $rule instanceof TestedDiscoveredRule));
+	}
+
+	public function testRegisteredRuleAboveCurrentLevelIsNotRegistered(): void
+	{
+		$rules = self::createContainer()->getServicesByTag(LazyRegistry::RULE_TAG);
+		$this->assertCount(0, array_filter($rules, static fn ($rule): bool => $rule instanceof TestedDiscoveredHighLevelRule));
+	}
+
+	public function testRegisteredCollector(): void
+	{
+		$collectors = self::createContainer()->getServicesByTag(RegistryFactory::COLLECTOR_TAG);
+		$this->assertCount(1, array_filter($collectors, static fn ($collector): bool => $collector instanceof TestedDiscoveredCollector));
+	}
+
+	public function testAutoTaggedExtension(): void
+	{
+		$extensions = self::createContainer()->getExtensionsCollection(ReadWritePropertiesExtension::class)->getAll();
+		$this->assertCount(1, array_filter($extensions, static fn ($extension): bool => $extension instanceof TestedDiscoveredReadWritePropertiesExtension));
+	}
+
+	public function testDiscoveredExtensionInterface(): void
+	{
+		$extensions = self::createContainer()->getExtensionsCollection(DiscoveredExtension::class)->getAll();
+		$this->assertCount(1, $extensions);
+		$this->assertInstanceOf(TestedDiscoveredExtension::class, $extensions[0]);
+	}
+
+	/**
+	 * Editing a discovered class has to invalidate the container the same way editing
+	 * a configuration file does - otherwise a changed #[AutowiredService] would keep
+	 * being served from the container cache.
+	 */
+	public function testEditingDiscoveredFileChangesTheContainer(): void
+	{
+		$dataDir = sys_get_temp_dir() . '/phpstan-discovered-service-' . md5(uniqid(more_entropy: true));
+		$tmpDir = $dataDir . '/tmp';
+		mkdir($dataDir . '/services', 0777, true);
+		mkdir($tmpDir, 0777, true);
+
+		$serviceFile = $dataDir . '/services/DiscoveredService.php';
+		FileWriter::write($serviceFile, "<?php declare(strict_types = 1);\n\nnamespace PHPStanTest\\Discovered;\n\n#[\\PHPStan\\DependencyInjection\\AutowiredService(name: 'discoveredTestService')]\nfinal class DiscoveredService\n{\n\n}\n");
+		FileWriter::write($dataDir . '/config.neon', "parameters:\n\tautowiredServiceDirectories:\n\t\t- services\n");
+
+		// the discoverer reflects on the class and the autoloader knows nothing about this directory
+		require_once $serviceFile;
+
+		$container = (new ContainerFactory($dataDir))->create($tmpDir, [$dataDir . '/config.neon'], []);
+		$this->assertTrue($container->hasService('discoveredTestService'));
+
+		$containersBeforeEdit = self::listGeneratedContainers($tmpDir);
+		$this->assertCount(1, $containersBeforeEdit);
+
+		FileWriter::write($serviceFile, FileReader::read($serviceFile) . "\n// edited\n");
+
+		(new ContainerFactory($dataDir))->create($tmpDir, [$dataDir . '/config.neon'], []);
+
+		$containersAfterEdit = self::listGeneratedContainers($tmpDir);
+		$this->assertCount(2, $containersAfterEdit);
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private static function listGeneratedContainers(string $tmpDir): array
+	{
+		$files = glob($tmpDir . '/cache/nette.configurator/Container_*.php');
+		if ($files === false) {
+			return [];
+		}
+
+		return $files;
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/DiscoveredExtension.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/DiscoveredExtension.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PHPStan\DependencyInjection\ExtensionInterface;
+
+#[ExtensionInterface(tag: 'phpstan.tests.discoveredExtension')]
+interface DiscoveredExtension
+{
+
+	public function getName(): string;
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredAliasedService.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredAliasedService.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PHPStan\DependencyInjection as DI;
+
+/**
+ * Refers to the attribute through an aliased namespace import, which neither spells out the
+ * attribute's short name nor its fully qualified one.
+ */
+#[DI\AutowiredService(name: 'testedDiscoveredAliasedService')]
+final class TestedDiscoveredAliasedService
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredCollector.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredCollector.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Echo_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\DependencyInjection\RegisteredCollector;
+
+/**
+ * @implements Collector<Echo_, string>
+ */
+#[RegisteredCollector(level: 0)]
+final class TestedDiscoveredCollector implements Collector
+{
+
+	public function getNodeType(): string
+	{
+		return Echo_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope)
+	{
+		return null;
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredExtension.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredExtension.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PHPStan\DependencyInjection\AutowiredService;
+
+#[AutowiredService]
+final class TestedDiscoveredExtension implements DiscoveredExtension
+{
+
+	public function getName(): string
+	{
+		return 'discovered';
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredHighLevelRule.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredHighLevelRule.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Echo_;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<Echo_>
+ */
+#[RegisteredRule(level: 9)]
+final class TestedDiscoveredHighLevelRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Echo_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return [];
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredNonAutowiredService.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredNonAutowiredService.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PHPStan\DependencyInjection\NonAutowiredService;
+
+#[NonAutowiredService(name: 'testedDiscoveredNonAutowiredService')]
+final class TestedDiscoveredNonAutowiredService
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredReadWritePropertiesExtension.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredReadWritePropertiesExtension.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\ExtendedPropertyReflection;
+use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
+
+#[AutowiredService]
+final class TestedDiscoveredReadWritePropertiesExtension implements ReadWritePropertiesExtension
+{
+
+	public function isAlwaysRead(ExtendedPropertyReflection $property, string $propertyName): bool
+	{
+		return false;
+	}
+
+	public function isAlwaysWritten(ExtendedPropertyReflection $property, string $propertyName): bool
+	{
+		return false;
+	}
+
+	public function isInitialized(ExtendedPropertyReflection $property, string $propertyName): bool
+	{
+		return false;
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredRule.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredRule.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Echo_;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<Echo_>
+ */
+#[RegisteredRule(level: 0)]
+final class TestedDiscoveredRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Echo_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return [];
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredService.php
+++ b/tests/PHPStan/DependencyInjection/AutowiredServices/TestedDiscoveredService.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\AutowiredServices;
+
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\AutowiredService;
+
+#[AutowiredService]
+final class TestedDiscoveredService
+{
+
+	public function __construct(
+		#[AutowiredParameter]
+		private string $tmpDir,
+		#[AutowiredParameter(ref: '%featureToggles.bleedingEdge%')]
+		private bool $bleedingEdge,
+	)
+	{
+	}
+
+	public function getTmpDir(): string
+	{
+		return $this->tmpDir;
+	}
+
+	public function isBleedingEdge(): bool
+	{
+		return $this->bleedingEdge;
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/autowiredServices.neon
+++ b/tests/PHPStan/DependencyInjection/autowiredServices.neon
@@ -1,0 +1,6 @@
+parameters:
+	autowiredServiceDirectories:
+		- AutowiredServices
+
+autowiredAttributeServices:
+	level: 0


### PR DESCRIPTION
Hello!

I really love the DI attributes and how much boilerplate they removed from the neon files! Unfortunately this mechanism was only usable in this repo so it couldn't be used to say clean up the Larastan `extension.neon`---until now 

This adds a new `autowiredServiceDirectories` parameter that extensions can configure like so:

```yaml
parameters:
  autowiredServiceDirectories: [src]
```

and then all of their classes will be automatically picked up by phpstan when running. The files are hashed by their contents, so if they change then the directory is re-walked

Additionally, this also allows conditionally registering rules with `#[RegisteredRule(level: 4, enabledBy: '%featureToggles.finiteTypesInHaystack%')]` and removes a ton of boilerplate from the `conditionalTags` config


Here's an example in a third-party extension of how much it cleans up: https://github.com/calebdw/phpstan-laravel/pull/10


Closes https://github.com/phpstan/phpstan/issues/15114

Thanks!