### PR TITLE
Correct calling mergeWith() on the wrong scope

### DIFF
--- a/src/Analyser/CalledMethodProcessor.php
+++ b/src/Analyser/CalledMethodProcessor.php
@@ -84,7 +84,7 @@ final class CalledMethodProcessor
 		});
 
 		$calledMethodEndScope = null;
-		if ($returnStatement !== null) {
+		if ($returnStatement instanceof MethodReturnStatementsNode) {
 			foreach ($returnStatement->getExecutionEnds() as $executionEnd) {
 				$statementResult = $executionEnd->getStatementResult();
 				$endNode = $executionEnd->getNode();
@@ -95,19 +95,19 @@ final class CalledMethodProcessor
 					}
 				}
 				if ($calledMethodEndScope === null) {
-					$calledMethodEndScope = $statementResult->getScope();
+					$calledMethodEndScope = $statementResult->getScope()->toWalkScope();
 					continue;
 				}
 
-				$calledMethodEndScope = $calledMethodEndScope->mergeWith($statementResult->getScope());
+				$calledMethodEndScope = $calledMethodEndScope->mergeWith($statementResult->getScope()->toWalkScope());
 			}
 			foreach ($returnStatement->getReturnStatements() as $statement) {
 				if ($calledMethodEndScope === null) {
-					$calledMethodEndScope = $statement->getScope();
+					$calledMethodEndScope = $statement->getScope()->toWalkScope();
 					continue;
 				}
 
-				$calledMethodEndScope = $calledMethodEndScope->mergeWith($statement->getScope());
+				$calledMethodEndScope = $calledMethodEndScope->mergeWith($statement->getScope()->toWalkScope());
 			}
 		}
 

--- a/src/Analyser/StmtHandler/ClassMethodHandler.php
+++ b/src/Analyser/StmtHandler/ClassMethodHandler.php
@@ -237,7 +237,7 @@ final class ClassMethodHandler implements StmtHandler
 						continue;
 					}
 
-					$endScope = $executionEnd->getStatementResult()->getScope();
+					$endScope = $executionEnd->getStatementResult()->getScope()->toWalkScope();
 					if ($finalScope === null) {
 						$finalScope = $endScope;
 						continue;

--- a/src/Node/ClassPropertiesNode.php
+++ b/src/Node/ClassPropertiesNode.php
@@ -291,19 +291,19 @@ final class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 					}
 				}
 				if ($methodScope === null) {
-					$methodScope = $statementResult->getScope();
+					$methodScope = $statementResult->getScope()->toWalkScope();
 					continue;
 				}
 
-				$methodScope = $methodScope->mergeWith($statementResult->getScope());
+				$methodScope = $methodScope->mergeWith($statementResult->getScope()->toWalkScope());
 			}
 
 			foreach ($returnStatementsNode->getReturnStatements() as $returnStatement) {
 				if ($methodScope === null) {
-					$methodScope = $returnStatement->getScope();
+					$methodScope = $returnStatement->getScope()->toWalkScope();
 					continue;
 				}
-				$methodScope = $methodScope->mergeWith($returnStatement->getScope());
+				$methodScope = $methodScope->mergeWith($returnStatement->getScope()->toWalkScope());
 			}
 
 			if ($methodScope === null) {

--- a/src/Rules/Properties/SetNonVirtualPropertyHookAssignRule.php
+++ b/src/Rules/Properties/SetNonVirtualPropertyHookAssignRule.php
@@ -57,19 +57,19 @@ final class SetNonVirtualPropertyHookAssignRule implements Rule
 				}
 			}
 			if ($finalHookScope === null) {
-				$finalHookScope = $statementResult->getScope();
+				$finalHookScope = $statementResult->getScope()->toWalkScope();
 				continue;
 			}
 
-			$finalHookScope = $finalHookScope->mergeWith($statementResult->getScope());
+			$finalHookScope = $finalHookScope->mergeWith($statementResult->getScope()->toWalkScope());
 		}
 
 		foreach ($node->getReturnStatements() as $returnStatement) {
 			if ($finalHookScope === null) {
-				$finalHookScope = $returnStatement->getScope();
+				$finalHookScope = $returnStatement->getScope()->toWalkScope();
 				continue;
 			}
-			$finalHookScope = $finalHookScope->mergeWith($returnStatement->getScope());
+			$finalHookScope = $finalHookScope->mergeWith($returnStatement->getScope()->toWalkScope());
 		}
 
 		if ($finalHookScope === null) {

--- a/src/Rules/TooWideTypehints/TooWideParameterOutTypeCheck.php
+++ b/src/Rules/TooWideTypehints/TooWideParameterOutTypeCheck.php
@@ -38,7 +38,7 @@ final class TooWideParameterOutTypeCheck
 	{
 		$finalScope = null;
 		foreach ($executionEnds as $executionEnd) {
-			$endScope = $executionEnd->getStatementResult()->getScope();
+			$endScope = $executionEnd->getStatementResult()->getScope()->toWalkScope();
 			if ($finalScope === null) {
 				$finalScope = $endScope;
 				continue;
@@ -49,11 +49,11 @@ final class TooWideParameterOutTypeCheck
 
 		foreach ($returnStatements as $statement) {
 			if ($finalScope === null) {
-				$finalScope = $statement->getScope();
+				$finalScope = $statement->getScope()->toWalkScope();
 				continue;
 			}
 
-			$finalScope = $finalScope->mergeWith($statement->getScope());
+			$finalScope = $finalScope->mergeWith($statement->getScope()->toWalkScope());
 		}
 
 		if ($finalScope === null) {


### PR DESCRIPTION
Scope doesn't have the `mergeWith()` method, the reason this wasn't being detected was that it triggered an error when self analyzing (`dumpType()` showing `*ERROR*`) which prevented analyzing of the remaining code.