### PR TITLE
Normalize paths in ResultCacheInfoCommandTest

### DIFF
--- a/tests/PHPStan/Command/ResultCacheInfoCommandTest.php
+++ b/tests/PHPStan/Command/ResultCacheInfoCommandTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
 use Override;
+use PHPStan\File\FileHelper;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -90,7 +91,12 @@ PHP);
 		$this->assertSame(2, $json['analysedFilesCount']);
 		$this->assertSame(2, $json['filesToAnalyseCount']);
 		$this->assertNull($json['lastFullAnalysisTime']);
-		$this->assertSame($this->projectDir . '/tmp/resultCache.php', $json['resultCachePath']);
+
+		$fileHelper = new FileHelper(__DIR__);
+		$this->assertSame(
+			$fileHelper->normalizePath($this->projectDir . '/tmp/resultCache.php', '/'),
+			$fileHelper->normalizePath($json['resultCachePath'], '/'),
+		);
 
 		[, $exitCode] = $this->runPhpstan(['result-cache-info', '--json', '--fail-without-result-cache']);
 		$this->assertSame(2, $exitCode);
@@ -155,7 +161,11 @@ PHP);
 	{
 		[$output, $exitCode] = $this->runPhpstan(['result-cache-info']);
 		$this->assertSame(0, $exitCode, $output);
-		$this->assertStringContainsString('Result cache file: ' . $this->projectDir . '/tmp/resultCache.php', $output);
+		$fileHelper = new FileHelper(__DIR__);
+		$this->assertStringContainsString(
+			'Result cache file: ' . $fileHelper->normalizePath($this->projectDir . '/tmp/resultCache.php', '/'),
+			$fileHelper->normalizeSeparator($output),
+		);
 		$this->assertStringContainsString('Result cache will not be used.', $output);
 		$this->assertStringContainsString('Reason: Result cache not used because the cache file does not exist.', $output);
 		$this->assertStringContainsString('2 out of 2 files will be analysed.', $output);


### PR DESCRIPTION
The test built the expected result cache path by appending forward slashes to `sys_get_temp_dir()`, while the command prints `%tmpDir%/resultCache.php` where `tmpDir` has already gone through `FileHelper::normalizePath()`. On Windows the two forms differ:

```
- C:\Users\RUNNER~1\AppData\Local\Temp/phpstan-result-cache-info-.../tmp/resultCache.php
+ C:\Users\RUNNER~1\AppData\Local\Temp\phpstan-result-cache-info-...\tmp/resultCache.php
```

Compare them through `FileHelper` the way other tests do (`DefaultStubFilesProviderTest`, `AutoloadFilesTest`, `ParallelAnalyserIntegrationTest`).

Fixes the `Integration tests (windows-latest)` failure in https://github.com/phpstan/phpstan-src/actions/runs/33372500218/job/99426547375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vx5cyyqmQ8WBboc64rN1iN