### PR TITLE
Make BackedEnum generic

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -155,6 +155,7 @@ parameters:
 		- ../stubs/ArrayObject.stub
 		- ../stubs/WeakReference.stub
 		- ../stubs/SensitiveParameterValue.stub
+		- ../stubs/BackedEnum.stub
 		- ../stubs/ext-ds.stub
 		- ../stubs/ImagickPixel.stub
 		- ../stubs/PDOStatement.stub

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -1121,6 +1121,12 @@ final class ClassReflection
 			}
 		}
 
+		// An interface resolved on this class itself is more specific than the same
+		// interface reached through one of its ancestors.
+		foreach ($immediateInterfaces as $name => $immediateInterface) {
+			$interfaces[$name] = $immediateInterface;
+		}
+
 		$this->cachedInterfaces = $interfaces;
 
 		return $interfaces;
@@ -1207,7 +1213,7 @@ final class ClassReflection
 
 			if ($immediateInterface->isGeneric()) {
 				$immediateInterfaces[$immediateInterface->getName()] = $immediateInterface->withTypes(
-					array_values($immediateInterface->getTemplateTypeMap()->map(static fn (): Type => new ErrorType())->getTypes()),
+					$this->getUnspecifiedAncestorTypes($immediateInterface),
 				);
 				continue;
 			}
@@ -1215,7 +1221,42 @@ final class ClassReflection
 			$immediateInterfaces[$immediateInterface->getName()] = $immediateInterface;
 		}
 
+		// PHP implicitly implements BackedEnum on backed enums, so there is no
+		// @implements tag that could carry the backing type.
+		$backedEnumType = $this->getBackedEnumType();
+		if ($backedEnumType !== null && $this->reflectionProvider->hasClass('BackedEnum')) {
+			$immediateInterfaces['BackedEnum'] = $this->reflectionProvider->getClass('BackedEnum')
+				->withTypes([$backedEnumType]);
+		}
+
 		return $immediateInterfaces;
+	}
+
+	/**
+	 * Type arguments for a generic ancestor that is not described by an @implements
+	 * or @extends tag. Declared template defaults are used when the ancestor has
+	 * one for every template type, otherwise the type arguments stay erroneous.
+	 *
+	 * @return list<Type>
+	 */
+	private function getUnspecifiedAncestorTypes(ClassReflection $ancestor): array
+	{
+		$defaults = [];
+		foreach ($ancestor->getTemplateTags() as $templateTag) {
+			$default = $templateTag->getDefault();
+			if ($default === null) {
+				$defaults = null;
+				break;
+			}
+
+			$defaults[] = $default;
+		}
+
+		if ($defaults !== null) {
+			return $defaults;
+		}
+
+		return array_values($ancestor->getTemplateTypeMap()->map(static fn (): Type => new ErrorType())->getTypes());
 	}
 
 	/**

--- a/src/Rules/Generics/EnumAncestorsRule.php
+++ b/src/Rules/Generics/EnumAncestorsRule.php
@@ -11,7 +11,11 @@ use PHPStan\Node\InClassNode;
 use PHPStan\PhpDoc\Tag\ExtendsTag;
 use PHPStan\PhpDoc\Tag\ImplementsTag;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
 use function array_map;
 use function array_merge;
 use function sprintf;
@@ -64,8 +68,15 @@ final class EnumAncestorsRule implements Rule
 			'',
 		);
 
+		$implementsNames = $originalNode->implements;
+		if ($classReflection->isBackedEnum()) {
+			// PHP implicitly implements BackedEnum on backed enums, so an
+			// @implements tag for it has no counterpart in the declared list.
+			$implementsNames[] = new Node\Name\FullyQualified('BackedEnum');
+		}
+
 		$implementsErrors = $this->genericAncestorsCheck->check(
-			$originalNode->implements,
+			$implementsNames,
 			array_map(static fn (ImplementsTag $tag): Type => $tag->getType(), $classReflection->getImplementsTags()),
 			sprintf('Enum %s @implements tag contains incompatible type %%s.', $escapedEnumName),
 			sprintf('Enum %s @implements tag contains unresolvable type.', $enumName),
@@ -80,6 +91,30 @@ final class EnumAncestorsRule implements Rule
 			sprintf('Enum %s implements generic interface %%s but does not specify its types: %%s', $escapedEnumName),
 			sprintf('in implemented type %%s of enum %s', $escapedEnumName),
 		);
+
+		$backedEnumType = $classReflection->getBackedEnumType();
+		if ($backedEnumType !== null) {
+			$expectedTagType = new GenericObjectType('BackedEnum', [$backedEnumType]);
+			$bareTagType = new ObjectType('BackedEnum');
+			foreach ($classReflection->getImplementsTags() as $implementsTag) {
+				$implementsTagType = $implementsTag->getType();
+				if ($implementsTagType->getObjectClassNames() !== ['BackedEnum']) {
+					continue;
+				}
+				if ($implementsTagType->equals($bareTagType) || $implementsTagType->equals($expectedTagType)) {
+					continue;
+				}
+
+				$implementsErrors[] = RuleErrorBuilder::message(sprintf(
+					'The @implements tag of enum %s specifies %s but the enum is backed by %s.',
+					$enumName,
+					$implementsTagType->describe(VerbosityLevel::typeOnly()),
+					$backedEnumType->describe(VerbosityLevel::typeOnly()),
+				))
+					->identifier('enum.implementsBackingType')
+					->build();
+			}
+		}
 
 		foreach ($this->crossCheckInterfacesHelper->check($classReflection) as $error) {
 			$implementsErrors[] = $error;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1871,6 +1871,16 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return self::$ancestors[$description][$className] = $this->currentAncestors[$className] = $this;
 		}
 
+		// An interface resolved on this class itself is more specific than the same
+		// interface reached through one of its ancestors.
+		foreach ($this->getInterfaces() as $interface) {
+			if ($interface->getClassName() !== $className) {
+				continue;
+			}
+
+			return self::$ancestors[$description][$className] = $this->currentAncestors[$className] = $interface;
+		}
+
 		foreach ($this->getInterfaces() as $interface) {
 			$ancestor = $interface->getAncestorWithClassName($className);
 			if ($ancestor !== null) {

--- a/src/Type/ValueOfType.php
+++ b/src/Type/ValueOfType.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\LateResolvableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
+use function array_values;
 use function count;
 use function sprintf;
 
@@ -58,6 +59,33 @@ final class ValueOfType implements CompoundType, LateResolvableType
 				&& $this->type instanceof TemplateType
 				&& (new ObjectType('BackedEnum'))->isSuperTypeOf($this->type->getBound())->yes()
 			) {
+				$backingTypes = [];
+				foreach ($this->type->getBound()->getObjectClassReflections() as $classReflection) {
+					$ancestor = $classReflection->getAncestorWithClassName('BackedEnum');
+					if ($ancestor === null) {
+						$backingTypes = [];
+						break;
+					}
+
+					$ancestorTypes = $ancestor->getActiveTemplateTypeMap()->getTypes();
+					if (count($ancestorTypes) !== 1) {
+						$backingTypes = [];
+						break;
+					}
+
+					$backingType = array_values($ancestorTypes)[0];
+					if ($backingType instanceof ErrorType) {
+						$backingTypes = [];
+						break;
+					}
+
+					$backingTypes[] = $backingType;
+				}
+
+				if ($backingTypes !== []) {
+					return TypeCombinator::union(...$backingTypes);
+				}
+
 				return new UnionType([new IntegerType(), new StringType()]);
 			}
 

--- a/stubs/BackedEnum.stub
+++ b/stubs/BackedEnum.stub
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @template-covariant T of int|string = int|string
+ */
+interface BackedEnum extends UnitEnum
+{
+
+	/** @var T */
+	public readonly int|string $value;
+
+	/**
+	 * @template TValue of T
+	 * @param TValue $value
+	 * @return static
+	 * @throws \ValueError
+	 * @throws \TypeError
+	 */
+	public static function from(int|string $value): static;
+
+	/**
+	 * @template TValue of T
+	 * @param TValue $value
+	 * @return static|null
+	 */
+	public static function tryFrom(int|string $value): ?static;
+
+}

--- a/tests/PHPStan/Analyser/nsrt/generic-backed-enum.php
+++ b/tests/PHPStan/Analyser/nsrt/generic-backed-enum.php
@@ -1,0 +1,119 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace GenericBackedEnum;
+
+use BackedEnum;
+use UnitEnum;
+use function PHPStan\Testing\assertType;
+
+enum StringEnum: string
+{
+
+	case A = 'a';
+	case B = 'b';
+
+}
+
+enum IntEnum: int
+{
+
+	case One = 1;
+
+}
+
+enum PureEnum
+{
+
+	case X;
+
+}
+
+interface HasLabel extends BackedEnum
+{
+
+}
+
+/**
+ * @extends BackedEnum<string>
+ */
+interface StringBackedInterface extends BackedEnum
+{
+
+}
+
+enum ViaInterface: string implements HasLabel
+{
+
+	case A = 'a';
+
+}
+
+enum ViaStringInterface: string implements StringBackedInterface
+{
+
+	case A = 'a';
+
+}
+
+function bare(BackedEnum $e): void
+{
+	assertType('int|string', $e->value);
+	assertType('non-decimal-int-string&non-falsy-string', $e->name);
+}
+
+/**
+ * @param BackedEnum<string> $e
+ * @param BackedEnum<int> $i
+ */
+function withTypes(BackedEnum $e, BackedEnum $i): void
+{
+	assertType('string', $e->value);
+	assertType('int', $i->value);
+	assertType('BackedEnum<string>', $e::from('a'));
+	assertType('BackedEnum<string>|null', $e::tryFrom('a'));
+}
+
+function unresolvedInterface(HasLabel $e): void
+{
+	assertType('int|string', $e->value);
+}
+
+function resolvedInterface(StringBackedInterface $e): void
+{
+	assertType('string', $e->value);
+}
+
+/**
+ * @template T of BackedEnum
+ * @param T $e
+ * @return value-of<T>
+ */
+function valueOfAny(BackedEnum $e)
+{
+	return $e->value;
+}
+
+/**
+ * @template T of BackedEnum<string>
+ * @param class-string<T> $className
+ * @return T
+ */
+function fromString(string $className, string $value): BackedEnum
+{
+	return $className::from($value);
+}
+
+function templates(): void
+{
+	assertType("'a'", valueOfAny(StringEnum::A));
+	assertType('1', valueOfAny(IntEnum::One));
+	assertType('GenericBackedEnum\StringEnum', fromString(StringEnum::class, 'a'));
+}
+
+function unitEnumIsNotGeneric(UnitEnum $e, PureEnum $p): void
+{
+	assertType('non-decimal-int-string&non-falsy-string', $e->name);
+	assertType("'X'", $p->name);
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -3099,4 +3099,19 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.1.0')]
+	public function testGenericBackedEnumAcceptance(): void
+	{
+		$this->analyse([__DIR__ . '/data/generic-backed-enum-acceptance.php'], [
+			[
+				'Parameter #1 $e of function GenericBackedEnumAcceptance\acceptsStringBacked expects BackedEnum<string>, GenericBackedEnumAcceptance\IntEnum given.',
+				62,
+			],
+			[
+				'Parameter #1 $e of function GenericBackedEnumAcceptance\acceptsStringBacked expects BackedEnum<string>, GenericBackedEnumAcceptance\HasLabel given.',
+				63,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Functions;
 use PHPStan\Rules\MissingTypehintCheck;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<MissingFunctionParameterTypehintRule>
@@ -94,6 +95,12 @@ class MissingFunctionParameterTypehintRuleTest extends RuleTestCase
 				191,
 			],
 		]);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
+	public function testGenericBackedEnum(): void
+	{
+		$this->analyse([__DIR__ . '/data/generic-backed-enum-typehints.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/data/generic-backed-enum-acceptance.php
+++ b/tests/PHPStan/Rules/Functions/data/generic-backed-enum-acceptance.php
@@ -1,0 +1,64 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace GenericBackedEnumAcceptance;
+
+use BackedEnum;
+
+enum StringEnum: string
+{
+
+	case A = 'a';
+
+}
+
+enum IntEnum: int
+{
+
+	case One = 1;
+
+}
+
+interface HasLabel extends BackedEnum
+{
+
+}
+
+/**
+ * @extends BackedEnum<string>
+ */
+interface StringBackedInterface extends BackedEnum
+{
+
+}
+
+enum ViaInterface: string implements HasLabel
+{
+
+	case A = 'a';
+
+}
+
+enum ViaStringInterface: string implements StringBackedInterface
+{
+
+	case A = 'a';
+
+}
+
+/**
+ * @param BackedEnum<string> $e
+ */
+function acceptsStringBacked(BackedEnum $e): void
+{
+}
+
+function test(StringEnum $a, ViaInterface $b, ViaStringInterface $c, IntEnum $d, HasLabel $e): void
+{
+	acceptsStringBacked($a);
+	acceptsStringBacked($b);
+	acceptsStringBacked($c);
+	acceptsStringBacked($d);
+	acceptsStringBacked($e);
+}

--- a/tests/PHPStan/Rules/Functions/data/generic-backed-enum-typehints.php
+++ b/tests/PHPStan/Rules/Functions/data/generic-backed-enum-typehints.php
@@ -1,0 +1,21 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace GenericBackedEnumTypehints;
+
+use BackedEnum;
+
+function bareIsNotMissingTypes(BackedEnum $e): BackedEnum
+{
+	return $e;
+}
+
+/**
+ * @param BackedEnum<string> $e
+ * @return BackedEnum<string>
+ */
+function withTypes(BackedEnum $e): BackedEnum
+{
+	return $e;
+}

--- a/tests/PHPStan/Rules/Generics/EnumAncestorsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/EnumAncestorsRuleTest.php
@@ -56,6 +56,14 @@ class EnumAncestorsRuleTest extends RuleTestCase
 				'Call-site variance annotation of covariant EnumGenericAncestors\NonGeneric in generic type EnumGenericAncestors\Generic<covariant EnumGenericAncestors\NonGeneric, int> in PHPDoc tag @implements is not allowed.',
 				93,
 			],
+			[
+				'The @implements tag of enum EnumGenericAncestors\BackedEnumWrongTag specifies BackedEnum<string> but the enum is backed by int.',
+				122,
+			],
+			[
+				'Enum EnumGenericAncestors\BackedEnumTagOnPureEnum has @implements tag, but does not implement any interface.',
+				130,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generics/data/enum-ancestors.php
+++ b/tests/PHPStan/Rules/Generics/data/enum-ancestors.php
@@ -107,3 +107,27 @@ enum Foo9 implements GenericDefault
 {
 
 }
+
+/**
+ * @implements \BackedEnum<string>
+ */
+enum BackedEnumRightTag: string
+{
+
+}
+
+/**
+ * @implements \BackedEnum<string>
+ */
+enum BackedEnumWrongTag: int
+{
+
+}
+
+/**
+ * @implements \BackedEnum<int>
+ */
+enum BackedEnumTagOnPureEnum
+{
+
+}

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -1066,4 +1066,24 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-15002.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.1.0')]
+	public function testGenericBackedEnum(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/generic-backed-enum.php'], [
+			[
+				'Parameter #1 $value of static method BackedEnum<int>::from() expects TValue of int, string given.',
+				23,
+			],
+			[
+				'Parameter #1 $value of static method BackedEnum<string>::tryFrom() expects TValue of string, int given.',
+				24,
+			],
+			[
+				'Parameter #1 $value of static method BackedEnum<string>::from() expects TValue of string, int given.',
+				36,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/generic-backed-enum.php
+++ b/tests/PHPStan/Rules/Methods/data/generic-backed-enum.php
@@ -1,0 +1,44 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace GenericBackedEnumStaticCall;
+
+use BackedEnum;
+
+enum StringEnum: string
+{
+
+	case A = 'a';
+
+}
+
+/**
+ * @param BackedEnum<int> $intBacked
+ * @param BackedEnum<string> $stringBacked
+ */
+function backedEnumInterface(BackedEnum $intBacked, BackedEnum $stringBacked, BackedEnum $bare, int $i, string $s): void
+{
+	$intBacked::from($i);
+	$intBacked::from($s);
+	$stringBacked::tryFrom($i);
+	$stringBacked::tryFrom($s);
+	$bare::from($i);
+	$bare::from($s);
+}
+
+/**
+ * @template T of BackedEnum<string>
+ * @param class-string<T> $className
+ */
+function stringBackedClassString(string $className, int $i, string $s): void
+{
+	$className::from($i);
+	$className::from($s);
+}
+
+function concreteEnum(string $s): void
+{
+	StringEnum::from($s);
+	StringEnum::tryFrom($s);
+}


### PR DESCRIPTION
Follow-up to #6272, but a lot more involved.

`BackedEnum` now carries its backing type:

```php
/**
 * @template-covariant T of int|string = int|string
 */
interface BackedEnum extends UnitEnum
{
	/** @var T */
	public readonly int|string $value;
	...
}
```

```php
/** @param BackedEnum<string> $e */
function f(BackedEnum $e): void {
	$e->value;  // string, was int|string
}

/**
 * @template T of BackedEnum<string>
 * @param T $e
 * @return value-of<T>
 */
function g(BackedEnum $e) { return $e->value; }  // string, was int|string
```

## The implicit `implements` problem

Unlike `SensitiveParameterValue`, `BackedEnum` cannot get its type argument from a call site or from an `@implements` tag — PHP implements the interface implicitly, so no tag exists to carry it. `ClassReflection::getImmediateInterfaces()` fills it in from the enum backing type instead.

Two supporting changes were needed to make that stick:

* `ClassReflection::getInterfaces()` and `ObjectType::getAncestorWithClassName()` now prefer the interface as resolved on the class itself over the same interface reached through one of its ancestors. Without this, `enum E: string implements HasLabel` (where `interface HasLabel extends BackedEnum`) resolved `BackedEnum` through `HasLabel` and lost the `string`.
* A generic ancestor with no `@implements`/`@extends` tag now uses the declared template defaults instead of error types, when every template type has a default. This is what makes `interface Foo extends BackedEnum` resolve to `BackedEnum<int|string>` rather than `BackedEnum<*ERROR*>`.

## `from()` and `tryFrom()`

They take a method-level `@template TValue of T` rather than `@param T $value`. `@param T` would put a covariant type parameter in contravariant position, which `VarianceCheck` forbids in user code — PHPStan should not ship a stub doing what its own rule rejects. The method-level template keeps `T` in a bound only, and still reports:

```php
/** @param BackedEnum<int> $e */
function f(BackedEnum $e, string $s): void {
	$e::from($s);  // Parameter #1 $value of static method BackedEnum<int>::from()
	               // expects TValue of int, string given.
}
```

`@return` stays `static`. Feeding `TValue` into the return type (`BackedEnum<TValue>`, or `static&BackedEnum<TValue>`) narrows `T` to the argument literal, which is wrong — `T` is the enum's declared backing type, not the value of one instance. It makes this a false positive:

```php
$x = $bare::from('a');  // BackedEnum<'a'>
$x::from('b');          // reported, but perfectly legal at runtime
```

It also degrades `S::from($s)` from `S` to `BackedEnum<string>`.

The stub preserves the `@throws ValueError` / `@throws TypeError` tags from phpstorm-stubs — stub docblocks replace them wholesale, and dropping them made `SE::from($x);` statements report `resultUnused` and turned `catch (ValueError|TypeError)` around `from()` into dead catches.

Side note: `static&BackedEnum<TValue>` turned out to be a no-op anyway. Intersecting a bare `ObjectType('BackedEnum')` with `GenericObjectType('BackedEnum', ['a'])` keeps the bare one instead of the generic one. That looks like a `TypeCombinator` quirk unrelated to this PR; I have not touched it.

## `@implements BackedEnum<int>` is now a valid annotation

Because the interface is implemented implicitly, `EnumAncestorsRule` previously rejected the tag with "has @implements tag, but does not implement any interface" — even though a backed enum genuinely implements `BackedEnum`. It now accepts the tag, and reports a new `enum.implementsBackingType` error when the tag contradicts the actual backing type:

```php
/** @implements BackedEnum<string> */
enum Wrong: int {} // The @implements tag of enum Wrong specifies BackedEnum<string>
                   // but the enum is backed by int.
```

The tag is redundant for inference (the backing type always wins), but downstream code annotated this way — notably the ecosystem around shipmonk/phpstan-rules' `BackedEnumGenericsRule`, which simulated generic `BackedEnum` in userland — gets a working migration path instead of a hard error.

## Backward compatibility

Three properties keep this from breaking existing code:

* `T` defaults to `int|string`, so a bare `BackedEnum` in PHPDoc keeps its old meaning and is not reported as missing type arguments on level 6 and above.
* `T` is covariant, so every backed enum stays assignable to a bare `BackedEnum`.
* The type argument is implicit, so nobody has to write anything.

New errors appear only once someone opts in by writing `BackedEnum<string>`.

Measured on carbon, symfony/console + http-foundation + validator, doctrine/dbal, league/csv, monolog, guzzle and brick/money — 29 enum declarations, level 9, 6218 errors before the change: **0 new, 0 gone.** The single delta is message wording: calls through the interface now read `… BackedEnum<int|string>::from() expects TValue of int|string, mixed given` instead of `… BackedEnum::from() expects int|string, mixed given`, so baseline entries matching the old wording for such calls need regenerating (concrete-enum messages are unchanged).

Known ecosystem impact, verified via this repo's integration matrix (everything else that is red there fails identically for sibling PRs):

* **phpstan-doctrine on PHP ≤ 8.0**: its `compatibility/BackedEnum.stub` now collides with the bundled stub (`Class BackedEnum declared multiple times`). Needs a phpstan-doctrine release dropping (or version-guarding) that stub.
* **shipmonk/phpstan-rules' `BackedEnumGenericsRule`** activates (it fires when the `BackedEnum` ancestor `isGeneric()`), demanding `@implements` tags. The rule's own suggestion now works thanks to the `EnumAncestorsRule` change above, and the userland emulation is planned to be dropped in favour of this native support.

One more behavioural note: `ObjectType::getAncestorWithClassName()` now prefers the interface as resolved on the class itself; in ambiguous diamonds (`class C implements A, B` where `A extends I<int>`, `B extends I<string>`) the resolution can change — it now matches what `ClassReflection::getAncestorWithClassName()` already did.

The sharpest general edge is the template-defaults change: for any generic class with defaults that is extended without a tag, the argument goes from `*ERROR*` (permissive) to the default (stricter). The blast radius is small — `FFI\CData` is the only bundled stub that declares template defaults at all.

Two behaviours worth calling out for review:

* `interface Foo extends BackedEnum` without `@extends BackedEnum<string>` resolves to `BackedEnum<int|string>`, so `Foo` is not accepted where `BackedEnum<string>` is expected. A one-line `@extends` tag fixes it, but it is a real papercut for existing interfaces (pinned in the acceptance rule test).
* `StringEnum::from($int)` on a concrete enum is still unchecked — the enum's own native `from(int|string)` wins over the inherited stub template. That gap predates this PR and would need a separate rule.
* An enum whose interface claims a different backing type (`enum Wrong: int implements StringBacked` where `StringBacked` has `@extends BackedEnum<string>`) resolves silently to `BackedEnum<int>` — the actual backing type wins; the interface-level contradiction is not yet diagnosed.
