### PR TITLE
Run StubFilesExtensions only after bootstrapFiles have been executed

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -679,6 +679,13 @@ jobs:
               ../bashunit -a contains 'should return non-empty-string but returns string' "$OUTPUT"
               mv stubs/Foo.stub.orig stubs/Foo.stub
               ../../bin/phpstan analyse -vvv
+              patch -b stub-files.neon < config-change.patch
+              OUTPUT=$(../../bin/phpstan analyse -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache not used because the metadata do not match' "$OUTPUT"
+              ../bashunit -a contains 'configStubFiles' "$OUTPUT"
+              mv stub-files.neon.orig stub-files.neon
+              ../../bin/phpstan analyse -vvv
           - script: |
               cd e2e/nested-trait-use
               ../../bin/phpstan analyze

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -669,6 +669,17 @@ jobs:
               echo "$OUTPUT"
               ../bashunit -a contains 'Method StubFiles\Foo::doFoo() has no return type specified.' "$OUTPUT"
           - script: |
+              cd e2e/bug-15120
+              composer install
+              ../../bin/phpstan analyse -vvv
+              ../../bin/phpstan analyse -vvv
+              patch -b stubs/Foo.stub < stub-change.patch
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse --error-format=raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'should return non-empty-string but returns string' "$OUTPUT"
+              mv stubs/Foo.stub.orig stubs/Foo.stub
+              ../../bin/phpstan analyse -vvv
+          - script: |
               cd e2e/nested-trait-use
               ../../bin/phpstan analyze
           - script: |

--- a/e2e/bug-15120/.gitignore
+++ b/e2e/bug-15120/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/e2e/bug-15120/bootstrap.php
+++ b/e2e/bug-15120/bootstrap.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types = 1);
+
+define('Bug15120\FRAMEWORK_VERSION', '13.26.1');

--- a/e2e/bug-15120/composer.json
+++ b/e2e/bug-15120/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Bug15120\\": "extension/"
+        }
+    }
+}

--- a/e2e/bug-15120/config-change.patch
+++ b/e2e/bug-15120/config-change.patch
@@ -1,0 +1,7 @@
+--- stub-files.neon
++++ stub-files.neon
+@@ -1,3 +1,4 @@
+ parameters:
+ 	stubFiles:
+ 		- src/BazStub.php
++		- stubs/Bar.stub

--- a/e2e/bug-15120/extension/FrameworkStubFilesExtension.php
+++ b/e2e/bug-15120/extension/FrameworkStubFilesExtension.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120;
+
+use PHPStan\PhpDoc\StubFilesExtension;
+use function constant;
+use function version_compare;
+
+final class FrameworkStubFilesExtension implements StubFilesExtension
+{
+
+	public function getFiles(): array
+	{
+		// mimics larastan: the constant is defined by a bootstrapFiles entry
+		if (version_compare((string) constant('Bug15120\FRAMEWORK_VERSION'), '10.0', '<')) {
+			return [];
+		}
+
+		return [__DIR__ . '/../stubs/Foo.stub'];
+	}
+
+}

--- a/e2e/bug-15120/phpstan.neon
+++ b/e2e/bug-15120/phpstan.neon
@@ -1,0 +1,12 @@
+parameters:
+	level: 8
+	paths:
+		- src
+	bootstrapFiles:
+		- bootstrap.php
+
+services:
+	-
+		class: Bug15120\FrameworkStubFilesExtension
+		tags:
+			- phpstan.stubFilesExtension

--- a/e2e/bug-15120/phpstan.neon
+++ b/e2e/bug-15120/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+	- stub-files.neon
+
 parameters:
 	level: 8
 	paths:

--- a/e2e/bug-15120/src/BazStub.php
+++ b/e2e/bug-15120/src/BazStub.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug15120;
+
+class Baz
+{
+
+	/** @return non-empty-string */
+	public function name(): string
+	{
+
+	}
+
+}

--- a/e2e/bug-15120/src/Consumer.php
+++ b/e2e/bug-15120/src/Consumer.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120;
+
+class Consumer
+{
+
+	/** @return non-empty-string */
+	public function describe(Foo $foo): string
+	{
+		return $foo->get();
+	}
+
+}

--- a/e2e/bug-15120/src/Foo.php
+++ b/e2e/bug-15120/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120;
+
+class Foo
+{
+
+	public function get(): string
+	{
+		return 'hello';
+	}
+
+}

--- a/e2e/bug-15120/stub-change.patch
+++ b/e2e/bug-15120/stub-change.patch
@@ -1,0 +1,11 @@
+--- stubs/Foo.stub
++++ stubs/Foo.stub
+@@ -5,7 +5,7 @@
+ class Foo
+ {
+ 
+-	/** @return non-empty-string */
++	/** @return string */
+ 	public function get(): string
+ 	{
+ 

--- a/e2e/bug-15120/stub-files.neon
+++ b/e2e/bug-15120/stub-files.neon
@@ -1,0 +1,3 @@
+parameters:
+	stubFiles:
+		- src/BazStub.php

--- a/e2e/bug-15120/stubs/Bar.stub
+++ b/e2e/bug-15120/stubs/Bar.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug15120;
+
+class Bar
+{
+
+	/** @return non-empty-string */
+	public function name(): string
+	{
+
+	}
+
+}

--- a/e2e/bug-15120/stubs/Foo.stub
+++ b/e2e/bug-15120/stubs/Foo.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug15120;
+
+class Foo
+{
+
+	/** @return non-empty-string */
+	public function get(): string
+	{
+
+	}
+
+}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -34,6 +34,7 @@ use function array_fill_keys;
 use function array_filter;
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function array_merge;
 use function array_unique;
 use function array_values;
@@ -86,6 +87,7 @@ final class ResultCacheManager
 	 * @param string[] $bootstrapFiles
 	 * @param string[] $scanFiles
 	 * @param string[] $scanDirectories
+	 * @param string[] $configStubFiles
 	 * @param list<string|non-empty-list<string>> $parametersNotInvalidatingCache
 	 * @param array<string, string> $fileReplacements
 	 * @param ExtensionsCollection<ResultCacheMetaExtension> $resultCacheMetaExtensions
@@ -117,6 +119,8 @@ final class ResultCacheManager
 		private array $scanFiles,
 		#[AutowiredParameter]
 		private array $scanDirectories,
+		#[AutowiredParameter(ref: '%stubFiles%')]
+		private array $configStubFiles,
 		private array $fileReplacements,
 		#[AutowiredParameter(ref: '%resultCacheChecksProjectExtensionFilesDependencies%')]
 		private bool $checkDependenciesOfProjectExtensionFiles,
@@ -1596,6 +1600,12 @@ return [
 			'composerInstalled' => $this->getComposerInstalled(),
 			'executedFilesHashes' => $this->getExecutedFileHashes(),
 			'phpExtensions' => $extensions,
+			// only the statically configured stub files - the full list including the ones
+			// from StubFilesExtensions is recorded at save time (see save()), because the
+			// extensions may only run after the bootstrapFiles. This entry catches a changed
+			// list in any config file, including the included ones that are not part of the
+			// projectConfig entry above.
+			'configStubFiles' => array_map(fn (string $stubFile): string => $this->fileHelper->normalizePath($stubFile), $this->configStubFiles),
 			'level' => $this->usedLevel,
 		];
 	}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -303,6 +303,21 @@ final class ResultCacheManager
 		$exportedNodesCallback = $data['exportedNodesCallback'];
 		$data['exportedNodesCallback'] = static fn (): array => $transformer->absolutizeFileKeyed($exportedNodesCallback());
 
+		// The stub file hashes get into the meta only at save time, after the analysis - the
+		// only point where the StubFilesExtensions may run, because they can rely on
+		// bootstrapFiles having been executed. Restoring must not run them, so the entry is
+		// taken out of the cached meta here; the freshly computed meta below never contains it,
+		// and isMetaDifferent() never sees it on either side. Instead, the recorded hashes are
+		// verified after the meta comparison - a changed stub file invalidates the whole cache.
+		// A different list coming from an extension is not detected - projectExtensionFiles
+		// cover that.
+		$cachedStubFiles = [];
+		if (array_key_exists('stubFiles', $data['meta']) && is_array($data['meta']['stubFiles'])) {
+			/** @var array<string, string> $cachedStubFiles */
+			$cachedStubFiles = $data['meta']['stubFiles'];
+			unset($data['meta']['stubFiles']);
+		}
+
 		$meta = $this->getMeta($allAnalysedFiles, $projectConfigArray);
 		// absolutized above, so it is always present here
 		$packageDependencies = $data['packageDependencies'];
@@ -485,6 +500,57 @@ final class ResultCacheManager
 			);
 		}
 
+		foreach ($cachedStubFiles as $stubFile => $stubFileHash) {
+			if (!is_file($stubFile)) {
+				if ($output->isVeryVerbose()) {
+					$output->writeLineFormatted(sprintf('Result cache not used because stub file %s was not found.', $stubFile));
+				}
+				return new ResultCache(
+					filesToAnalyse: $allAnalysedFiles,
+					fullAnalysis: true,
+					lastFullAnalysisTime: time(),
+					meta: $meta,
+					errors: [],
+					locallyIgnoredErrors: [],
+					linesToIgnore: [],
+					unmatchedLineIgnores: [],
+					collectedData: [],
+					dependencies: [],
+					usedTraitDependencies: [],
+					packageDependencies: [],
+					exportedNodes: [],
+					projectExtensionFiles: [],
+					currentFileHashes: $currentFileHashes,
+				);
+			}
+
+			if ($this->getFileHash($stubFile) === $stubFileHash) {
+				continue;
+			}
+
+			if ($output->isVeryVerbose()) {
+				$output->writeLineFormatted(sprintf('Result cache not used because stub file %s hash does not match.', $stubFile));
+			}
+
+			return new ResultCache(
+				filesToAnalyse: $allAnalysedFiles,
+				fullAnalysis: true,
+				lastFullAnalysisTime: time(),
+				meta: $meta,
+				errors: [],
+				locallyIgnoredErrors: [],
+				linesToIgnore: [],
+				unmatchedLineIgnores: [],
+				collectedData: [],
+				dependencies: [],
+				usedTraitDependencies: [],
+				packageDependencies: [],
+				exportedNodes: [],
+				projectExtensionFiles: [],
+				currentFileHashes: $currentFileHashes,
+			);
+		}
+
 		$invertedDependencies = $data['dependencies'];
 		$deletedFiles = array_fill_keys(array_keys($invertedDependencies), true);
 		$filesToAnalyse = [];
@@ -504,7 +570,7 @@ final class ResultCacheManager
 		$filteredExportedNodes = [];
 		$newFileAppeared = false;
 
-		foreach (array_keys($this->getStubFiles()) as $stubFile) {
+		foreach (array_keys($cachedStubFiles) as $stubFile) {
 			if (!array_key_exists($stubFile, $errors)) {
 				continue;
 			}
@@ -1254,6 +1320,11 @@ final class ResultCacheManager
 
 		ksort($exportedNodes);
 
+		// The only point where the StubFilesExtensions may run: the analysis is over, bootstrapFiles
+		// have been executed, so the extensions can rely on them. restore() reads these hashes back
+		// instead of running the extensions again.
+		$meta['stubFiles'] = $this->getStubFiles();
+
 		// Store paths relative to the anchor so the cache survives a change of the project's absolute
 		// path prefix (a fresh CI checkout dir, a git worktree). projectConfig inside $meta is already a
 		// Neon-encoded string here (encoded in process()), so it is relativized at the array level before
@@ -1525,7 +1596,6 @@ return [
 			'composerInstalled' => $this->getComposerInstalled(),
 			'executedFilesHashes' => $this->getExecutedFileHashes(),
 			'phpExtensions' => $extensions,
-			'stubFiles' => $this->getStubFiles(),
 			'level' => $this->usedLevel,
 		];
 	}

--- a/src/Analyser/ResultCache/ResultCachePathTransformer.php
+++ b/src/Analyser/ResultCache/ResultCachePathTransformer.php
@@ -307,8 +307,11 @@ final class ResultCachePathTransformer
 	 */
 	private function transformMeta(array $meta, bool $absolutize): array
 	{
-		if (array_key_exists('analysedPaths', $meta) && is_array($meta['analysedPaths'])) {
-			$meta['analysedPaths'] = $this->transformList($meta['analysedPaths'], $absolutize);
+		foreach (['analysedPaths', 'configStubFiles'] as $listKey) {
+			if (!array_key_exists($listKey, $meta) || !is_array($meta[$listKey])) {
+				continue;
+			}
+			$meta[$listKey] = $this->transformList($meta[$listKey], $absolutize);
 		}
 
 		foreach (['scannedFiles', 'composerLocks', 'executedFilesHashes', 'stubFiles'] as $key) {

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -889,6 +889,17 @@ final class AnalyseCommand extends Command
 			return $inceptionResult->handleReturn(1, null, $this->analysisStartTime);
 		}
 
+		// this process defers bootstrapFiles like the rest of the analyse flow but never
+		// reaches the points that run them - and FixerApplication asks the
+		// StubFilesExtensions (file monitor), which may rely on bootstrapFiles. Its
+		// workers are spawned, never forked, so no child inherits resources the files open
+		// and the eager run is safe.
+		try {
+			$container->getByType(BootstrapFilesRunner::class)->run($inceptionResult->getErrorOutput(), (bool) $input->getOption('debug'));
+		} catch (InceptionNotSuccessfulException) {
+			return $inceptionResult->handleReturn(1, null, $this->analysisStartTime);
+		}
+
 		/** @var FixerApplication $fixerApplication */
 		$fixerApplication = $container->getByType(FixerApplication::class);
 

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -23,6 +23,7 @@ use PHPStan\DependencyInjection\InvalidIgnoredErrorPatternsException;
 use PHPStan\DependencyInjection\LoaderFactory;
 use PHPStan\DependencyInjection\MissingImplementedInterfaceInServiceWithTagException;
 use PHPStan\ExtensionInstaller\GeneratedConfig;
+use PHPStan\File\FileExcluder;
 use PHPStan\File\FileFinder;
 use PHPStan\File\FileHelper;
 use PHPStan\File\ParentDirectoryRelativePathHelper;
@@ -36,8 +37,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
+use function array_filter;
 use function array_key_exists;
 use function array_map;
+use function array_values;
 use function class_exists;
 use function count;
 use function dirname;
@@ -588,7 +591,10 @@ final class CommandHelper
 
 		$pathRoutingParser = $container->getService('pathRoutingParser');
 
-		$filesCallback = static function () use ($fileFinder, $pathRoutingParser, $paths, $errorOutput): array {
+		/** @var string[] $configStubFiles */
+		$configStubFiles = $container->getParameter('stubFiles');
+
+		$filesCallback = static function () use ($currentWorkingDirectoryFileHelper, $configStubFiles, $fileFinder, $pathRoutingParser, $paths, $errorOutput): array {
 			if (count($paths) === 0) {
 				$errorOutput->writeLineFormatted('At least one path must be specified to analyse.');
 				throw new InceptionNotSuccessfulException();
@@ -597,6 +603,12 @@ final class CommandHelper
 			$files = $fileFinderResult->getFiles();
 
 			$pathRoutingParser->setAnalysedFiles($files);
+
+			// only the statically configured stub files can be excluded here - asking
+			// the StubFilesExtensions is not possible before the bootstrapFiles have run
+			$stubFilesExcluder = new FileExcluder($currentWorkingDirectoryFileHelper, $configStubFiles);
+
+			$files = array_values(array_filter($files, static fn (string $file) => !$stubFilesExcluder->isExcludedFromAnalysing($file)));
 
 			return [$files, $fileFinderResult->isOnlyFiles()];
 		};

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -23,7 +23,6 @@ use PHPStan\DependencyInjection\InvalidIgnoredErrorPatternsException;
 use PHPStan\DependencyInjection\LoaderFactory;
 use PHPStan\DependencyInjection\MissingImplementedInterfaceInServiceWithTagException;
 use PHPStan\ExtensionInstaller\GeneratedConfig;
-use PHPStan\File\FileExcluder;
 use PHPStan\File\FileFinder;
 use PHPStan\File\FileHelper;
 use PHPStan\File\ParentDirectoryRelativePathHelper;
@@ -31,17 +30,14 @@ use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Internal\DirectoryCreator;
 use PHPStan\Internal\DirectoryCreatorException;
-use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\ShouldNotHappenException;
 use ReflectionClass;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
-use function array_filter;
 use function array_key_exists;
 use function array_map;
-use function array_values;
 use function class_exists;
 use function count;
 use function dirname;
@@ -592,9 +588,7 @@ final class CommandHelper
 
 		$pathRoutingParser = $container->getService('pathRoutingParser');
 
-		$stubFilesProvider = $container->getByType(StubFilesProvider::class);
-
-		$filesCallback = static function () use ($currentWorkingDirectoryFileHelper, $stubFilesProvider, $fileFinder, $pathRoutingParser, $paths, $errorOutput): array {
+		$filesCallback = static function () use ($fileFinder, $pathRoutingParser, $paths, $errorOutput): array {
 			if (count($paths) === 0) {
 				$errorOutput->writeLineFormatted('At least one path must be specified to analyse.');
 				throw new InceptionNotSuccessfulException();
@@ -603,10 +597,6 @@ final class CommandHelper
 			$files = $fileFinderResult->getFiles();
 
 			$pathRoutingParser->setAnalysedFiles($files);
-
-			$stubFilesExcluder = new FileExcluder($currentWorkingDirectoryFileHelper, $stubFilesProvider->getProjectStubFiles());
-
-			$files = array_values(array_filter($files, static fn (string $file) => !$stubFilesExcluder->isExcludedFromAnalysing($file)));
 
 			return [$files, $fileFinderResult->isOnlyFiles()];
 		};

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -121,7 +121,10 @@ final class WorkerCommand extends Command
 		// The master published the analysed-file list its job schedule was
 		// built from; walking the analysed paths again would just re-derive
 		// the same list. The parser router must still learn it — that is a
-		// side effect of the walk this shortcut skips.
+		// side effect of the walk this shortcut skips. (The router normally
+		// also sees the statically configured stub files the excluder later
+		// removes; those are never analysed, so their ignore-collection
+		// routing is unused either way.)
 		$analysedFiles = ArenaCache::lookup('analysed-files');
 		if (is_array($analysedFiles)) {
 			$pathRoutingParser = $container->getService('pathRoutingParser');

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -121,10 +121,7 @@ final class WorkerCommand extends Command
 		// The master published the analysed-file list its job schedule was
 		// built from; walking the analysed paths again would just re-derive
 		// the same list. The parser router must still learn it — that is a
-		// side effect of the walk this shortcut skips. (The router normally
-		// also sees the project stub files the stub excluder later removes;
-		// those are never analysed, so their ignore-collection routing is
-		// unused either way.)
+		// side effect of the walk this shortcut skips.
 		$analysedFiles = ArenaCache::lookup('analysed-files');
 		if (is_array($analysedFiles)) {
 			$pathRoutingParser = $container->getService('pathRoutingParser');


### PR DESCRIPTION
Since bootstrapFiles are deferred past `CommandHelper::begin()`, a `StubFilesExtension` relying on their side effects crashed before the analysis started - larastan reads a constant its bootstrap file defines, taking down every larastan user on the current tip.

The series makes every `StubFilesExtension::getFiles()` call site run after the bootstrapFiles:

- **Do not exclude stub files from the list of analysed files** - the files callback ran the extensions just to filter project stub files out of the analysed-file list.
- **Verify recorded stub file hashes when restoring the result cache** - the stub file list is recorded into the meta only at save time, after the analysis. `restore()` no longer runs the extensions: it verifies the recorded hashes and invalidates the whole cache when a stub file changed or disappeared. The on-disk format is unchanged, so existing caches keep working in both directions.
- **Run deferred bootstrapFiles before the fixer application asks for stub files** - the PHPStan Pro flow never reaches the analyse-flow points that run them; its workers are spawned, never forked, so the eager run is safe.
- **Exclude statically configured stub files from the list of analysed files** - brings the exclusion back, limited to the `stubFiles` config parameter, which is known without asking the extensions.
- **Invalidate the result cache when the configured stubFiles list changes** - records the statically configured list in the meta as `configStubFiles`, relativized like the other meta paths.

The `e2e/bug-15120` project covers the whole arc: a bootstrap-defined constant read by a stub files extension, a cached run, a stub content change invalidating the cache, a stub file living inside an analysed path (would report a missing return statement if analysed as a regular file), and a `stubFiles` list change in an included config file invalidating the cache.

Closes https://github.com/phpstan/phpstan/issues/15120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cAV6sztxvNeaEQ78RVFad