### PR TITLE
Survive the shared-memory arena running out of space, and report workers killed by a signal

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -911,6 +911,17 @@ jobs:
               OUTPUT=$(docker run --rm -v "$PWD:/repo" -w /repo php:8.2-cli-alpine sh -c "rm /etc/alpine-release && $DIAGNOSE")
               echo "$OUTPUT"
               e2e/bashunit -a contains 'Turbo platform: linux-musl-' "$OUTPUT"
+          - script: |
+              # A parallel worker killed by a signal writes nothing of its own -
+              # no PHP error, no shutdown function, an empty capture file. The
+              # main process has to name the signal; treating the dead worker
+              # like one that quit cleanly leaves the whole run with nothing but
+              # "Some parallel worker jobs have not finished", which is what made
+              # https://github.com/phpstan/phpstan/issues/15131 undiagnosable.
+              cd e2e/parallel-worker-signal
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan analyse --no-progress")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'killed by signal 9 (SIGKILL)' "$OUTPUT"
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -938,3 +949,77 @@ jobs:
 
       - name: "Test"
         run: ${{ matrix.script }}
+
+  turbo-arena-e2e-tests:
+    name: "Turbo arena E2E tests"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: "Checkout"
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # the extension bakes its version from `git log -- turbo-ext/src`, and
+          # TurboExtensionEnabler activates only the expected version - a shallow
+          # clone hands us a "dev" build, which would skip the whole test
+          fetch-depth: 0
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
+        with:
+          coverage: "none"
+          php-version: "8.5"
+
+      - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
+
+      - name: "Install bashunit"
+        uses: "TypedDevs/bashunit@94933c088b0719e0c4cf5e3147dad67f713b970d" # 0.44.0
+        with:
+          directory: "e2e"
+
+      - name: "Build the turbo extension"
+        run: make -C turbo-ext -j"$(nproc)"
+
+      - name: "Verify the arena is actually exercised"
+        # Without an active extension ArenaCache is the no-op PHP twin and no
+        # shared memory exists at all; without fork the workers do not publish in
+        # lockstep. Either would make the test below pass for the wrong reason.
+        run: |
+          OUTPUT=$(php -d extension="$PWD/turbo-ext/phpstan_turbo.so" bin/phpstan diagnose -c e2e/turbo-arena/phpstan.neon)
+          echo "$OUTPUT"
+          e2e/bashunit -a contains 'Turbo extension: enabled' "$OUTPUT"
+          e2e/bashunit -a contains 'Mechanism:                 fork (pcntl_fork)' "$OUTPUT"
+
+      - name: "Test"
+        # The arena is a per-run POSIX shared-memory object: shm_open() plus an
+        # ftruncate() to 256 MB that tmpfs honours sparsely, committing pages on
+        # first touch. When the backing store cannot commit one, the worker that
+        # touches it takes SIGBUS and dies where it stands. 64 MB is what docker
+        # gives /dev/shm by default, which is how
+        # https://github.com/phpstan/phpstan/issues/15131 reached users; 32 MB
+        # makes it deterministic on a 4-core runner. Running out of shared memory
+        # must cost sharing, never results - the analysis has to come out exactly
+        # as it does with the runner's normal /dev/shm.
+        run: |
+          SO="$PWD/turbo-ext/phpstan_turbo.so"
+          cd e2e/turbo-arena
+          rm -rf tmp
+          php -d extension="$SO" ../../bin/phpstan analyse --no-progress > "$RUNNER_TEMP/reference.txt" 2>&1 || true
+          tail -5 "$RUNNER_TEMP/reference.txt"
+          # a warm disk cache is the worst case: every worker loads and publishes
+          # the same entries at the same moment, so duplicates pile up fastest
+          php -d extension="$SO" ../../bin/phpstan clear-result-cache
+          sudo mount -o remount,size=32M /dev/shm
+          df -h /dev/shm
+          php -d extension="$SO" ../../bin/phpstan analyse --no-progress > "$RUNNER_TEMP/small-shm.txt" 2>&1 || true
+          tail -40 "$RUNNER_TEMP/small-shm.txt"
+          # bashunit takes the haystack as a single argv entry, and execve caps
+          # one argument at 128 KB - a few hundred KB of analysis output only
+          # fits through the assertion once grep has narrowed it down
+          ../bashunit -a not_contains 'parallel worker' "$(grep -F 'parallel worker' "$RUNNER_TEMP/small-shm.txt" || true)"
+          diff "$RUNNER_TEMP/reference.txt" "$RUNNER_TEMP/small-shm.txt"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 tmp/.memory_limit
 e2e/bashunit
 /.phpbench
+/e2e/turbo-arena/tmp

--- a/e2e/parallel-worker-signal/kill-worker.php
+++ b/e2e/parallel-worker-signal/kill-worker.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+// Kills the parallel worker the way a native crash does: a signal, with no PHP
+// error, no shutdown function, and nothing written to the output the main
+// process reads back. That is how the shared-memory arena's SIGBUS killed
+// workers in https://github.com/phpstan/phpstan/issues/15131, and the main
+// process must say so instead of treating the dead worker like one that quit.
+
+use PHPStan\Process\ForkedChildCrashReporter;
+
+// A forked worker has the main process's argv; a spawned one runs the worker
+// command. Killing the main process instead would prove nothing.
+$isWorker = ForkedChildCrashReporter::isActive()
+	|| in_array('worker', $_SERVER['argv'], true);
+
+if (!$isWorker) {
+	return;
+}
+
+posix_kill(posix_getpid(), SIGKILL);

--- a/e2e/parallel-worker-signal/phpstan.neon
+++ b/e2e/parallel-worker-signal/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: 0
+	paths:
+		- test.php
+	bootstrapFiles:
+		- kill-worker.php

--- a/e2e/parallel-worker-signal/test.php
+++ b/e2e/parallel-worker-signal/test.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace ParallelWorkerSignal;
+
+class Foo
+{
+
+	public function doFoo(): int
+	{
+		return 1;
+	}
+
+}

--- a/e2e/turbo-arena/phpstan.neon
+++ b/e2e/turbo-arena/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+	level: 0
+	tmpDir: tmp
+	paths:
+		- ../../src
+	scanFiles:
+		- ../../turbo-ext/analysis-stub.php

--- a/src/Parallel/ForkedProcess.php
+++ b/src/Parallel/ForkedProcess.php
@@ -16,6 +16,8 @@ use function pcntl_fork;
 use function pcntl_waitpid;
 use function pcntl_wexitstatus;
 use function pcntl_wifexited;
+use function pcntl_wifsignaled;
+use function pcntl_wtermsig;
 use function rewind;
 use function stream_get_contents;
 use function tmpfile;
@@ -63,7 +65,7 @@ final class ForkedProcess extends ProcessBase
 	/**
 	 * @param callable(mixed[] $json) : void $onData
 	 * @param callable(Throwable $exception): void $onError
-	 * @param callable(?int $exitCode, string $output) : void $onExit
+	 * @param callable(?int $exitCode, string $output, ?int $termSignal) : void $onExit
 	 */
 	public function start(callable $onData, callable $onError, callable $onExit): void
 	{
@@ -89,7 +91,7 @@ final class ForkedProcess extends ProcessBase
 			// Deferred so it runs after ParallelAnalyser has attached this
 			// process to the pool — otherwise tryQuitProcess() would no-op.
 			$this->loop->futureTick(static function () use ($onExit): void {
-				$onExit(null, 'pcntl_fork() failed.');
+				$onExit(null, 'pcntl_fork() failed.', null);
 			});
 			return;
 		}
@@ -140,10 +142,16 @@ final class ForkedProcess extends ProcessBase
 			$this->cancelTimer();
 
 			$exitCode = null;
+			$termSignal = null;
 			if ($result > 0 && pcntl_wifexited($status)) {
 				$exitStatus = pcntl_wexitstatus($status);
 				if ($exitStatus !== false) {
 					$exitCode = $exitStatus;
+				}
+			} elseif ($result > 0 && pcntl_wifsignaled($status)) {
+				$signal = pcntl_wtermsig($status);
+				if ($signal !== false) {
+					$termSignal = $signal;
 				}
 			}
 
@@ -158,7 +166,7 @@ final class ForkedProcess extends ProcessBase
 			}
 			$this->closeCaptureFiles();
 
-			$onExit($exitCode, $output);
+			$onExit($exitCode, $output, $termSignal);
 		});
 	}
 

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -15,6 +15,7 @@ use PHPStan\Dependency\RootExportedNode;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Process\ProcessHelper;
+use PHPStan\Process\TerminationSignal;
 use PHPStan\Reflection\BetterReflection\SourceLocator\PreForkDirectorySymbolScanner;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
@@ -386,7 +387,7 @@ final class ParallelAnalyser
 
 				$job = array_pop($jobs);
 				$process->request(['action' => 'analyse', 'files' => $job]);
-			}, $handleError, function ($exitCode, string $output) use (&$someChildEnded, &$internalErrors, &$internalErrorsCount, $processIdentifier): void {
+			}, $handleError, function ($exitCode, string $output, ?int $termSignal) use (&$someChildEnded, &$internalErrors, &$internalErrorsCount, $processIdentifier): void {
 				// The main process is not sampled here any more: its own peak comes
 				// later (collecting the workers' results, saving the result cache) and
 				// is read where the number is printed. Only worker peaks are summed.
@@ -396,7 +397,30 @@ final class ParallelAnalyser
 					$this->processPool->tryQuitProcess($processIdentifier);
 					return;
 				}
+
+				// A worker killed by a signal never gets to run any PHP: no error
+				// is printed, no shutdown function runs, and the output the main
+				// process reads back is empty. The signal is the whole report -
+				// without it the run says nothing but "Some parallel worker jobs
+				// have not finished", or, when the dead worker was holding the
+				// last job, nothing at all.
+				if ($termSignal !== null) {
+					$internalErrors[] = new InternalError(sprintf(
+						"Child process was killed by signal %s.\n%s%s",
+						TerminationSignal::describe($termSignal),
+						'The OS kills a worker this way when it runs out of memory (the kernel OOM killer sends SIGKILL) or shared memory (SIGBUS), or when it crashes natively (SIGSEGV).',
+						$output === '' ? '' : "\n" . $output,
+					), 'running parallel worker', trace: [], traceAsString: null, shouldReportBug: false);
+					$internalErrorsCount++;
+					$this->processPool->tryQuitProcess($processIdentifier);
+					return;
+				}
+
 				if ($exitCode === null) {
+					if ($output !== '') {
+						$internalErrors[] = new InternalError(sprintf('Child process ended unexpectedly: %s', $output), 'running parallel worker', trace: [], traceAsString: null, shouldReportBug: true);
+						$internalErrorsCount++;
+					}
 					$this->processPool->tryQuitProcess($processIdentifier);
 					return;
 				}

--- a/src/Parallel/Process.php
+++ b/src/Parallel/Process.php
@@ -19,9 +19,13 @@ interface Process
 {
 
 	/**
+	 * $onExit receives the worker's exit code, everything it wrote, and the
+	 * signal it was killed by - a worker killed by one has no exit code and
+	 * writes nothing, so the signal is all there is to report about it.
+	 *
 	 * @param callable(mixed[] $json) : void $onData
 	 * @param callable(Throwable $exception): void $onError
-	 * @param callable(?int $exitCode, string $output) : void $onExit
+	 * @param callable(?int $exitCode, string $output, ?int $termSignal) : void $onExit
 	 */
 	public function start(callable $onData, callable $onError, callable $onExit): void;
 

--- a/src/Parallel/SpawnedProcess.php
+++ b/src/Parallel/SpawnedProcess.php
@@ -40,7 +40,7 @@ final class SpawnedProcess extends ProcessBase
 	/**
 	 * @param callable(mixed[] $json) : void $onData
 	 * @param callable(Throwable $exception): void $onError
-	 * @param callable(?int $exitCode, string $output) : void $onExit
+	 * @param callable(?int $exitCode, string $output, ?int $termSignal) : void $onExit
 	 */
 	public function start(callable $onData, callable $onError, callable $onExit): void
 	{
@@ -60,7 +60,7 @@ final class SpawnedProcess extends ProcessBase
 		]);
 		$this->process->start($this->loop);
 		$this->setCallbacks($onData, $onError);
-		$this->process->on('exit', function ($exitCode) use ($onExit): void {
+		$this->process->on('exit', function ($exitCode, $termSignal) use ($onExit): void {
 			$this->cancelTimer();
 
 			$output = '';
@@ -70,7 +70,7 @@ final class SpawnedProcess extends ProcessBase
 			rewind($this->stdErr);
 			$output .= stream_get_contents($this->stdErr);
 
-			$onExit($exitCode, $output);
+			$onExit($exitCode, $output, $termSignal);
 			fclose($this->stdOut);
 			fclose($this->stdErr);
 		});

--- a/src/Process/ForkedProcessPromise.php
+++ b/src/Process/ForkedProcessPromise.php
@@ -20,8 +20,11 @@ use function pcntl_fork;
 use function pcntl_waitpid;
 use function pcntl_wexitstatus;
 use function pcntl_wifexited;
+use function pcntl_wifsignaled;
+use function pcntl_wtermsig;
 use function posix_kill;
 use function rewind;
+use function sprintf;
 use function stream_get_contents;
 use function tmpfile;
 use const SIGTERM;
@@ -165,6 +168,20 @@ final class ForkedProcessPromise implements ProcessPromise
 			if ($exitCode === 0) {
 				$this->deferred->resolve($stdOut);
 				return;
+			}
+
+			// A child killed by a signal writes nothing of its own, so naming
+			// the signal is all the crash report there is.
+			if ($result > 0 && pcntl_wifsignaled($status)) {
+				$signal = pcntl_wtermsig($status);
+				if ($signal !== false) {
+					$this->deferred->reject(new ProcessCrashedException(sprintf(
+						"Child process was killed by signal %s.\n%s",
+						TerminationSignal::describe($signal),
+						$stdOut . $stdErr,
+					)));
+					return;
+				}
 			}
 
 			$this->deferred->reject(new ProcessCrashedException($stdOut . $stdErr));

--- a/src/Process/TerminationSignal.php
+++ b/src/Process/TerminationSignal.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use function constant;
+use function defined;
+use function sprintf;
+
+/**
+ * Names the signal a child process was killed by, for an error message.
+ *
+ * Signal numbers are platform-specific - SIGBUS is 7 on Linux and 10 on macOS
+ * - so the names come from the running platform's own SIG* constants. Those
+ * are defined by ext-pcntl, hence the bare number when it is not loaded.
+ */
+final class TerminationSignal
+{
+
+	/**
+	 * Ordered so that the canonical name wins among the aliases sharing a
+	 * number (SIGABRT over SIGIOT, SIGCHLD over SIGCLD, SIGIO over SIGPOLL).
+	 */
+	private const NAMES = [
+		'SIGHUP',
+		'SIGINT',
+		'SIGQUIT',
+		'SIGILL',
+		'SIGTRAP',
+		'SIGABRT',
+		'SIGBUS',
+		'SIGFPE',
+		'SIGKILL',
+		'SIGUSR1',
+		'SIGSEGV',
+		'SIGUSR2',
+		'SIGPIPE',
+		'SIGALRM',
+		'SIGTERM',
+		'SIGSTKFLT',
+		'SIGCHLD',
+		'SIGCONT',
+		'SIGSTOP',
+		'SIGTSTP',
+		'SIGTTIN',
+		'SIGTTOU',
+		'SIGURG',
+		'SIGXCPU',
+		'SIGXFSZ',
+		'SIGVTALRM',
+		'SIGPROF',
+		'SIGWINCH',
+		'SIGIO',
+		'SIGPWR',
+		'SIGSYS',
+	];
+
+	public static function describe(int $signal): string
+	{
+		foreach (self::NAMES as $name) {
+			if (!defined($name) || constant($name) !== $signal) {
+				continue;
+			}
+
+			return sprintf('%d (%s)', $signal, $name);
+		}
+
+		return (string) $signal;
+	}
+
+}

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -22,7 +22,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '2659ad4';
+	public const EXPECTED_EXTENSION_VERSION = '7435abf';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/tests/PHPStan/Process/TerminationSignalTest.php
+++ b/tests/PHPStan/Process/TerminationSignalTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use PHPStan\Testing\PHPStanTestCase;
+use function defined;
+use function sprintf;
+use const SIGBUS;
+use const SIGKILL;
+
+final class TerminationSignalTest extends PHPStanTestCase
+{
+
+	public function testKnownSignal(): void
+	{
+		if (!defined('SIGKILL')) {
+			self::markTestSkipped('Requires ext-pcntl for the SIG* constants.');
+		}
+
+		$this->assertSame('9 (SIGKILL)', TerminationSignal::describe(SIGKILL));
+	}
+
+	public function testPlatformSpecificNumber(): void
+	{
+		if (!defined('SIGBUS')) {
+			self::markTestSkipped('Requires ext-pcntl for the SIG* constants.');
+		}
+
+		// 7 on Linux, 10 on macOS - the name has to come from the platform's
+		// own constant rather than a table of numbers.
+		$this->assertSame(sprintf('%d (SIGBUS)', SIGBUS), TerminationSignal::describe(SIGBUS));
+	}
+
+	public function testUnknownSignal(): void
+	{
+		$this->assertSame('4242', TerminationSignal::describe(4242));
+	}
+
+}

--- a/turbo-ext/src/ArenaCache.cpp
+++ b/turbo-ext/src/ArenaCache.cpp
@@ -60,16 +60,30 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <unistd.h>
 #endif
 
 namespace phpstanturbo {
 
-/* Total mapped size per run. Virtual reservation only: POSIX shm and Windows
+/* Largest mapped size per run. Virtual reservation only: POSIX shm and Windows
  * pagefile sections allocate physical pages on first touch, so an idle arena
  * costs a few pages. When the cursor passes the end, publishing stops and
  * analysis continues unshared. */
 static constexpr uint64_t ARENA_SIZE_LIMIT = 256ULL << 20;
+
+/* POSIX shm is a tmpfs file: ftruncate() to ARENA_SIZE_LIMIT succeeds however
+ * little space that filesystem has, because the file is sparse, and the
+ * shortfall only surfaces as SIGBUS on the first touch of a page it cannot
+ * back. A worker dies on the spot then, with no PHP error and nothing written
+ * - which is what phpstan/phpstan#15131 was: docker gives /dev/shm 64 MB by
+ * default. So the arena is sized to what the backing filesystem can actually
+ * give, and running out of it costs sharing (the cursor passes the end and
+ * publishing stops) instead of workers. The reserve keeps the arena from
+ * claiming the last of a filesystem others are using too, and below the
+ * minimum there is not enough to be worth sharing at all. */
+static constexpr uint64_t ARENA_BACKING_RESERVE_LIMIT = 8ULL << 20;
+static constexpr uint64_t ARENA_MIN_SIZE_LIMIT = 4ULL << 20;
 
 /* Top-level index: open-addressed table of 8-byte slots (record offsets).
  * Sized for the record *count* (records are whole maps/blobs, not entries):
@@ -954,14 +968,46 @@ static bool runIdValid(zend_string *runId)
 	return true;
 }
 
-static bool headerValid(const ArenaHeader *header)
+static bool headerValid(const ArenaHeader *header, uint64_t mappedSize)
 {
 	return header->magic == ARENA_MAGIC
 		&& header->formatVersion == ARENA_FORMAT_VERSION
-		&& header->totalSize == ARENA_SIZE_LIMIT
+		&& header->totalSize == mappedSize
 		&& header->indexOffset == INDEX_OFFSET
 		&& header->indexSlotCount == INDEX_SLOT_COUNT;
 }
+
+#ifndef _WIN32
+/* How much of the shm filesystem the arena may take, or 0 when what is left
+ * is not worth an arena. Failing to stat it is not a reason to give up - the
+ * platform may not report anything useful (macOS shm is not a filesystem at
+ * all), and the pre-existing behaviour of reserving the full limit is no
+ * worse there than it has always been. */
+static uint64_t backedArenaSize(int fd)
+{
+	struct statvfs backing;
+	if (fstatvfs(fd, &backing) != 0) {
+		return ARENA_SIZE_LIMIT;
+	}
+
+	uint64_t blockSize = backing.f_frsize != 0 ? (uint64_t) backing.f_frsize : (uint64_t) backing.f_bsize;
+	uint64_t available = (uint64_t) backing.f_bavail * blockSize;
+	if (blockSize == 0 || available <= ARENA_BACKING_RESERVE_LIMIT) {
+		return 0;
+	}
+
+	uint64_t size = available - ARENA_BACKING_RESERVE_LIMIT;
+	if (size < ARENA_MIN_SIZE_LIMIT) {
+		return 0;
+	}
+	if (size > ARENA_SIZE_LIMIT) {
+		return ARENA_SIZE_LIMIT;
+	}
+
+	/* the index is indexed off page-aligned offsets; keep the tail whole */
+	return size & ~(uint64_t) 4095;
+}
+#endif
 
 class ArenaCache
 {
@@ -974,6 +1020,9 @@ public:
 		}
 
 #ifdef _WIN32
+		// a pagefile-backed section is committed when it is created, so
+		// Windows either backs the whole reservation or fails right here
+		uint64_t size = ARENA_SIZE_LIMIT;
 		char name[64];
 		snprintf(name, sizeof(name), "Local\\phpstan-%s", ZSTR_VAL(runId));
 		HANDLE section = CreateFileMappingA(
@@ -1003,12 +1052,18 @@ public:
 		if (fd < 0) {
 			return;
 		}
-		if (ftruncate(fd, (off_t) ARENA_SIZE_LIMIT) != 0) {
+		uint64_t size = backedArenaSize(fd);
+		if (size == 0) {
 			close(fd);
 			shm_unlink(name);
 			return;
 		}
-		void *base = mmap(NULL, ARENA_SIZE_LIMIT, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		if (ftruncate(fd, (off_t) size) != 0) {
+			close(fd);
+			shm_unlink(name);
+			return;
+		}
+		void *base = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 		close(fd);
 		if (base == MAP_FAILED) {
 			shm_unlink(name);
@@ -1017,7 +1072,7 @@ public:
 #endif
 
 		pt_arena_base = base;
-		pt_arena_total = ARENA_SIZE_LIMIT;
+		pt_arena_total = size;
 		pt_arena_creator = true;
 		pt_arena_name_unlinked = false;
 		snprintf(pt_arena_name, sizeof(pt_arena_name), "%s", name);
@@ -1028,7 +1083,7 @@ public:
 		ArenaHeader *header = arenaHeader();
 		header->magic = ARENA_MAGIC;
 		header->formatVersion = ARENA_FORMAT_VERSION;
-		header->totalSize = ARENA_SIZE_LIMIT;
+		header->totalSize = size;
 		header->indexOffset = INDEX_OFFSET;
 		header->indexSlotCount = INDEX_SLOT_COUNT;
 		header->allocCursor = arenaDataStart();
@@ -1050,6 +1105,7 @@ public:
 		if (strncmp(ZSTR_VAL(name), "Local\\phpstan-", 14) != 0) {
 			return false;
 		}
+		uint64_t size = ARENA_SIZE_LIMIT;
 		HANDLE section = OpenFileMappingA(FILE_MAP_READ | FILE_MAP_WRITE, FALSE, ZSTR_VAL(name));
 		if (section == NULL) {
 			return false;
@@ -1059,7 +1115,7 @@ public:
 			CloseHandle(section);
 			return false;
 		}
-		if (!headerValid((const ArenaHeader *) base)) {
+		if (!headerValid((const ArenaHeader *) base, size)) {
 			UnmapViewOfFile(base);
 			CloseHandle(section);
 			return false;
@@ -1073,24 +1129,31 @@ public:
 		if (fd < 0) {
 			return false;
 		}
+		/* the creator sized the object to what its filesystem could back, so
+		 * the object itself says how much there is to map */
 		struct stat objectStat;
-		if (fstat(fd, &objectStat) != 0 || (uint64_t) objectStat.st_size < ARENA_SIZE_LIMIT) {
+		if (fstat(fd, &objectStat) != 0) {
 			close(fd);
 			return false;
 		}
-		void *base = mmap(NULL, ARENA_SIZE_LIMIT, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		uint64_t size = (uint64_t) objectStat.st_size;
+		if (size < arenaDataStart() || size > ARENA_SIZE_LIMIT) {
+			close(fd);
+			return false;
+		}
+		void *base = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 		close(fd);
 		if (base == MAP_FAILED) {
 			return false;
 		}
-		if (!headerValid((const ArenaHeader *) base)) {
-			munmap(base, ARENA_SIZE_LIMIT);
+		if (!headerValid((const ArenaHeader *) base, size)) {
+			munmap(base, size);
 			return false;
 		}
 #endif
 
 		pt_arena_base = base;
-		pt_arena_total = ARENA_SIZE_LIMIT;
+		pt_arena_total = size;
 		pt_arena_creator = false;
 		snprintf(pt_arena_name, sizeof(pt_arena_name), "%s", ZSTR_VAL(name));
 		return true;

--- a/turbo-ext/src/ArenaCache.cpp
+++ b/turbo-ext/src/ArenaCache.cpp
@@ -729,7 +729,7 @@ static bool findRecord(const char *key, size_t keyLen, RecordView *view)
 }
 
 /* Copies a fully-built record into the arena and CAS-publishes it; loses
- * gracefully to a concurrent publisher of the same key. */
+ * gracefully to a concurrent publisher of the same key, as late as it can. */
 static void publishRecord(const char *key, size_t keyLen, uint32_t kind, const WriteBuffer &payload)
 {
 	if (pt_arena_base == NULL || keyLen > UINT32_MAX) {
@@ -740,6 +740,16 @@ static void publishRecord(const char *key, size_t keyLen, uint32_t kind, const W
 	uint64_t offset = atomicFetchAdd(&arenaHeader()->allocCursor, alignUp8(recordSize));
 	if (offset > pt_arena_total || recordSize > pt_arena_total - offset) {
 		return; /* arena full: analysis continues, just unshared */
+	}
+
+	/* The callers checked the index before building the payload; check it once
+	 * more before writing it. Building a record takes long enough for another
+	 * process to have published the same key meanwhile, and every byte written
+	 * here is a page the backing store commits for good - a loser that returns
+	 * now costs nothing but the bump it already took. */
+	RecordView published;
+	if (findRecord(key, keyLen, &published)) {
+		return;
 	}
 
 	char *record = (char *) pt_arena_base + offset;


### PR DESCRIPTION
Forked parallel workers die silently under 2.2.10. Root cause, verified end to end:

**The shared-memory arena can be handed memory it cannot commit.** `ArenaCache::create()` does `shm_open` → `ftruncate(fd, 256MB)` → `mmap(MAP_SHARED)`. POSIX shm is tmpfs: the truncate is sparse and pages commit on **first touch**. When the backing store is out of space, the touching process takes **SIGBUS** — instant death, no PHP error, no shutdown function, an empty capture file. Docker's default `/dev/shm` is 64 MB, so every containerised user is exposed; all reporters on the issue are in containers.

Measured on the reporter's repro (`doctrine/orm` + `symfony/http-kernel`, level 10, `/dev/shm` = 64 MB):

| config | arena | after `clear-result-cache` |
|---|---|---|
| 2.2.10 phar, as reported | yes | **3/6 runs die** |
| 2.2.10 extracted out of the phar | yes | **4/6 runs die** |
| 2.2.10, `--shm-size=1g` | yes | 0/4 |
| 2.2.10, `PHPSTAN_ARENA=0` | no | 0/4 |
| 2.2.9 | none created | 0/3 |

`/dev/shm` peak during a run: 53 MB cold, **65536 K (100%) warm**. A dying worker reports `signaled=true signal=7` — SIGBUS.

**Why 2.2.10 and not 2.2.9.** 2.2.9 ran the main process without turbo (`Turbo extension: enabled in worker processes`), so `ArenaCache::create()` was the no-op PHP twin and no arena existed at all — 0 K of `/dev/shm`, measured. 2.2.10's `TurboProcessRestarter` re-execs the main process with the extension, which is what switched the arena on for these users for the first time.

**Why a warm cache and not a cold one.** `publishRecord()` bump-allocates and writes the whole record *before* trying to CAS the index slot, so a publisher that loses the race leaves its copy as permanently committed dead space; `Cache::save()` publishes with no prior check at all. Forked workers start from an identical image at the same instant, so 7-9 of them publish the same keys simultaneously. A warm disk cache is the worst case — every worker streams the same entries in lockstep.

**Why it is undiagnosable.** `ForkedProcess` reports `$exitCode = null` for a non-`wifexited` child and `ParallelAnalyser`'s `onExit` treats `null` exactly like exit 0: quit the process, record nothing. The job it was holding is popped and lost, so a worker dying on the last jobs can end the run *reporting success with files silently unanalysed*. `SpawnedProcess` has the same hole.

We already knew the symptom: `.github/workflows/phar.yml` runs its docker legs with `--shm-size=1g` and the comment *"docker's default 64M /dev/shm makes parallel analysis SIGBUS"*. The workaround went into our CI instead of into the arena.

## This PR so far

Only the E2E coverage, so CI is red first:

- `turbo-arena-e2e-tests` — builds the extension, analyses `src` with the runner's `/dev/shm` and again with it remounted at 32 MB, and requires the two outputs to be identical.
- `e2e/parallel-worker-signal` — SIGKILLs one worker from a bootstrap file and requires the run to name the signal.

## Still to come

- cut the duplicate publishing so the arena's committed footprint stops multiplying by worker count
- report a signalled worker as an internal error naming the signal, in both `ForkedProcess` and `SpawnedProcess`

Closes https://github.com/phpstan/phpstan/issues/15131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMcokMDwXGSugGttoDhhJf
