### PR TITLE
Use early exit when collecting the registered class loaders

### DIFF
--- a/src/autoloadFunctions.php
+++ b/src/autoloadFunctions.php
@@ -49,6 +49,31 @@ function isComposerClassLoader($autoloadFunction): bool // phpcs:ignore Squiz.Fu
 }
 
 /**
+ * Index of the given class loader in the queue, or null when it is not registered any more -
+ * a bootstrap file has then taken Composer's place and there is no boundary to split on.
+ *
+ * @param list<mixed> $autoloadFunctions
+ */
+function findClassLoaderIndex(array $autoloadFunctions, ?int $classLoaderId): ?int // phpcs:ignore Squiz.Functions.GlobalFunction.Found
+{
+	if ($classLoaderId === null) {
+		return null;
+	}
+
+	foreach ($autoloadFunctions as $index => $autoloadFunction) {
+		if (!isComposerClassLoader($autoloadFunction)) {
+			continue;
+		}
+
+		if (spl_object_id($autoloadFunction[0]) === $classLoaderId) {
+			return $index;
+		}
+	}
+
+	return null;
+}
+
+/**
  * Splits the autoload functions registered while loading Composer's autoloader
  * and the bootstrap files into those registered before and after Composer's own
  * class loader in the spl_autoload queue. This lets PHPStan consult them in the
@@ -83,23 +108,17 @@ function collectNewAutoloadFunctions($autoloadFunctionsBefore, $autoloadFunction
 	// it below the static source locators.
 	$classLoaderIds = [];
 	foreach ($autoloadFunctionsBefore as $before) {
-		if (isComposerClassLoader($before)) {
-			$classLoaderIds[] = spl_object_id($before[0]);
+		if (!isComposerClassLoader($before)) {
+			continue;
 		}
+
+		$classLoaderIds[] = spl_object_id($before[0]);
 	}
 
 	array_shift($classLoaderIds);
 	$projectLoaderId = $classLoaderIds === [] ? null : $classLoaderIds[count($classLoaderIds) - 1];
 
-	$composerIndex = null;
-	if ($projectLoaderId !== null) {
-		foreach ($autoloadFunctionsAfter as $index => $after) {
-			if (isComposerClassLoader($after) && spl_object_id($after[0]) === $projectLoaderId) {
-				$composerIndex = $index;
-				break;
-			}
-		}
-	}
+	$composerIndex = findClassLoaderIndex($autoloadFunctionsAfter, $projectLoaderId);
 
 	foreach ($autoloadFunctionsAfter as $index => $after) {
 		if (is_array($after) && count($after) > 0) {


### PR DESCRIPTION
The `Coding Standard` job is red on `2.2.x` after c10897b1f (#6281 - my fault, the fix was on the branch but not in the merged commit):

```
FILE: src/autoloadFunctions.php
 111 | ERROR | [x] Use early exit to reduce code nesting.
     |       |     (SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed)
```

The collect loop is inverted to `if (!isComposerClassLoader(...)) { continue; }`, and the boundary lookup - a `foreach` nested in an `if` - becomes `findClassLoaderIndex()`, which returns early. No behaviour change.

Verified: `phpcs` over the whole repo reports the error on the current tip and nothing with this change; `CollectNewAutoloadFunctionsTest` 6/6; self-analysis clean; `e2e/bug-15102` still green.