### PR TITLE
Emit more node callbacks after their expressions' results are stored

### DIFF
--- a/src/Analyser/ExprHandler/ArrayHandler.php
+++ b/src/Analyser/ExprHandler/ArrayHandler.php
@@ -82,7 +82,7 @@ final class ArrayHandler implements ExprHandler
 		$isAlwaysTerminating = false;
 		foreach ($expr->items as $arrayItem) {
 			$itemNodes[] = new LiteralArrayItem($scope, $arrayItem);
-			$nodeScopeResolver->callNodeCallback($nodeCallback, $arrayItem, $scope, $storage);
+			$itemCallbackScope = $scope;
 			if ($arrayItem->key !== null) {
 				$keyResult = $nodeScopeResolver->processExprNode($stmt, $arrayItem->key, $scope, $storage, $nodeCallback, $context->enterDeep());
 				$hasYield = $hasYield || $keyResult->hasYield();
@@ -98,6 +98,10 @@ final class ArrayHandler implements ExprHandler
 			$impurePoints = array_merge($impurePoints, $valueResult->getImpurePoints());
 			$isAlwaysTerminating = $isAlwaysTerminating || $valueResult->isAlwaysTerminating();
 			$scope = $valueResult->getScope();
+			// the item's callback fires after its key and value were processed,
+			// with the item's entry scope - callback-side asks answer from the
+			// storage instead of re-walking the yet-unstored sub-expressions
+			$nodeScopeResolver->callNodeCallback($nodeCallback, $arrayItem, $itemCallbackScope, $storage);
 		}
 		$nodeScopeResolver->callNodeCallback($nodeCallback, new LiteralArrayNode($expr, $itemNodes), $scope, $storage);
 

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -578,11 +578,7 @@ final class AssignHandler implements ExprHandler
 			$lastDimKey = array_key_last($dimFetchStack);
 			foreach ($dimFetchStack as $key => $dimFetch) {
 				$dimExpr = $dimFetch->dim;
-
-				// Callback was already called for last dim at the beginning of the method.
-				if ($key !== $lastDimKey) {
-					$nodeScopeResolver->callNodeCallback($nodeCallback, $dimFetch, $enterExpressionAssign ? $scope->enterExpressionAssign($dimFetch) : $scope, $storage);
-				}
+				$callbackScope = $scope;
 
 				if ($dimExpr === null) {
 					$dimResults[$key] = null;
@@ -623,6 +619,16 @@ final class AssignHandler implements ExprHandler
 						$scope = $scope->exitExpressionAssign($dimExpr);
 					}
 				}
+
+				// The whole target's callback fires in prepareTarget() after the
+				// walk; an intermediate link's fires here, after its dimension was
+				// processed, so callback-side asks about the dimension answer from
+				// the storage with the link's entry scope.
+				if ($key === $lastDimKey) {
+					continue;
+				}
+
+				$nodeScopeResolver->callNodeCallback($nodeCallback, $dimFetch, $enterExpressionAssign ? $callbackScope->enterExpressionAssign($dimFetch) : $callbackScope, $storage);
 			}
 
 			if ($mode->issetSemanticsForRead()) {

--- a/src/Analyser/ExprHandler/AssignOpHandler.php
+++ b/src/Analyser/ExprHandler/AssignOpHandler.php
@@ -100,6 +100,20 @@ final class AssignOpHandler implements ExprHandler
 			);
 		}
 
+		// applyWrite() emits nodes (PropertyAssignNode) whose rules ask about
+		// this whole `$lvalue OP= value` expression - store a before-scope
+		// anchored result first so those asks answer from the storage;
+		// processExprNode() overwrites it with the final result after this
+		// handler returns
+		$nodeScopeResolver->storeExpressionResult($storage, $expr, $this->expressionResultFactory->create(
+			$valueResult->getScope(),
+			$beforeScope,
+			$expr,
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: [],
+			impurePoints: [],
+		));
 		$assignResult = $this->assignHandler->applyWrite(
 			$nodeScopeResolver,
 			$target,

--- a/src/Analyser/ExprHandler/PostDecHandler.php
+++ b/src/Analyser/ExprHandler/PostDecHandler.php
@@ -40,6 +40,20 @@ final class PostDecHandler implements ExprHandler
 	{
 		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, $context->enterDeep());
 
+		// processVirtualAssign() emits nodes (PropertyAssignNode) whose rules ask
+		// about this whole expression - store a before-scope anchored result
+		// first so those asks answer from the storage; processExprNode()
+		// overwrites it with the final result after this handler returns
+		$nodeScopeResolver->storeExpressionResult($storage, $expr, $this->expressionResultFactory->create(
+			$varResult->getScope(),
+			$scope,
+			$expr,
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: [],
+			impurePoints: [],
+		));
+
 		return $this->expressionResultFactory->create(
 			$nodeScopeResolver->processVirtualAssign(
 				$varResult->getScope(),

--- a/src/Analyser/ExprHandler/PostIncHandler.php
+++ b/src/Analyser/ExprHandler/PostIncHandler.php
@@ -40,6 +40,20 @@ final class PostIncHandler implements ExprHandler
 	{
 		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, $context->enterDeep());
 
+		// processVirtualAssign() emits nodes (PropertyAssignNode) whose rules ask
+		// about this whole expression - store a before-scope anchored result
+		// first so those asks answer from the storage; processExprNode()
+		// overwrites it with the final result after this handler returns
+		$nodeScopeResolver->storeExpressionResult($storage, $expr, $this->expressionResultFactory->create(
+			$varResult->getScope(),
+			$scope,
+			$expr,
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: [],
+			impurePoints: [],
+		));
+
 		return $this->expressionResultFactory->create(
 			$nodeScopeResolver->processVirtualAssign(
 				$varResult->getScope(),

--- a/src/Analyser/ExprHandler/PreDecHandler.php
+++ b/src/Analyser/ExprHandler/PreDecHandler.php
@@ -103,6 +103,20 @@ final class PreDecHandler implements ExprHandler
 	{
 		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, $context->enterDeep());
 
+		// processVirtualAssign() emits nodes (PropertyAssignNode) whose rules ask
+		// about this whole expression - store a before-scope anchored result
+		// first so those asks answer from the storage; processExprNode()
+		// overwrites it with the final result after this handler returns
+		$nodeScopeResolver->storeExpressionResult($storage, $expr, $this->expressionResultFactory->create(
+			$varResult->getScope(),
+			$scope,
+			$expr,
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: [],
+			impurePoints: [],
+		));
+
 		return $this->expressionResultFactory->create(
 			$nodeScopeResolver->processVirtualAssign(
 				$varResult->getScope(),

--- a/src/Analyser/ExprHandler/PreIncHandler.php
+++ b/src/Analyser/ExprHandler/PreIncHandler.php
@@ -104,6 +104,20 @@ final class PreIncHandler implements ExprHandler
 	{
 		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, $context->enterDeep());
 
+		// processVirtualAssign() emits nodes (PropertyAssignNode) whose rules ask
+		// about this whole expression - store a before-scope anchored result
+		// first so those asks answer from the storage; processExprNode()
+		// overwrites it with the final result after this handler returns
+		$nodeScopeResolver->storeExpressionResult($storage, $expr, $this->expressionResultFactory->create(
+			$varResult->getScope(),
+			$scope,
+			$expr,
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: [],
+			impurePoints: [],
+		));
+
 		return $this->expressionResultFactory->create(
 			$nodeScopeResolver->processVirtualAssign(
 				$varResult->getScope(),

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -729,7 +729,9 @@ class NodeScopeResolver
 		// PHP < 8.1) then finds the expressions' results in the storage instead
 		// of re-walking them on demand, mirroring processExprNodeInternal().
 		$deferredStmtCallback = $stmt instanceof Return_ || $stmt instanceof Node\Stmt\Expression || $stmt instanceof Echo_
-			|| $stmt instanceof If_ || $stmt instanceof Switch_ || $stmt instanceof Foreach_;
+			|| $stmt instanceof If_ || $stmt instanceof Switch_ || $stmt instanceof Foreach_
+			|| $stmt instanceof Node\Stmt\Unset_ || $stmt instanceof Node\Stmt\ClassConst
+			|| $stmt instanceof Node\Stmt\Const_ || $stmt instanceof Node\Stmt\While_;
 		if (!$deferredStmtCallback) {
 			$this->callNodeCallback($nodeCallback, $stmt, $stmtScope, $storage);
 		}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -731,7 +731,8 @@ class NodeScopeResolver
 		$deferredStmtCallback = $stmt instanceof Return_ || $stmt instanceof Node\Stmt\Expression || $stmt instanceof Echo_
 			|| $stmt instanceof If_ || $stmt instanceof Switch_ || $stmt instanceof Foreach_
 			|| $stmt instanceof Node\Stmt\Unset_ || $stmt instanceof Node\Stmt\ClassConst
-			|| $stmt instanceof Node\Stmt\Const_ || $stmt instanceof Node\Stmt\While_;
+			|| $stmt instanceof Node\Stmt\Const_ || $stmt instanceof Node\Stmt\While_
+			|| $stmt instanceof Node\Stmt\Do_;
 		if (!$deferredStmtCallback) {
 			$this->callNodeCallback($nodeCallback, $stmt, $stmtScope, $storage);
 		}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2054,7 +2054,6 @@ class NodeScopeResolver
 					}
 				}
 
-				$this->callNodeCallbackWithExpression($nodeCallback, $arg->value, $scopeToPass, $storage, $context);
 				$closureResult = $this->processClosureNode($stmt, $arg->value, $scopeToPass, $storage, $nodeCallback, $context, $parameterType, $parameterNativeType);
 				// the preferred ClosureType read below now answers from this seed
 				// instead of walking the body again (unless a parked fiber may
@@ -2074,6 +2073,10 @@ class NodeScopeResolver
 					throwPoints: [],
 					impurePoints: [],
 				));
+				// the closure node's own callback fires after its result is
+				// stored, mirroring processExprNodeInternal() - callback-side
+				// getType() answers from the stored result
+				$this->callNodeCallbackWithExpression($nodeCallback, $arg->value, $scopeToPass, $storage, $context);
 
 				$uses = [];
 				foreach ($arg->value->uses as $use) {
@@ -2142,7 +2145,6 @@ class NodeScopeResolver
 					}
 				}
 
-				$this->callNodeCallbackWithExpression($nodeCallback, $arg->value, $scopeToPass, $storage, $context);
 				$processArrowFunctionResult = $this->processArrowFunctionNode($stmt, $arg->value, $scopeToPass, $storage, $nodeCallback, $parameterType, $parameterNativeType);
 				// the invalidation read below now answers from this seed instead
 				// of walking the body again (unless a parked fiber may still
@@ -2160,6 +2162,10 @@ class NodeScopeResolver
 					}
 				}
 				$this->storeExpressionResult($storage, $arg->value, $arrowFunctionResult);
+				// the arrow function node's own callback fires after its result
+				// is stored, mirroring processExprNodeInternal() - callback-side
+				// getType() answers from the stored result
+				$this->callNodeCallbackWithExpression($nodeCallback, $arg->value, $scopeToPass, $storage, $context);
 			} else {
 				$exprType = $scope->getType($arg->value);
 				$enterExpressionAssignForByRef = $assignByReference && $arg->value instanceof ArrayDimFetch && $arg->value->dim === null;

--- a/src/Analyser/StmtHandler/ClassConstHandler.php
+++ b/src/Analyser/StmtHandler/ClassConstHandler.php
@@ -38,11 +38,14 @@ final class ClassConstHandler implements StmtHandler
 		StatementContext $context,
 	): InternalStatementResult
 	{
+		$entryScope = $scope;
 		$impurePoints = [];
 		$nodeScopeResolver->processAttributeGroups($stmt, $stmt->attrGroups, $scope, $storage, $nodeCallback);
 		foreach ($stmt->consts as $const) {
-			$nodeScopeResolver->callNodeCallback($nodeCallback, $const, $scope, $storage);
 			$constResult = $nodeScopeResolver->processExprNode($stmt, $const->value, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			// the constant's callback fires after its value was processed, so
+			// rule-side asks about the value answer from the storage
+			$nodeScopeResolver->callNodeCallback($nodeCallback, $const, $scope, $storage);
 			$impurePoints = array_merge($impurePoints, $constResult->getImpurePoints());
 			if ($scope->getClassReflection() === null) {
 				throw new ShouldNotHappenException();
@@ -53,6 +56,9 @@ final class ClassConstHandler implements StmtHandler
 				$constResult->getNativeType(),
 			);
 		}
+
+		// deferred from processStmtNode() - fires after the values were processed
+		$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $entryScope, $storage);
 
 		return new InternalStatementResult($scope, hasYield: false, isAlwaysTerminating: false, exitPoints: [], throwPoints: [], impurePoints: $impurePoints);
 	}

--- a/src/Analyser/StmtHandler/ClassLikeHandler.php
+++ b/src/Analyser/StmtHandler/ClassLikeHandler.php
@@ -86,7 +86,6 @@ final class ClassLikeHandler implements StmtHandler
 		if (isset($stmt->namespacedName)) {
 			$classReflection = $this->getCurrentClassReflection($nodeScopeResolver, $stmt, $stmt->namespacedName->toString(), $scope);
 			$classScope = $scope->enterClass($classReflection);
-			$nodeScopeResolver->callNodeCallback($nodeCallback, new InClassNode($stmt, $classReflection), $classScope, $storage);
 		} elseif ($stmt instanceof Class_) {
 			if ($stmt->name === null) {
 				throw new ShouldNotHappenException();
@@ -97,13 +96,16 @@ final class ClassLikeHandler implements StmtHandler
 				$classReflection = $this->reflectionProvider->getAnonymousClassReflection($stmt, $scope);
 			}
 			$classScope = $scope->enterClass($classReflection);
-			$nodeScopeResolver->callNodeCallback($nodeCallback, new InClassNode($stmt, $classReflection), $classScope, $storage);
 		} else {
 			throw new ShouldNotHappenException();
 		}
 
 		$classStatementsGatherer = new ClassStatementsGatherer($classReflection, $nodeCallback);
+		// the class attributes are processed before the InClassNode emission, so
+		// rules firing on it (ClassAttributesRule) read the attribute arguments
+		// from the storage
 		$nodeScopeResolver->processAttributeGroups($stmt, $stmt->attrGroups, $classScope, $storage, $classStatementsGatherer);
+		$nodeScopeResolver->callNodeCallback($nodeCallback, new InClassNode($stmt, $classReflection), $classScope, $storage);
 
 		$classLikeStatements = $stmt->stmts;
 		// analyze static methods first; constructor next; instance methods and property hooks last so we can carry over the scope

--- a/src/Analyser/StmtHandler/ConstHandler.php
+++ b/src/Analyser/StmtHandler/ConstHandler.php
@@ -37,10 +37,13 @@ final class ConstHandler implements StmtHandler
 		StatementContext $context,
 	): InternalStatementResult
 	{
+		$entryScope = $scope;
 		$impurePoints = [];
 		foreach ($stmt->consts as $const) {
-			$nodeScopeResolver->callNodeCallback($nodeCallback, $const, $scope, $storage);
 			$constResult = $nodeScopeResolver->processExprNode($stmt, $const->value, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			// the constant's callback fires after its value was processed, so
+			// rule-side asks about the value answer from the storage
+			$nodeScopeResolver->callNodeCallback($nodeCallback, $const, $scope, $storage);
 			$impurePoints = array_merge($impurePoints, $constResult->getImpurePoints());
 			if ($const->namespacedName !== null) {
 				$constantName = new Name\FullyQualified($const->namespacedName->toString());
@@ -49,6 +52,9 @@ final class ConstHandler implements StmtHandler
 			}
 			$scope = $scope->assignExpression(new ConstFetch($constantName), $constResult->getType(), $constResult->getNativeType());
 		}
+
+		// deferred from processStmtNode() - fires after the values were processed
+		$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $entryScope, $storage);
 
 		return new InternalStatementResult($scope, hasYield: false, isAlwaysTerminating: false, exitPoints: [], throwPoints: [], impurePoints: $impurePoints);
 	}

--- a/src/Analyser/StmtHandler/DoWhileHandler.php
+++ b/src/Analyser/StmtHandler/DoWhileHandler.php
@@ -125,8 +125,6 @@ final class DoWhileHandler implements StmtHandler
 			$alwaysIterates = $condBooleanType->isTrue()->yes();
 		}
 
-		$nodeScopeResolver->callNodeCallback($nodeCallback, new DoWhileLoopConditionNode($stmt->cond, $bodyScopeResult->toPublic()->getExitPoints(), $bodyScopeResult->hasYield()), $bodyScope, $storage);
-
 		if ($alwaysIterates) {
 			$alwaysTerminating = count($bodyScopeResult->getExitPointsByType(Break_::class)) === 0;
 		} else {
@@ -145,6 +143,12 @@ final class DoWhileHandler implements StmtHandler
 		} else {
 			$nodeScopeResolver->processExprNode($stmt, $stmt->cond, $bodyScope, $storage, $nodeCallback, ExpressionContext::createDeep());
 		}
+
+		// both emissions fire after the condition's final walk stored its
+		// results, so rule-side asks about the condition answer from the
+		// storage; the Do_ callback is deferred from processStmtNode()
+		$nodeScopeResolver->callNodeCallback($nodeCallback, new DoWhileLoopConditionNode($stmt->cond, $bodyScopeResult->toPublic()->getExitPoints(), $bodyScopeResult->hasYield()), $bodyScope, $storage);
+		$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $scope, $storage);
 
 		$breakExitPoints = $bodyScopeResult->getExitPointsByType(Break_::class);
 		if (count($breakExitPoints) > 0) {

--- a/src/Analyser/StmtHandler/SwitchHandler.php
+++ b/src/Analyser/StmtHandler/SwitchHandler.php
@@ -44,7 +44,6 @@ final class SwitchHandler implements StmtHandler
 	{
 		$entryScope = $scope;
 		$condResult = $nodeScopeResolver->processExprNode($stmt, $stmt->cond, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
-		$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $entryScope, $storage);
 		$scope = $condResult->getScope();
 		$scopeForBranches = $scope;
 		$finalScope = null;
@@ -116,6 +115,11 @@ final class SwitchHandler implements StmtHandler
 				$prevScope = $branchScope;
 			}
 		}
+
+		// the Switch_ callback is deferred from processStmtNode(): it fires
+		// after every case condition's walk stored its result, with the entry
+		// scope, so rules pricing the case conditions answer from the storage
+		$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $entryScope, $storage);
 
 		if ($switchConditionArms !== []) {
 			$nodeScopeResolver->callNodeCallback($nodeCallback, new SwitchConditionNode($stmt->cond, $switchConditionArms, $stmt), $scope, $storage);

--- a/src/Analyser/StmtHandler/UnsetHandler.php
+++ b/src/Analyser/StmtHandler/UnsetHandler.php
@@ -52,6 +52,7 @@ final class UnsetHandler implements StmtHandler
 		StatementContext $context,
 	): InternalStatementResult
 	{
+		$entryScope = $scope;
 		$hasYield = false;
 		$throwPoints = [];
 		$impurePoints = [];
@@ -103,6 +104,11 @@ final class UnsetHandler implements StmtHandler
 
 			$scope = $scope->invalidateExpression(new ForeachValueByRefExpr($var));
 		}
+
+		// the Unset_ callback is deferred from processStmtNode(): it fires after
+		// the unset targets were processed, with the entry scope, so rule-side
+		// asks about them answer from the storage
+		$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $entryScope, $storage);
 
 		return new InternalStatementResult($scope, hasYield: $hasYield, isAlwaysTerminating: false, exitPoints: [], throwPoints: $throwPoints, impurePoints: $impurePoints);
 	}

--- a/src/Analyser/StmtHandler/WhileHandler.php
+++ b/src/Analyser/StmtHandler/WhileHandler.php
@@ -121,10 +121,16 @@ final class WhileHandler implements StmtHandler
 			// and replay its emissions through the real callback instead
 			$originalStorage->mergeResults($replayPassStorage);
 			$nodeScopeResolver->replayRecording($replayCondRecording, $nodeCallback, $originalStorage);
+			// the While_ callback is deferred from processStmtNode(): it fires
+			// after the condition's results are in the storage, with the entry scope
+			$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $scope, $originalStorage);
 			$nodeScopeResolver->replayRecording($replayBodyRecording, $nodeCallback, $originalStorage);
 			$finalScopeResult = $replayPassResult;
 		} else {
 			$bodyScope = $nodeScopeResolver->processExprNode($stmt, $stmt->cond, $bodyScope, $storage, $nodeCallback, ExpressionContext::createDeep())->getTruthyScope();
+			// the While_ callback is deferred from processStmtNode(): it fires
+			// after the condition's real walk stored its result, with the entry scope
+			$nodeScopeResolver->callNodeCallback($nodeCallback, $stmt, $scope, $storage);
 			$finalScopeResult = $nodeScopeResolver->processStmtNodesInternal($stmt, $stmt->stmts, $bodyScope, $storage, $nodeCallback, $context)->filterOutLoopExitPoints();
 		}
 		$finalScope = $finalScopeResult->getScope()->filterByFalseyValue($stmt->cond);


### PR DESCRIPTION
Extracted from `resolve-type-rewrite-2` (extraction series, follows #6274/#6275). Continues the post-order callback emission that #6248 established (`ae03ab3ec1`, `1dc598762f`, `8bb4d4d352`): each reorder makes rule-side `getType()` asks answer from the storage instead of re-walking yet-unstored sub-expressions on demand.

Six reorders, each gated individually with the full test suite — zero expectation churn at every step:

- **Closure and arrow-function argument callbacks** fire after their results are stored (re-authored on mainline's `processArgs` arms, emission scope unchanged).
- **Intermediate assign-target links** (`$a[$x][$y] = …`) emit after their dimension was processed, with the link's entry scope — defer-only on mainline, matching the whole-target idiom from `1dc598762f`.
- **The AssignOp result is stored before `applyWrite()`** emits assignment nodes, so `PropertyAssignNode` rules asking about the whole `$lvalue OP= value` expression answer from the storage. The stored entry is the same before-scope-anchored result the engine stores after the handler returns, just visible earlier.
- **Array item callbacks** fire after their key and value were processed.
- **`Unset_`, `ClassConst`, `Const_` and `While_` statement callbacks** are deferred past their expressions, joining `Return_`/`Expression`/`Echo_`/`If_`/`Switch_`/`Foreach_`. In `WhileHandler` the deferred emission sits in both arms of the #6249 replay split: after the condition's replay, or after its real walk, before the body either way.
- **Class attributes are processed before the `InClassNode` emission**, so rules firing on it (e.g. `ClassAttributesRule`) read the attribute arguments from the storage.

Gates: full suite 21155 tests / 96002 assertions green after each commit, `make phpstan` clean, `make cs` clean. None of the touched files have turbo mirrors; only existing `ExpressionResultStorage` API calls are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7pqAkCx4xP6WYxBo2nMJE

---

**Round 2 — miss census.** A temporary census guard in `NodeCallbackScope` (log every stored-result miss with the emitting callback node, the asked expression, and the asking rule) over the full test suite + self-analysis found three more real emission-order gaps, fixed in the follow-up commits:

- **`Switch_` fired before its case conditions were walked** — `MatchingTypeInSwitchCaseConditionRule` (strict-rules) re-priced every case condition on demand (~250 walk-scope re-pricings on self-analysis). The deferred emission now sits after the cases.
- **`Do_` was not deferred at all, and `DoWhileLoopConditionNode` fired before the final condition walk** — both now emit after the condition's results are stored.
- **Inc/dec expressions lacked the AssignOp treatment**: `PropertyAssignNode` rules asking about the whole `$x++` missed the storage; all four handlers now store a before-scope-anchored result before the virtual assign runs.

Everything else the census surfaced is classified non-actionable: rule-fabricated synthetic nodes (including `DataProviderDataRule`'s simulated test-method calls, which carry a real `startLine` but are `TypeExpr`-based fabrications), aggregate-node forward asks (`ClassPropertiesNode` scanning bodies), O(1) variable state reads, and a handful of `ArgumentsNormalizer` clones.

Gates re-run after the instrumentation was removed: full suite 21155/96002 green, `make phpstan` clean, `make cs` clean — zero churn.
