### PR TITLE
Split bootstrap autoloaders at the project's class loader

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -144,6 +144,10 @@ jobs:
               cd e2e/bug-15102b
               ../../bin/phpstan analyze
           - script: |
+              cd e2e/bug-15102
+              composer install
+              ../../bin/phpstan analyze
+          - script: |
               cd e2e/bug-14724
               composer install
               ../../bin/phpstan analyze app/

--- a/e2e/bug-15102/.gitignore
+++ b/e2e/bug-15102/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/e2e/bug-15102/bootstrap.php
+++ b/e2e/bug-15102/bootstrap.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+// The shape typo3/class-alias-loader creates: the project's own Composer loader is taken
+// out of the spl_autoload queue and a wrapper takes its place, resolving legacy names
+// through class_alias() and delegating everything else. The wrapper is not a ClassLoader
+// instance, so the project has no Composer entry left in the queue.
+$composerLoader = require __DIR__ . '/vendor/autoload.php';
+spl_autoload_unregister([$composerLoader, 'loadClass']);
+
+final class AliasLoader
+{
+
+	public function __construct(private Composer\Autoload\ClassLoader $wrapped)
+	{
+	}
+
+	public function loadClass(string $class): void
+	{
+		if ($class === 'Legacy\\Validate') {
+			class_alias(Modern\Validate::class, 'Legacy\\Validate');
+
+			return;
+		}
+
+		$this->wrapped->loadClass($class);
+	}
+
+}
+
+spl_autoload_register([new AliasLoader($composerLoader), 'loadClass']);

--- a/e2e/bug-15102/composer.json
+++ b/e2e/bug-15102/composer.json
@@ -1,0 +1,7 @@
+{
+	"autoload": {
+		"psr-4": {
+			"Modern\\": "src/"
+		}
+	}
+}

--- a/e2e/bug-15102/phpstan.dist.neon
+++ b/e2e/bug-15102/phpstan.dist.neon
@@ -1,0 +1,8 @@
+parameters:
+	level: 8
+	bootstrapFiles:
+		- bootstrap.php
+	paths:
+		- test.php
+		- src
+		- stub

--- a/e2e/bug-15102/src/Validate.php
+++ b/e2e/bug-15102/src/Validate.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Modern;
+
+class Validate
+{
+
+	public function doFoo(): void
+	{
+	}
+
+}

--- a/e2e/bug-15102/stub/Validate.php
+++ b/e2e/bug-15102/stub/Validate.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Legacy;
+
+// An IDE-only stub, never loaded at runtime: it declares the legacy name as a plain class
+// so editors resolve it. At runtime the name is a class_alias to Modern\Validate, which is
+// the declaration PHPStan has to use.
+die('never loaded at runtime');
+
+class Validate
+{
+
+}

--- a/e2e/bug-15102/test.php
+++ b/e2e/bug-15102/test.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types = 1);
+
+function (Legacy\Validate $validate): void {
+	$validate->doFoo();
+};

--- a/src/autoloadFunctions.php
+++ b/src/autoloadFunctions.php
@@ -3,10 +3,12 @@
 namespace PHPStan;
 
 use Composer\Autoload\ClassLoader;
+use function array_shift;
 use function count;
 use function get_class;
 use function is_array;
 use function is_object;
+use function spl_object_id;
 
 /**
  * Autoloaders that were registered *after* Composer's class loader in the
@@ -34,11 +36,32 @@ function autoloadFunctionsPrependedToComposer(): array // phpcs:ignore Squiz.Fun
 }
 
 /**
+ * Whether the spl_autoload entry is a Composer ClassLoader's loadClass() callable.
+ *
+ * @param mixed $autoloadFunction
+ */
+function isComposerClassLoader($autoloadFunction): bool // phpcs:ignore Squiz.Functions.GlobalFunction.Found
+{
+	return is_array($autoloadFunction)
+		&& count($autoloadFunction) > 0
+		&& is_object($autoloadFunction[0])
+		&& get_class($autoloadFunction[0]) === ClassLoader::class;
+}
+
+/**
  * Splits the autoload functions registered while loading Composer's autoloader
  * and the bootstrap files into those registered before and after Composer's own
  * class loader in the spl_autoload queue. This lets PHPStan consult them in the
  * same order relative to Composer as PHP does at runtime, instead of always
  * invoking them before (or after) the static Composer source locators.
+ *
+ * When no Composer ClassLoader instance is left in the queue there is no
+ * boundary to split on: a bootstrap file has taken Composer's place, so its
+ * loader carries Composer's runtime priority and belongs before the static
+ * source locators. Bucketing those as appended would demote a loader that
+ * actually resolves the class first, which is what
+ * https://github.com/phpstan/phpstan/issues/15102 reported for
+ * typo3/class-alias-loader.
  *
  * @param list<mixed>|false $autoloadFunctionsBefore
  * @param list<mixed>|false $autoloadFunctionsAfter
@@ -53,16 +76,28 @@ function collectNewAutoloadFunctions($autoloadFunctionsBefore, $autoloadFunction
 		return ['prepended' => $prepended, 'appended' => $appended];
 	}
 
+	// The split has to happen at the *analysed project's* class loader. PHPStan's own
+	// loader is a ClassLoader as well and is always registered first - before any project
+	// code runs - so searching the queue for the first ClassLoader instance would make
+	// every bootstrap-registered autoloader look like it came after Composer, and demote
+	// it below the static source locators.
+	$classLoaderIds = [];
+	foreach ($autoloadFunctionsBefore as $before) {
+		if (isComposerClassLoader($before)) {
+			$classLoaderIds[] = spl_object_id($before[0]);
+		}
+	}
+
+	array_shift($classLoaderIds);
+	$projectLoaderId = $classLoaderIds === [] ? null : $classLoaderIds[count($classLoaderIds) - 1];
+
 	$composerIndex = null;
-	foreach ($autoloadFunctionsAfter as $index => $after) {
-		if (
-			is_array($after)
-			&& count($after) > 0
-			&& is_object($after[0])
-			&& get_class($after[0]) === ClassLoader::class
-		) {
-			$composerIndex = $index;
-			break;
+	if ($projectLoaderId !== null) {
+		foreach ($autoloadFunctionsAfter as $index => $after) {
+			if (isComposerClassLoader($after) && spl_object_id($after[0]) === $projectLoaderId) {
+				$composerIndex = $index;
+				break;
+			}
 		}
 	}
 
@@ -85,7 +120,7 @@ function collectNewAutoloadFunctions($autoloadFunctionsBefore, $autoloadFunction
 			}
 		}
 
-		if ($composerIndex !== null && $index < $composerIndex) {
+		if ($composerIndex === null || $index < $composerIndex) {
 			$prepended[] = $after;
 		} else {
 			$appended[] = $after;

--- a/tests/PHPStan/CollectNewAutoloadFunctionsTest.php
+++ b/tests/PHPStan/CollectNewAutoloadFunctionsTest.php
@@ -5,6 +5,12 @@ namespace PHPStan;
 use Composer\Autoload\ClassLoader;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * The before-snapshot always starts with PHPStan's own Composer ClassLoader - bin/phpstan
+ * requires its own autoloader long before any project code runs - so every case here models
+ * that entry. Which loader the split happens at is the whole point: see
+ * https://github.com/phpstan/phpstan/issues/15102
+ */
 class CollectNewAutoloadFunctionsTest extends TestCase
 {
 
@@ -23,16 +29,17 @@ class CollectNewAutoloadFunctionsTest extends TestCase
 		);
 	}
 
-	public function testAutoloadersAreSplitByComposerPosition(): void
+	public function testAutoloadersAreSplitByTheProjectsComposerPosition(): void
 	{
+		$phpstanOwn = [new ClassLoader(), 'loadClass'];
+		$project = [new ClassLoader(), 'loadClass'];
 		$prepended = static function (string $class): void {
 		};
-		$composer = new ClassLoader();
 		$appended = static function (string $class): void {
 		};
 
-		$before = [];
-		$after = [$prepended, [$composer, 'loadClass'], $appended];
+		$before = [$phpstanOwn, $project];
+		$after = [$phpstanOwn, $prepended, $project, $appended];
 
 		$result = collectNewAutoloadFunctions($before, $after);
 
@@ -40,29 +47,68 @@ class CollectNewAutoloadFunctionsTest extends TestCase
 		$this->assertSame([$appended], $result['appended']);
 	}
 
-	public function testWithoutComposerEverythingIsAppended(): void
+	/**
+	 * PHPStan's own loader must never be the boundary. It is registered before anything
+	 * else, so splitting on the first ClassLoader in the queue would classify every
+	 * bootstrap-registered autoloader as "after Composer" and consult it only after the
+	 * static source locators - the regression this test pins.
+	 */
+	public function testPhpstansOwnLoaderIsNotTheBoundary(): void
 	{
-		$first = static function (string $class): void {
-		};
-		$second = static function (string $class): void {
+		$phpstanOwn = [new ClassLoader(), 'loadClass'];
+		$bootstrap = static function (string $class): void {
 		};
 
-		$result = collectNewAutoloadFunctions([], [$first, $second]);
+		$before = [$phpstanOwn];
+		$after = [$phpstanOwn, $bootstrap];
 
-		$this->assertSame([], $result['prepended']);
-		$this->assertSame([$first, $second], $result['appended']);
+		$result = collectNewAutoloadFunctions($before, $after);
+
+		$this->assertSame([$bootstrap], $result['prepended']);
+		$this->assertSame([], $result['appended']);
+	}
+
+	/**
+	 * The shape typo3/class-alias-loader creates: the bootstrap unregisters
+	 * [$composerLoader, 'loadClass'] and registers a wrapper that delegates to it. With the
+	 * project's loader gone from the queue there is no boundary left, and the wrapper holds
+	 * the priority Composer had, so everything collected is consulted first.
+	 */
+	public function testProjectLoaderReplacedByABootstrapWrapperIsPrepended(): void
+	{
+		$phpstanOwn = [new ClassLoader(), 'loadClass'];
+		$project = [new ClassLoader(), 'loadClass'];
+		$replacement = new class {
+
+			public function loadClass(string $class): void
+			{
+			}
+
+		};
+		$wrapper = [$replacement, 'loadClass'];
+		$bootstrap = static function (string $class): void {
+		};
+
+		$before = [$phpstanOwn, $project];
+		$after = [$phpstanOwn, $wrapper, $bootstrap];
+
+		$result = collectNewAutoloadFunctions($before, $after);
+
+		$this->assertSame([$wrapper, $bootstrap], $result['prepended']);
+		$this->assertSame([], $result['appended']);
 	}
 
 	public function testComposerAndPharAutoloaderAndPreexistingAreExcluded(): void
 	{
+		$phpstanOwn = [new ClassLoader(), 'loadClass'];
 		$preexisting = static function (string $class): void {
 		};
-		$composer = new ClassLoader();
+		$project = [new ClassLoader(), 'loadClass'];
 		$bootstrap = static function (string $class): void {
 		};
 
-		$before = [$preexisting];
-		$after = [$preexisting, [$composer, 'loadClass'], ['PHPStan\\PharAutoloader', 'loadClass'], $bootstrap];
+		$before = [$phpstanOwn, $preexisting, $project];
+		$after = [$phpstanOwn, $preexisting, $project, ['PHPStan\\PharAutoloader', 'loadClass'], $bootstrap];
 
 		$result = collectNewAutoloadFunctions($before, $after);
 
@@ -72,16 +118,17 @@ class CollectNewAutoloadFunctionsTest extends TestCase
 
 	public function testPreexistingAutoloaderBeforeComposerIsNotReported(): void
 	{
+		$phpstanOwn = [new ClassLoader(), 'loadClass'];
 		$preexisting = static function (string $class): void {
 		};
-		$composer = new ClassLoader();
+		$project = [new ClassLoader(), 'loadClass'];
 		$prependedBootstrap = static function (string $class): void {
 		};
 
 		// $preexisting was registered before PHPStan loaded the project - it must
 		// be ignored even though it sits before Composer in the queue.
-		$before = [$preexisting];
-		$after = [$preexisting, $prependedBootstrap, [$composer, 'loadClass']];
+		$before = [$phpstanOwn, $preexisting, $project];
+		$after = [$phpstanOwn, $preexisting, $prependedBootstrap, $project];
 
 		$result = collectNewAutoloadFunctions($before, $after);
 


### PR DESCRIPTION
The ordering half of phpstan/phpstan#15102 - @sbuerk's original report. #6265 fixes @hoetaek's half.

**The mechanism is not the one the issue proposes.** I built a phar from the first version of this PR (which implemented the suggested `$composerIndex === null` fallback) and it does not fix the reported case. Measured on the `e2e/bug-15102` project added here, each run with its own `tmpDir` so no result cache is shared:

| build | result |
| --- | --- |
| 2.2.8 phar | No errors |
| 2.2.9 phar | 1 error |
| phar of this PR's **first** version (`$composerIndex === null` fallback) | **1 error** |
| this PR | No errors |

## What actually happens

`collectNewAutoloadFunctions()` looks for the first `Composer\Autoload\ClassLoader` instance in the queue to decide what came "before Composer". That instance is **PHPStan's own** - `bin/phpstan` requires its own autoloader long before any project code runs. Dumping the queue during analysis:

```
composerIndex=0
  after[0] Composer\Autoload\ClassLoader   <- PHPStan's own loader
  after[1] Hoa\Consistency\Autoloader
  after[2] AliasLoader::loadClass          <- the bootstrap's loader, index > 0
  => APPENDED AliasLoader::loadClass
```

So *every* bootstrap-registered autoloader is classified as "after Composer" and consulted only after the static source locators. `$composerIndex` is never `null` - which is why the fallback the issue proposes changes nothing on its own.

The fix skips the first `ClassLoader` in the before-snapshot and splits at the last one, i.e. the analysed project's loader. When that loader is gone after the bootstrap files ran, a bootstrap has replaced Composer (`typo3/class-alias-loader` unregisters `[$composerLoader, 'loadClass']` and registers a wrapper) and there is no boundary left, so the collected loaders are consulted first - the order they had until 2.2.9.

## Verification

- **`e2e/bug-15102`** (new, registered in `e2e-tests.yml`): a bootstrap replaces the project's loader and resolves `Legacy\Validate` via `class_alias`, while an IDE-only stub in the analysed paths declares the same name as a plain class - the TYPO3 shape. Without the fix the stub wins and PHPStan reports `Call to an undefined method Legacy\Validate::doFoo()`; with it, clean. It reproduces in a **source run**, so no phar is needed to keep it honest.
- `CollectNewAutoloadFunctionsTest`: 6 green, **4 fail without the source change**. The cases now model the real snapshot, which always starts with PHPStan's own loader, and `testPhpstansOwnLoaderIsNotTheBoundary` pins the regression directly.
- `e2e/bug-12972b`, `e2e/bug-12972c` (#6069's own ordering coverage) and `e2e/bug-14988` exit 0.
- Full suite 21156 green, self-analysis clean, phpcs clean.

Closes the ordering half of https://github.com/phpstan/phpstan/issues/15102
