### PR TITLE
Check written case of single-part class names imported with use statements

### DIFF
--- a/src/Rules/AttributesCheck.php
+++ b/src/Rules/AttributesCheck.php
@@ -73,7 +73,7 @@ final class AttributesCheck
 						->build();
 				}
 
-				foreach ($this->classCheck->checkClassNames($scope, [new ClassNameNodePair($name, $attribute)], ClassNameUsageLocation::from(ClassNameUsageLocation::ATTRIBUTE)) as $caseSensitivityError) {
+				foreach ($this->classCheck->checkClassNames($scope, [new ClassNameNodePair($name, $attribute->name)], ClassNameUsageLocation::from(ClassNameUsageLocation::ATTRIBUTE)) as $caseSensitivityError) {
 					$errors[] = $caseSensitivityError;
 				}
 

--- a/src/Rules/ClassCaseSensitivityCheck.php
+++ b/src/Rules/ClassCaseSensitivityCheck.php
@@ -2,10 +2,13 @@
 
 namespace PHPStan\Rules;
 
+use PhpParser\Node\Name;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Parser\UseAliasVisitor;
 use PHPStan\Reflection\ReflectionProvider;
+use function count;
+use function implode;
 use function sprintf;
 use function strtolower;
 
@@ -29,7 +32,7 @@ final class ClassCaseSensitivityCheck
 	{
 		$errors = [];
 		foreach ($pairs as $pair) {
-			$className = $pair->getClassName();
+			$className = $this->getClassNameAsWritten($pair);
 			if (!$this->reflectionProvider->hasClass($className)) {
 				continue;
 			}
@@ -61,6 +64,50 @@ final class ClassCaseSensitivityCheck
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * @return non-empty-string
+	 */
+	private function getClassNameAsWritten(ClassNameNodePair $pair): string
+	{
+		$className = $pair->getClassName();
+		$node = $pair->getNode();
+		if (!$node instanceof Name || $node->toString() !== $className) {
+			return $className;
+		}
+
+		return self::getNameAsWritten($node);
+	}
+
+	/**
+	 * NameResolver replaces a single-part imported name entirely with the use statement's
+	 * spelling, so the case the user wrote survives only in the originalName attribute.
+	 * Multi-part names keep the written case of everything after the first part.
+	 *
+	 * @return non-empty-string
+	 */
+	public static function getNameAsWritten(Name $node): string
+	{
+		$resolvedName = $node->toString();
+		$originalName = $node->getAttribute('originalName');
+		if (
+			!$originalName instanceof Name
+			|| $originalName instanceof Name\FullyQualified
+			|| $originalName instanceof Name\Relative
+		) {
+			return $resolvedName;
+		}
+
+		$originalParts = $originalName->getParts();
+		if (count($originalParts) !== 1) {
+			return $resolvedName;
+		}
+
+		$resolvedParts = $node->getParts();
+		$resolvedParts[count($resolvedParts) - 1] = $originalParts[0];
+
+		return implode('\\', $resolvedParts);
 	}
 
 }

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -41,9 +41,7 @@ use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
-use function array_slice;
 use function count;
-use function implode;
 use function in_array;
 use function is_string;
 use function sprintf;
@@ -846,30 +844,13 @@ final class FunctionDefinitionCheck
 		}
 
 		if ($typeNode instanceof Name) {
-			$originalName = $typeNode->getAttribute('originalName');
-			if (!$originalName instanceof Name) {
-				return [];
-			}
-
 			$resolvedName = $typeNode->toString();
-			$originalParts = $originalName->getParts();
-			$resolvedParts = $typeNode->getParts();
-
-			$originalPartsCount = count($originalParts);
-			$resolvedPartsCount = count($resolvedParts);
-
-			if ($originalPartsCount <= $resolvedPartsCount) {
-				$prefixParts = array_slice($resolvedParts, 0, $resolvedPartsCount - $originalPartsCount);
-				$originalCaseClassName = implode('\\', array_merge($prefixParts, $originalParts));
-			} else {
-				$originalCaseClassName = $originalName->toString();
-			}
-
-			if ($originalCaseClassName === $resolvedName) {
+			$nameAsWritten = ClassCaseSensitivityCheck::getNameAsWritten($typeNode);
+			if ($nameAsWritten === $resolvedName) {
 				return [];
 			}
 
-			return [strtolower($resolvedName) => new ClassNameNodePair($originalCaseClassName, $typeNode)];
+			return [strtolower($resolvedName) => new ClassNameNodePair($nameAsWritten, $typeNode)];
 		}
 
 		if ($typeNode instanceof NullableType) {

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -569,4 +569,15 @@ class ClassConstantRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12827(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
+			[
+				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
+				25,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -739,4 +739,14 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-15047.php'], []);
 	}
 
+	public function testBug12827(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
+			[
+				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
+				15,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-12827.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-12827.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12827Classes {
+	class Post {}
+}
+
+namespace Bug12827ClassesConsumer {
+	use Bug12827Classes\Post;
+
+	class Consumer
+	{
+
+		public function doFoo(): object
+		{
+			return new POST();
+		}
+
+		public function doBar(): object
+		{
+			return new Post();
+		}
+
+		public function doBaz(): string
+		{
+			return POST::class;
+		}
+
+		public function doLorem(): string
+		{
+			return Post::class;
+		}
+
+	}
+}

--- a/tests/PHPStan/Rules/Exceptions/CaughtExceptionExistenceRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CaughtExceptionExistenceRuleTest.php
@@ -76,4 +76,14 @@ class CaughtExceptionExistenceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12827(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
+			[
+				'Class Bug12827Exceptions\MissingRoutingReferenceException referenced with incorrect case: Bug12827Exceptions\MissingRoutingreferenceException.',
+				20,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Exceptions/data/bug-12827.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-12827.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12827Exceptions {
+	final class MissingRoutingReferenceException extends \RuntimeException {}
+	final class UnpickedOrderException extends \RuntimeException {}
+}
+
+namespace Bug12827ExceptionsConsumer {
+	use Bug12827Exceptions\MissingRoutingReferenceException;
+	use Bug12827Exceptions\UnpickedOrderException;
+
+	class Consumer
+	{
+
+		public function doFoo(): void
+		{
+			try {
+				echo 'x';
+			} catch (
+				MissingRoutingreferenceException |
+				UnpickedOrderException $e
+			) {
+			}
+		}
+
+	}
+}

--- a/tests/PHPStan/Rules/Methods/MethodAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodAttributesRuleTest.php
@@ -83,4 +83,14 @@ class MethodAttributesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/deprecated-attribute.php'], []);
 	}
 
+	public function testBug12827(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
+			[
+				'Class Bug12827\Post referenced with incorrect case: Bug12827\POST.',
+				12,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-12827.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12827.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12827 {
+	#[\Attribute(\Attribute::TARGET_METHOD)]
+	class Post {}
+}
+
+namespace Bug12827Consumer {
+	use Bug12827\Post;
+
+	class Controller {
+		#[POST]
+		public function action(): void {}
+
+		#[Post]
+		public function correctAction(): void {}
+	}
+}
+
+namespace Bug12827Alias {
+	use Bug12827\Post as MyPost;
+
+	class Controller {
+		#[MyPost]
+		public function action(): void {}
+	}
+}


### PR DESCRIPTION
NameResolver replaces a single-part imported name with the use statement's spelling. The written case survives only in the `originalName` attribute. `ClassCaseSensitivityCheck` now reconstructs the written name from that attribute.

Because every affected rule goes through this check, one change fixes the case check for attributes, `new`, `::class`, `instanceof`, `extends`, `implements`, trait use and `catch`. Multi-part, fully qualified and relative names keep their written case in the resolved name, so the reconstruction applies only to single-part unqualified names. The existing `UseAliasVisitor` skip keeps explicit `use ... as` aliases exempt (https://github.com/phpstan/phpstan/issues/14205 stays fixed).

`FunctionDefinitionCheck` now shares the same reconstruction logic instead of its own copy. This also fixes its old splice logic, which produced non-existent names like `App\S\FOO` for aliased namespace prefixes and silently skipped the check.

Closes https://github.com/phpstan/phpstan/issues/12827

---

Integration-test triage: the new `nameCase` errors in doctrine/dbal, neos/flow, drupal and efabrica/phpstan-latte are true positives (e.g. dbal imports `SQLitePlatform` and writes `extends SqlitePlatform`; neos imports `MySQLPlatform` and writes `instanceof MySqlPlatform`). The rector, larastan, phpstan-laravel and phpstan-doctrine failures come from unrelated `2.2.x` changes (`toMutatingScope()` deprecation, model property message), and the `e2e/bug-11826` job already fails on `2.2.x`.
