### PR TITLE
Include a bootstrap autoloader's located files for real before re-running it

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -152,6 +152,9 @@ jobs:
               composer install
               ../../bin/phpstan analyze
           - script: |
+              cd e2e/bug-15102d
+              ../../bin/phpstan analyze
+          - script: |
               cd e2e/bug-14724
               composer install
               ../../bin/phpstan analyze app/

--- a/e2e/bug-15102d/dep/E2eNestedClassLoader.php
+++ b/e2e/bug-15102d/dep/E2eNestedClassLoader.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+// The shape of Composer's ClassLoader: register() + loadClass() reading a file.
+final class E2eNestedClassLoader
+{
+
+	public function register(): void
+	{
+		spl_autoload_register([$this, 'loadClass']);
+	}
+
+	public function loadClass(string $class): void
+	{
+		if ($class !== 'E2eDepInternal\\SomeInterface') {
+			return;
+		}
+
+		require __DIR__ . '/SomeInterface.php';
+	}
+
+}

--- a/e2e/bug-15102d/dep/SomeInterface.php
+++ b/e2e/bug-15102d/dep/SomeInterface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace E2eDepInternal;
+
+interface SomeInterface
+{
+
+	public function handle(): string;
+
+}

--- a/e2e/bug-15102d/dep/autoload.php
+++ b/e2e/bug-15102d/dep/autoload.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+require_once __DIR__ . '/E2eNestedClassLoader.php';
+
+$loader = new E2eNestedClassLoader();
+$loader->register();
+
+return $loader;

--- a/e2e/bug-15102d/dep/bootstrap.php
+++ b/e2e/bug-15102d/dep/bootstrap.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+// The shape deptrac's bootstrap.php creates: an autoloader that lazily requires a nested
+// Composer-style autoloader and memoizes the result in a closure static. The file-read
+// trap's pseudo-include makes that require "succeed" with dummy data, so the memo ends up
+// holding an int and the require is never retried.
+spl_autoload_register(static function (string $class): void {
+	static $composerAutoloader;
+
+	if (!str_starts_with($class, 'E2eDepInternal\\')) {
+		return;
+	}
+
+	if ($composerAutoloader === null) {
+		$composerAutoloader = require __DIR__ . '/autoload.php';
+	}
+
+	if ($composerAutoloader instanceof E2eNestedClassLoader) {
+		$composerAutoloader->loadClass($class);
+	}
+});

--- a/e2e/bug-15102d/phpstan.dist.neon
+++ b/e2e/bug-15102d/phpstan.dist.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: 8
+	bootstrapFiles:
+		- dep/bootstrap.php
+	paths:
+		- test.php

--- a/e2e/bug-15102d/test.php
+++ b/e2e/bug-15102d/test.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace E2eMemoizedRequire;
+
+use E2eDepInternal\SomeInterface;
+
+final class Handler implements SomeInterface
+{
+
+	public function handle(): string
+	{
+		return 'ok';
+	}
+
+}

--- a/src/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/AutoloadFunctionsSourceLocator.php
@@ -11,6 +11,7 @@ use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use function class_exists;
 use function function_exists;
 use function interface_exists;
+use function is_file;
 use function opcache_invalidate;
 use function PHPStan\autoloadFunctions;
 use function PHPStan\autoloadFunctionsPrependedToComposer;
@@ -90,6 +91,26 @@ final class AutoloadFunctionsSourceLocator implements SourceLocator
 		// https://github.com/phpstan/phpstan/issues/14988 reported.
 		if ($this->autoloadSourceLocator->wouldIncludingFilesRedeclareSymbols($locatedFiles)) {
 			return null;
+		}
+
+		// Include the located files for real first. The probe's pseudo-include succeeds with
+		// dummy data, so an autoloader that memoizes such a require's result - deptrac's
+		// bootstrap caches `$loader = require .../vendor/autoload.php` in a closure static -
+		// is left holding an int and never retries it. This include does what that autoloader
+		// can no longer do itself: an autoload-infrastructure file registers its own class
+		// loader, and locating the class again consults it through the file-read trap.
+		foreach ($locatedFiles as $locatedFile) {
+			if (!is_file($locatedFile)) {
+				continue;
+			}
+			(static function (string $file): void {
+				require $file;
+			})($locatedFile);
+		}
+
+		$reflection = $this->locateWithoutAutoloading($reflector, $identifier);
+		if ($reflection !== null) {
+			return $reflection;
 		}
 
 		foreach ($autoloadFunctions as $autoloadFunction) {


### PR DESCRIPTION
The file-read trap's pseudo-include succeeds with dummy data, so a bootstrap autoloader that memoizes a require's result — deptrac's `bootstrap.php` caches `$loader = require .../vendor/autoload.php` in a closure static — is left holding an `int` instead of the class loader, and never retries the require. The run-for-real fallback added in 598faaade1 then re-runs a permanently broken autoloader, and the class stays unresolvable. On a project using deptrac's contract interfaces this surfaces as:

```
Internal error: Interface "DEPTRAC_INTERNAL\Symfony\Component\EventDispatcher\EventSubscriberInterface" not found
```

aborting the analysis (this is also what turned the "other tests" jobs red since 598faaade1, e.g. run 33088005533).

The fix: when the located files declare nothing under the wanted name and the redeclare gate allows a real run, include those files for real first — that performs the include the poisoned autoloader can no longer do itself. An autoload-infrastructure file registers its nested class loader, and locating the class again consults it through the file-read trap, so the class is still located statically without executing its file. The existing run-the-autoloaders fallback stays for the class_alias shapes.

The new `e2e/bug-15102d` mirrors deptrac's memoizing bootstrap shape and fails with `interface.notFound` without the fix; the existing bug-15102/b/c cases stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fMtimQECyyBNKTmFddr8L