### PR TITLE
Bound ObjectType's static caches with a shared LRU over description keys

### DIFF
--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -11,6 +11,7 @@ use Iterator;
 use IteratorAggregate;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Broker\ClassNotFoundException;
+use PHPStan\Internal\LruCache;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
@@ -76,6 +77,8 @@ class ObjectType implements TypeWithClassName, SubtractableType
 	use NonGeneralizableTypeTrait;
 	use SubstractableTypeTrait;
 
+	private const DESCRIPTION_CACHE_LIMIT = 1024;
+
 	private const EXTRA_OFFSET_CLASSES = [
 		'DOMNamedNodeMap', // Only read and existence
 		'Dom\NamedNodeMap', // Only read and existence
@@ -135,6 +138,12 @@ class ObjectType implements TypeWithClassName, SubtractableType
 	/** @var array<string, list<EnumCaseObjectType>> */
 	private static array $enumCases = [];
 
+	/** @var LruCache<true>|null shared LRU over the description keys of the static caches above */
+	private static ?LruCache $descriptionCacheOrder = null;
+
+	/** consecutive lookups mostly touch the same description — skip the LRU bookkeeping for them */
+	private static ?string $lastTouchedDescription = null;
+
 	/** @var array<string, ExtendedMethodReflection> */
 	private array $methodCache = [];
 
@@ -161,6 +170,38 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		self::$staticProperties = [];
 		self::$ancestors = [];
 		self::$enumCases = [];
+		self::$descriptionCacheOrder = null;
+		self::$lastTouchedDescription = null;
+	}
+
+	/**
+	 * Moves the description to the most-recently-used position of the shared LRU
+	 * governing the static caches above; evicts the least recently used description's
+	 * entries from all of them once the limit is reached. Misses are pure recomputation.
+	 */
+	private static function touchDescriptionCacheKey(string $description): void
+	{
+		if ($description === self::$lastTouchedDescription) {
+			return;
+		}
+		self::$lastTouchedDescription = $description;
+
+		self::$descriptionCacheOrder ??= new LruCache(self::DESCRIPTION_CACHE_LIMIT);
+		if (self::$descriptionCacheOrder->get($description) !== null) {
+			return;
+		}
+
+		foreach (self::$descriptionCacheOrder->set($description, true, 0) as $evictKey) {
+			unset(
+				self::$superTypes[$evictKey],
+				self::$methods[$evictKey],
+				self::$properties[$evictKey],
+				self::$instanceProperties[$evictKey],
+				self::$staticProperties[$evictKey],
+				self::$ancestors[$evictKey],
+				self::$enumCases[$evictKey],
+			);
+		}
 	}
 
 	public function getClassName(): string
@@ -204,6 +245,8 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			$canAccessProperty = $scope->getClassReflection()->getName();
 		}
 		$description = $this->describeCache();
+
+		self::touchDescriptionCacheKey($description);
 
 		if (isset(self::$properties[$description][$propertyName][$canAccessProperty])) {
 			return self::$properties[$description][$propertyName][$canAccessProperty];
@@ -311,6 +354,8 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 		$description = $this->describeCache();
 
+		self::touchDescriptionCacheKey($description);
+
 		if (isset(self::$instanceProperties[$description][$propertyName][$canAccessProperty])) {
 			return self::$instanceProperties[$description][$propertyName][$canAccessProperty];
 		}
@@ -412,6 +457,8 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			$canAccessProperty = $scope->getClassReflection()->getName();
 		}
 		$description = $this->describeCache();
+
+		self::touchDescriptionCacheKey($description);
 
 		if (isset(self::$staticProperties[$description][$propertyName][$canAccessProperty])) {
 			return self::$staticProperties[$description][$propertyName][$canAccessProperty];
@@ -533,6 +580,8 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		} else {
 			$description = $type->describe(VerbosityLevel::cache());
 		}
+
+		self::touchDescriptionCacheKey($thisDescription);
 
 		if (isset(self::$superTypes[$thisDescription][$description])) {
 			return self::$superTypes[$thisDescription][$description];
@@ -1064,6 +1113,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			$canCallMethod = $scope->getClassReflection()->getName();
 		}
 		$description = $this->describeCache();
+		self::touchDescriptionCacheKey($description);
 		if (isset(self::$methods[$description][$methodName][$canCallMethod])) {
 			return self::$methods[$description][$methodName][$canCallMethod];
 		}
@@ -1568,6 +1618,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		$cacheKey = $this->describeCache();
+		self::touchDescriptionCacheKey($cacheKey);
 		if (array_key_exists($cacheKey, self::$enumCases)) {
 			return self::$enumCases[$cacheKey];
 		}
@@ -1850,6 +1901,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		$description = $this->describeCache();
+		self::touchDescriptionCacheKey($description);
 		if (
 			array_key_exists($description, self::$ancestors)
 			&& array_key_exists($className, self::$ancestors[$description])

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -39,6 +39,8 @@ use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\ConstantNumericComparisonTypeTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
+use ReflectionClassConstant;
+use ReflectionProperty;
 use SimpleXMLElement;
 use stdClass;
 use Throwable;
@@ -794,6 +796,28 @@ class ObjectTypeTest extends PHPStanTestCase
 			$actualResult,
 			sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
 		);
+	}
+
+	public function testStaticCachesAreBoundedByDescriptionCacheLimit(): void
+	{
+		$limit = (new ReflectionClassConstant(ObjectType::class, 'DESCRIPTION_CACHE_LIMIT'))->getValue();
+		$this->assertIsInt($limit);
+
+		ObjectType::resetCaches();
+		try {
+			for ($i = 0; $i < $limit + 100; $i++) {
+				(new ObjectType(sprintf('DescriptionCacheEviction\Class%d', $i)))->isSuperTypeOf(new ObjectType('DescriptionCacheEviction\Other'));
+			}
+
+			$superTypesProperty = new ReflectionProperty(ObjectType::class, 'superTypes');
+			$superTypesProperty->setAccessible(true);
+			$superTypes = $superTypesProperty->getValue();
+			$this->assertIsArray($superTypes);
+			$this->assertGreaterThan(0, count($superTypes));
+			$this->assertLessThanOrEqual($limit, count($superTypes));
+		} finally {
+			ObjectType::resetCaches();
+		}
 	}
 
 }


### PR DESCRIPTION
The per-description static caches in `ObjectType` (`$methods`, `$properties`, `$instanceProperties`, `$staticProperties`, `$superTypes`, `$ancestors`, `$enumCases`) grew without bound for the lifetime of the process — about 36 MB per worker on self-analysis when few workers each analyse many files, at roughly 2 KB per `$methods` entry.

This governs all seven caches with one shared `LruCache` over the `describeCache()` keys, following the `touchMemberCacheKey()` pattern in `PhpClassReflectionExtension`: touching a description moves it to the most recently used position, and evicting one drops its entries from every governed cache — misses are pure recomputation. Consecutive lookups mostly touch the same description, so a last-touched fast path keeps the bookkeeping off the hot path (without it, touching cost ~2% of user CPU; with it, CPU is within measurement noise).

Measured on a 3-worker self-analysis run with the turbo extension loaded (the operating point of the macOS `Run with Turbo Extension` lane — 3 vCPU runners, ~820 files per worker), on top of the ondrejmirtes/better-reflection 6.70.0.4 bump:

| configuration | max worker peak | Δ summed peaks per worker |
| --- | --- | --- |
| before both fixes | 448–462 MiB (over the 450M cap → red lane) | — |
| better-reflection 6.70.0.4 (lazy stub sources) | 414–422 MiB | −25 MB |
| + this PR | **392–416 MiB** | **−17 MB more** |

Analysis output is byte-identical with and without the change on the full self-analysis corpus. The included regression test fills the caches past `DESCRIPTION_CACHE_LIMIT` and asserts they stay bounded.

Closes https://github.com/phpstan/phpstan/issues/15119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fMtimQECyyBNKTmFddr8L