### PR TITLE
Cover the loader shapes the reverted autoloader attempts broke

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -142,6 +142,14 @@ jobs:
               composer install
               ../../bin/phpstan analyze
           - script: |
+              cd e2e/class-alias-loader
+              composer install
+              ../../bin/phpstan analyze
+          - script: |
+              cd e2e/robot-loader
+              composer install
+              ../../bin/phpstan analyze
+          - script: |
               cd e2e/bug-15102b
               ../../bin/phpstan analyze
           - script: |

--- a/e2e/class-alias-loader/.gitignore
+++ b/e2e/class-alias-loader/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/e2e/class-alias-loader/alias-map.php
+++ b/e2e/class-alias-loader/alias-map.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+// typo3/class-alias-loader replaces Composer's class loader with its own wrapper and
+// resolves these names through class_alias() at runtime.
+return [
+	'AliasLoaderE2e\\LegacyName' => 'AliasLoaderE2e\\ModernName',
+];

--- a/e2e/class-alias-loader/composer.json
+++ b/e2e/class-alias-loader/composer.json
@@ -1,0 +1,23 @@
+{
+	"require": {
+		"typo3/class-alias-loader": "^1.2"
+	},
+	"autoload": {
+		"psr-4": {
+			"AliasLoaderE2e\\": "src/"
+		}
+	},
+	"extra": {
+		"typo3/class-alias-loader": {
+			"class-alias-maps": [
+				"alias-map.php"
+			],
+			"always-add-alias-loader": true
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"typo3/class-alias-loader": true
+		}
+	}
+}

--- a/e2e/class-alias-loader/phpstan.dist.neon
+++ b/e2e/class-alias-loader/phpstan.dist.neon
@@ -1,0 +1,7 @@
+parameters:
+	level: 8
+	bootstrapFiles:
+		- vendor/autoload.php
+	paths:
+		- test.php
+		- stub

--- a/e2e/class-alias-loader/src/ModernName.php
+++ b/e2e/class-alias-loader/src/ModernName.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace AliasLoaderE2e;
+
+class ModernName
+{
+
+	public function doFoo(): int
+	{
+		return 1;
+	}
+
+}

--- a/e2e/class-alias-loader/stub/LegacyName.php
+++ b/e2e/class-alias-loader/stub/LegacyName.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace AliasLoaderE2e;
+
+// An IDE-only stub, never loaded at runtime: it declares the legacy name as a plain class so
+// editors resolve it. At runtime typo3/class-alias-loader makes the name a class_alias to
+// ModernName, which is the declaration PHPStan has to use - it has doFoo(), this does not.
+die('never loaded at runtime');
+
+class LegacyName
+{
+
+}

--- a/e2e/class-alias-loader/test.php
+++ b/e2e/class-alias-loader/test.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+use AliasLoaderE2e\LegacyName;
+
+function (LegacyName $legacy): int {
+	return $legacy->doFoo();
+};

--- a/e2e/robot-loader/.gitignore
+++ b/e2e/robot-loader/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/e2e/robot-loader/bootstrap.php
+++ b/e2e/robot-loader/bootstrap.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+$loader = new Nette\Loaders\RobotLoader();
+$loader->addDirectory(__DIR__ . '/classes');
+$loader->setTempDirectory(sys_get_temp_dir() . '/phpstan-e2e-robot-loader');
+$loader->register();

--- a/e2e/robot-loader/classes/Discovered.php
+++ b/e2e/robot-loader/classes/Discovered.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace RobotLoaderE2e;
+
+// Deliberately outside any Composer autoload mapping: only RobotLoader can find this class,
+// by scanning the directory. PHPStan has to consult the bootstrap-registered loader for it.
+class Discovered
+{
+
+	public function doFoo(): int
+	{
+		return 1;
+	}
+
+}

--- a/e2e/robot-loader/composer.json
+++ b/e2e/robot-loader/composer.json
@@ -1,0 +1,5 @@
+{
+	"require": {
+		"nette/robot-loader": "^4.0"
+	}
+}

--- a/e2e/robot-loader/phpstan.dist.neon
+++ b/e2e/robot-loader/phpstan.dist.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: 8
+	bootstrapFiles:
+		- bootstrap.php
+	paths:
+		- test.php

--- a/e2e/robot-loader/test.php
+++ b/e2e/robot-loader/test.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+use RobotLoaderE2e\Discovered;
+
+function (Discovered $discovered): int {
+	return $discovered->doFoo();
+};


### PR DESCRIPTION
Test-only. No behaviour change - `src/` is untouched.

#6292 reverted five commits because, as you put it, every intervention in this area fixes one use case and breaks another. The problem for a future attempt is that only *some* of those breakages had an e2e project, so the next person gets no signal until a user reports it. These two projects pin the shapes that actually broke, using the real loaders rather than hand-rolled stand-ins.

| project | 2.2.9 (#6069 + #6185) | `598faaade` (#6287 series) | this commit |
| --- | --- | --- | --- |
| `class-alias-loader` | **1 error** | No errors | No errors |
| `robot-loader` | No errors | **Internal error** | No errors |

Between them they cover both eras of breakage, and neither duplicates an existing project.

**`class-alias-loader`** uses the real `typo3/class-alias-loader` with `always-add-alias-loader`: it takes Composer's loader out of the queue and puts its own wrapper in, resolves a legacy name through a class alias map, and an IDE-only stub inside the analysed paths declares that same name as a plain class without the method. The alias has to win. On 2.2.9 the stub wins and PHPStan reports a missing method - the TYPO3 shape from phpstan/phpstan#15102, now with the actual package instead of my synthetic wrapper in `bug-15102`.

**`robot-loader`** registers a Nette `RobotLoader` over a directory Composer does not map, so only that loader can resolve the class (verified: without the bootstrap the project reports 2 errors, and the class has no Composer classmap entry). RobotLoader locks and writes a cache file while resolving, and on `598faaade` that fails:

```
Internal error: Unable to create file '<tmp>/phpstan-e2e-robot-loader/<hash>.php.lock'
  Nette\Loaders\RobotLoader->acquireLock()
  Nette\Loaders\RobotLoader->tryLoad()
```

because the loader runs while the file-read trap has replaced the `file` stream wrapper. That is a shape none of the existing projects covered - an autoloader that *writes* during resolution - and it is the one I would have wanted before touching this code at all. It reproduces 3/3 runs, cold or warm cache, and with or without the explicit `setTempDirectory()`.

## Notes

- Both are green here, so CI stays green; they only turn red if the shapes regress again.
- `bug-14988` and `bug-12972b` stay commented out as you left them - they document phpstan/phpstan#14988 and phpstan/phpstan#14976, which are open.
- Nothing here attempts a fix. If someone retries, the gate is: turn those two green without turning these two, `bug-12972c`, `bug-15102`, `bug-15102b` or `bug-15102c` red.

