### PR TITLE
Price enum case values through InitializerExprTypeResolver in EnumSanityRule

### DIFF
--- a/src/Rules/Classes/EnumSanityRule.php
+++ b/src/Rules/Classes/EnumSanityRule.php
@@ -190,7 +190,7 @@ final class EnumSanityRule implements Rule
 				continue;
 			}
 
-			$exprType = $scope->getType($stmt->expr);
+			$exprType = $this->initializerExprTypeResolver->getType($stmt->expr, InitializerExprContext::fromScope($scope));
 			$scalarType = $enumNode->scalarType->toLowerString() === 'int' ? new IntegerType() : new StringType();
 			if ($scalarType->isSuperTypeOf($exprType)->yes()) {
 				$constantValues = $exprType->getConstantScalarValues();


### PR DESCRIPTION
Extracted from `resolve-type-rewrite-2` (extraction series, follows #6274).

The backing-type check was the last place in `EnumSanityRule` pricing an enum case value via `$scope->getType()` — the not-backed-enum message a few lines above already prices the very same `$stmt->expr` through `InitializerExprTypeResolver`. Enum case values are constant initializer expressions, so the initializer resolver is the right tool in both places; the rule now uses it consistently.

No behavioral difference is expected or observed — case values cannot reference runtime scope state.

Gates: full suite 21155 tests / 96002 assertions green, `make phpstan` clean, `make cs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7pqAkCx4xP6WYxBo2nMJE