### PR TITLE
Hint type blind spots

### DIFF
--- a/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
+++ b/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
@@ -801,7 +801,9 @@ final class ClosureTypeResolver implements PerFileAnalysisResettable
 
 		$callableParameters = null;
 		$nativeCallableParameters = null;
+		/** @var Node\Arg[]|null $arrayMapArgs */
 		$arrayMapArgs = $expr->getAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME);
+		/** @var Node\Arg[]|null $immediatelyInvokedArgs */
 		$immediatelyInvokedArgs = $expr->getAttribute(ImmediatelyInvokedClosureVisitor::ARGS_ATTRIBUTE_NAME);
 		if ($arrayMapArgs !== null) {
 			$callableParameters = [];

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1873,7 +1873,9 @@ class NodeScopeResolver
 
 		$processingOrder = array_keys($args);
 		usort($processingOrder, static function (int $a, int $b) use ($args): int {
+			/** @var Node\Arg|null $aOriginalArg */
 			$aOriginalArg = $args[$a]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
+			/** @var Node\Arg|null $bOriginalArg */
 			$bOriginalArg = $args[$b]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
 			$aValue = $aOriginalArg !== null ? $aOriginalArg->value : $args[$a]->value;
 			$bValue = $bOriginalArg !== null ? $bOriginalArg->value : $args[$b]->value;
@@ -1885,19 +1887,17 @@ class NodeScopeResolver
 				return $aIsClosure ? 1 : -1;
 			}
 
-			$aOriginal = $args[$a]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
-			$bOriginal = $args[$b]->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE);
-			if ($aOriginal === null && $bOriginal === null) {
+			if ($aOriginalArg === null && $bOriginalArg === null) {
 				return $a <=> $b;
 			}
-			if ($aOriginal === null) {
+			if ($aOriginalArg === null) {
 				return 1;
 			}
-			if ($bOriginal === null) {
+			if ($bOriginalArg === null) {
 				return -1;
 			}
 
-			return $aOriginal->getStartTokenPos() <=> $bOriginal->getStartTokenPos();
+			return $aOriginalArg->getStartTokenPos() <=> $bOriginalArg->getStartTokenPos();
 		});
 
 		$countStableMetadataAcceptor = null;

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -856,6 +856,18 @@ final class ResultCacheManager
 			$projectConfigArray = $this->getPathTransformer()->relativizeProjectConfig($projectConfigArray);
 			$meta['projectConfig'] = Neon::encode($projectConfigArray);
 		}
+		/**
+		 * @param array<string, list<Error>> $errorsByFile
+		 * @param array<string, list<Error>> $locallyIgnoredErrorsByFile
+		 * @param array<string, LinesToIgnore> $linesToIgnore
+		 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
+		 * @param CollectorData $collectedDataByFile
+		 * @param array<string, array<string>>|null $dependencies
+		 * @param array<string, array<string>>|null $usedTraitDependencies
+		 * @param array<string, array<string>>|null $packageDependencies
+		 * @param array<string, array<RootExportedNode>> $exportedNodes
+		 * @param array<string, array{string, bool, string}> $projectExtensionFiles
+		 */
 		$doSave = function (array $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, ?array $dependencies, ?array $usedTraitDependencies, ?array $packageDependencies, array $exportedNodes, array $projectExtensionFiles) use ($internalErrors, $resultCache, $output, $onlyFiles, $meta): bool {
 			if ($onlyFiles) {
 				if ($output->isVeryVerbose()) {

--- a/src/Analyser/ScopeOps.php
+++ b/src/Analyser/ScopeOps.php
@@ -72,7 +72,9 @@ final class ScopeOps
 			&& (($attributes['startFilePos'] ?? null) !== null)
 		) {
 			$key .= '/*' . $attributes['startFilePos'];
-			foreach ($attributes[ArrayMapArgVisitor::ATTRIBUTE_NAME] as $arg) {
+			/** @var Node\Arg[] $arrayMapArgs */
+			$arrayMapArgs = $attributes[ArrayMapArgVisitor::ATTRIBUTE_NAME];
+			foreach ($arrayMapArgs as $arg) {
 				$key .= ':' . $exprPrinter->printExpr($arg->value);
 			}
 			$key .= '*/';

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -31,6 +31,7 @@ use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Internal\DirectoryCreator;
 use PHPStan\Internal\DirectoryCreatorException;
+use PHPStan\Parser\PathRoutingParser;
 use PHPStan\Process\ForkedChildCrashReporter;
 use PHPStan\ShouldNotHappenException;
 use ReflectionClass;
@@ -602,6 +603,7 @@ final class CommandHelper
 		/** @var FileFinder $fileFinder */
 		$fileFinder = $container->getService('fileFinderAnalyse');
 
+		/** @var PathRoutingParser $pathRoutingParser */
 		$pathRoutingParser = $container->getService('pathRoutingParser');
 
 		/** @var string[] $configStubFiles */

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -6,6 +6,7 @@ use Override;
 use PHPStan\Cache\ArenaCache;
 use PHPStan\File\PathNotFoundException;
 use PHPStan\Parallel\WorkerRunner;
+use PHPStan\Parser\PathRoutingParser;
 use PHPStan\ShouldNotHappenException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -127,6 +128,7 @@ final class WorkerCommand extends Command
 		// routing is unused either way.)
 		$analysedFiles = ArenaCache::lookup('analysed-files');
 		if (is_array($analysedFiles)) {
+			/** @var PathRoutingParser $pathRoutingParser */
 			$pathRoutingParser = $container->getService('pathRoutingParser');
 			$pathRoutingParser->setAnalysedFiles($analysedFiles);
 		} else {

--- a/src/Dependency/ExportedNode/ExportedClassNode.php
+++ b/src/Dependency/ExportedNode/ExportedClassNode.php
@@ -158,6 +158,7 @@ final class ExportedClassNode implements RootExportedNode, JsonSerializable
 				return ExportedTraitUseAdaptation::decode($traitUseAdaptationData['data']);
 			}, $data['traitUseAdaptations']),
 			array_map(static function (array $node): ExportedNode {
+				/** @var class-string<ExportedNode> $nodeType */
 				$nodeType = $node['type'];
 
 				return $nodeType::decode($node['data']);

--- a/src/Dependency/ExportedNode/ExportedEnumNode.php
+++ b/src/Dependency/ExportedNode/ExportedEnumNode.php
@@ -121,6 +121,7 @@ final class ExportedEnumNode implements RootExportedNode, JsonSerializable
 			$data['phpDoc'] !== null ? ExportedPhpDocNode::decode($data['phpDoc']['data']) : null,
 			$data['implements'],
 			array_map(static function (array $node): ExportedNode {
+				/** @var class-string<ExportedNode> $nodeType */
 				$nodeType = $node['type'];
 
 				return $nodeType::decode($node['data']);

--- a/src/Dependency/ExportedNode/ExportedInterfaceNode.php
+++ b/src/Dependency/ExportedNode/ExportedInterfaceNode.php
@@ -96,6 +96,7 @@ final class ExportedInterfaceNode implements RootExportedNode, JsonSerializable
 			$data['phpDoc'] !== null ? ExportedPhpDocNode::decode($data['phpDoc']['data']) : null,
 			$data['extends'],
 			array_map(static function (array $node): ExportedNode {
+				/** @var class-string<ExportedNode> $nodeType */
 				$nodeType = $node['type'];
 
 				return $nodeType::decode($node['data']);

--- a/src/Dependency/ExportedNode/ExportedTraitNode.php
+++ b/src/Dependency/ExportedNode/ExportedTraitNode.php
@@ -137,6 +137,7 @@ final class ExportedTraitNode implements RootExportedNode, JsonSerializable
 				return ExportedTraitUseAdaptation::decode($traitUseAdaptationData['data']);
 			}, $data['traitUseAdaptations']),
 			array_map(static function (array $node): ExportedNode {
+				/** @var class-string<ExportedNode> $nodeType */
 				$nodeType = $node['type'];
 
 				return $nodeType::decode($node['data']);

--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -98,6 +98,7 @@ final class NeonAdapter implements Adapter
 				if ($val->value === Neon::CHAIN) {
 					$tmp = null;
 					foreach ($this->process($val->attributes, $fileKeyToPass, $file) as $st) {
+						/** @var Statement $st */
 						$tmp = new Statement(
 							$tmp === null ? $st->getEntity() : [$tmp, ltrim(implode('::', (array) $st->getEntity()), ':')],
 							$st->arguments,

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -344,6 +344,7 @@ final class ParallelAnalyser
 						continue;
 					}
 					$exportedNodes[$file] = array_map(static function (array $node): RootExportedNode {
+						/** @var class-string<RootExportedNode> $class */
 						$class = $node['type'];
 
 						return $class::decode($node['data']);

--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -11,6 +11,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\ContainerFactory;
 use PHPStan\DependencyInjection\DerivativeContainerFactory;
+use PHPStan\Parser\PathRoutingParser;
 use PHPStan\Rules\DirectRegistry as DirectRuleRegistry;
 use Throwable;
 use function array_fill_keys;
@@ -53,6 +54,7 @@ final class StubValidator
 			$nodeScopeResolver = $container->getByType(NodeScopeResolver::class);
 			$nodeScopeResolver->setAnalysedFiles($stubFiles);
 
+			/** @var PathRoutingParser $pathRoutingParser */
 			$pathRoutingParser = $container->getService('pathRoutingParser');
 			$pathRoutingParser->setAnalysedFiles($stubFiles);
 

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -203,6 +203,7 @@ final class ParametersAcceptorSelector
 			count($args) > 0
 			&& count($parametersAcceptors) > 0
 		) {
+			/** @var Node\Arg[]|null $arrayMapArgs */
 			$arrayMapArgs = $args[0]->value->getAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME);
 			if ($arrayMapArgs !== null) {
 				$callbackParameters = [];

--- a/src/Rules/Debug/FileAssertRule.php
+++ b/src/Rules/Debug/FileAssertRule.php
@@ -200,6 +200,7 @@ final class FileAssertRule implements Rule
 			];
 		}
 
+		/** @var TrinaryLogic $expectedCertaintyValue */
 		// @phpstan-ignore staticMethod.dynamicName
 		$expectedCertaintyValue = TrinaryLogic::{$certainty->name->toString()}();
 		$variable = $args[1]->value;

--- a/src/Testing/PHPUnit/ContainerInitializer.php
+++ b/src/Testing/PHPUnit/ContainerInitializer.php
@@ -3,10 +3,14 @@
 namespace PHPStan\Testing\PHPUnit;
 
 use PHPStan\DependencyInjection\InvalidIgnoredErrorExceptionTest;
+use PHPStan\Testing\PHPStanTestCase;
 
 final class ContainerInitializer
 {
 
+	/**
+	 * @param class-string<PHPStanTestCase> $testClassName
+	 */
 	public static function initialize(string $testClassName): void
 	{
 		// This test expects an exception during container initialization

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -134,6 +134,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				$expectedType = $args[0];
 				$this->assertInstanceOf(ConstantScalarType::class, $expectedType);
 				$expected = $expectedType->getValue();
+				/** @var Type $actualType */
 				$actualType = $args[1];
 				$actual = $actualType->describe(VerbosityLevel::precise());
 			} else {
@@ -182,7 +183,9 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				$failureMessage,
 			);
 		} elseif ($assertType === 'variableCertainty') {
+			/** @var TrinaryLogic $expectedCertainty */
 			$expectedCertainty = $args[0];
+			/** @var TrinaryLogic $actualCertainty */
 			$actualCertainty = $args[1];
 			$variableName = $args[2];
 

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -377,6 +377,7 @@ final class FileTypeMapper
 		$cached = $this->cache->load($cacheKey, $variableCacheKey);
 		if ($cached !== null) {
 			/**
+			 * @var array<string, IntermediaryNameScope> $nameScopeMap
 			 * @var array<string, string> $filesWithHashes
 			 */
 			[$nameScopeMap, $filesWithHashes] = $cached;

--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -152,6 +152,7 @@ final class RegexGroupParser
 
 	private function updateAlternationAstRemoveVerticalBarsAndAddEmptyToken(TreeNode $ast): void
 	{
+		/** @var TreeNode[] $children */
 		$children = $ast->getChildren();
 
 		foreach ($children as $i => $child) {

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -499,6 +499,9 @@ class UnionType implements CompoundType
 		if (isset($this->cachedDescriptions[$level->getLevelValue()])) {
 			return $this->cachedDescriptions[$level->getLevelValue()];
 		}
+		/**
+		 * @param Type[] $types
+		 */
 		$joinTypes = static function (array $types) use ($level): string {
 			$typeNames = [];
 			foreach ($types as $i => $type) {


### PR DESCRIPTION
This adds hints where ever variables with out a known type is used, basically this is the benefit of level 9 + 10 without having to pay the high tax.

No real issues where found, the only thing else here is the removal of a couple of redundant calls in `src/Analyser/NodeScopeResolver.php`.