### PR TITLE
Decline only the file that declares the function of that name

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -142,6 +142,7 @@ jobs:
               ../../bin/phpstan analyze
           - script: |
               cd e2e/bug-15102b
+              composer install
               ../../bin/phpstan analyze
           - script: |
               cd e2e/bug-15102

--- a/e2e/bug-15102b/.gitignore
+++ b/e2e/bug-15102b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/e2e/bug-15102b/bootstrap.php
+++ b/e2e/bug-15102b/bootstrap.php
@@ -1,9 +1,10 @@
 <?php declare(strict_types = 1);
 
-// The shape Illuminate\Foundation\AliasLoader creates: a prepended autoloader that
-// resolves a short alias to a real class with class_alias(), reading no file. The alias
-// names collide with global functions - Laravel's Cache, File, Str, Hash all do.
-require_once __DIR__ . '/src/Real.php';
+// The shape Illuminate\Foundation\AliasLoader creates: a prepended autoloader that resolves a
+// short alias with class_alias(). The alias names collide with global functions - Laravel's
+// Cache, File, Str and Hash all do - and the alias *target* is autoloaded on demand, so the
+// class_alias() call is what pulls it in. Nothing is re-included and no function is redeclared.
+require __DIR__ . '/vendor/autoload.php';
 
 spl_autoload_register(static function (string $class): void {
 	if ($class !== 'File') {

--- a/e2e/bug-15102b/composer.json
+++ b/e2e/bug-15102b/composer.json
@@ -1,0 +1,7 @@
+{
+	"autoload": {
+		"psr-4": {
+			"E2eFacadeAlias\\": "src/"
+		}
+	}
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -361,6 +361,12 @@ parameters:
 			path: src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php
 
 		-
+			rawMessage: Creating new ReflectionFunction is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+			identifier: phpstanApi.runtimeReflection
+			count: 1
+			path: src/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocator.php
+
+		-
 			rawMessage: 'Parameter #2 $node of method PHPStan\BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection::__invoke() expects PhpParser\Node\Expr\ArrowFunction|PhpParser\Node\Expr\Closure|PhpParser\Node\Expr\FuncCall|PhpParser\Node\Stmt\Class_|PhpParser\Node\Stmt\Const_|PhpParser\Node\Stmt\Enum_|PhpParser\Node\Stmt\Function_|PhpParser\Node\Stmt\Interface_|PhpParser\Node\Stmt\Trait_, PhpParser\Node\Stmt\ClassLike given.'
 			identifier: argument.type
 			count: 1

--- a/src/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocator.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Reflection\BetterReflection\SourceLocator;
 
 use Override;
+use ReflectionFunction;
 use PHPStan\BetterReflection\Identifier\Identifier;
 use PHPStan\BetterReflection\Identifier\IdentifierType;
 use PHPStan\BetterReflection\Reflection\Reflection;
@@ -140,11 +141,25 @@ final class AutoloadFunctionsSourceLocator implements SourceLocator
 			return false;
 		}
 
+		// Only re-including the file that *declares the function of this name* can redeclare it.
+		// A trapped read of any other file is not the hazard: an aliasing autoloader reads the
+		// file of the class it aliases to, and that file already being loaded is the normal case -
+		// class_alias() includes nothing, it names a class that is there. A built-in function has
+		// no declaring file, so there is nothing it could redeclare.
+		$functionFileName = (new ReflectionFunction($className))->getFileName();
+		if ($functionFileName === false) {
+			return false;
+		}
+
 		// PHP canonicalises the path before it reaches a stream wrapper - a `/./` segment, a
 		// symlinked directory or an include-path-relative name all arrive resolved - so the
 		// trapped paths compare directly against get_included_files().
 		$includedFiles = get_included_files();
 		foreach ($locatedFiles as $locatedFile) {
+			if ($locatedFile !== $functionFileName) {
+				continue;
+			}
+
 			if (in_array($locatedFile, $includedFiles, true)) {
 				return true;
 			}


### PR DESCRIPTION
Fixes the Laravel half of phpstan/phpstan#15102, which is **still red on the merged tip** - reported, diagnosed and patched by @hoetaek in phpstan/phpstan-src#6265; I verified it and ran the gates he flagged as decisive.

## What my #6265 guard got wrong

`wouldReIncludeALoadedFile()` declined on *any* trapped read of an already-loaded file. But an aliasing autoloader reads the file of the class it aliases **to**: `class_alias(\Repro\Target::class, 'File')` autoloads `Repro\Target`, and that file already being loaded is the normal case - and the precondition for success, since `class_alias()` includes nothing. So the guard declined exactly the case it was written to keep working, and `use File;` still reported `class.notFound`.

Reproduced on the merged tip (`c10897b1f`) with @hoetaek's portable repro - prepended `class_alias` autoloader, `File` colliding with the built-in `file()`, no Laravel involved - each run with its own empty `tmpDir`:

| build | result |
| --- | --- |
| 2.2.8 phar | No errors |
| tip without this change | **2x `class.notFound`** |
| tip with this change | No errors |

## The narrowing

Only re-including the file that *declares the function of that name* can redeclare it, so the trapped read is compared against that file. A built-in has no declaring file, so there is nothing it could redeclare.

The `new ReflectionFunction` is deliberate runtime reflection - the hazard is a runtime redeclare - and it gets a baseline entry next to the two `AutoloadSourceLocator` already has for the same rule.

## Why the e2e project did not catch it

`e2e/bug-15102b` (mine, from #6265) `require_once`'d its alias target in the bootstrap, so `class_alias()` read no file and the guard never fired. It now autoloads the target through Composer the way `AliasLoader` does. Verified both ways:

| | e2e/bug-15102b |
| --- | --- |
| without this change | 2 errors |
| with this change | No errors |

## Verification

- @hoetaek's red-team case - an autoloader that maps a class name to the file declaring a userland function of that name, with the file already required at bootstrap - is **still declined**, no fatal redeclare.
- `e2e/bug-14988` (the redeclare fatal the guard exists for), `bug-15102`, `bug-15102b`, `bug-12972b`, `bug-12972c`: all exit 0.
- Full suite **21159** green, self-analysis clean, phpcs clean over the whole repo.

Closes the Laravel half of https://github.com/phpstan/phpstan/issues/15102
