### PR TITLE
Proper handeling of unknown paths

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,12 +157,6 @@ parameters:
 			path: src/Command/CommandHelper.php
 
 		-
-			rawMessage: 'Parameter #1 $path of function dirname expects string, string|false given.'
-			identifier: argument.type
-			count: 1
-			path: src/Command/CommandHelper.php
-
-		-
 			rawMessage: 'Static property PHPStan\Command\CommandHelper::$reservedMemory is never read, only written.'
 			identifier: property.onlyWritten
 			count: 1
@@ -239,12 +233,6 @@ parameters:
 			identifier: classConstant.deprecatedClass
 			count: 1
 			path: src/DependencyInjection/NeonAdapter.php
-
-		-
-			rawMessage: 'Parameter #1 $path of function dirname expects string, string|false given.'
-			identifier: argument.type
-			count: 1
-			path: src/Diagnose/PHPStanDiagnoseExtension.php
 
 		-
 			rawMessage: 'Call to method getContent() of internal class PhpMerge\internal\Line from outside its root namespace PhpMerge.'

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -312,7 +312,11 @@ final class CommandHelper
 
 		if (class_exists('PHPStan\ExtensionInstaller\GeneratedConfig')) {
 			$generatedConfigReflection = new ReflectionClass('PHPStan\ExtensionInstaller\GeneratedConfig');
-			$generatedConfigDirectory = dirname($generatedConfigReflection->getFileName());
+			$generatedConfigFileName = $generatedConfigReflection->getFileName();
+			if ($generatedConfigFileName === false) {
+				throw new ShouldNotHappenException('PHPStan\ExtensionInstaller\GeneratedConfig is not defined in a file.');
+			}
+			$generatedConfigDirectory = dirname($generatedConfigFileName);
 			foreach (GeneratedConfig::EXTENSIONS as $name => $extensionConfig) {
 				foreach ($extensionConfig['extra']['includes'] ?? [] as $includedFile) {
 					if (!is_string($includedFile)) {

--- a/src/Diagnose/PHPStanDiagnoseExtension.php
+++ b/src/Diagnose/PHPStanDiagnoseExtension.php
@@ -12,6 +12,7 @@ use PHPStan\File\RelativePathHelper;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Php\ComposerPhpVersionFactory;
 use PHPStan\Php\PhpVersion;
+use PHPStan\ShouldNotHappenException;
 use ReflectionClass;
 use function array_count_values;
 use function array_key_exists;
@@ -133,7 +134,11 @@ final class PHPStanDiagnoseExtension
 			}
 
 			$generatedConfigReflection = new ReflectionClass('PHPStan\ExtensionInstaller\GeneratedConfig');
-			$generatedConfigDirectory = dirname($generatedConfigReflection->getFileName());
+			$generatedConfigFileName = $generatedConfigReflection->getFileName();
+			if ($generatedConfigFileName === false) {
+				throw new ShouldNotHappenException('PHPStan\ExtensionInstaller\GeneratedConfig is not defined in a file.');
+			}
+			$generatedConfigDirectory = dirname($generatedConfigFileName);
 			foreach (GeneratedConfig::EXTENSIONS as $name => $extensionConfig) {
 				$output->writeLineFormatted(sprintf('%s: %s', $name, $extensionConfig['version'] ?? 'Unknown version'));
 				foreach ($extensionConfig['extra']['includes'] ?? [] as $includedFile) {

--- a/src/Testing/TestCaseSourceLocatorFactory.php
+++ b/src/Testing/TestCaseSourceLocatorFactory.php
@@ -22,6 +22,7 @@ use ReflectionClass;
 use function dirname;
 use function hash;
 use function is_file;
+use function is_string;
 use function serialize;
 use const PHP_VERSION_ID;
 
@@ -72,7 +73,12 @@ final class TestCaseSourceLocatorFactory
 				$vendorDirProperty->setAccessible(true);
 			}
 			foreach ($classLoaders as $classLoader) {
-				$composerProjectPath = dirname($vendorDirProperty->getValue($classLoader));
+				$vendorDir = $vendorDirProperty->getValue($classLoader);
+				if (!is_string($vendorDir)) {
+					continue;
+				}
+
+				$composerProjectPath = dirname($vendorDir);
 				if (!is_file($composerProjectPath . '/composer.json')) {
 					continue;
 				}


### PR DESCRIPTION
These could potentially cause a crash, but likely won't, in any case I thought it would be better to handle them rather then simply ignoring them. One was not caught because of the surrounding type being unknown (level 8).