### PR TITLE
E2E test for turbo libc detection

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -886,6 +886,31 @@ jobs:
                 echo "FAIL: tmp was created by a worker, meaning sys_temp_dir='tmp~1' was incorrectly evaluated to 'tmp'"
                 exit 1
               fi
+          - script: |
+              # A glibc system can carry a musl loader without being a musl system:
+              # musl-tools, a musl cross-compilation sysroot, or anything else built
+              # against musl installs /lib/ld-musl-<arch>.so.1 as well. PHPStan must
+              # still pick the glibc turbo build there - picking the musl one makes
+              # PHP refuse to load the extension at startup: "Unable to load dynamic
+              # library '.../linux-musl-x86_64/phpstan_turbo-8.5.so'
+              # (libc.musl-x86_64.so.1: cannot open shared object file)".
+              sudo touch /lib/ld-musl-x86_64.so.1
+              OUTPUT=$(bin/phpstan diagnose -l 0 -c tests/e2e/data/empty.neon)
+              echo "$OUTPUT"
+              e2e/bashunit -a contains 'Turbo platform: linux-gnu-' "$OUTPUT"
+          - script: |
+              # The mirror image of the leg above: an actual musl system must keep
+              # picking the musl build - both on Alpine, and (since /etc/alpine-release
+              # is not what makes a system musl) with that file taken away. The images
+              # ship no php.ini, so memory_limit would default to 128M, which building
+              # the DI container already exceeds.
+              DIAGNOSE='php -d memory_limit=-1 bin/phpstan diagnose -l 0 -c tests/e2e/data/empty.neon'
+              OUTPUT=$(docker run --rm -v "$PWD:/repo" -w /repo php:8.2-cli-alpine sh -c "$DIAGNOSE")
+              echo "$OUTPUT"
+              e2e/bashunit -a contains 'Turbo platform: linux-musl-' "$OUTPUT"
+              OUTPUT=$(docker run --rm -v "$PWD:/repo" -w /repo php:8.2-cli-alpine sh -c "rm /etc/alpine-release && $DIAGNOSE")
+              echo "$OUTPUT"
+              e2e/bashunit -a contains 'Turbo platform: linux-musl-' "$OUTPUT"
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
Test-only PR: the first of the three new E2E legs is **expected to be red** on 2.2.x. It reproduces what #6308 fixes.

### How it reproduces

`TurboExtensionSelector` decides between the glibc and the musl turbo build by looking at the filesystem, so it can only be exercised on a real system whose libc is what it is. No fixture needed — `phpstan diagnose` already prints the verdict:

```
Turbo platform: linux-gnu-x86_64 (os: Linux, machine: x86_64, libc: gnu, php: 8.2, zts: no, debug: no)
```

Three legs:

| leg | environment | expected | on 2.2.x |
| --- | --- | --- | --- |
| 1 | glibc runner with `/lib/ld-musl-x86_64.so.1` present | `linux-gnu-*` | ❌ says `linux-musl-x86_64`, `libc: musl` |
| 2a | `php:8.2-cli-alpine` | `linux-musl-*` | ✅ |
| 2b | `php:8.2-cli-alpine` with `/etc/alpine-release` removed | `linux-musl-*` | ✅ |

Leg 1 creates the loader file with `sudo touch`: that is exactly what the `musl` / `musl-tools` package or a musl cross-compilation sysroot leaves at that path, and exactly what `glob('/lib/ld-musl-*')` looks at. Legs 2a/2b are the mirror image — they guard that the fix does not lose musl detection, 2b specifically that it does not fall back to depending on `/etc/alpine-release`.

### Verified locally

Same three commands under Docker. Against the current `2.2.x` selector:

```
glibc + musl loader on disk    -> Turbo platform: linux-musl-x86_64 (... libc: musl ...)   wrong
alpine                         -> Turbo platform: linux-musl-x86_64 (... libc: musl ...)
alpine, no /etc/alpine-release -> Turbo platform: linux-musl-x86_64 (... libc: musl ...)
```

Against the selector from #6308:

```
glibc + musl loader on disk    -> Turbo platform: linux-gnu-x86_64  (... libc: gnu ...)
alpine                         -> Turbo platform: linux-musl-x86_64 (... libc: musl ...)
alpine, no /etc/alpine-release -> Turbo platform: linux-musl-x86_64 (... libc: musl ...)
```