### PR TITLE
Fix simplexml_import_dom() parameter type on PHP 8.4

### DIFF
--- a/resources/functionMap_php84delta.php
+++ b/resources/functionMap_php84delta.php
@@ -20,8 +20,9 @@ return [
 		'http_clear_last_response_headers' => ['void'],
 		'mb_lcfirst' => ['string', 'string'=>'string', 'encoding='=>'string'],
 		'mb_ucfirst' => ['string', 'string'=>'string', 'encoding='=>'string'],
+		'simplexml_import_dom' => ['SimpleXMLElement|null', 'node'=>'object', 'class_name='=>'string'],
 	],
 	'old' => [
-
+		'simplexml_import_dom' => ['SimpleXMLElement|null', 'node'=>'DOMNode', 'class_name='=>'string'],
 	]
 ];


### PR DESCRIPTION
PHP 8.4 widened the first parameter of `simplexml_import_dom()` to `object`:

- php-src commit: https://github.com/php/php-src/commit/4bd63568fb80d1f9c5b0b30d5e461fb3aa3d6b0e ("Fix argument type of simplexml_import_dom", php/php-src#13170)
- The commit adds its BC note to the **PHP 8.4** UPGRADE NOTES; it is contained in `PHP-8.4` and not in `PHP-8.3`.

```php
// PHP-8.3 ext/simplexml/simplexml.stub.php
function simplexml_import_dom(SimpleXMLElement|DOMNode $node, ?string $class_name = SimpleXMLElement::class): ?SimpleXMLElement {}

// PHP-8.4 ext/simplexml/simplexml.stub.php
function simplexml_import_dom(object $node, ?string $class_name = SimpleXMLElement::class): ?SimpleXMLElement {}
```

The upstream reasoning, quoted from that commit message:

> It needs to be "object". This is because first- and third-party extension can register custom node types using `php_libxml_register_export`. So we don't know upfront what types can be expected.

## The bug

`php-8-stubs` already carries both signatures, gated by `#[\Until('8.4')]` / `#[\Since('8.4')]`. But `resources/functionMap.php` declares `'node'=>'DOMNode'` for every version, and `Php8SignatureMapProvider::mergeSignatures()` runs the map type through `TypehintHelper::decideType()` against the native one. On 8.4+ that **narrows the stub's `object` back down to `DOMNode`**.

Measured on 2.2.x (`level: 8`), before this change:

| argument | `phpVersion: 80300` | `phpVersion: 80400` |
|---|---|---|
| `Dom\Node` | n/a (class does not exist) | ❌ `expects DOMNode, Dom\Node given` |
| `SimpleXMLElement` | ✅ accepted | ❌ `expects DOMNode` |
| `stdClass` | ❌ rejected | ❌ rejected |

Pre-8.4 is unaffected because `decideType()` does not narrow the native union `SimpleXMLElement|DOMNode` with the map's `DOMNode` — so this is purely an 8.4+ regression in the map.

Both false positives are real: this is valid code that PHPStan rejects on 8.4+.

```php
$document = Dom\XMLDocument::createFromString('<root><a>1</a></root>');
$node = $document->firstChild;
if ($node !== null) {
    simplexml_import_dom($node);
}
```

## The fix

Adds the 8.4 signature to `functionMap_php84delta.php`, so the map stops narrowing the stub. Versions below 8.4 keep the previous entry and are untouched.

## Verification

- `phpVersion: 80400`: both the `Dom\Node` and the `SimpleXMLElement` example report an error before this change and none after it.
- `phpVersion: 80300`: unchanged — `SimpleXMLElement` still accepted, `stdClass` still reported.
- `tests/PHPStan/Reflection/SignatureMap/` passes (2844 tests).

## Trade-off

On 8.4+ `stdClass` is no longer reported, because `object` is what php-src declares. A closed union such as `DOMNode|Dom\Node|SimpleXMLElement` would restore that check but reject valid arguments from extensions registering their own node types, which is exactly what the upstream commit message rules out. Happy to change it if you prefer the stricter shape.

Claude