### PR TITLE
Report incorrect case of imported class names only with bleeding edge

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -25,3 +25,4 @@ parameters:
 		unnecessaryNullCoalesce: true
 		finiteTypesInHaystack: true
 		switchConditionAlwaysFalse: true
+		checkImportedClassNameCase: true

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -56,6 +56,7 @@ parameters:
 		unnecessaryNullCoalesce: false
 		finiteTypesInHaystack: false
 		switchConditionAlwaysFalse: false
+		checkImportedClassNameCase: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -54,6 +54,7 @@ parametersSchema:
 		unnecessaryNullCoalesce: bool()
 		finiteTypesInHaystack: bool()
 		switchConditionAlwaysFalse: bool()
+		checkImportedClassNameCase: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/src/Rules/ClassCaseSensitivityCheck.php
+++ b/src/Rules/ClassCaseSensitivityCheck.php
@@ -20,6 +20,8 @@ final class ClassCaseSensitivityCheck
 		private ReflectionProvider $reflectionProvider,
 		#[AutowiredParameter]
 		private bool $checkInternalClassCaseSensitivity,
+		#[AutowiredParameter(ref: '%featureToggles.checkImportedClassNameCase%')]
+		private bool $checkImportedClassNameCase,
 	)
 	{
 	}
@@ -72,6 +74,10 @@ final class ClassCaseSensitivityCheck
 	private function getClassNameAsWritten(ClassNameNodePair $pair): string
 	{
 		$className = $pair->getClassName();
+		if (!$this->checkImportedClassNameCase) {
+			return $className;
+		}
+
 		$node = $pair->getNode();
 		if (!$node instanceof Name || $node->toString() !== $className) {
 			return $className;

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -41,7 +41,9 @@ use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
+use function array_slice;
 use function count;
+use function implode;
 use function in_array;
 use function is_string;
 use function sprintf;
@@ -60,6 +62,8 @@ final class FunctionDefinitionCheck
 		private bool $checkClassCaseSensitivity,
 		#[AutowiredParameter]
 		private bool $checkThisOnly,
+		#[AutowiredParameter(ref: '%featureToggles.checkImportedClassNameCase%')]
+		private bool $checkImportedClassNameCase,
 	)
 	{
 	}
@@ -845,12 +849,38 @@ final class FunctionDefinitionCheck
 
 		if ($typeNode instanceof Name) {
 			$resolvedName = $typeNode->toString();
-			$nameAsWritten = ClassCaseSensitivityCheck::getNameAsWritten($typeNode);
-			if ($nameAsWritten === $resolvedName) {
+			if ($this->checkImportedClassNameCase) {
+				$nameAsWritten = ClassCaseSensitivityCheck::getNameAsWritten($typeNode);
+				if ($nameAsWritten === $resolvedName) {
+					return [];
+				}
+
+				return [strtolower($resolvedName) => new ClassNameNodePair($nameAsWritten, $typeNode)];
+			}
+
+			$originalName = $typeNode->getAttribute('originalName');
+			if (!$originalName instanceof Name) {
 				return [];
 			}
 
-			return [strtolower($resolvedName) => new ClassNameNodePair($nameAsWritten, $typeNode)];
+			$originalParts = $originalName->getParts();
+			$resolvedParts = $typeNode->getParts();
+
+			$originalPartsCount = count($originalParts);
+			$resolvedPartsCount = count($resolvedParts);
+
+			if ($originalPartsCount <= $resolvedPartsCount) {
+				$prefixParts = array_slice($resolvedParts, 0, $resolvedPartsCount - $originalPartsCount);
+				$originalCaseClassName = implode('\\', array_merge($prefixParts, $originalParts));
+			} else {
+				$originalCaseClassName = $originalName->toString();
+			}
+
+			if ($originalCaseClassName === $resolvedName) {
+				return [];
+			}
+
+			return [strtolower($resolvedName) => new ClassNameNodePair($originalCaseClassName, $typeNode)];
 		}
 
 		if ($typeNode instanceof NullableType) {

--- a/tests/PHPStan/Rules/Classes/ClassAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassAttributesRuleTest.php
@@ -55,7 +55,7 @@ class ClassAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ClassConstantAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantAttributesRuleTest.php
@@ -50,7 +50,7 @@ class ClassConstantAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -23,6 +23,8 @@ class ClassConstantRuleTest extends RuleTestCase
 
 	private int $phpVersion;
 
+	private bool $checkImportedClassNameCase = false;
+
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
@@ -40,7 +42,7 @@ class ClassConstantRuleTest extends RuleTestCase
 				discoveringSymbolsTip: true,
 			),
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: true),
+				new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: true, checkImportedClassNameCase: $this->checkImportedClassNameCase),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -569,15 +571,29 @@ class ClassConstantRuleTest extends RuleTestCase
 		]);
 	}
 
-	public function testBug12827(): void
+	public static function dataBug12827(): array
+	{
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	#[DataProvider('dataBug12827')]
+	public function testBug12827(bool $checkImportedClassNameCase): void
 	{
 		$this->phpVersion = PHP_VERSION_ID;
-		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
-			[
+		$this->checkImportedClassNameCase = $checkImportedClassNameCase;
+
+		$expectedErrors = [];
+		if ($checkImportedClassNameCase) {
+			$expectedErrors[] = [
 				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
 				25,
-			],
-		]);
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], $expectedErrors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/ExistingClassInClassExtendsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInClassExtendsRuleTest.php
@@ -23,7 +23,7 @@ class ExistingClassInClassExtendsRuleTest extends RuleTestCase
 		$container = self::getContainer();
 		return new ExistingClassInClassExtendsRule(
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ExistingClassInInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInInstanceOfRuleTest.php
@@ -24,7 +24,7 @@ class ExistingClassInInstanceOfRuleTest extends RuleTestCase
 		return new ExistingClassInInstanceOfRule(
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ExistingClassInTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInTraitUseRuleTest.php
@@ -23,7 +23,7 @@ class ExistingClassInTraitUseRuleTest extends RuleTestCase
 		$container = self::getContainer();
 		return new ExistingClassInTraitUseRule(
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ExistingClassesInClassImplementsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassesInClassImplementsRuleTest.php
@@ -23,7 +23,7 @@ class ExistingClassesInClassImplementsRuleTest extends RuleTestCase
 		$container = self::getContainer();
 		return new ExistingClassesInClassImplementsRule(
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ExistingClassesInEnumImplementsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassesInEnumImplementsRuleTest.php
@@ -24,7 +24,7 @@ class ExistingClassesInEnumImplementsRuleTest extends RuleTestCase
 		$container = self::getContainer();
 		return new ExistingClassesInEnumImplementsRule(
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ExistingClassesInInterfaceExtendsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassesInInterfaceExtendsRuleTest.php
@@ -23,7 +23,7 @@ class ExistingClassesInInterfaceExtendsRuleTest extends RuleTestCase
 		$container = self::getContainer();
 		return new ExistingClassesInInterfaceExtendsRule(
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/ForbiddenNameCheckExtensionRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ForbiddenNameCheckExtensionRuleTest.php
@@ -52,7 +52,7 @@ class ForbiddenNameCheckExtensionRuleTest extends RuleTestCase
 				checkMissingTypehints: true,
 			),
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: true),
+				new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: true, checkImportedClassNameCase: true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -15,6 +15,7 @@ use PHPStan\Rules\RestrictedUsage\RestrictedMethodUsageExtension;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
@@ -26,6 +27,8 @@ class InstantiationRuleTest extends RuleTestCase
 	private bool $checkExplicitMixed = false;
 
 	private bool $checkImplicitMixed = false;
+
+	private bool $checkImportedClassNameCase = false;
 
 	protected function getRule(): Rule
 	{
@@ -56,7 +59,7 @@ class InstantiationRuleTest extends RuleTestCase
 				checkMissingTypehints: true,
 			),
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: true),
+				new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: true, checkImportedClassNameCase: $this->checkImportedClassNameCase),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -739,14 +742,28 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-15047.php'], []);
 	}
 
-	public function testBug12827(): void
+	public static function dataBug12827(): array
 	{
-		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
-			[
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	#[DataProvider('dataBug12827')]
+	public function testBug12827(bool $checkImportedClassNameCase): void
+	{
+		$this->checkImportedClassNameCase = $checkImportedClassNameCase;
+
+		$expectedErrors = [];
+		if ($checkImportedClassNameCase) {
+			$expectedErrors[] = [
 				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
 				15,
-			],
-		]);
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], $expectedErrors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/LocalTypeAliasesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/LocalTypeAliasesRuleTest.php
@@ -33,7 +33,7 @@ class LocalTypeAliasesRuleTest extends RuleTestCase
 				$container->getByType(TypeNodeResolver::class),
 				new MissingTypehintCheck(true, [], true),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/LocalTypeTraitAliasesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/LocalTypeTraitAliasesRuleTest.php
@@ -32,7 +32,7 @@ class LocalTypeTraitAliasesRuleTest extends RuleTestCase
 				$container->getByType(TypeNodeResolver::class),
 				new MissingTypehintCheck(true, [], true),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/LocalTypeTraitUseAliasesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/LocalTypeTraitUseAliasesRuleTest.php
@@ -32,7 +32,7 @@ class LocalTypeTraitUseAliasesRuleTest extends RuleTestCase
 				$container->getByType(TypeNodeResolver::class),
 				new MissingTypehintCheck(true, [], true),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/MethodTagRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MethodTagRuleTest.php
@@ -28,7 +28,7 @@ class MethodTagRuleTest extends RuleTestCase
 			new MethodTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/MethodTagTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MethodTagTraitRuleTest.php
@@ -28,7 +28,7 @@ class MethodTagTraitRuleTest extends RuleTestCase
 			new MethodTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/MethodTagTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MethodTagTraitUseRuleTest.php
@@ -29,7 +29,7 @@ class MethodTagTraitUseRuleTest extends RuleTestCase
 			new MethodTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/MixinRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinRuleTest.php
@@ -29,7 +29,7 @@ class MixinRuleTest extends RuleTestCase
 			new MixinCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/MixinTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinTraitRuleTest.php
@@ -28,7 +28,7 @@ class MixinTraitRuleTest extends RuleTestCase
 			new MixinCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/MixinTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinTraitUseRuleTest.php
@@ -28,7 +28,7 @@ class MixinTraitUseRuleTest extends RuleTestCase
 			new MixinCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/PropertyTagRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/PropertyTagRuleTest.php
@@ -28,7 +28,7 @@ class PropertyTagRuleTest extends RuleTestCase
 			new PropertyTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/PropertyTagTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/PropertyTagTraitRuleTest.php
@@ -28,7 +28,7 @@ class PropertyTagTraitRuleTest extends RuleTestCase
 			new PropertyTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Classes/PropertyTagTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/PropertyTagTraitUseRuleTest.php
@@ -28,7 +28,7 @@ class PropertyTagTraitUseRuleTest extends RuleTestCase
 			new PropertyTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Constants/ConstantAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ConstantAttributesRuleTest.php
@@ -59,6 +59,7 @@ class ConstantAttributesRuleTest extends RuleTestCase
 					new ClassCaseSensitivityCheck(
 						$reflectionProvider,
 						checkInternalClassCaseSensitivity: false,
+						checkImportedClassNameCase: true,
 					),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,

--- a/tests/PHPStan/Rules/EnumCases/EnumCaseAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/EnumCases/EnumCaseAttributesRuleTest.php
@@ -51,7 +51,7 @@ class EnumCaseAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Exceptions/CaughtExceptionExistenceRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CaughtExceptionExistenceRuleTest.php
@@ -9,12 +9,15 @@ use PHPStan\Rules\ClassNameCheck;
 use PHPStan\Rules\RestrictedUsage\RestrictedClassNameUsageExtension;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @extends RuleTestCase<CaughtExceptionExistenceRule>
  */
 class CaughtExceptionExistenceRuleTest extends RuleTestCase
 {
+
+	private bool $checkImportedClassNameCase = false;
 
 	protected function getRule(): Rule
 	{
@@ -23,7 +26,7 @@ class CaughtExceptionExistenceRuleTest extends RuleTestCase
 		return new CaughtExceptionExistenceRule(
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, $this->checkImportedClassNameCase),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -76,14 +79,28 @@ class CaughtExceptionExistenceRuleTest extends RuleTestCase
 		]);
 	}
 
-	public function testBug12827(): void
+	public static function dataBug12827(): array
 	{
-		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
-			[
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	#[DataProvider('dataBug12827')]
+	public function testBug12827(bool $checkImportedClassNameCase): void
+	{
+		$this->checkImportedClassNameCase = $checkImportedClassNameCase;
+
+		$expectedErrors = [];
+		if ($checkImportedClassNameCase) {
+			$expectedErrors[] = [
 				'Class Bug12827Exceptions\MissingRoutingReferenceException referenced with incorrect case: Bug12827Exceptions\MissingRoutingreferenceException.',
 				20,
-			],
-		]);
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], $expectedErrors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/ArrowFunctionAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrowFunctionAttributesRuleTest.php
@@ -50,7 +50,7 @@ class ArrowFunctionAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Functions/ClosureAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ClosureAttributesRuleTest.php
@@ -50,7 +50,7 @@ class ClosureAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -32,7 +32,7 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -41,6 +41,7 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 				new PhpVersion($this->phpVersionId),
 				true,
 				false,
+				true,
 			),
 			new PhpVersion(PHP_VERSION_ID),
 		);

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -32,7 +32,7 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -41,6 +41,7 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 				new PhpVersion($this->phpVersionId),
 				true,
 				false,
+				true,
 			),
 		);
 	}

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -32,7 +32,7 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -41,6 +41,7 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 				new PhpVersion($this->phpVersionId),
 				true,
 				false,
+				true,
 			),
 		);
 	}

--- a/tests/PHPStan/Rules/Functions/FunctionAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/FunctionAttributesRuleTest.php
@@ -50,7 +50,7 @@ class FunctionAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Functions/ParamAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ParamAttributesRuleTest.php
@@ -50,7 +50,7 @@ class ParamAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
@@ -27,7 +27,7 @@ class ClassTemplateTypeRuleTest extends RuleTestCase
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
@@ -28,7 +28,7 @@ class FunctionTemplateTypeRuleTest extends RuleTestCase
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Generics/InterfaceTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/InterfaceTemplateTypeRuleTest.php
@@ -26,7 +26,7 @@ class InterfaceTemplateTypeRuleTest extends RuleTestCase
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeRuleTest.php
@@ -29,7 +29,7 @@ class MethodTagTemplateTypeRuleTest extends RuleTestCase
 				new TemplateTypeCheck(
 					$reflectionProvider,
 					new ClassNameCheck(
-						new ClassCaseSensitivityCheck($reflectionProvider, true),
+						new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 						new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 						$reflectionProvider,
 						$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeTraitRuleTest.php
@@ -29,7 +29,7 @@ class MethodTagTemplateTypeTraitRuleTest extends RuleTestCase
 				new TemplateTypeCheck(
 					$reflectionProvider,
 					new ClassNameCheck(
-						new ClassCaseSensitivityCheck($reflectionProvider, true),
+						new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 						new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 						$reflectionProvider,
 						$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Generics/MethodTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodTemplateTypeRuleTest.php
@@ -28,7 +28,7 @@ class MethodTemplateTypeRuleTest extends RuleTestCase
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Generics/TraitTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/TraitTemplateTypeRuleTest.php
@@ -28,7 +28,7 @@ class TraitTemplateTypeRuleTest extends RuleTestCase
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -53,6 +53,7 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 					new ClassCaseSensitivityCheck(
 						$reflectionProvider,
 						checkInternalClassCaseSensitivity: true,
+						checkImportedClassNameCase: true,
 					),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -32,7 +32,7 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -41,6 +41,7 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 				new PhpVersion($this->phpVersionId),
 				true,
 				false,
+				true,
 			),
 		);
 	}

--- a/tests/PHPStan/Rules/Methods/MethodAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodAttributesRuleTest.php
@@ -15,12 +15,15 @@ use PHPStan\Rules\RestrictedUsage\RestrictedClassNameUsageExtension;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @extends RuleTestCase<MethodAttributesRule>
  */
 class MethodAttributesRuleTest extends RuleTestCase
 {
+
+	private bool $checkImportedClassNameCase = false;
 
 	protected function getRule(): Rule
 	{
@@ -53,6 +56,7 @@ class MethodAttributesRuleTest extends RuleTestCase
 					new ClassCaseSensitivityCheck(
 						$reflectionProvider,
 						checkInternalClassCaseSensitivity: false,
+						checkImportedClassNameCase: $this->checkImportedClassNameCase,
 					),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
@@ -83,14 +87,28 @@ class MethodAttributesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/deprecated-attribute.php'], []);
 	}
 
-	public function testBug12827(): void
+	public static function dataBug12827(): array
 	{
-		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
-			[
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	#[DataProvider('dataBug12827')]
+	public function testBug12827(bool $checkImportedClassNameCase): void
+	{
+		$this->checkImportedClassNameCase = $checkImportedClassNameCase;
+
+		$expectedErrors = [];
+		if ($checkImportedClassNameCase) {
+			$expectedErrors[] = [
 				'Class Bug12827\Post referenced with incorrect case: Bug12827\POST.',
 				12,
-			],
-		]);
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], $expectedErrors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
@@ -45,6 +45,7 @@ class StaticMethodCallableRuleTest extends RuleTestCase
 					new ClassCaseSensitivityCheck(
 						$reflectionProvider,
 						checkInternalClassCaseSensitivity: true,
+						checkImportedClassNameCase: true,
 					),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,

--- a/tests/PHPStan/Rules/Namespaces/ExistingNamesInGroupUseRuleTest.php
+++ b/tests/PHPStan/Rules/Namespaces/ExistingNamesInGroupUseRuleTest.php
@@ -23,7 +23,7 @@ class ExistingNamesInGroupUseRuleTest extends RuleTestCase
 		return new ExistingNamesInGroupUseRule(
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Namespaces/ExistingNamesInUseRuleTest.php
+++ b/tests/PHPStan/Rules/Namespaces/ExistingNamesInUseRuleTest.php
@@ -23,7 +23,7 @@ class ExistingNamesInUseRuleTest extends RuleTestCase
 		return new ExistingNamesInUseRule(
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/FunctionAssertRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/FunctionAssertRuleTest.php
@@ -26,7 +26,7 @@ class FunctionAssertRuleTest extends RuleTestCase
 			$reflectionProvider,
 			new UnresolvableTypeHelper(),
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -35,7 +35,7 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 					new TemplateTypeCheck(
 						$reflectionProvider,
 						new ClassNameCheck(
-							new ClassCaseSensitivityCheck($reflectionProvider, true),
+							new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 							new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 							$reflectionProvider,
 							$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyHookPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyHookPhpDocTypeRuleTest.php
@@ -35,7 +35,7 @@ class IncompatiblePropertyHookPhpDocTypeRuleTest extends RuleTestCase
 					new TemplateTypeCheck(
 						$reflectionProvider,
 						new ClassNameCheck(
-							new ClassCaseSensitivityCheck($reflectionProvider, true),
+							new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 							new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 							$reflectionProvider,
 							$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
@@ -32,7 +32,7 @@ class IncompatiblePropertyPhpDocTypeRuleTest extends RuleTestCase
 				new TemplateTypeCheck(
 					$reflectionProvider,
 					new ClassNameCheck(
-						new ClassCaseSensitivityCheck($reflectionProvider, true),
+						new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 						new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 						$reflectionProvider,
 						$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -28,7 +28,7 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 			$container->getByType(FileTypeMapper::class),
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/MethodAssertRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/MethodAssertRuleTest.php
@@ -26,7 +26,7 @@ class MethodAssertRuleTest extends RuleTestCase
 			$reflectionProvider,
 			new UnresolvableTypeHelper(),
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
@@ -26,7 +26,7 @@ class RequireExtendsDefinitionClassRuleTest extends RuleTestCase
 			new RequireExtendsCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
@@ -27,7 +27,7 @@ class RequireExtendsDefinitionTraitRuleTest extends RuleTestCase
 			new RequireExtendsCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/RequireImplementsDefinitionTraitRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireImplementsDefinitionTraitRuleTest.php
@@ -25,7 +25,7 @@ class RequireImplementsDefinitionTraitRuleTest extends RuleTestCase
 		return new RequireImplementsDefinitionTraitRule(
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -25,7 +25,7 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 		return new SealedDefinitionClassRule(
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Properties/AccessStaticPropertiesInAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessStaticPropertiesInAssignRuleTest.php
@@ -37,7 +37,7 @@ class AccessStaticPropertiesInAssignRuleTest extends RuleTestCase
 					discoveringSymbolsTip: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck(self::getContainer()->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					self::getContainer()->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
@@ -37,7 +37,7 @@ class AccessStaticPropertiesRuleTest extends RuleTestCase
 					discoveringSymbolsTip: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck(self::getContainer()->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					self::getContainer()->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Properties/ExistingClassesInPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ExistingClassesInPropertiesRuleTest.php
@@ -29,7 +29,7 @@ class ExistingClassesInPropertiesRuleTest extends RuleTestCase
 		return new ExistingClassesInPropertiesRule(
 			$reflectionProvider,
 			new ClassNameCheck(
-				new ClassCaseSensitivityCheck($reflectionProvider, true),
+				new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 				new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 				$reflectionProvider,
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Properties/ExistingClassesInPropertyHookTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ExistingClassesInPropertyHookTypehintsRuleTest.php
@@ -29,7 +29,7 @@ class ExistingClassesInPropertyHookTypehintsRuleTest extends RuleTestCase
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, true),
+					new ClassCaseSensitivityCheck($reflectionProvider, true, true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
@@ -38,6 +38,7 @@ class ExistingClassesInPropertyHookTypehintsRuleTest extends RuleTestCase
 				new PhpVersion(PHP_VERSION_ID),
 				true,
 				false,
+				true,
 			),
 		);
 	}

--- a/tests/PHPStan/Rules/Properties/PropertyAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyAttributesRuleTest.php
@@ -52,7 +52,7 @@ class PropertyAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Properties/PropertyHookAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyHookAttributesRuleTest.php
@@ -50,7 +50,7 @@ class PropertyHookAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),

--- a/tests/PHPStan/Rules/Traits/TraitAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Traits/TraitAttributesRuleTest.php
@@ -57,7 +57,7 @@ class TraitAttributesRuleTest extends RuleTestCase
 					checkMissingTypehints: true,
 				),
 				new ClassNameCheck(
-					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false),
+					new ClassCaseSensitivityCheck($reflectionProvider, checkInternalClassCaseSensitivity: false, checkImportedClassNameCase: true),
 					new ClassForbiddenNameCheck($container->getExtensionsCollection(ForbiddenClassNameExtension::class)),
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),


### PR DESCRIPTION
The written-case reconstruction from #6271 produced new `nameCase` errors unconditionally. This gates it behind a new `checkImportedClassNameCase` feature toggle, enabled in `bleedingEdge.neon`.

With the toggle off, `ClassCaseSensitivityCheck` and `FunctionDefinitionCheck` behave exactly as before that PR — the toggle-off branch in `FunctionDefinitionCheck::getOriginalClassNamePairsFromTypeNode()` is the restored pre-#6271 splice logic, to be deleted when the toggle graduates. The `AttributesCheck` change (passing `$attribute->name` as the pair node) stays ungated because it is inert with the toggle off.

The four bug-12827 tests now run against both toggle states via a data provider and expect the errors only when the toggle is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MGaekUJQDX9kJR9PdJtQu