### PR TITLE
Report peak memory per process instead of a summed total

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -12,7 +12,6 @@ use Throwable;
 use function array_fill_keys;
 use function array_merge;
 use function count;
-use function memory_get_peak_usage;
 
 /**
  * @phpstan-import-type CollectorData from CollectedData
@@ -147,7 +146,8 @@ final class Analyser
 			packageDependencies: $internalErrorsCount === 0 ? $packageDependencies : null,
 			exportedNodes: $exportedNodes,
 			reachedInternalErrorsCountLimit: $reachedInternalErrorsCountLimit,
-			peakMemoryUsageBytes: memory_get_peak_usage(true),
+			// analysis ran in this process - its peak is read where the number is printed
+			peakMemoryUsageBytes: 0,
 			processedFiles: $allProcessedFiles,
 		);
 	}

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -47,8 +47,18 @@ final class AnalyserResult
 		private bool $reachedInternalErrorsCountLimit,
 		private int $peakMemoryUsageBytes,
 		private array $processedFiles,
+		private int $workerCount = 0,
 	)
 	{
+	}
+
+	/**
+	 * How many parallel workers produced this result; 0 when the analysis ran in
+	 * the main process.
+	 */
+	public function getWorkerCount(): int
+	{
+		return $this->workerCount;
 	}
 
 	/**

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -156,6 +156,7 @@ final class AnalyserResultFinalizer
 			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
 			processedFiles: $analyserResult->getProcessedFiles(),
+			workerCount: $analyserResult->getWorkerCount(),
 		), $collectorErrors, $locallyIgnoredCollectorErrors);
 	}
 
@@ -177,6 +178,7 @@ final class AnalyserResultFinalizer
 			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
 			processedFiles: $analyserResult->getProcessedFiles(),
+			workerCount: $analyserResult->getWorkerCount(),
 		);
 	}
 
@@ -243,6 +245,7 @@ final class AnalyserResultFinalizer
 				reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 				peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
 				processedFiles: $analyserResult->getProcessedFiles(),
+				workerCount: $analyserResult->getWorkerCount(),
 			),
 			$collectorErrors,
 			$locallyIgnoredCollectorErrors,

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -82,7 +82,8 @@ final class AnalyseApplication
 			$internalErrors = [];
 			$collectedData = [];
 			$savedResultCache = false;
-			$memoryUsageBytes = memory_get_peak_usage(true);
+			$memoryUsageBytes = 0;
+			$workerCount = 0;
 			$processedFiles = [];
 			if ($errorOutput->isVeryVerbose()) {
 				$errorOutput->writeLineFormatted('Result cache was not saved because of ignoredErrorHelperResult errors.');
@@ -127,6 +128,7 @@ final class AnalyseApplication
 					reachedInternalErrorsCountLimit: $intermediateAnalyserResult->hasReachedInternalErrorsCountLimit(),
 					peakMemoryUsageBytes: $intermediateAnalyserResult->getPeakMemoryUsageBytes(),
 					processedFiles: $intermediateAnalyserResult->getProcessedFiles(),
+					workerCount: $intermediateAnalyserResult->getWorkerCount(),
 				);
 			}
 
@@ -145,6 +147,7 @@ final class AnalyseApplication
 			);
 			$hasInternalErrors = count($internalErrors) > 0 || $analyserResult->hasReachedInternalErrorsCountLimit();
 			$memoryUsageBytes = $analyserResult->getPeakMemoryUsageBytes();
+			$workerCount = $analyserResult->getWorkerCount();
 			$isResultCacheUsed = !$resultCache->isFullAnalysis();
 
 			$changedProjectExtensionFilesOutsideOfAnalysedPaths = [];
@@ -194,6 +197,7 @@ final class AnalyseApplication
 			$changedProjectExtensionFilesOutsideOfAnalysedPaths,
 			$processedFiles,
 			$resultCacheExisted,
+			$workerCount,
 		);
 	}
 
@@ -255,7 +259,7 @@ final class AnalyseApplication
 				packageDependencies: [],
 				exportedNodes: [],
 				reachedInternalErrorsCountLimit: false,
-				peakMemoryUsageBytes: memory_get_peak_usage(true),
+				peakMemoryUsageBytes: 0,
 				processedFiles: [],
 			);
 		}

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -496,7 +496,7 @@ final class AnalyseCommand extends Command
 					count($internalErrors) === 1 ? 'An internal error' : 'Internal errors',
 				));
 
-				return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime);
+				return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime, $analysisResult->getWorkerCount());
 			}
 
 			return $this->generateBaseline($generateBaselineFile, $inceptionResult, $analysisResult, $output, $allowEmptyBaseline, $baselineExtension, $failWithoutResultCache);
@@ -535,6 +535,7 @@ final class AnalyseCommand extends Command
 				$exitCode,
 				$analysisResult->getPeakMemoryUsageBytes(),
 				$this->analysisStartTime,
+				$analysisResult->getWorkerCount(),
 			);
 		}
 
@@ -672,7 +673,7 @@ final class AnalyseCommand extends Command
 
 				$errorOutput->writeLineFormatted('');
 
-				return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime);
+				return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime, $analysisResult->getWorkerCount());
 			}
 		}
 
@@ -684,6 +685,7 @@ final class AnalyseCommand extends Command
 			$exitCode,
 			$analysisResult->getPeakMemoryUsageBytes(),
 			$this->analysisStartTime,
+			$analysisResult->getWorkerCount(),
 		);
 	}
 
@@ -798,7 +800,7 @@ final class AnalyseCommand extends Command
 			$inceptionResult->getStdOutput()->getStyle()->error('No errors were found during the analysis. Baseline could not be generated.');
 			$inceptionResult->getStdOutput()->writeLineFormatted('To allow generating empty baselines, pass <fg=cyan>--allow-empty-baseline</> option.');
 
-			return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime);
+			return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime, $analysisResult->getWorkerCount());
 		}
 
 		$streamOutput = $this->createStreamOutput();
@@ -826,7 +828,7 @@ final class AnalyseCommand extends Command
 		} catch (DirectoryCreatorException $e) {
 			$inceptionResult->getStdOutput()->writeLineFormatted($e->getMessage());
 
-			return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime);
+			return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime, $analysisResult->getWorkerCount());
 		}
 
 		try {
@@ -834,7 +836,7 @@ final class AnalyseCommand extends Command
 		} catch (CouldNotWriteFileException $e) {
 			$inceptionResult->getStdOutput()->writeLineFormatted($e->getMessage());
 
-			return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime);
+			return $inceptionResult->handleReturn(1, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime, $analysisResult->getWorkerCount());
 		}
 
 		$errorsCount = 0;
@@ -874,7 +876,7 @@ final class AnalyseCommand extends Command
 			$exitCode = 2;
 		}
 
-		return $inceptionResult->handleReturn($exitCode, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime);
+		return $inceptionResult->handleReturn($exitCode, $analysisResult->getPeakMemoryUsageBytes(), $this->analysisStartTime, $analysisResult->getWorkerCount());
 	}
 
 	/**

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -19,7 +19,6 @@ use function count;
 use function filesize;
 use function function_exists;
 use function is_file;
-use function memory_get_peak_usage;
 
 #[AutowiredService]
 final class AnalyserRunner
@@ -72,7 +71,7 @@ final class AnalyserRunner
 				packageDependencies: [],
 				exportedNodes: [],
 				reachedInternalErrorsCountLimit: false,
-				peakMemoryUsageBytes: memory_get_peak_usage(true),
+				peakMemoryUsageBytes: 0,
 				processedFiles: [],
 			);
 		}

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -40,6 +40,7 @@ final class AnalysisResult
 		private array $changedProjectExtensionFilesOutsideOfAnalysedPaths,
 		private array $processedFiles = [],
 		private bool $resultCacheExisted = true,
+		private int $workerCount = 0,
 	)
 	{
 		usort(
@@ -136,6 +137,15 @@ final class AnalysisResult
 	public function getPeakMemoryUsageBytes(): int
 	{
 		return $this->peakMemoryUsageBytes;
+	}
+
+	/**
+	 * How many parallel workers produced this result; 0 when the analysis ran in
+	 * the main process.
+	 */
+	public function getWorkerCount(): int
+	{
+		return $this->workerCount;
 	}
 
 	public function isResultCacheUsed(): bool

--- a/src/Command/InceptionResult.php
+++ b/src/Command/InceptionResult.php
@@ -5,9 +5,9 @@ namespace PHPStan\Command;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\File\PathNotFoundException;
 use PHPStan\Internal\BytesHelper;
+use PHPStan\Parallel\ForkParallelChecker;
 use function floor;
 use function implode;
-use function max;
 use function memory_get_peak_usage;
 use function microtime;
 use function round;
@@ -100,7 +100,11 @@ final class InceptionResult
 		return $this->editorModeInsteadOfFile;
 	}
 
-	public function handleReturn(int $exitCode, ?int $peakMemoryUsageBytes, float $analysisStartTime): int
+	/**
+	 * @param int|null $peakMemoryUsageBytes the heaviest parallel worker's peak, 0 when the
+	 * analysis ran in this process
+	 */
+	public function handleReturn(int $exitCode, ?int $peakMemoryUsageBytes, float $analysisStartTime, int $workerCount = 0): int
 	{
 		if ($this->getErrorOutput()->isVerbose()) {
 			$elapsedTime = round(microtime(true) - $analysisStartTime, 2);
@@ -116,10 +120,27 @@ final class InceptionResult
 		}
 
 		if ($peakMemoryUsageBytes !== null && $this->getErrorOutput()->isVerbose()) {
-			$this->getErrorOutput()->writeLineFormatted(sprintf(
-				'Used memory: %s',
-				BytesHelper::bytes(max(memory_get_peak_usage(true), $peakMemoryUsageBytes)),
-			));
+			// This process's peak is read here, at the very end, so it covers collecting
+			// the workers' results and saving the result cache - the part of a parallel
+			// run where the main process is at its largest. Both numbers are per process,
+			// which is also how memory_limit applies.
+			$mainProcessPeak = memory_get_peak_usage(true);
+			if ($peakMemoryUsageBytes === 0 || $workerCount === 0) {
+				$this->getErrorOutput()->writeLineFormatted(sprintf(
+					'Peak memory: %s',
+					BytesHelper::bytes($mainProcessPeak),
+				));
+			} else {
+				$mechanism = $this->container->getByType(ForkParallelChecker::class)->isSupported() ? 'forked' : 'spawned';
+				$this->getErrorOutput()->writeLineFormatted(sprintf(
+					'Peak memory: %s (main process), %s (%s)',
+					BytesHelper::bytes($mainProcessPeak),
+					BytesHelper::bytes($peakMemoryUsageBytes),
+					$workerCount === 1
+						? sprintf('the %s worker', $mechanism)
+						: sprintf('largest of %d %s workers', $workerCount, $mechanism),
+				));
+			}
 		}
 
 		return $exitCode;

--- a/src/Parallel/ForkedProcess.php
+++ b/src/Parallel/ForkedProcess.php
@@ -11,6 +11,7 @@ use React\Socket\TcpServer;
 use Symfony\Component\Console\Output\StreamOutput;
 use Throwable;
 use function fclose;
+use function function_exists;
 use function pcntl_fork;
 use function pcntl_waitpid;
 use function pcntl_wexitstatus;
@@ -97,6 +98,17 @@ final class ForkedProcess extends ProcessBase
 			// Child: drop the inherited listening socket immediately, then run
 			// the worker on its own fresh event loop and never return.
 			$this->server->close();
+			// memory_get_peak_usage() carries over into the child, so without this a
+			// worker would report the main process's peak instead of its own - on an
+			// incremental run, the spike taken while loading the result cache, which
+			// every worker would then repeat. Restarting the peak here keeps the
+			// reported number the worker's own high-water usage, inherited memory it
+			// still holds included.
+			/** phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName */
+			if (function_exists('memory_reset_peak_usage')) {
+				\memory_reset_peak_usage();
+			}
+			/** phpcs:enable */
 			ForkedChildCrashReporter::install($tmpStdErr);
 			$output = new StreamOutput($tmpStdOut);
 			try {

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -25,14 +25,12 @@ use Throwable;
 use function array_map;
 use function array_pop;
 use function array_reverse;
-use function array_sum;
 use function count;
 use function defined;
 use function escapeshellarg;
 use function getenv;
 use function ini_get;
 use function max;
-use function memory_get_usage;
 use function parse_url;
 use function sprintf;
 use function str_contains;
@@ -110,6 +108,7 @@ final class ParallelAnalyser
 		$locallyIgnoredErrors = [];
 		$linesToIgnore = [];
 		$unmatchedLineIgnores = [];
+		/** @var array<string, int> $peakMemoryUsages */
 		$peakMemoryUsages = [];
 		$internalErrors = [];
 		$internalErrorsCount = 0;
@@ -156,8 +155,12 @@ final class ParallelAnalyser
 				packageDependencies: $internalErrorsCount === 0 ? $packageDependencies : null,
 				exportedNodes: $exportedNodes,
 				reachedInternalErrorsCountLimit: $reachedInternalErrorsCountLimit,
-				peakMemoryUsageBytes: array_sum($peakMemoryUsages), // not 100% correct as the peak usages of workers might not have met
+				// The heaviest single worker. Summing the workers' peaks would describe a
+				// moment that never happens - they do not peak at the same time - while
+				// each worker's own peak is what its memory_limit is measured against.
+				peakMemoryUsageBytes: $peakMemoryUsages === [] ? 0 : max($peakMemoryUsages),
 				processedFiles: $allProcessedFiles,
+				workerCount: count($peakMemoryUsages),
 			));
 		});
 		$server->on('connection', function (ConnectionInterface $connection) use (&$jobs, $arenaName, $expectedWorkerCount, &$helloCount): void {
@@ -372,10 +375,10 @@ final class ParallelAnalyser
 
 				$job = array_pop($jobs);
 				$process->request(['action' => 'analyse', 'files' => $job]);
-			}, $handleError, function ($exitCode, string $output) use (&$someChildEnded, &$peakMemoryUsages, &$internalErrors, &$internalErrorsCount, $processIdentifier): void {
-				if ($someChildEnded === false) {
-					$peakMemoryUsages['main'] = memory_get_usage(true);
-				}
+			}, $handleError, function ($exitCode, string $output) use (&$someChildEnded, &$internalErrors, &$internalErrorsCount, $processIdentifier): void {
+				// The main process is not sampled here any more: its own peak comes
+				// later (collecting the workers' results, saving the result cache) and
+				// is read where the number is printed. Only worker peaks are summed.
 				$someChildEnded = true;
 
 				if ($exitCode === 0) {


### PR DESCRIPTION
Verbose runs printed `Used memory:` — a number that never corresponded to anything the operating system could confirm. This replaces it with two figures that can be checked:

```
Peak memory: 3.07 GB (main process), 1.18 GB (largest of 10 forked workers)
```

Single-process runs print `Peak memory: 401.02 MB`.

## Why the old number was fiction

It was `array_sum()` of every worker's peak, plus a snapshot of the main process's *current* usage taken the moment the first worker exited. Workers never peak at the same instant, so the sum described a moment that never happened. On top of that, two concrete defects:

**The main process was understated.** We recorded current usage, sampled early, while the main process's real peak comes much later — when it aggregates worker results and writes the result cache. On PHPStan's own self-analysis we recorded **136 MB** for a process that actually peaked at **405 MB**.

**`memory_get_peak_usage()` is inherited across `pcntl_fork()`.** A child reports its parent's peak before allocating anything:

```php
$a = str_repeat('x', 800 * 1024 * 1024);
unset($a);                            // parent: peak 802 MB, current 2 MB
if (pcntl_fork() === 0) {
    echo memory_get_peak_usage(true); // child that allocated nothing: 802 MB
}
```

Summed across workers, that multiplied the main process's pre-fork spike — on an incremental run, the loaded result cache — by the number of workers.

## What the OS saw, before this change

Two real projects, PHP 8.5, 10 workers. "Largest process" is the kernel's `maximum resident set size`; the sum column is RSS polled across the whole process tree.

| Project / mode | printed | largest process | sum of per-process peaks |
|---|---|---|---|
| **Dolor**, fork, warm result cache | **29.21 GB** | 3.14 GB | 16.69 GB |
| Dolor, fork, cold cache | 12.31 GB | 3.04 GB | 15.03 GB |
| Dolor, spawn, cold cache | 11.46 GB | 2.89 GB | 13.98 GB |
| **Lorem**, fork, cold cache | 7.81 GB | 0.98 GB | 8.03 GB |
| Lorem, spawn, cold cache | 7.55 GB | 0.98 GB | 8.13 GB |

**It was wrong with spawning too.** Lorem spawned: 7.55 GB printed against a largest process of 0.98 GB — 7.7×. Dolor spawned: 11.46 GB printed, 2.89 GB largest, and 18% *below* the sum it was nominally computing (because the main process's contribution was that early snapshot).

**Forking made it far worse.** Same project, same work — the only difference is that the main process had the result cache loaded when it forked: **29.21 GB printed against a 3.14 GB largest process**, 9.3×, and 1.75× even the sum of every process's peak. Nothing on that machine ever held 29 GB.

## After this change

| Project / mode | printed: main | largest process (OS) | printed: top worker | 2nd-largest process (OS) |
|---|---|---|---|---|
| Dolor, fork, warm | 3.07 GB | 3.05 GB | 2.19 GB | 1.48 GB |
| Dolor, fork, cold | 2.92 GB | 3.07 GB | 1.18 GB | 1.34 GB |
| Dolor, spawn, cold | 2.89 GB | 2.92 GB | 1.13 GB | 1.17 GB |
| Lorem, fork, cold | 682 MB | 1.13 GB (a worker) | 1006.5 MB | 1.12 GB |
| Lorem, spawn, cold | 682 MB | 0.97 GB (a worker) | 968.6 MB | 0.96 GB |

Where the main process is the largest one, the printed figure matches the kernel's within 1–5%. Worker figures land within 3–13% in spawn mode. Both are per-process, which is also how `memory_limit` applies — so if a run dies at its limit, these are the numbers that explain why.

## What these numbers are not

They are **not** the memory the run costs the machine. Sampling machine-wide physical memory during these same runs gives ~5.6 GB (Dolor fork, cold) and ~10.3 GB (Dolor fork, warm) — more than any single process, far less than the sum, because forked workers share most of their pages with the parent.

No number derived from `memory_get_*` can express that: when a forked worker writes to an inherited page, copy-on-write allocates real memory while ZendMM sees nothing. The one honest figure for fork mode is the worker heap number above, which includes memory the worker inherited and still holds — an upper bound on its private footprint (2.19 GB printed against 1.48 GB resident in the warm-cache row).

A machine-level footprint would need OS counters — `Pss` from `/proc/<pid>/smaps_rollup` on Linux, `phys_footprint` on macOS — and is deliberately left for separate work.

## The change

- `ForkedProcess` calls `memory_reset_peak_usage()` in the child right after the fork, so a worker reports its own high-water mark instead of its parent's.
- `ParallelAnalyser` stops folding the main process into the total; `peakMemoryUsageBytes` now means "the heaviest worker's peak", and single-process paths report `0`.
- `InceptionResult` reads this process's peak at the very end — after the result cache is written — and prints both figures with the worker count and mechanism.
