### PR TITLE
Don't reuse cleaned ASTs for analysed files

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -347,6 +347,12 @@ jobs:
               composer install
               ../../bin/phpstan
           - script: |
+              cd e2e/early-reflection-extension
+              composer install
+              # The regression happens on the first reflection parse, before the reflection cache under tmp exists.
+              rm -rf tmp
+              ../../bin/phpstan
+          - script: |
               cd e2e/in-trait
               OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan --error-format=raw")
               ../bashunit -a contains 'FooTrait.php:10:Strict comparison using === between int<0, max> and false will always evaluate to false.' "$OUTPUT"

--- a/e2e/early-reflection-extension/.gitignore
+++ b/e2e/early-reflection-extension/.gitignore
@@ -1,0 +1,2 @@
+/tmp
+/vendor

--- a/e2e/early-reflection-extension/composer.json
+++ b/e2e/early-reflection-extension/composer.json
@@ -1,0 +1,8 @@
+{
+	"autoload-dev": {
+		"classmap": [
+			"extension/",
+			"src/"
+		]
+	}
+}

--- a/e2e/early-reflection-extension/composer.lock
+++ b/e2e/early-reflection-extension/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d751713988987e9331980363e24189ce",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/e2e/early-reflection-extension/extension/EarlyReflectionMethodsClassReflectionExtension.php
+++ b/e2e/early-reflection-extension/extension/EarlyReflectionMethodsClassReflectionExtension.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace EarlyReflectionExtension;
+
+use Override;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\ShouldNotHappenException;
+
+final class EarlyReflectionMethodsClassReflectionExtension implements MethodsClassReflectionExtension
+{
+
+	public function __construct(ReflectionProvider $reflectionProvider)
+	{
+		// Without a cache upgrade, this cleaned AST is reused during analysis and reports return.missing.
+		$reflectionProvider->getClass(AnalysedClass::class)->getNativeReflection();
+	}
+
+	#[Override]
+	public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+	{
+		return false;
+	}
+
+	#[Override]
+	public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+	{
+		throw new ShouldNotHappenException();
+	}
+
+}

--- a/e2e/early-reflection-extension/phpstan.neon
+++ b/e2e/early-reflection-extension/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+	level: 8
+	tmpDir: tmp
+	paths:
+		- src
+
+services:
+	-
+		class: EarlyReflectionExtension\EarlyReflectionMethodsClassReflectionExtension
+		tags:
+			- phpstan.broker.methodsClassReflectionExtension

--- a/e2e/early-reflection-extension/src/AnalysedClass.php
+++ b/e2e/early-reflection-extension/src/AnalysedClass.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace EarlyReflectionExtension;
+
+final class AnalysedClass
+{
+
+	public function getValue(): string
+	{
+		return 'value';
+	}
+
+}

--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -41,8 +41,8 @@ final class CachedParser implements Parser
 	/** @var LruCache<Node\Stmt[]> keyed by source code, weighing the length of that source */
 	private LruCache $cachedNodesByString;
 
-	/** @var array<string, true> */
-	private array $parsedByString = [];
+	/** @var array<string, true> source code parsed into the richest file representation */
+	private array $cachedNodesByStringAreRich = [];
 
 	/** @var LruCache<array{int, int, string}> path => [mtime, size, source code] */
 	private LruCache $cachedSourceByFile;
@@ -78,7 +78,18 @@ final class CachedParser implements Parser
 	{
 		$sourceCode = $this->readFile($file);
 		$cachedNodes = $this->cachedNodesByString->get($sourceCode);
-		if ($cachedNodes !== null && !isset($this->parsedByString[$sourceCode])) {
+		if ($cachedNodes !== null && isset($this->cachedNodesByStringAreRich[$sourceCode])) {
+			return $cachedNodes;
+		}
+
+		// An entry the routing parser produced before the analysed-file list
+		// arrived holds a cleaned AST. Serving it to a request that has to see
+		// the file in full is the bug this marker prevents.
+		$richRequest = !$this->originalParser instanceof PathRoutingParser
+			|| $this->originalParser->shouldUseRichParser($file);
+		if ($cachedNodes !== null && !$richRequest) {
+			// Repeated file parses have to return the same node objects. A fixable rule can
+			// locate a node through another parser caller and match it by object identity.
 			return $cachedNodes;
 		}
 
@@ -87,12 +98,13 @@ final class CachedParser implements Parser
 			// upgrade an entry previously produced by parseString() in place -
 			// no net change to the entry count, just refresh its LRU position
 			$this->cachedNodesByString->replace($sourceCode, $nodes);
-			unset($this->parsedByString[$sourceCode]);
-
-			return $nodes;
+		} else {
+			$this->store($sourceCode, $nodes);
 		}
 
-		$this->store($sourceCode, $nodes);
+		if ($richRequest) {
+			$this->cachedNodesByStringAreRich[$sourceCode] = true;
+		}
 
 		return $nodes;
 	}
@@ -109,7 +121,6 @@ final class CachedParser implements Parser
 
 		$nodes = $this->originalParser->parseString($sourceCode);
 		$this->store($sourceCode, $nodes);
-		$this->parsedByString[$sourceCode] = true;
 
 		return $nodes;
 	}
@@ -120,7 +131,7 @@ final class CachedParser implements Parser
 	private function store(string $sourceCode, array $nodes): void
 	{
 		foreach ($this->cachedNodesByString->set($sourceCode, $nodes, strlen($sourceCode)) as $evictedSourceCode) {
-			unset($this->parsedByString[$evictedSourceCode]);
+			unset($this->cachedNodesByStringAreRich[$evictedSourceCode]);
 		}
 	}
 

--- a/src/Parser/PathRoutingParser.php
+++ b/src/Parser/PathRoutingParser.php
@@ -21,6 +21,9 @@ final class PathRoutingParser implements Parser
 	/** @var array<string, true> filePath(string) => bool(true) */
 	private array $analysedFiles = [];
 
+	/** @var array<string, bool> */
+	private array $shouldUseRichParserCache = [];
+
 	public function __construct(
 		private FileHelper $fileHelper,
 		private Parser $currentPhpVersionRichParser,
@@ -38,16 +41,31 @@ final class PathRoutingParser implements Parser
 	public function setAnalysedFiles(array $files): void
 	{
 		$this->analysedFiles = array_fill_keys($files, true);
+		$this->shouldUseRichParserCache = [];
 	}
 
 	public function parseFile(string $file): array
 	{
-		$normalizedPath = $this->fileHelper->normalizePath($file, '/');
-		if (str_contains($normalizedPath, 'vendor/jetbrains/phpstorm-stubs')) {
+		if ($this->isPhp8StubFile($file)) {
 			return $this->php8Parser->parseFile($file);
 		}
-		if (str_contains($normalizedPath, 'vendor/phpstan/php-8-stubs/stubs')) {
-			return $this->php8Parser->parseFile($file);
+
+		$parser = $this->shouldUseRichParser($file)
+			? $this->currentPhpVersionRichParser
+			: $this->currentPhpVersionSimpleParser;
+
+		return $parser->parseFile($this->fileHelper->normalizePath($file));
+	}
+
+	public function shouldUseRichParser(string $file): bool
+	{
+		return $this->shouldUseRichParserCache[$file] ??= $this->resolveShouldUseRichParser($file);
+	}
+
+	private function resolveShouldUseRichParser(string $file): bool
+	{
+		if ($this->isPhp8StubFile($file)) {
+			return false;
 		}
 
 		$file = $this->fileHelper->normalizePath($file);
@@ -64,21 +82,29 @@ final class PathRoutingParser implements Parser
 				if ($realFilePath !== false) {
 					$normalizedRealFilePath = $this->fileHelper->normalizePath($realFilePath);
 					if (isset($this->analysedFiles[$normalizedRealFilePath])) {
-						return $this->currentPhpVersionRichParser->parseFile($file);
+						return true;
 					}
 				}
 				break;
 			}
 
-			return $this->currentPhpVersionSimpleParser->parseFile($file);
+			return false;
 		}
 
-		return $this->currentPhpVersionRichParser->parseFile($file);
+		return true;
 	}
 
 	public function parseString(string $sourceCode): array
 	{
 		return $this->currentPhpVersionSimpleParser->parseString($sourceCode);
+	}
+
+	private function isPhp8StubFile(string $file): bool
+	{
+		$normalizedPath = $this->fileHelper->normalizePath($file, '/');
+
+		return str_contains($normalizedPath, 'vendor/jetbrains/phpstorm-stubs')
+			|| str_contains($normalizedPath, 'vendor/phpstan/php-8-stubs/stubs');
 	}
 
 }

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -198,6 +198,68 @@ class CachedParserTest extends PHPStanTestCase
 		$this->assertSame(2, $stmts[0]->stmts[1]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
 	}
 
+	public function testParseFileBeforeAnalysedFilesAreSet(): void
+	{
+		$fileHelper = self::getContainer()->getByType(FileHelper::class);
+		$pathRoutingParser = new PathRoutingParser(
+			$fileHelper,
+			self::getContainer()->getService('currentPhpVersionRichParser'),
+			self::getContainer()->getService('currentPhpVersionSimpleDirectParser'),
+			self::getContainer()->getService('php8Parser'),
+			null,
+		);
+		$parser = new CachedParser($pathRoutingParser, 500, 4194304);
+		$path = $fileHelper->normalizePath(__DIR__ . '/data/test.php');
+
+		$stmts = $parser->parseFile($path);
+		$this->assertInstanceOf(Namespace_::class, $stmts[0]);
+		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
+		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
+		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
+		$this->assertNull($stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+
+		$pathRoutingParser->setAnalysedFiles([$path]);
+
+		$stmts = $parser->parseFile($path);
+		$this->assertInstanceOf(Namespace_::class, $stmts[0]);
+		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
+		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
+		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
+		$this->assertSame(1, $stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+	}
+
+	public function testParseStringEntryIsNotUpgradedBeforeAnalysedFilesAreSet(): void
+	{
+		$fileHelper = self::getContainer()->getByType(FileHelper::class);
+		$pathRoutingParser = new PathRoutingParser(
+			$fileHelper,
+			self::getContainer()->getService('currentPhpVersionRichParser'),
+			self::getContainer()->getService('currentPhpVersionSimpleDirectParser'),
+			self::getContainer()->getService('php8Parser'),
+			null,
+		);
+		$parser = new CachedParser($pathRoutingParser, 500, 4194304);
+		$path = $fileHelper->normalizePath(__DIR__ . '/data/test.php');
+
+		$stringStmts = $parser->parseString(FileReader::read($path));
+		$stmts = $parser->parseFile($path);
+		$this->assertSame($stringStmts, $stmts);
+		$this->assertInstanceOf(Namespace_::class, $stmts[0]);
+		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
+		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
+		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
+		$this->assertNull($stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+
+		$pathRoutingParser->setAnalysedFiles([$path]);
+
+		$stmts = $parser->parseFile($path);
+		$this->assertInstanceOf(Namespace_::class, $stmts[0]);
+		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
+		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
+		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
+		$this->assertSame(1, $stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+	}
+
 	public function testWithExprCacheHelper(): void
 	{
 		$fileHelper = self::getContainer()->getByType(FileHelper::class);


### PR DESCRIPTION
`PathRoutingParser` can't choose the parser for analysed files until the analysed file list is set. If an eagerly created extension uses `ReflectionProvider` in its constructor, `CachedParser` can store a cleaned AST and return it later during analysis. The affected extension types are property and method class reflection extensions, dynamic function, method, and static method return type extensions, and function, method, and static method type-specifying extensions. Rules and collectors are created after the analysed file list is set, so they can't trigger it.

This PR tracks whether cached ASTs contain the full file representation and upgrades cleaned entries when an analysed file needs one. It adds unit coverage for both cache entry paths and an e2e case for early reflection. In a cold Hypervel analysis, the new per-process route memo reached at most 1,787 entries.
