### PR TITLE
Report a forked worker's crash to the parent process

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -323,6 +323,13 @@ jobs:
               ../bashunit -a contains 'Child process error (exit code 255): PHP Fatal error' "$OUTPUT"
               ../bashunit -a contains 'Result is incomplete because of severe errors.' "$OUTPUT"
           - script: |
+              cd e2e/oom-forked-worker
+              composer install
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse --memory-limit=300M")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Child process error: PHPStan process crashed' "$OUTPUT"
+              ../bashunit -a contains 'Result is incomplete because of severe errors.' "$OUTPUT"
+          - script: |
               cd e2e/bug-11857
               composer install
               ../../bin/phpstan

--- a/e2e/oom-forked-worker/.gitignore
+++ b/e2e/oom-forked-worker/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/e2e/oom-forked-worker/composer.json
+++ b/e2e/oom-forked-worker/composer.json
@@ -1,0 +1,8 @@
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/",
+            "Rules\\": "rules/"
+        }
+    }
+}

--- a/e2e/oom-forked-worker/phpstan.neon.dist
+++ b/e2e/oom-forked-worker/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+    level: 9
+    paths:
+        - src
+        - rules
+
+rules:
+    - Rules\DummyRule

--- a/e2e/oom-forked-worker/rules/DummyRule.php
+++ b/e2e/oom-forked-worker/rules/DummyRule.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace Rules;
+
+use App\EatsMemoryWhenAutoloaded;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+class DummyRule implements Rule
+{
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(
+        Node $node,
+        Scope $scope,
+    ): array
+    {
+        return EatsMemoryWhenAutoloaded::ERRORS;
+    }
+
+}

--- a/e2e/oom-forked-worker/src/EatsMemoryWhenAutoloaded.php
+++ b/e2e/oom-forked-worker/src/EatsMemoryWhenAutoloaded.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace App;
+
+$hog = [];
+for ($i = 0; $i < 200; $i++) {
+    $hog[] = str_repeat('x', 10 * 1024 * 1024) . $i;
+}
+
+interface EatsMemoryWhenAutoloaded
+{
+
+    public const ERRORS = [];
+
+}

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -31,6 +31,7 @@ use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Internal\DirectoryCreator;
 use PHPStan\Internal\DirectoryCreatorException;
+use PHPStan\Process\ForkedChildCrashReporter;
 use PHPStan\ShouldNotHappenException;
 use ReflectionClass;
 use Symfony\Component\Console\Input\InputInterface;
@@ -69,6 +70,8 @@ final class CommandHelper
 {
 
 	public const DEFAULT_LEVEL = '0';
+
+	public const MEMORY_LIMIT_CRASH_MESSAGE = 'PHPStan process crashed because it reached configured PHP memory limit';
 
 	private static ?string $reservedMemory = null;
 
@@ -140,6 +143,16 @@ final class CommandHelper
 		self::$reservedMemory = str_repeat('PHPStan', 1463); // reserve 10 kB of space
 		register_shutdown_function(static function () use ($errorOutput): void {
 			self::$reservedMemory = null;
+			if (ForkedChildCrashReporter::isActive()) {
+				// in a forked worker the crash reporter's own shutdown
+				// function writes the message into the parent-readable
+				// capture file; $errorOutput here is the fork-inherited
+				// parent output whose fd bypasses it, and the formatted
+				// write below allocates enough to die again under OOM,
+				// aborting the shutdown-function queue before the crash
+				// reporter's one runs
+				return;
+			}
 			$error = error_get_last();
 			if ($error === null) {
 				return;
@@ -153,7 +166,7 @@ final class CommandHelper
 			}
 
 			$errorOutput->writeLineFormatted('');
-			$errorOutput->writeLineFormatted(sprintf('<error>PHPStan process crashed because it reached configured PHP memory limit</error>: %s', ini_get('memory_limit')));
+			$errorOutput->writeLineFormatted(sprintf('<error>%s</error>: %s', self::MEMORY_LIMIT_CRASH_MESSAGE, ini_get('memory_limit')));
 			$errorOutput->writeLineFormatted('Increase your memory limit in php.ini or run PHPStan with --memory-limit CLI option.');
 		});
 

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -601,7 +601,6 @@ final class FixerApplication
 				$loop,
 				$this->fixerWorkerRunner,
 				$server,
-				$inceptionResult->getErrorOutput(),
 				$inceptionFiles,
 				$isOnlyFiles,
 				$inceptionResult->getProjectConfigArray(),

--- a/src/Parallel/ForkedProcess.php
+++ b/src/Parallel/ForkedProcess.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Parallel;
 
 use PHPStan\Command\InceptionNotSuccessfulException;
+use PHPStan\Process\ForkedChildCrashReporter;
 use PHPStan\ShouldNotHappenException;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
@@ -34,6 +35,9 @@ final class ForkedProcess extends ProcessBase
 
 	/** @var resource|null */
 	private $stdOut = null;
+
+	/** @var resource|null */
+	private $stdErr = null;
 
 	private ?TimerInterface $waitTimer = null;
 
@@ -69,13 +73,18 @@ final class ForkedProcess extends ProcessBase
 		if ($tmpStdOut === false) {
 			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
 		}
+		$tmpStdErr = tmpfile();
+		if ($tmpStdErr === false) {
+			fclose($tmpStdOut);
+			throw new ShouldNotHappenException('Failed creating temp file for stderr.');
+		}
 		$this->stdOut = $tmpStdOut;
+		$this->stdErr = $tmpStdErr;
 
 		$pid = pcntl_fork();
 
 		if ($pid === -1) {
-			fclose($this->stdOut);
-			$this->stdOut = null;
+			$this->closeCaptureFiles();
 			// Deferred so it runs after ParallelAnalyser has attached this
 			// process to the pool — otherwise tryQuitProcess() would no-op.
 			$this->loop->futureTick(static function () use ($onExit): void {
@@ -88,7 +97,8 @@ final class ForkedProcess extends ProcessBase
 			// Child: drop the inherited listening socket immediately, then run
 			// the worker on its own fresh event loop and never return.
 			$this->server->close();
-			$output = new StreamOutput($this->stdOut);
+			ForkedChildCrashReporter::install($tmpStdErr);
+			$output = new StreamOutput($tmpStdOut);
 			try {
 				$exitCode = $this->workerRunner->run(
 					$output,
@@ -128,10 +138,13 @@ final class ForkedProcess extends ProcessBase
 			$output = '';
 			if ($this->stdOut !== null) {
 				rewind($this->stdOut);
-				$output = (string) stream_get_contents($this->stdOut);
-				fclose($this->stdOut);
-				$this->stdOut = null;
+				$output .= (string) stream_get_contents($this->stdOut);
 			}
+			if ($this->stdErr !== null) {
+				rewind($this->stdErr);
+				$output .= (string) stream_get_contents($this->stdErr);
+			}
+			$this->closeCaptureFiles();
 
 			$onExit($exitCode, $output);
 		});
@@ -153,6 +166,20 @@ final class ForkedProcess extends ProcessBase
 
 		$this->loop->cancelTimer($this->waitTimer);
 		$this->waitTimer = null;
+	}
+
+	private function closeCaptureFiles(): void
+	{
+		if ($this->stdOut !== null) {
+			fclose($this->stdOut);
+			$this->stdOut = null;
+		}
+		if ($this->stdErr === null) {
+			return;
+		}
+
+		fclose($this->stdErr);
+		$this->stdErr = null;
 	}
 
 }

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -10,6 +10,7 @@ use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\InternalError;
 use PHPStan\Cache\ArenaCache;
+use PHPStan\Command\CommandHelper;
 use PHPStan\Dependency\RootExportedNode;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -386,7 +387,7 @@ final class ParallelAnalyser
 					return;
 				}
 
-				$memoryLimitMessage = 'PHPStan process crashed because it reached configured PHP memory limit';
+				$memoryLimitMessage = CommandHelper::MEMORY_LIMIT_CRASH_MESSAGE;
 				if (str_contains($output, $memoryLimitMessage)) {
 					foreach ($internalErrors as $internalError) {
 						if (!str_contains($internalError->getMessage(), $memoryLimitMessage)) {

--- a/src/Process/ForkedChildCrashReporter.php
+++ b/src/Process/ForkedChildCrashReporter.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use PHPStan\Command\CommandHelper;
+use function error_get_last;
+use function fwrite;
+use function in_array;
+use function ini_get;
+use function ini_set;
+use function register_shutdown_function;
+use function sprintf;
+use function str_contains;
+use function stream_set_write_buffer;
+use const E_COMPILE_ERROR;
+use const E_CORE_ERROR;
+use const E_ERROR;
+use const E_PARSE;
+
+/**
+ * Makes a fatal error in a pcntl_fork()ed child reach the parent - the
+ * fork-mode counterpart of a spawned worker whose stderr is a pipe the parent
+ * reads.
+ *
+ * A forked child inherits the parent's stdout/stderr, so the engine prints a
+ * fatal error straight to the console while the parent-readable capture file
+ * stays empty - the parent would report "Child process error" with no message.
+ * install() suppresses that console output and registers a shutdown function
+ * recreating the canonical "PHP Fatal error" line (and the memory-limit
+ * message) in the capture file instead. CommandHelper's inherited shutdown
+ * function steps aside in such a child: its formatted write would go to the
+ * fork-inherited console fd, and its allocations can die again under OOM,
+ * aborting the shutdown-function queue before the one installed here runs.
+ */
+final class ForkedChildCrashReporter
+{
+
+	private static bool $active = false;
+
+	/**
+	 * Whether the current process is a forked child with crash reporting
+	 * installed.
+	 */
+	public static function isActive(): bool
+	{
+		return self::$active;
+	}
+
+	/**
+	 * @param resource $stdErrCapture
+	 */
+	public static function install($stdErrCapture): void
+	{
+		// The engine displays a fatal error on stdout/stderr and, with no
+		// error_log configured, logs it to stderr - in a forked child both
+		// leak to the console. Suppress them; the shutdown function below
+		// reports the crash instead. An error_log pointing to a real file
+		// keeps working like it does in a spawned worker.
+		ini_set('display_errors', '0');
+		$errorLog = ini_get('error_log');
+		if (in_array($errorLog, ['', false], true)) {
+			ini_set('log_errors', '0');
+		}
+
+		// Unbuffered writes need no stream-buffer allocation, so the shutdown
+		// function below can still deliver when the crash being reported is
+		// the process running out of memory.
+		stream_set_write_buffer($stdErrCapture, 0);
+
+		register_shutdown_function(static function () use ($stdErrCapture): void {
+			$error = error_get_last();
+			if ($error === null || !in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+				return;
+			}
+
+			fwrite($stdErrCapture, sprintf("PHP Fatal error:  %s in %s on line %d\n", $error['message'], $error['file'], $error['line']));
+
+			if (!str_contains($error['message'], 'Allowed memory size')) {
+				return;
+			}
+
+			fwrite($stdErrCapture, sprintf("%s: %s\n", CommandHelper::MEMORY_LIMIT_CRASH_MESSAGE, ini_get('memory_limit')));
+			fwrite($stdErrCapture, "Increase your memory limit in php.ini or run PHPStan with --memory-limit CLI option.\n");
+		});
+
+		self::$active = true;
+	}
+
+}

--- a/src/Process/ForkedProcessPromise.php
+++ b/src/Process/ForkedProcessPromise.php
@@ -2,8 +2,10 @@
 
 namespace PHPStan\Process;
 
+use PHPStan\Command\ErrorsConsoleStyle;
 use PHPStan\Command\FixerWorkerRunner;
-use PHPStan\Command\Output;
+use PHPStan\Command\Symfony\SymfonyOutput;
+use PHPStan\Command\Symfony\SymfonyStyle;
 use PHPStan\ShouldNotHappenException;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
@@ -11,6 +13,8 @@ use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Socket\TcpServer;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\StreamOutput;
 use function fclose;
 use function pcntl_fork;
 use function pcntl_waitpid;
@@ -44,6 +48,9 @@ final class ForkedProcessPromise implements ProcessPromise
 	/** @var resource|null */
 	private $stdOut = null;
 
+	/** @var resource|null */
+	private $stdErr = null;
+
 	private ?TimerInterface $waitTimer = null;
 
 	private bool $canceled = false;
@@ -56,7 +63,6 @@ final class ForkedProcessPromise implements ProcessPromise
 		private LoopInterface $loop,
 		private FixerWorkerRunner $fixerWorkerRunner,
 		private TcpServer $server,
-		private Output $errorOutput,
 		private array $inceptionFiles,
 		private bool $isOnlyFiles,
 		private ?array $projectConfigArray,
@@ -80,13 +86,18 @@ final class ForkedProcessPromise implements ProcessPromise
 		if ($tmpStdOut === false) {
 			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
 		}
+		$tmpStdErr = tmpfile();
+		if ($tmpStdErr === false) {
+			fclose($tmpStdOut);
+			throw new ShouldNotHappenException('Failed creating temp file for stderr.');
+		}
 		$this->stdOut = $tmpStdOut;
+		$this->stdErr = $tmpStdErr;
 
 		$pid = pcntl_fork();
 
 		if ($pid === -1) {
-			fclose($this->stdOut);
-			$this->stdOut = null;
+			$this->closeCaptureFiles();
 			// Deferred so it runs after FixerApplication has stored the promise.
 			$this->loop->futureTick(function (): void {
 				$this->deferred->reject(new ProcessCrashedException('pcntl_fork() failed.'));
@@ -99,8 +110,12 @@ final class ForkedProcessPromise implements ProcessPromise
 			// Child: drop the inherited listening socket immediately, then run
 			// the worker on its own fresh event loop and never return.
 			$this->server->close();
+			ForkedChildCrashReporter::install($tmpStdErr);
+			// The worker writes its errors into the capture the parent reads,
+			// like a spawned worker whose stderr is the capture itself.
+			$childErrorStream = new StreamOutput($tmpStdErr);
 			$exitCode = $this->fixerWorkerRunner->run(
-				$this->errorOutput,
+				new SymfonyOutput($childErrorStream, new SymfonyStyle(new ErrorsConsoleStyle(new StringInput(''), $childErrorStream))),
 				$this->inceptionFiles,
 				$this->isOnlyFiles,
 				$this->projectConfigArray,
@@ -122,13 +137,17 @@ final class ForkedProcessPromise implements ProcessPromise
 
 			$this->cancelWaitTimer();
 
-			$output = '';
+			$stdOut = '';
 			if ($this->stdOut !== null) {
 				rewind($this->stdOut);
-				$output = (string) stream_get_contents($this->stdOut);
-				fclose($this->stdOut);
-				$this->stdOut = null;
+				$stdOut = (string) stream_get_contents($this->stdOut);
 			}
+			$stdErr = '';
+			if ($this->stdErr !== null) {
+				rewind($this->stdErr);
+				$stdErr = (string) stream_get_contents($this->stdErr);
+			}
+			$this->closeCaptureFiles();
 
 			if ($this->canceled) {
 				// cancel() already rejected the promise; just reap the child.
@@ -144,11 +163,11 @@ final class ForkedProcessPromise implements ProcessPromise
 			}
 
 			if ($exitCode === 0) {
-				$this->deferred->resolve($output);
+				$this->deferred->resolve($stdOut);
 				return;
 			}
 
-			$this->deferred->reject(new ProcessCrashedException($output));
+			$this->deferred->reject(new ProcessCrashedException($stdOut . $stdErr));
 		});
 
 		return $this->deferred->promise();
@@ -174,6 +193,20 @@ final class ForkedProcessPromise implements ProcessPromise
 
 		$this->loop->cancelTimer($this->waitTimer);
 		$this->waitTimer = null;
+	}
+
+	private function closeCaptureFiles(): void
+	{
+		if ($this->stdOut !== null) {
+			fclose($this->stdOut);
+			$this->stdOut = null;
+		}
+		if ($this->stdErr === null) {
+			return;
+		}
+
+		fclose($this->stdErr);
+		$this->stdErr = null;
 	}
 
 }


### PR DESCRIPTION
Fixes the failing `e2e/bug-11826` E2E test (https://github.com/phpstan/phpstan-src/actions/runs/33013813155/job/98326696805).

A forked child inherits the parent's stdout/stderr, so a fatal error in a worker was printed straight to the console while the parent-readable capture file stayed empty — `Child process error (exit code 255):  while running parallel worker` with no message. A spawned worker does not have this problem because its fds 1 and 2 are capture files the parent reads, which is why the test only started failing when fork became the default worker-creation mechanism.

`ForkedChildCrashReporter`, installed in the child right after the fork:
- suppresses the engine's console error output (`display_errors`, and `log_errors` only when no `error_log` file is configured), so nothing leaks to the terminal;
- registers a shutdown function that recreates the canonical `PHP Fatal error:  %s in %s on line %d` line (and the memory-limit message) in a new stderr capture file, which `ForkedProcess` appends to the worker's output on abnormal exit — the same shape `SpawnedProcess` produces.

Two adjacent gaps fixed alongside:
- **Worker OOM in fork mode** was equally contentless: `CommandHelper`'s inherited shutdown function wrote to the fork-inherited console fd, and its formatted write allocates enough to die again under OOM, aborting the shutdown-function queue. It now steps aside when the crash reporter is active, and the reporter's allocation-light unbuffered write delivers the message, so `ParallelAnalyser`'s memory-limit detection works in fork mode exactly like in spawn mode. The message string is now the shared `CommandHelper::MEMORY_LIMIT_CRASH_MESSAGE` constant. Covered by the new `e2e/oom-forked-worker` test.
- **The forked PHPStan Pro worker** (`ForkedProcessPromise`) captures stderr the same way and gives the child a capture-backed error output instead of the fork-inherited parent output.

An fd-takeover approach (`fclose(STDOUT)` + `fopen()` reusing the freed descriptor) was tried first and rejected: the engine writes fatals through the C-level `stderr` FILE, which the fclose kills on macOS and Linux alike, and the then-closed `STDOUT`/`STDERR` constants crash better-reflection's PhpStormStubs CachingVisitor (`constant('STDOUT')` returns a closed resource, which fails `is_resource()` and reaches `BuilderFactory::val()`).

Both E2E cases were verified red on the unfixed baseline and green with the fix, in fork and spawn mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmAeFo7zNNQ4AsU2MtxPpb