### PR TITLE
Remove last unused variables in catch()

### DIFF
--- a/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use Throwable;
 use function count;
 
 #[AutowiredService]
@@ -40,7 +41,7 @@ final class DateIntervalConstructorThrowTypeExtension implements DynamicStaticMe
 		foreach ($constantStrings as $constantString) {
 			try {
 				new DateInterval($constantString->getValue());
-			} catch (\Exception $e) { // phpcs:ignore
+			} catch (Throwable) {
 				return $this->exceptionType();
 			}
 

--- a/src/Type/Php/DateTimeConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateTimeConstructorThrowTypeExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use Throwable;
 use function count;
 use function in_array;
 
@@ -42,7 +43,7 @@ final class DateTimeConstructorThrowTypeExtension implements DynamicStaticMethod
 		foreach ($constantStrings as $constantString) {
 			try {
 				new DateTime($constantString->getValue());
-			} catch (\Exception $e) { // phpcs:ignore
+			} catch (Throwable) {
 				return $this->exceptionType();
 			}
 

--- a/src/Type/Php/DateTimeModifyMethodThrowTypeExtension.php
+++ b/src/Type/Php/DateTimeModifyMethodThrowTypeExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use Throwable;
 use function count;
 use function in_array;
 
@@ -47,7 +48,7 @@ final class DateTimeModifyMethodThrowTypeExtension implements DynamicMethodThrow
 			try {
 				$dateTime = new DateTime();
 				$dateTime->modify($constantString->getValue());
-			} catch (\Exception $e) { // phpcs:ignore
+			} catch (Throwable) {
 				return $this->exceptionType();
 			}
 

--- a/src/Type/Php/DateTimeZoneConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateTimeZoneConstructorThrowTypeExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use Throwable;
 use function count;
 
 #[AutowiredService]
@@ -40,7 +41,7 @@ final class DateTimeZoneConstructorThrowTypeExtension implements DynamicStaticMe
 		foreach ($constantStrings as $constantString) {
 			try {
 				new DateTimeZone($constantString->getValue());
-			} catch (\Exception $e) { // phpcs:ignore
+			} catch (Throwable) {
 				return $this->exceptionType();
 			}
 

--- a/src/Type/Php/SimpleXMLElementConstructorThrowTypeExtension.php
+++ b/src/Type/Php/SimpleXMLElementConstructorThrowTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use SimpleXMLElement;
+use Throwable;
 use function count;
 use function extension_loaded;
 use function libxml_use_internal_errors;
@@ -41,7 +42,7 @@ final class SimpleXMLElementConstructorThrowTypeExtension implements DynamicStat
 			foreach ($constantStrings as $constantString) {
 				try {
 					new SimpleXMLElement($constantString->getValue());
-				} catch (\Exception $e) { // phpcs:ignore
+				} catch (Throwable) {
 					return $methodReflection->getThrowType();
 				}
 


### PR DESCRIPTION
This also align the style of catch all around DateTime with what's been done in recent years.