### PR TITLE
Support per-file result cache dependencies

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -485,6 +485,134 @@ jobs:
               ../bashunit -a matches "Note: Using configuration file .+phpstan.neon." "$OUTPUT"
               ../bashunit -a contains 'Result cache not used because the metadata do not match: metaExtensions' "$OUTPUT"
           - script: |
+              cd e2e/result-cache-dependency
+              composer install
+              ../../bin/phpstan clear-result-cache
+              mkdir -p tmp
+              : > tmp/hash-calls.log
+              : > tmp/rule-pids.log
+              : > tmp/collected-data.log
+              set +e
+              ../../bin/phpstan analyse -vv --error-format raw > tmp/analysis-output.log 2>&1 &
+              PHPSTAN_MAIN_PID=$!
+              wait "$PHPSTAN_MAIN_PID"
+              STATUS=$?
+              set -e
+              ../bashunit -a equals "0" "$STATUS"
+              OUTPUT=$(cat tmp/analysis-output.log)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache is saved.' "$OUTPUT"
+              ../bashunit -a equals 'hashed=0 unhashed=6' "$(cat tmp/collected-data.log)"
+              php assert-hash-calls.php cold "$PHPSTAN_MAIN_PID"
+              php assert-result-cache-dependencies.php
+              : > tmp/hash-calls.log
+              : > tmp/rule-pids.log
+              : > tmp/collected-data.log
+              set +e
+              ../../bin/phpstan analyse -vv --error-format raw > tmp/analysis-output.log 2>&1 &
+              PHPSTAN_MAIN_PID=$!
+              wait "$PHPSTAN_MAIN_PID"
+              STATUS=$?
+              set -e
+              ../bashunit -a equals "0" "$STATUS"
+              OUTPUT=$(cat tmp/analysis-output.log)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+              ../bashunit -a equals 'hashed=0 unhashed=6' "$(cat tmp/collected-data.log)"
+              php assert-hash-calls.php warm "$PHPSTAN_MAIN_PID"
+              php assert-result-cache-dependencies.php
+              # Duplicate provider keys are rejected before analysis.
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -c duplicate-provider.neon -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Duplicate ResultCacheDependencyExtension with key' "$OUTPUT"
+              ../bashunit -a contains 'ConfigTypeRegistry" found.' "$OUTPUT"
+              ../bashunit -a not_contains '100%' "$OUTPUT"
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -c duplicate-provider.neon --debug --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Duplicate ResultCacheDependencyExtension with key' "$OUTPUT"
+              ../bashunit -a not_contains 'src/Consumer.php' "$OUTPUT"
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -c duplicate-provider.neon src/Consumer.php -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Duplicate ResultCacheDependencyExtension with key' "$OUTPUT"
+              ../bashunit -a not_contains '100%' "$OUTPUT"
+              # The same dependency key in different provider namespaces must not collide.
+              sed -i 's/"checkout.label": "string"/"checkout.label": "int"/' tenant-config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              ../bashunit -a contains 'TenantConsumer.php:7:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              # Changing a key shared by two consumers invalidates both files.
+              sed -i 's/"checkout.label": "string"/"checkout.label": "int"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 2 files will be reanalysed.' "$OUTPUT"
+              ../bashunit -a contains 'Consumer.php:11:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              ../bashunit -a contains 'SecondConsumer.php:7:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              # Changing an unused key invalidates no files.
+              sed -i 's/"unused": "string"/"unused": "int"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+              ../bashunit -a contains 'Consumer.php:11:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              # Changing a key used by one consumer invalidates only that file.
+              sed -i 's/"profile.name": "string"/"profile.name": "int"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              ../bashunit -a contains 'Consumer.php:16:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              # A source-invalidated file does not need its obsolete dependency hashes.
+              sed -i 's/"profile.name": "int"/"profile.name": "throw"/' config-types.json
+              sed -i "s/configValue('profile.name')/configValue('replacement')/" src/Consumer.php
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              ../bashunit -a not_contains 'boom from dependency getHash' "$OUTPUT"
+              ../bashunit -a not_contains 'Consumer.php:16:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              sed -i 's/"profile.name": "throw"/"profile.name": "string"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+              sed -i 's/"replacement": "string"/"replacement": "int"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              ../bashunit -a contains 'Consumer.php:16:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              # A selector change invalidates the file before its old selected key is hashed.
+              sed -i 's/"database.default": "legacy"/"database.default": "modern"/' config-types.json
+              sed -i 's/"database.connection.legacy": "string"/"database.connection.legacy": "throw"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              ../bashunit -a not_contains 'boom from dependency getHash' "$OUTPUT"
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+              ../bashunit -a not_contains 'boom from dependency getHash' "$OUTPUT"
+              sed -i 's/"database.connection.modern": "string"/"database.connection.modern": "int"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              ../bashunit -a contains 'Consumer.php:21:Parameter #1 $string of function strlen expects string, int given.' "$OUTPUT"
+              # Malformed or unknown persisted records invalidate their emitting files.
+              php mutate-result-cache.php unknown-provider
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 2 files will be reanalysed.' "$OUTPUT"
+              php mutate-result-cache.php malformed-record
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              php mutate-result-cache.php malformed-payload
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 1 file will be reanalysed.' "$OUTPUT"
+              # Provider exceptions propagate instead of being treated as cache misses.
+              sed -i 's/"replacement": "int"/"replacement": "throw"/' config-types.json
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse -vv --error-format raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'boom from dependency getHash' "$OUTPUT"
+              ../bashunit -a not_contains 'Swallowed by global exception handler' "$OUTPUT"
+          - script: |
               cd e2e/result-cache-meta-extension-throw
               composer install
               # https://github.com/phpstan/phpstan/issues/14805

--- a/e2e/result-cache-dependency/.gitignore
+++ b/e2e/result-cache-dependency/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/tmp

--- a/e2e/result-cache-dependency/assert-hash-calls.php
+++ b/e2e/result-cache-dependency/assert-hash-calls.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+$phase = $argv[1] ?? null;
+if ($phase !== 'cold' && $phase !== 'warm') {
+	throw new RuntimeException('Expected a cold or warm phase.');
+}
+
+$mainPid = filter_var($argv[2] ?? null, FILTER_VALIDATE_INT);
+if (!is_int($mainPid) || $mainPid <= 0) {
+	throw new RuntimeException('Expected the PHPStan main-process PID.');
+}
+
+$hashCallLines = file(__DIR__ . '/tmp/hash-calls.log', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+if ($hashCallLines === false) {
+	throw new RuntimeException('Could not read dependency hash calls.');
+}
+
+$hashCallPids = [];
+$hashCallDependencies = [];
+foreach ($hashCallLines as $line) {
+	if (preg_match('/^(\d+) (\S+) (.+)$/D', $line, $matches) !== 1) {
+		throw new RuntimeException(sprintf('Malformed dependency hash call: %s', $line));
+	}
+
+	$hashCallPids[] = (int) $matches[1];
+	$hashCallDependencies[] = sprintf('%s %s', $matches[2], $matches[3]);
+}
+
+$expectedDependencies = [
+	'ResultCacheE2E\\Dependency\\ConfigTypeRegistry checkout.label',
+	'ResultCacheE2E\\Dependency\\ConfigTypeRegistry database.connection.legacy',
+	'ResultCacheE2E\\Dependency\\ConfigTypeRegistry database.default',
+	'ResultCacheE2E\\Dependency\\ConfigTypeRegistry profile.name',
+	'ResultCacheE2E\\Dependency\\TenantConfigTypeRegistry checkout.label',
+];
+sort($hashCallDependencies);
+if ($hashCallDependencies !== $expectedDependencies) {
+	throw new RuntimeException(sprintf(
+		'Expected one hash call for each unique provider and dependency key, got: %s',
+		implode(', ', $hashCallDependencies),
+	));
+}
+
+$uniqueHashCallPids = array_values(array_unique($hashCallPids));
+if ($uniqueHashCallPids !== [$mainPid]) {
+	throw new RuntimeException(sprintf(
+		'Expected dependency hashes to be calculated by main process %d, got: %s',
+		$mainPid,
+		implode(', ', $uniqueHashCallPids),
+	));
+}
+
+$rulePidLines = file(__DIR__ . '/tmp/rule-pids.log', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+if ($rulePidLines === false) {
+	throw new RuntimeException('Could not read semantic dependency rule processes.');
+}
+$rulePids = [];
+foreach ($rulePidLines as $line) {
+	if (preg_match('/^\d+$/D', $line) !== 1) {
+		throw new RuntimeException(sprintf('Malformed semantic dependency rule process: %s', $line));
+	}
+	$rulePids[] = (int) $line;
+}
+
+if ($phase === 'cold') {
+	if ($rulePids === []) {
+		throw new RuntimeException('Expected semantic dependency rules to run during cold analysis.');
+	}
+	if (in_array($mainPid, $rulePids, true)) {
+		throw new RuntimeException('Expected semantic dependency rules to run in worker processes.');
+	}
+} elseif ($rulePids !== []) {
+	throw new RuntimeException('Expected no semantic dependency rules during warm cache restoration.');
+}
+
+printf(
+	"%s cache phase calculated five unique dependency hashes in main process %d.\n",
+	$phase,
+	$mainPid,
+);

--- a/e2e/result-cache-dependency/assert-result-cache-dependencies.php
+++ b/e2e/result-cache-dependency/assert-result-cache-dependencies.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Collectors\ResultCacheDependencyCollector;
+
+$cache = require __DIR__ . '/tmp/resultCache.php';
+$collectedData = $cache['collectedDataCallback']();
+$recordCount = 0;
+foreach ($collectedData as $file => $collectedDataForFile) {
+	$records = $collectedDataForFile[ResultCacheDependencyCollector::class] ?? [];
+	$seen = [];
+	foreach ($records as $record) {
+		$identity = $record['extensionKey'] . "\0" . $record['dependencyKey'];
+		if (isset($seen[$identity])) {
+			throw new RuntimeException(sprintf('Duplicate result-cache dependency persisted for %s.', $file));
+		}
+		$seen[$identity] = true;
+		if ($record['hash'] === 'extension-supplied') {
+			throw new RuntimeException(sprintf('Extension-supplied hash persisted for %s.', $file));
+		}
+		$recordCount++;
+	}
+}
+
+if ($recordCount !== 6) {
+	throw new RuntimeException(sprintf('Expected 6 persisted dependency records, got %d.', $recordCount));
+}
+
+echo "result cache contains six unique main-process dependency hashes.\n";

--- a/e2e/result-cache-dependency/bootstrap.php
+++ b/e2e/result-cache-dependency/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+function configValue(string $key): mixed
+{
+	return null;
+}
+
+function configuredConnectionValue(string $selectorKey): mixed
+{
+	return null;
+}
+
+function tenantConfigValue(string $key): mixed
+{
+	return null;
+}
+
+set_exception_handler(static function (\Throwable $e): void {
+	fwrite(STDERR, 'Swallowed by global exception handler: ' . $e->getMessage() . "\n");
+	exit(0);
+});

--- a/e2e/result-cache-dependency/composer.json
+++ b/e2e/result-cache-dependency/composer.json
@@ -1,0 +1,5 @@
+{
+	"autoload-dev": {
+		"classmap": ["extension/", "src/"]
+	}
+}

--- a/e2e/result-cache-dependency/composer.lock
+++ b/e2e/result-cache-dependency/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d751713988987e9331980363e24189ce",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/e2e/result-cache-dependency/config-types.json
+++ b/e2e/result-cache-dependency/config-types.json
@@ -1,0 +1,9 @@
+{
+    "checkout.label": "string",
+    "profile.name": "string",
+    "unused": "string",
+    "replacement": "string",
+    "database.default": "legacy",
+    "database.connection.legacy": "string",
+    "database.connection.modern": "string"
+}

--- a/e2e/result-cache-dependency/duplicate-provider.neon
+++ b/e2e/result-cache-dependency/duplicate-provider.neon
@@ -1,0 +1,11 @@
+includes:
+	- phpstan.neon
+
+parameters:
+	tmpDir: tmp/duplicate
+
+services:
+	-
+		class: ResultCacheE2E\Dependency\DuplicateResultCacheDependencyExtension
+		tags:
+			- phpstan.resultCacheDependencyExtension

--- a/e2e/result-cache-dependency/extension/ConfigResultCacheDependencyRule.php
+++ b/e2e/result-cache-dependency/extension/ConfigResultCacheDependencyRule.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ResultCacheE2E\Dependency;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\ResultCacheDependencyCollector;
+use PHPStan\Rules\Rule;
+use RuntimeException;
+use function file_put_contents;
+use function getmypid;
+use function sprintf;
+use const FILE_APPEND;
+use const LOCK_EX;
+
+/** @implements Rule<FuncCall> */
+final class ConfigResultCacheDependencyRule implements Rule
+{
+	public function __construct(
+		private ConfigTypeRegistry $configTypeRegistry,
+		private TenantConfigTypeRegistry $tenantConfigTypeRegistry,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	/** @param Scope&CollectedDataEmitter $scope */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (
+			!$node->name instanceof Name
+			|| !isset($node->getArgs()[0])
+			|| !$node->getArgs()[0]->value instanceof String_
+		) {
+			return [];
+		}
+
+		$functionName = $node->name->toString();
+		if (
+			$functionName !== 'configValue'
+			&& $functionName !== 'configuredConnectionValue'
+			&& $functionName !== 'tenantConfigValue'
+		) {
+			return [];
+		}
+
+		$pid = getmypid();
+		if ($pid === false) {
+			throw new RuntimeException('Could not determine the configuration dependency rule process.');
+		}
+		if (file_put_contents(
+			__DIR__ . '/../tmp/rule-pids.log',
+			sprintf("%d\n", $pid),
+			FILE_APPEND | LOCK_EX,
+		) === false) {
+			throw new RuntimeException('Could not record the configuration dependency rule process.');
+		}
+
+		$key = $node->getArgs()[0]->value->value;
+		$extension = $functionName === 'tenantConfigValue'
+			? $this->tenantConfigTypeRegistry
+			: $this->configTypeRegistry;
+		$this->emitDependency($scope, $extension, $key);
+		if ($functionName === 'configuredConnectionValue') {
+			$this->emitDependency(
+				$scope,
+				$this->configTypeRegistry,
+				$this->configTypeRegistry->getSelectedConnectionKey($key),
+			);
+		}
+
+		return [];
+	}
+
+	private function emitDependency(
+		CollectedDataEmitter $scope,
+		ResultCacheDependencyExtension $extension,
+		string $key,
+	): void
+	{
+		$data = ResultCacheDependencyCollector::createData($extension, $key);
+		if ($key === 'profile.name') {
+			$data += ['hash' => 'extension-supplied'];
+		}
+		$scope->emitCollectedData(
+			ResultCacheDependencyCollector::class,
+			$data,
+		);
+	}
+}

--- a/e2e/result-cache-dependency/extension/ConfigTypeRegistry.php
+++ b/e2e/result-cache-dependency/extension/ConfigTypeRegistry.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ResultCacheE2E\Dependency;
+
+use Error;
+use PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension;
+use RuntimeException;
+use function file_get_contents;
+use function file_put_contents;
+use function getmypid;
+use function hash;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function sprintf;
+use const FILE_APPEND;
+use const JSON_THROW_ON_ERROR;
+use const LOCK_EX;
+
+final class ConfigTypeRegistry implements ResultCacheDependencyExtension
+{
+	private const CONNECTION_PREFIX = 'database.connection.';
+
+	public function getKey(): string
+	{
+		return self::class;
+	}
+
+	public function getHash(string $dependencyKey): string
+	{
+		$pid = getmypid();
+		if ($pid === false) {
+			throw new RuntimeException('Could not determine the dependency hash process.');
+		}
+		if (file_put_contents(
+			__DIR__ . '/../tmp/hash-calls.log',
+			sprintf("%d %s %s\n", $pid, $this->getKey(), $dependencyKey),
+			FILE_APPEND | LOCK_EX,
+		) === false) {
+			throw new RuntimeException('Could not record dependency hash call.');
+		}
+
+		$value = $this->get($dependencyKey);
+		if ($value === 'throw') {
+			throw new Error('boom from dependency getHash');
+		}
+
+		return hash('sha256', $value);
+	}
+
+	public function get(string $dependencyKey): string
+	{
+		$contents = file_get_contents(__DIR__ . '/../config-types.json');
+		if ($contents === false) {
+			throw new RuntimeException('Could not read configuration types.');
+		}
+		$configTypes = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+		if (!is_array($configTypes)) {
+			throw new RuntimeException('Configuration types must be an object.');
+		}
+		$value = $configTypes[$dependencyKey] ?? 'missing';
+		if (!is_string($value)) {
+			throw new RuntimeException('Configuration types must be strings.');
+		}
+
+		return $value;
+	}
+
+	public function getSelectedConnectionKey(string $selectorKey): string
+	{
+		return self::CONNECTION_PREFIX . $this->get($selectorKey);
+	}
+}

--- a/e2e/result-cache-dependency/extension/ConfigValueDynamicReturnTypeExtension.php
+++ b/e2e/result-cache-dependency/extension/ConfigValueDynamicReturnTypeExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ResultCacheE2E\Dependency;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+final class ConfigValueDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+	public function __construct(
+		private ConfigTypeRegistry $configTypeRegistry,
+		private TenantConfigTypeRegistry $tenantConfigTypeRegistry,
+	)
+	{
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'configValue'
+			|| $functionReflection->getName() === 'configuredConnectionValue'
+			|| $functionReflection->getName() === 'tenantConfigValue';
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope,
+	): Type
+	{
+		$keyArgument = $functionCall->getArgs()[0] ?? null;
+		if ($keyArgument === null || !$keyArgument->value instanceof String_) {
+			return new MixedType();
+		}
+
+		$key = $keyArgument->value->value;
+		$configTypeRegistry = $functionReflection->getName() === 'tenantConfigValue'
+			? $this->tenantConfigTypeRegistry
+			: $this->configTypeRegistry;
+		if ($functionReflection->getName() === 'configuredConnectionValue') {
+			$key = $this->configTypeRegistry->getSelectedConnectionKey($key);
+		}
+
+		return match ($configTypeRegistry->get($key)) {
+			'string' => new StringType(),
+			'int' => new IntegerType(),
+			default => new MixedType(),
+		};
+	}
+}

--- a/e2e/result-cache-dependency/extension/DuplicateResultCacheDependencyExtension.php
+++ b/e2e/result-cache-dependency/extension/DuplicateResultCacheDependencyExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ResultCacheE2E\Dependency;
+
+use PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension;
+
+final class DuplicateResultCacheDependencyExtension implements ResultCacheDependencyExtension
+{
+	public function getKey(): string
+	{
+		return ConfigTypeRegistry::class;
+	}
+
+	public function getHash(string $dependencyKey): string
+	{
+		return 'duplicate';
+	}
+}

--- a/e2e/result-cache-dependency/extension/ResultCacheDependencyDataRule.php
+++ b/e2e/result-cache-dependency/extension/ResultCacheDependencyDataRule.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ResultCacheE2E\Dependency;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\ResultCacheDependencyCollector;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use RuntimeException;
+use function array_key_exists;
+use function file_put_contents;
+use function is_array;
+use function sprintf;
+use const LOCK_EX;
+
+/** @implements Rule<CollectedDataNode> */
+final class ResultCacheDependencyDataRule implements Rule
+{
+	public function getNodeType(): string
+	{
+		return CollectedDataNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$hashed = 0;
+		$unhashed = 0;
+		foreach ($node->get(ResultCacheDependencyCollector::class) as $records) {
+			foreach ($records as $record) {
+				if ($this->hasHash($record)) {
+					$hashed++;
+					continue;
+				}
+
+				$unhashed++;
+			}
+		}
+		if (file_put_contents(
+			__DIR__ . '/../tmp/collected-data.log',
+			sprintf("hashed=%d unhashed=%d\n", $hashed, $unhashed),
+			LOCK_EX,
+		) === false) {
+			throw new RuntimeException('Could not record the result-cache dependency data shape.');
+		}
+
+		return [];
+	}
+
+	private function hasHash(mixed $record): bool
+	{
+		return is_array($record) && array_key_exists('hash', $record);
+	}
+}

--- a/e2e/result-cache-dependency/extension/TenantConfigTypeRegistry.php
+++ b/e2e/result-cache-dependency/extension/TenantConfigTypeRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ResultCacheE2E\Dependency;
+
+use PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension;
+use RuntimeException;
+use function file_get_contents;
+use function file_put_contents;
+use function getmypid;
+use function hash;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function sprintf;
+use const FILE_APPEND;
+use const JSON_THROW_ON_ERROR;
+use const LOCK_EX;
+
+final class TenantConfigTypeRegistry implements ResultCacheDependencyExtension
+{
+	public function getKey(): string
+	{
+		return self::class;
+	}
+
+	public function getHash(string $dependencyKey): string
+	{
+		$pid = getmypid();
+		if ($pid === false) {
+			throw new RuntimeException('Could not determine the dependency hash process.');
+		}
+		if (file_put_contents(
+			__DIR__ . '/../tmp/hash-calls.log',
+			sprintf("%d %s %s\n", $pid, $this->getKey(), $dependencyKey),
+			FILE_APPEND | LOCK_EX,
+		) === false) {
+			throw new RuntimeException('Could not record dependency hash call.');
+		}
+
+		return hash('sha256', $this->get($dependencyKey));
+	}
+
+	public function get(string $dependencyKey): string
+	{
+		$contents = file_get_contents(__DIR__ . '/../tenant-config-types.json');
+		if ($contents === false) {
+			throw new RuntimeException('Could not read tenant configuration types.');
+		}
+		$configTypes = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+		if (!is_array($configTypes)) {
+			throw new RuntimeException('Tenant configuration types must be an object.');
+		}
+		$value = $configTypes[$dependencyKey] ?? 'missing';
+		if (!is_string($value)) {
+			throw new RuntimeException('Tenant configuration types must be strings.');
+		}
+
+		return $value;
+	}
+}

--- a/e2e/result-cache-dependency/mutate-result-cache.php
+++ b/e2e/result-cache-dependency/mutate-result-cache.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+$cacheFile = __DIR__ . '/tmp/resultCache.php';
+$contents = file_get_contents($cacheFile);
+if ($contents === false) {
+	throw new RuntimeException('Could not read result cache.');
+}
+
+$mutation = $argv[1] ?? null;
+if ($mutation === 'malformed-payload') {
+	$cache = require $cacheFile;
+	$collectedData = $cache['collectedDataCallback']();
+	$collectorType = 'PHPStan\\Collectors\\ResultCacheDependencyCollector';
+	foreach ($collectedData as $file => $collectedDataPerFile) {
+		if (!array_key_exists($collectorType, $collectedDataPerFile)) {
+			continue;
+		}
+
+		$search = substr(var_export([$file => $collectedDataPerFile], true), 8, -2);
+		$collectedDataPerFile[$collectorType] = 'malformed';
+		$replacement = substr(var_export([$file => $collectedDataPerFile], true), 8, -2);
+		break;
+	}
+} else {
+	[$search, $replacement] = match ($mutation) {
+		'unknown-provider' => [
+			"'extensionKey' => " . var_export('ResultCacheE2E\\Dependency\\ConfigTypeRegistry', true),
+			"'extensionKey' => 'missing-extension'",
+		],
+		'malformed-record' => [
+			"'dependencyKey' => 'replacement'",
+			"'dependencyKey' => array ()",
+		],
+		default => throw new RuntimeException('Unknown mutation.'),
+	};
+}
+
+if (!isset($search, $replacement)) {
+	throw new RuntimeException('Result cache did not contain dependency collected data.');
+}
+
+$contents = str_replace($search, $replacement, $contents, $count);
+if ($count === 0) {
+	throw new RuntimeException('Result-cache mutation did not match anything.');
+}
+if (file_put_contents($cacheFile, $contents) === false) {
+	throw new RuntimeException('Could not write result cache.');
+}

--- a/e2e/result-cache-dependency/phpstan.neon
+++ b/e2e/result-cache-dependency/phpstan.neon
@@ -1,0 +1,33 @@
+parameters:
+	level: max
+	tmpDir: tmp
+	paths:
+		- src
+	bootstrapFiles:
+		- bootstrap.php
+	parallel:
+		jobSize: 1
+		maximumNumberOfProcesses: 2
+		minimumNumberOfJobsPerProcess: 1
+
+services:
+	-
+		class: ResultCacheE2E\Dependency\ConfigTypeRegistry
+		tags:
+			- phpstan.resultCacheDependencyExtension
+	-
+		class: ResultCacheE2E\Dependency\TenantConfigTypeRegistry
+		tags:
+			- phpstan.resultCacheDependencyExtension
+	-
+		class: ResultCacheE2E\Dependency\ConfigResultCacheDependencyRule
+		tags:
+			- phpstan.rules.rule
+	-
+		class: ResultCacheE2E\Dependency\ConfigValueDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+	-
+		class: ResultCacheE2E\Dependency\ResultCacheDependencyDataRule
+		tags:
+			- phpstan.rules.rule

--- a/e2e/result-cache-dependency/src/Consumer.php
+++ b/e2e/result-cache-dependency/src/Consumer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+class Consumer
+{
+}
+
+function checkoutLabelLength(): int
+{
+	return strlen(configValue('checkout.label')) + strlen(configValue('checkout.label'));
+}
+
+function profileNameLength(): int
+{
+	return strlen(configValue('profile.name'));
+}
+
+function defaultConnectionValueLength(): int
+{
+	return strlen(configuredConnectionValue('database.default'));
+}

--- a/e2e/result-cache-dependency/src/Dependent.php
+++ b/e2e/result-cache-dependency/src/Dependent.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+class Dependent extends Consumer
+{
+}

--- a/e2e/result-cache-dependency/src/SecondConsumer.php
+++ b/e2e/result-cache-dependency/src/SecondConsumer.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+function secondCheckoutLabelLength(): int
+{
+	return strlen(configValue('checkout.label'));
+}

--- a/e2e/result-cache-dependency/src/TenantConsumer.php
+++ b/e2e/result-cache-dependency/src/TenantConsumer.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+function tenantCheckoutLabelLength(): int
+{
+	return strlen(tenantConfigValue('checkout.label'));
+}

--- a/e2e/result-cache-dependency/src/Unrelated.php
+++ b/e2e/result-cache-dependency/src/Unrelated.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+function unrelated(): void
+{
+}

--- a/e2e/result-cache-dependency/tenant-config-types.json
+++ b/e2e/result-cache-dependency/tenant-config-types.json
@@ -1,0 +1,3 @@
+{
+    "checkout.label": "string"
+}

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -140,6 +140,17 @@ final class AnalyserResult
 	}
 
 	/**
+	 * @param CollectorData $collectedData
+	 */
+	public function withCollectedData(array $collectedData): self
+	{
+		$self = clone $this;
+		$self->collectedData = $collectedData;
+
+		return $self;
+	}
+
+	/**
 	 * @return array<string, array<string>>|null
 	 */
 	public function getDependencies(): ?array

--- a/src/Analyser/CollectedDataEmitter.php
+++ b/src/Analyser/CollectedDataEmitter.php
@@ -6,13 +6,7 @@ use PhpParser\Node;
 use PHPStan\Collectors\Collector;
 
 /**
- * The interface CollectedDataEmitter can be typehinted in 2nd parameter of Rule::processNode():
- *
- * ```php
- * public function processNode(Node $node, Scope&CollectedDataEmitter $scope): array
- * ```
- *
- * It allows rules to emit collected data directly, without having to write
+ * CollectedDataEmitter allows rules to emit collected data directly, without having to write
  * a separate complex Collector class. The emitted data is aggregated the same way
  * as data from Collectors and can be consumed by rules registered
  * for CollectedDataNode.
@@ -23,8 +17,17 @@ use PHPStan\Collectors\Collector;
  * The referenced MyCollector class should NOT be registered
  * as a collector, unless you also want it to collect data on its own.
  *
+ * The scope passed to Rule::processNode() implements CollectedDataEmitter. Keep the native parameter type
+ * as Scope so the rule is compatible with the distributed PHPStan PHAR. Declare
+ * `@param Scope&CollectedDataEmitter $scope` in the method PHPDoc:
+ *
  * ```php
- * $scope->emitCollectedData(MyCollector::class, ['some', 'data']);
+ * public function processNode(Node $node, Scope $scope): array
+ * {
+ *     $scope->emitCollectedData(MyCollector::class, ['some', 'data']);
+ *
+ *     return [];
+ * }
  * ```
  *
  * @api

--- a/src/Analyser/ResultCache/ResultCacheDependencyExtension.php
+++ b/src/Analyser/ResultCache/ResultCacheDependencyExtension.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ResultCache;
+
+use PHPStan\DependencyInjection\ExtensionInterface;
+
+/**
+ * Calculates the current hash of an extension-defined semantic dependency.
+ *
+ * Register implementations with the `phpstan.resultCacheDependencyExtension` service tag:
+ *
+ * ```
+ * services:
+ * 	-
+ *		class: App\PHPStan\MyResultCacheDependencyExtension
+ *		tags:
+ *			- phpstan.resultCacheDependencyExtension
+ * ```
+ *
+ * Rules can associate a dependency with the file currently being analysed by emitting a record from
+ * Rule::processNode(). Keep the native parameter type as Scope and declare
+ * `@param Scope&CollectedDataEmitter $scope` in the method PHPDoc:
+ *
+ * ```php
+ * public function processNode(Node $node, Scope $scope): array
+ * {
+ *     $scope->emitCollectedData(
+ *         ResultCacheDependencyCollector::class,
+ *         ResultCacheDependencyCollector::createData($this->extension, $dependencyKey),
+ *     );
+ *
+ *     return [];
+ * }
+ * ```
+ *
+ * Emit dependencies only from Rule::processNode(). Other extension callbacks, including dynamic return
+ * type extensions, can receive scopes without an active collected-data callback.
+ * Repeated emissions of the same provider and dependency key for one file are deduplicated.
+ *
+ * If a cached hash changes, PHPStan reanalyses only files that emitted the dependency, not their ordinary
+ * PHPStan dependants. Each affected file must emit its own dependency. Use ResultCacheMetaExtension
+ * instead for state with global or indirect effects.
+ *
+ * @api
+ */
+#[ExtensionInterface(tag: self::EXTENSION_TAG)]
+interface ResultCacheDependencyExtension
+{
+
+	public const EXTENSION_TAG = 'phpstan.resultCacheDependencyExtension';
+
+	/**
+	 * Returns a globally unique, stable key identifying this dependency provider.
+	 *
+	 * The implementation class name (self::class) is recommended. Multiple instances of the same class
+	 * need distinct keys. The key must be stable across all analysis processes. Changing it makes previously
+	 * cached records unknown and reanalyses their files.
+	 */
+	public function getKey(): string;
+
+	/**
+	 * Returns a deterministic hash of the dependency identified by the opaque key.
+	 *
+	 * The key can come from an older result cache, so obsolete keys must be handled deterministically.
+	 *
+	 * The hash must describe the same state used during analysis, and that state must remain stable for
+	 * the duration of the run.
+	 *
+	 * Restoring happens before configured bootstrapFiles are executed in the main process, while saving
+	 * happens afterwards. The hash must not depend on state initialized by bootstrapFiles.
+	 *
+	 * Calls can be repeated and can happen in any order or process. They must return the same hash while
+	 * the backing state is unchanged.
+	 */
+	public function getHash(string $dependencyKey): string;
+
+}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Collectors\CollectedData;
+use PHPStan\Collectors\ResultCacheDependencyCollector;
 use PHPStan\Command\Output;
 use PHPStan\Dependency\ExportedNode\ExportedTraitNode;
 use PHPStan\Dependency\ExportedNodeFetcher;
@@ -51,6 +52,7 @@ use function implode;
 use function is_array;
 use function is_dir;
 use function is_file;
+use function is_string;
 use function ksort;
 use function microtime;
 use function sort;
@@ -80,6 +82,9 @@ final class ResultCacheManager
 	/** @var array<string, true> */
 	private array $alreadyProcessed = [];
 
+	/** @var array<string, ResultCacheDependencyExtension>|null */
+	private ?array $resultCacheDependencyExtensionsByKey = null;
+
 	/**
 	 * @param string[] $analysedPaths
 	 * @param string[] $analysedPathsFromConfig
@@ -91,10 +96,13 @@ final class ResultCacheManager
 	 * @param list<string|non-empty-list<string>> $parametersNotInvalidatingCache
 	 * @param array<string, string> $fileReplacements
 	 * @param ExtensionsCollection<ResultCacheMetaExtension> $resultCacheMetaExtensions
+	 * @param ExtensionsCollection<ResultCacheDependencyExtension> $resultCacheDependencyExtensions
 	 */
 	public function __construct(
 		#[AutowiredExtensions(of: ResultCacheMetaExtension::class)]
 		private ExtensionsCollection $resultCacheMetaExtensions,
+		#[AutowiredExtensions(of: ResultCacheDependencyExtension::class)]
+		private ExtensionsCollection $resultCacheDependencyExtensions,
 		private ExportedNodeFetcher $exportedNodeFetcher,
 		#[AutowiredParameter(ref: '@fileFinderScan')]
 		private FileFinder $scanFileFinder,
@@ -162,6 +170,10 @@ final class ResultCacheManager
 			}
 			$currentFileHashes[$analysedFile] = $this->getFileHash($analysedFile);
 		}
+
+		// Validate extension keys even when result-cache use is disabled.
+		$this->getResultCacheDependencyExtensionsByKey();
+
 		if ($debug) {
 			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache not used because of debug mode.');
@@ -701,6 +713,18 @@ final class ResultCacheManager
 			$filesToAnalyse[] = $packageSeededFile;
 		}
 
+		$resultCacheDependencySeededFiles = $this->restoreResultCacheDependencies(
+			$filteredCollectedData,
+			array_fill_keys($filesToAnalyse, true),
+		);
+
+		foreach ($resultCacheDependencySeededFiles as $resultCacheDependencySeededFile) {
+			if (!is_file($resultCacheDependencySeededFile)) {
+				continue;
+			}
+			$filesToAnalyse[] = $resultCacheDependencySeededFile;
+		}
+
 		$filesToAnalyse = array_unique($filesToAnalyse);
 		$filesToAnalyseCount = count($filesToAnalyse);
 
@@ -848,7 +872,9 @@ final class ResultCacheManager
 			$freshLocallyIgnoredErrorsByFile[$error->getFilePath()][] = $error;
 		}
 
-		$freshCollectedDataByFile = $analyserResult->getCollectedData();
+		// Hashes are cache metadata. Records received from analysis workers cannot supply them.
+		$freshCollectedDataByFile = $this->removeResultCacheDependencyHashes($analyserResult->getCollectedData());
+		$freshCollectedDataByFile = $this->deduplicateResultCacheDependencies($freshCollectedDataByFile);
 
 		$meta = $resultCache->getMeta();
 		$projectConfigArray = $meta['projectConfig'];
@@ -910,6 +936,7 @@ final class ResultCacheManager
 				}
 			}
 
+			$collectedDataByFile = $this->addResultCacheDependencyHashes($collectedDataByFile);
 			$this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles, $resultCache->getCurrentFileHashes(), $meta);
 
 			if ($output->isVeryVerbose()) {
@@ -933,12 +960,16 @@ final class ResultCacheManager
 				}
 			}
 
-			return new ResultCacheProcessResult($analyserResult, $saved);
+			return new ResultCacheProcessResult(
+				$analyserResult->withCollectedData($freshCollectedDataByFile),
+				$saved,
+			);
 		}
 
 		$errorsByFile = $this->mergeErrors($resultCache, $freshErrorsByFile);
 		$locallyIgnoredErrorsByFile = $this->mergeLocallyIgnoredErrors($resultCache, $freshLocallyIgnoredErrorsByFile);
 		$collectedDataByFile = $this->mergeCollectedData($resultCache, $freshCollectedDataByFile);
+		$collectedDataByFile = $this->deduplicateResultCacheDependencies($collectedDataByFile);
 		$dependencies = $this->mergeDependencies($resultCache->getDependencies(), $resultCache->getFilesToAnalyse(), $analyserResult->getDependencies());
 		$usedTraitDependencies = $this->mergeDependencies($resultCache->getUsedTraitDependencies(), $resultCache->getFilesToAnalyse(), $analyserResult->getUsedTraitDependencies());
 		$packageDependencies = $this->mergePackageDependencies($resultCache->getPackageDependencies(), $resultCache->getFilesToAnalyse(), $analyserResult->getPackageDependencies());
@@ -984,6 +1015,7 @@ final class ResultCacheManager
 				$flatLocallyIgnoredErrors[] = $fileError;
 			}
 		}
+		$collectedDataByFile = $this->removeResultCacheDependencyHashes($collectedDataByFile);
 
 		return new ResultCacheProcessResult(new AnalyserResult(
 			unorderedErrors: $flatErrors,
@@ -1068,6 +1100,188 @@ final class ResultCacheManager
 		}
 
 		return $collectedDataByFile;
+	}
+
+	/**
+	 * @param array<string, array<string, mixed>> $collectedData
+	 * @param array<string, true> $alreadyScheduledFiles
+	 * @return list<string>
+	 */
+	private function restoreResultCacheDependencies(array $collectedData, array $alreadyScheduledFiles): array
+	{
+		$extensions = $this->getResultCacheDependencyExtensionsByKey();
+
+		$currentHashes = [];
+		$filesToAnalyse = [];
+		foreach ($collectedData as $file => $collectedDataPerFile) {
+			if (isset($alreadyScheduledFiles[$file])) {
+				continue;
+			}
+			if (!array_key_exists(ResultCacheDependencyCollector::class, $collectedDataPerFile)) {
+				continue;
+			}
+			$records = $collectedDataPerFile[ResultCacheDependencyCollector::class];
+			if (!is_array($records)) {
+				$filesToAnalyse[] = $file;
+				continue;
+			}
+
+			foreach ($records as $record) {
+				if (
+					!is_array($record)
+					|| !isset($record['extensionKey'], $record['dependencyKey'], $record['hash'])
+					|| !is_string($record['extensionKey'])
+					|| !is_string($record['dependencyKey'])
+					|| !is_string($record['hash'])
+					|| !isset($extensions[$record['extensionKey']])
+				) {
+					$filesToAnalyse[] = $file;
+					break;
+				}
+
+				$extensionKey = $record['extensionKey'];
+				$dependencyKey = $record['dependencyKey'];
+				$currentHashes[$extensionKey][$dependencyKey] ??= $extensions[$extensionKey]->getHash($dependencyKey);
+				$currentHash = $currentHashes[$extensionKey][$dependencyKey];
+				if ($record['hash'] === $currentHash) {
+					continue;
+				}
+
+				$filesToAnalyse[] = $file;
+				break;
+			}
+		}
+
+		return $filesToAnalyse;
+	}
+
+	/**
+	 * @param CollectorData $collectedData
+	 * @return CollectorData
+	 */
+	private function addResultCacheDependencyHashes(array $collectedData): array
+	{
+		$extensions = $this->getResultCacheDependencyExtensionsByKey();
+		$currentHashes = [];
+		foreach ($collectedData as $file => $collectedDataPerFile) {
+			if (!isset($collectedDataPerFile[ResultCacheDependencyCollector::class])) {
+				continue;
+			}
+
+			$records = [];
+			foreach ($collectedDataPerFile[ResultCacheDependencyCollector::class] as $record) {
+				if (
+					!is_array($record)
+					|| !isset($record['extensionKey'], $record['dependencyKey'])
+					|| !is_string($record['extensionKey'])
+					|| !is_string($record['dependencyKey'])
+					|| !isset($extensions[$record['extensionKey']])
+					|| (isset($record['hash']) && is_string($record['hash']))
+				) {
+					$records[] = $record;
+					continue;
+				}
+
+				$extensionKey = $record['extensionKey'];
+				$dependencyKey = $record['dependencyKey'];
+				$currentHashes[$extensionKey][$dependencyKey] ??= $extensions[$extensionKey]->getHash($dependencyKey);
+				$record['hash'] = $currentHashes[$extensionKey][$dependencyKey];
+				$records[] = $record;
+			}
+			$collectedData[$file][ResultCacheDependencyCollector::class] = $records;
+		}
+
+		return $collectedData;
+	}
+
+	/**
+	 * @param CollectorData $collectedData
+	 * @return CollectorData
+	 */
+	private function removeResultCacheDependencyHashes(array $collectedData): array
+	{
+		foreach ($collectedData as $file => $collectedDataPerFile) {
+			if (!isset($collectedDataPerFile[ResultCacheDependencyCollector::class])) {
+				continue;
+			}
+
+			$records = [];
+			foreach ($collectedDataPerFile[ResultCacheDependencyCollector::class] as $record) {
+				if (is_array($record)) {
+					unset($record['hash']);
+				}
+
+				$records[] = $record;
+			}
+			$collectedData[$file][ResultCacheDependencyCollector::class] = $records;
+		}
+
+		return $collectedData;
+	}
+
+	/**
+	 * @param CollectorData $collectedData
+	 * @return CollectorData
+	 */
+	private function deduplicateResultCacheDependencies(array $collectedData): array
+	{
+		foreach ($collectedData as $file => $collectedDataPerFile) {
+			if (!isset($collectedDataPerFile[ResultCacheDependencyCollector::class])) {
+				continue;
+			}
+
+			$seen = [];
+			$records = [];
+			foreach ($collectedDataPerFile[ResultCacheDependencyCollector::class] as $record) {
+				if (
+					!is_array($record)
+					|| !isset($record['extensionKey'], $record['dependencyKey'])
+					|| !is_string($record['extensionKey'])
+					|| !is_string($record['dependencyKey'])
+				) {
+					$records[] = $record;
+					continue;
+				}
+
+				$extensionKey = $record['extensionKey'];
+				$dependencyKey = $record['dependencyKey'];
+				if (isset($seen[$extensionKey][$dependencyKey])) {
+					continue;
+				}
+
+				$seen[$extensionKey][$dependencyKey] = true;
+				$records[] = $record;
+			}
+			$collectedData[$file][ResultCacheDependencyCollector::class] = $records;
+		}
+
+		return $collectedData;
+	}
+
+	/**
+	 * @return array<string, ResultCacheDependencyExtension>
+	 * @throws ShouldNotHappenException
+	 */
+	private function getResultCacheDependencyExtensionsByKey(): array
+	{
+		if ($this->resultCacheDependencyExtensionsByKey !== null) {
+			return $this->resultCacheDependencyExtensionsByKey;
+		}
+
+		$extensions = [];
+		foreach ($this->resultCacheDependencyExtensions->getAll() as $extension) {
+			$key = $extension->getKey();
+			if (array_key_exists($key, $extensions)) {
+				throw new ShouldNotHappenException(sprintf(
+					'Duplicate ResultCacheDependencyExtension with key "%s" found.',
+					$key,
+				));
+			}
+
+			$extensions[$key] = $extension;
+		}
+
+		return $this->resultCacheDependencyExtensionsByKey = $extensions;
 	}
 
 	/**

--- a/src/Collectors/ResultCacheDependencyCollector.php
+++ b/src/Collectors/ResultCacheDependencyCollector.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Collectors;
+
+use Override;
+use PhpParser\Node;
+use PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension;
+use PHPStan\Analyser\Scope;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Marker collector for per-file result-cache dependency records emitted through CollectedDataEmitter.
+ * Do not register this class as a collector.
+ *
+ * Emitted records contain only the extension and dependency keys. ResultCacheManager calculates and
+ * adds their hashes immediately before persisting the result cache.
+ *
+ * @phpstan-type ResultCacheDependencyData array{extensionKey: string, dependencyKey: string}
+ * @implements Collector<never, ResultCacheDependencyData>
+ */
+final class ResultCacheDependencyCollector implements Collector
+{
+
+	/**
+	 * @api
+	 * @return ResultCacheDependencyData
+	 */
+	public static function createData(ResultCacheDependencyExtension $extension, string $dependencyKey): array
+	{
+		return [
+			'extensionKey' => $extension->getKey(),
+			'dependencyKey' => $dependencyKey,
+		];
+	}
+
+	#[Override]
+	public function getNodeType(): string
+	{
+		throw new ShouldNotHappenException();
+	}
+
+	#[Override]
+	public function processNode(Node $node, Scope $scope): ?array
+	{
+		throw new ShouldNotHappenException();
+	}
+
+}

--- a/tests/PHPStan/Analyser/ResultCache/ResultCacheManagerTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/ResultCacheManagerTest.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ResultCache;
+
+use PHPStan\Analyser\AnalyserResult;
+use PHPStan\Collectors\CollectedData;
+use PHPStan\Collectors\ResultCacheDependencyCollector;
+use PHPStan\Command\Output;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/** @phpstan-import-type CollectorData from CollectedData */
+class ResultCacheManagerTest extends PHPStanTestCase
+{
+
+	/** @return iterable<string, array{bool, bool}> */
+	public static function providePartialCacheSaveModes(): iterable
+	{
+		yield 'saving disabled' => [false, true];
+		yield 'save rejected because dependencies are unavailable' => [true, false];
+	}
+
+	#[DataProvider('providePartialCacheSaveModes')]
+	public function testProcessDoesNotExposeDependencyHashesWhenPartialCacheIsNotSaved(bool $save, bool $dependenciesAvailable): void
+	{
+		$file = '/analysed.php';
+		$result = $this->createManager()->process(
+			$this->createAnalyserResult([], $dependenciesAvailable ? [] : null),
+			$this->createResultCache(false, [], [
+				$file => [ResultCacheDependencyCollector::class => [[
+					'extensionKey' => 'provider',
+					'dependencyKey' => 'dependency',
+					'hash' => 'internal-cache-hash',
+				]]],
+			]),
+			$this->createStub(Output::class),
+			false,
+			$save,
+		);
+
+		$this->assertFalse($result->isSaved());
+		$this->assertSame([
+			$file => [ResultCacheDependencyCollector::class => [[
+				'extensionKey' => 'provider',
+				'dependencyKey' => 'dependency',
+			]]],
+		], $result->getAnalyserResult()->getCollectedData());
+	}
+
+	public function testProcessUsesFreshDependencyRecordInsteadOfMalformedCachedRecord(): void
+	{
+		$file = '/analysed.php';
+		$freshCollectedData = [
+			$file => [ResultCacheDependencyCollector::class => [[
+				'extensionKey' => 'provider',
+				'dependencyKey' => 'fresh-dependency',
+			]]],
+		];
+		$result = $this->createManager()->process(
+			$this->createAnalyserResult($freshCollectedData),
+			$this->createResultCache(false, [$file], [
+				$file => [ResultCacheDependencyCollector::class => [[
+					'extensionKey' => 'provider',
+					'dependencyKey' => [],
+					'hash' => 'internal-cache-hash',
+				]]],
+			]),
+			$this->createStub(Output::class),
+			false,
+			false,
+		);
+
+		$this->assertSame($freshCollectedData, $result->getAnalyserResult()->getCollectedData());
+	}
+
+	public function testProcessNormalizesFreshDependencyRecords(): void
+	{
+		$file = '/analysed.php';
+		$result = $this->createManager()->process(
+			$this->createAnalyserResult([
+				$file => [ResultCacheDependencyCollector::class => [
+					[
+						'extensionKey' => 'provider',
+						'dependencyKey' => 'dependency',
+						'hash' => 'extension-supplied',
+					],
+					[
+						'extensionKey' => 'provider',
+						'dependencyKey' => 'dependency',
+					],
+				]],
+			]),
+			$this->createResultCache(true, [$file], []),
+			$this->createStub(Output::class),
+			false,
+			false,
+		);
+
+		$this->assertSame([
+			$file => [ResultCacheDependencyCollector::class => [[
+				'extensionKey' => 'provider',
+				'dependencyKey' => 'dependency',
+			]]],
+		], $result->getAnalyserResult()->getCollectedData());
+	}
+
+	private function createManager(): ResultCacheManager
+	{
+		return self::getContainer()->getByType(ResultCacheManagerFactory::class)->create([]);
+	}
+
+	/**
+	 * @param string[] $filesToAnalyse
+	 * @param CollectorData $collectedData
+	 */
+	private function createResultCache(bool $fullAnalysis, array $filesToAnalyse, array $collectedData): ResultCache
+	{
+		return new ResultCache(
+			filesToAnalyse: $filesToAnalyse,
+			fullAnalysis: $fullAnalysis,
+			lastFullAnalysisTime: 0,
+			meta: ['projectConfig' => null],
+			errors: [],
+			locallyIgnoredErrors: [],
+			linesToIgnore: [],
+			unmatchedLineIgnores: [],
+			collectedData: $collectedData,
+			dependencies: [],
+			usedTraitDependencies: [],
+			packageDependencies: [],
+			exportedNodes: [],
+			projectExtensionFiles: [],
+			currentFileHashes: [],
+		);
+	}
+
+	/**
+	 * @param CollectorData $collectedData
+	 * @param array<string, array<string>>|null $dependencies
+	 */
+	private function createAnalyserResult(array $collectedData, ?array $dependencies = []): AnalyserResult
+	{
+		return new AnalyserResult(
+			unorderedErrors: [],
+			filteredPhpErrors: [],
+			allPhpErrors: [],
+			locallyIgnoredErrors: [],
+			linesToIgnore: [],
+			unmatchedLineIgnores: [],
+			internalErrors: [],
+			collectedData: $collectedData,
+			dependencies: $dependencies,
+			usedTraitDependencies: [],
+			packageDependencies: [],
+			exportedNodes: [],
+			reachedInternalErrorsCountLimit: false,
+			peakMemoryUsageBytes: 0,
+			processedFiles: [],
+		);
+	}
+
+}

--- a/tests/PHPStan/Collectors/ResultCacheDependencyCollectorTest.php
+++ b/tests/PHPStan/Collectors/ResultCacheDependencyCollectorTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Collectors;
+
+use PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension;
+use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework\TestCase;
+
+class ResultCacheDependencyCollectorTest extends TestCase
+{
+
+	public function testCreateDataDoesNotCalculateHash(): void
+	{
+		$extension = new class implements ResultCacheDependencyExtension {
+
+			public function getKey(): string
+			{
+				return 'provider';
+			}
+
+			public function getHash(string $dependencyKey): string
+			{
+				throw new ShouldNotHappenException();
+			}
+
+		};
+
+		$this->assertSame([
+			'extensionKey' => 'provider',
+			'dependencyKey' => 'dependency',
+		], ResultCacheDependencyCollector::createData($extension, 'dependency'));
+	}
+
+	public function testGetNodeTypeCannotBeCalled(): void
+	{
+		$this->expectException(ShouldNotHappenException::class);
+
+		(new ResultCacheDependencyCollector())->getNodeType();
+	}
+
+}

--- a/tests/PHPStan/Rules/Api/data/class-const-fetch-out-of-phpstan.php
+++ b/tests/PHPStan/Rules/Api/data/class-const-fetch-out-of-phpstan.php
@@ -21,3 +21,13 @@ class Foo
 	}
 
 }
+
+class ResultCacheDependencyUser
+{
+
+	public function doFoo()
+	{
+		echo \PHPStan\Collectors\ResultCacheDependencyCollector::class;
+	}
+
+}

--- a/tests/PHPStan/Rules/Api/data/class-implements-out-of-phpstan.php
+++ b/tests/PHPStan/Rules/Api/data/class-implements-out-of-phpstan.php
@@ -376,3 +376,6 @@ abstract class MyFunctionReflection implements FunctionReflection
 
 abstract class MyMethodReflection implements ExtendedMethodReflection
 {}
+
+abstract class MyResultCacheDependencyExtension implements \PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension
+{}

--- a/tests/PHPStan/Rules/Api/data/static-call-out-of-phpstan.php
+++ b/tests/PHPStan/Rules/Api/data/static-call-out-of-phpstan.php
@@ -44,3 +44,13 @@ class Baz extends ObjectType
 	}
 
 }
+
+class ResultCacheDependencyUser
+{
+
+	public function createData(\PHPStan\Analyser\ResultCache\ResultCacheDependencyExtension $extension): void
+	{
+		\PHPStan\Collectors\ResultCacheDependencyCollector::createData($extension, 'dependency');
+	}
+
+}


### PR DESCRIPTION
## Summary

This adds an extension point for attaching extension-defined semantic dependencies to the result of analysing a file.

An extension provides a globally unique, stable provider key. Implementations should normally return `self::class`; the explicit key also allows multiple configured instances of the same class to have separate identities. A rule records that a file used an opaque `(provider key, dependency key)` pair through `ResultCacheDependencyCollector`. When saving or restoring the result cache, PHPStan asks the registered provider to calculate the hash for that dependency. On restore, PHPStan compares the stored and current hashes and reanalyses the files that emitted a changed dependency.

The main pieces are:

- `ResultCacheDependencyExtension`, registered with the `phpstan.resultCacheDependencyExtension` tag;
- `ResultCacheDependencyCollector::createData()`, emitted through `CollectedDataEmitter` from a rule;
- result-cache handling that stores the hashes, checks them on restore, and fails closed by reanalysing the affected file when a cached record is malformed or names an unknown provider.

The collector is only a marker for data emitted by rules. It is not registered as a normal collector.

## Motivation

`ResultCacheMetaExtension` is deliberately global: when its hash changes, the whole result cache is invalidated. That is safe, but expensive for extensions backed by a large metadata source when a file only depends on one small part of it.

External file tracking, as proposed in [phpstan/phpstan-src#5364](https://github.com/phpstan/phpstan-src/pull/5364), narrows invalidation when the state is naturally represented by separate files. It does not help as much when separate semantic values are stored in one generated object or derived from several source files. Examples include the inferred validation shape of an individual FormRequest or one service/parameter in a Symfony container.

This follows the special-collector direction discussed on that PR, using `CollectedDataEmitter` to record per-file dependencies.

## Invalidation contract

A result-cache dependency represents analysis state consumed directly by a particular analysed file. It does not represent state that changes that file's exported PHP API.

Only files that emitted a changed dependency are reanalysed. Unlike the external-file proposal in [phpstan/phpstan-src#5364](https://github.com/phpstan/phpstan-src/pull/5364), their ordinary PHPStan dependants are not added automatically.

This means every file whose analysis result can be affected by the semantic state has to emit its own dependency. If an extension cannot guarantee that—for example because the state has global or indirect effects—it should continue using `ResultCacheMetaExtension`.

Dependencies must be emitted from `Rule::processNode()`. If another extension callback, such as a dynamic return-type extension, consumes the semantic state, a companion rule must recognize that use and emit the same dependency. Other extension callbacks can receive scopes without an active collected-data callback.

Dependency keys can come from an older result cache, so `getHash()` implementations also need to handle missing or obsolete keys deterministically. The API does not promise a particular call count, order, or process context. Restore can call `getHash()` before configured `bootstrapFiles` run, while save can call it afterwards, so the hash cannot depend on application state initialized by those files.

Malformed cached records and unknown provider keys reanalyse the affected file. Duplicate provider keys and exceptions thrown by `getHash()` abort the analysis instead of being treated as cache misses.

Hashes are cache metadata only. A hash supplied on a newly emitted record is discarded and recomputed through the registered provider. Repeated emissions of the same provider/key pair are stored once per file. Hashes are removed before collected data is exposed to `CollectedDataNode` rules or returned in the final analysis result, so extensions see the same record shape on cold and warm runs.

## Prototypes

The [phpstan-laravel-validation prototype](https://github.com/jbboehr/phpstan-laravel-validation/tree/result-cache-dependencies) uses the concrete FormRequest class as the dependency key. Changing one request's validation rules reanalyses that request's consumers without invalidating consumers of unrelated requests.

The opt-in [phpstan-symfony prototype](https://github.com/jbboehr/phpstan-symfony/tree/prototype/result-cache-dependencies) uses service IDs and parameter names as dependency keys, while keeping the existing global cache metadata extension enabled by default. It excludes Messenger because that return-type map also depends on handler reflection unavailable during pre-bootstrap restore; the broader safety concern in [phpstan/phpstan-symfony#455](https://github.com/phpstan/phpstan-symfony/issues/455#issuecomment-4161012853) still applies. For comparison, [phpstan/phpstan-symfony#478](https://github.com/phpstan/phpstan-symfony/pull/478) uses the earlier external-file proposal.

## Tests

The end-to-end fixture models a dynamic return-type extension backed by per-key configuration types. Coverage includes selective invalidation, malformed and obsolete records, provider isolation, deduplication, untrusted emitted hashes, and cold, warm, and partial cache runs.

I also built the PHAR and ran the external-extension fixture against it:

```bash
cd e2e/result-cache-dependency
composer install --no-interaction --no-progress
../../tmp/phpstan.phar clear-result-cache
../../tmp/phpstan.phar analyse --no-progress
../../tmp/phpstan.phar analyse --no-progress --fail-without-result-cache
```

This verifies that the fixture's rule loads with the public `Scope` method signature and that the result cache is restored on the second run.

I also ran the full PHPUnit suite, self-analysis, PHP_CodeSniffer, and the new end-to-end scenario locally.

## Benchmark

I compared a provider emitting no records with one emitting the same shared dependency key from each of 10,000 analysed files. These are 12 alternating warm runs after separate cold-cache primes on PHP 8.3.33; both configurations restored the cache with 0 files reanalysed.

| | No records | 10,000 records |
|---|---:|---:|
| Median wall time | 0.37 s | 0.42 s |
| Range | 0.36–0.37 s | 0.39–0.43 s |
| Median peak RSS | 133.2 MiB | 150.8 MiB |
| Result-cache size | 9.24 MiB | 12.52 MiB |

The 10,000 records added about 50 ms, 17.6 MiB of peak RSS, and 3.28 MiB to the cache (about 344 bytes per record). All records share one key, so `getHash()` is memoized once; this isolates record storage and restore traversal rather than provider-specific hash cost, high-cardinality keys, or the savings from narrower invalidation.

## Questions for review

- Is emitting dependencies from a companion Rule through `CollectedDataEmitter` an acceptable API? Semantic state is often consumed by another extension callback, such as a dynamic return-type extension, so the Rule has to recognize the same use independently.
- Is requiring `getHash()` to be independent of `bootstrapFiles` an acceptable limitation, or should providers be able to create a post-bootstrap snapshot that can be checked during cache restore?
- Is a provider key plus an opaque dependency key the right level of abstraction?
- Should invalidation remain limited to files that emit the dependency, or are there cases where PHPStan should also add their ordinary dependants?
- Are `ResultCacheDependencyExtension` and `ResultCacheDependencyCollector` reasonable names, given that the collector is used only as an emitted-data marker?
