### PR TITLE
Ignore the turbo version constant in the typos check

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,6 +4,12 @@ extend-exclude = [
 ]
 ignore-hidden = false
 
+[default]
+# TurboExtensionEnabler::EXPECTED_EXTENSION_VERSION is a git short SHA, not a
+# word. It changes on every turbo-ext/src commit, and a hex SHA occasionally
+# spells a dictionary word fragment - '873ede9' reads as "ede" -> "edge".
+extend-ignore-re = ["EXPECTED_EXTENSION_VERSION = '[0-9a-f]+'"]
+
 [default.extend-identifiers]
 # Known typos
 NonRemoveableTypeTrait = "NonRemoveableTypeTrait"


### PR DESCRIPTION
`EXPECTED_EXTENSION_VERSION` is a git short SHA, and `873ede9` reads as `ede` -> `edge`, so `Check for typos` fails on it:

```
error: `ede` should be `edge`
   ╭▸ src/Turbo/TurboExtensionEnabler.php:25:48
25 │     public const EXPECTED_EXTENSION_VERSION = '873ede9';
```

`9fdc13de1` allowlisted that exact SHA when it bumped the constant, and `65fd60974` removed the entry again while the SHA was still current - so Spelling is red on the tip of `2.2.x` itself, and on every PR opened or rebased since.

Matching the constant's line instead of the individual SHA needs no follow-up at the next `make bump-turbo`, which is what went wrong here: the per-SHA entry has to be added by the bump and must not be cleaned up until the SHA changes.

## Verified with the version CI pins (typos 1.48.0)

- `typos README.md src/` on `2.2.x`: the error above. With this change: clean.
- Still narrow - a real typo elsewhere is reported: adding `// the ede case is real` to a file under `src/` gives `error: 'ede' should be 'edge'`.
- Survives future bumps - `deadbee`, `873ede9`, `0ffe1ca` and `abcdefa` in that constant are all clean.

The minimal alternative is restoring the `873ede9 = "873ede9"` entry that `65fd60974` deleted, but that puts the same trap back.
