### PR TITLE
Make SensitiveParameterValue generic

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -154,6 +154,7 @@ parameters:
 		- ../stubs/iterable.stub
 		- ../stubs/ArrayObject.stub
 		- ../stubs/WeakReference.stub
+		- ../stubs/SensitiveParameterValue.stub
 		- ../stubs/ext-ds.stub
 		- ../stubs/ImagickPixel.stub
 		- ../stubs/PDOStatement.stub

--- a/stubs/SensitiveParameterValue.stub
+++ b/stubs/SensitiveParameterValue.stub
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @template-covariant T = mixed
+ */
+final class SensitiveParameterValue
+{
+
+	/**
+	 * @param T $value
+	 */
+	public function __construct(mixed $value) {}
+
+	/**
+	 * @return T
+	 */
+	public function getValue(): mixed {}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/sensitive-parameter-value.php
+++ b/tests/PHPStan/Analyser/nsrt/sensitive-parameter-value.php
@@ -1,0 +1,44 @@
+<?php // lint >= 8.2
+
+declare(strict_types = 1);
+
+namespace SensitiveParameterValueGenerics;
+
+use SensitiveParameterValue;
+use function PHPStan\Testing\assertType;
+
+function inference(string $password, int $pin): void
+{
+	$value = new SensitiveParameterValue($password);
+	assertType('SensitiveParameterValue<string>', $value);
+	assertType('string', $value->getValue());
+
+	$value = new SensitiveParameterValue([$pin]);
+	assertType('SensitiveParameterValue<array{int}>', $value);
+	assertType('array{int}', $value->getValue());
+}
+
+/**
+ * @param SensitiveParameterValue<non-empty-string> $value
+ */
+function withTypeArgs(SensitiveParameterValue $value): void
+{
+	assertType('non-empty-string', $value->getValue());
+}
+
+function withoutTypeArgs(SensitiveParameterValue $value): void
+{
+	assertType('SensitiveParameterValue', $value);
+	assertType('mixed', $value->getValue());
+}
+
+/**
+ * @param SensitiveParameterValue<non-empty-string> $value
+ * @return SensitiveParameterValue<string>
+ */
+function covariance(SensitiveParameterValue $value): SensitiveParameterValue
+{
+	assertType('SensitiveParameterValue<non-empty-string>', $value);
+
+	return $value;
+}


### PR DESCRIPTION
`SensitiveParameterValue::getValue()` returns exactly the value that was passed to the constructor, so the class can carry that type instead of widening it to `mixed`.

```php
$value = new SensitiveParameterValue($password); // SensitiveParameterValue<string>
$value->getValue(); // string, was mixed
```

The template parameter is declared `@template-covariant T = mixed`:

* covariant, because the class is immutable — the value is a private `readonly` property with only a getter,
* with a `mixed` default, so a bare `SensitiveParameterValue` type in existing code keeps working and is not reported as missing type arguments on level 6 and above.

https://www.php.net/manual/en/class.sensitiveparametervalue.php

Co-Authored-By: Claude Code

https://claude.ai/code/session_018u931gZ2H5LQNTzsSfNdF4