### PR TITLE
Restore the result cache without reading PHPDocs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -722,6 +722,15 @@ jobs:
               ../bashunit -a contains 'No errors' "$OUTPUT"
               mv src/Consumer.php.orig src/Consumer.php
               ../../bin/phpstan analyse -vvv
+              # a changed file with a generic @template bound - resolving it reflects the
+              # bound's class to learn whether it is generic
+              patch -b src/Repository.php < generic-change.patch
+              OUTPUT=$(../../bin/phpstan analyse -vvv 2>&1 || true)
+              echo "$OUTPUT"
+              ../bashunit -a not_contains 'Undefined constant' "$OUTPUT"
+              ../bashunit -a contains 'No errors' "$OUTPUT"
+              mv src/Repository.php.orig src/Repository.php
+              ../../bin/phpstan analyse -vvv
           - script: |
               cd e2e/nested-trait-use
               ../../bin/phpstan analyze

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -731,6 +731,15 @@ jobs:
               ../bashunit -a contains 'No errors' "$OUTPUT"
               mv src/Repository.php.orig src/Repository.php
               ../../bin/phpstan analyse -vvv
+              # a changed file with a non-private property - exporting it asks whether the
+              # property is virtual
+              patch -b src/Entity.php < property-change.patch
+              OUTPUT=$(../../bin/phpstan analyse -vvv 2>&1 || true)
+              echo "$OUTPUT"
+              ../bashunit -a not_contains 'Undefined constant' "$OUTPUT"
+              ../bashunit -a contains 'No errors' "$OUTPUT"
+              mv src/Entity.php.orig src/Entity.php
+              ../../bin/phpstan analyse -vvv
           - script: |
               cd e2e/nested-trait-use
               ../../bin/phpstan analyze

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -707,6 +707,22 @@ jobs:
               mv stub-files.neon.orig stub-files.neon
               ../../bin/phpstan analyse -vvv
           - script: |
+              # Restoring the result cache fetches the exported nodes of every changed file,
+              # and resolving their PHPDocs asks the ReflectionProvider for classes. That
+              # reaches StubPhpDocProvider, which runs the StubFilesExtensions - all in the
+              # main process, before the deferred bootstrapFiles have run.
+              cd e2e/bug-15120b
+              composer install
+              ../../bin/phpstan analyse -vvv
+              # a changed file using a trait - the name scope map reflects the trait
+              patch -b src/Consumer.php < source-change.patch
+              OUTPUT=$(../../bin/phpstan analyse -vvv 2>&1 || true)
+              echo "$OUTPUT"
+              ../bashunit -a not_contains 'Undefined constant' "$OUTPUT"
+              ../bashunit -a contains 'No errors' "$OUTPUT"
+              mv src/Consumer.php.orig src/Consumer.php
+              ../../bin/phpstan analyse -vvv
+          - script: |
               cd e2e/nested-trait-use
               ../../bin/phpstan analyze
           - script: |

--- a/e2e/bug-15120b/.gitignore
+++ b/e2e/bug-15120b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/e2e/bug-15120b/bootstrap.php
+++ b/e2e/bug-15120b/bootstrap.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types = 1);
+
+define('Bug15120b\FRAMEWORK_VERSION', '13.26.1');

--- a/e2e/bug-15120b/composer.json
+++ b/e2e/bug-15120b/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Bug15120b\\": "extension/"
+        }
+    }
+}

--- a/e2e/bug-15120b/extension/FrameworkStubFilesExtension.php
+++ b/e2e/bug-15120b/extension/FrameworkStubFilesExtension.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120b;
+
+use PHPStan\PhpDoc\StubFilesExtension;
+use function constant;
+use function version_compare;
+
+final class FrameworkStubFilesExtension implements StubFilesExtension
+{
+
+	public function getFiles(): array
+	{
+		// mimics larastan: the constant is defined by a bootstrapFiles entry
+		if (version_compare((string) constant('Bug15120b\FRAMEWORK_VERSION'), '10.0', '<')) {
+			return [];
+		}
+
+		return [__DIR__ . '/../stubs/Foo.stub'];
+	}
+
+}

--- a/e2e/bug-15120b/generic-change.patch
+++ b/e2e/bug-15120b/generic-change.patch
@@ -1,0 +1,16 @@
+--- src/Repository.php
++++ src/Repository.php
+@@ -17,4 +17,13 @@
+ 		return $box->get()->get();
+ 	}
+ 
++	/**
++	 * @param T $box
++	 * @return non-empty-string
++	 */
++	public function label($box): string
++	{
++		return 'box: ' . $this->describe($box);
++	}
++
+ }

--- a/e2e/bug-15120b/phpstan.neon
+++ b/e2e/bug-15120b/phpstan.neon
@@ -1,0 +1,12 @@
+parameters:
+	level: 8
+	paths:
+		- src
+	bootstrapFiles:
+		- bootstrap.php
+
+services:
+	-
+		class: Bug15120b\FrameworkStubFilesExtension
+		tags:
+			- phpstan.stubFilesExtension

--- a/e2e/bug-15120b/property-change.patch
+++ b/e2e/bug-15120b/property-change.patch
@@ -1,0 +1,13 @@
+--- src/Entity.php
++++ src/Entity.php
+@@ -13,4 +13,10 @@
+ 		return $foo->get();
+ 	}
+ 
++	/** @return non-empty-string */
++	public function label(Foo $foo): string
++	{
++		return $this->name . ': ' . $this->describe($foo);
++	}
++
+ }

--- a/e2e/bug-15120b/source-change.patch
+++ b/e2e/bug-15120b/source-change.patch
@@ -1,0 +1,13 @@
+--- src/Consumer.php
++++ src/Consumer.php
+@@ -13,4 +13,10 @@
+ 		return $foo->get();
+ 	}
+ 
++	/** @return non-empty-string */
++	public function label(Foo $foo): string
++	{
++		return $this->name() . ': ' . $this->describe($foo);
++	}
++
+ }

--- a/e2e/bug-15120b/src/Box.php
+++ b/e2e/bug-15120b/src/Box.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120b;
+
+/** @template T */
+class Box
+{
+
+	/** @var T */
+	private $item;
+
+	/** @param T $item */
+	public function __construct($item)
+	{
+		$this->item = $item;
+	}
+
+	/** @return T */
+	public function get()
+	{
+		return $this->item;
+	}
+
+}

--- a/e2e/bug-15120b/src/Consumer.php
+++ b/e2e/bug-15120b/src/Consumer.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120b;
+
+class Consumer
+{
+
+	use HasName;
+
+	/** @return non-empty-string */
+	public function describe(Foo $foo): string
+	{
+		return $foo->get();
+	}
+
+}

--- a/e2e/bug-15120b/src/Entity.php
+++ b/e2e/bug-15120b/src/Entity.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120b;
+
+class Entity
+{
+
+	public string $name = 'entity';
+
+	/** @return non-empty-string */
+	public function describe(Foo $foo): string
+	{
+		return $foo->get();
+	}
+
+}

--- a/e2e/bug-15120b/src/Foo.php
+++ b/e2e/bug-15120b/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120b;
+
+class Foo
+{
+
+	public function get(): string
+	{
+		return 'hello';
+	}
+
+}

--- a/e2e/bug-15120b/src/HasName.php
+++ b/e2e/bug-15120b/src/HasName.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120b;
+
+trait HasName
+{
+
+	public function name(): string
+	{
+		return 'name';
+	}
+
+}

--- a/e2e/bug-15120b/src/Repository.php
+++ b/e2e/bug-15120b/src/Repository.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Bug15120b;
+
+/**
+ * @template T of Box<Foo>
+ */
+class Repository
+{
+
+	/**
+	 * @param T $box
+	 * @return non-empty-string
+	 */
+	public function describe($box): string
+	{
+		return $box->get()->get();
+	}
+
+}

--- a/e2e/bug-15120b/stubs/Foo.stub
+++ b/e2e/bug-15120b/stubs/Foo.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug15120b;
+
+class Foo
+{
+
+	/** @return non-empty-string */
+	public function get(): string
+	{
+
+	}
+
+}

--- a/src/Dependency/ExportedNodeResolver.php
+++ b/src/Dependency/ExportedNodeResolver.php
@@ -319,15 +319,11 @@ final class ExportedNodeResolver
 			return null;
 		}
 
-		$resolvedPhpDocBlock = $this->fileTypeMapper->getResolvedPhpDoc(
-			$file,
-			$className,
-			null,
-			$functionName,
-			$text,
-		);
-
-		$nameScope = $resolvedPhpDocBlock->getNullableNameScope();
+		// Only the namespace and the uses are exported, so the fully resolved PHPDoc block is not
+		// needed - and building it would resolve the surrounding @template bounds through the
+		// ReflectionProvider. The result cache restore fetches exported nodes in the main process
+		// before the deferred bootstrapFiles have run, where reading PHPDocs is not allowed.
+		$nameScope = $this->fileTypeMapper->getIntermediaryNameScope($file, $className, null, $functionName);
 		if ($nameScope === null) {
 			return null;
 		}

--- a/src/Dependency/ExportedNodeResolver.php
+++ b/src/Dependency/ExportedNodeResolver.php
@@ -386,11 +386,14 @@ final class ExportedNodeResolver
 			$docComment = $node->getDocComment();
 
 			$names = array_map(static fn (Node\PropertyItem $prop): string => $prop->name->toString(), $node->props);
+			// Virtuality is decided by the native reflection, so it is read straight off it.
+			// PhpPropertyReflection would give the same answer, but building it resolves the
+			// class PHPDoc - see exportPhpDocNode() for why that is not allowed here.
 			$virtual = false;
 			if ($this->reflectionProvider->hasClass($namespacedName)) {
-				$classReflection = $this->reflectionProvider->getClass($namespacedName);
-				if ($classReflection->hasNativeProperty($names[0])) {
-					$virtual = $classReflection->getNativeProperty($names[0])->isVirtual()->yes();
+				$nativeReflection = $this->reflectionProvider->getClass($namespacedName)->getNativeReflection();
+				if ($nativeReflection->hasProperty($names[0])) {
+					$virtual = $nativeReflection->getProperty($names[0])->isVirtual();
 				}
 			}
 

--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -29,6 +29,7 @@ use PHPStan\File\FileReader;
 use PHPStan\File\RelativePathHelper;
 use PHPStan\Parser\AnonymousClassVisitor;
 use PHPStan\Php\PhpVersion;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\PhpDoc\Tag\ParamClosureThisTag;
 use PHPStan\PhpDoc\Tag\ParamOutTag;
@@ -156,7 +157,7 @@ final class BetterReflectionProvider implements ReflectionProvider
 			$adaptedClass,
 			null,
 			null,
-			$this->stubPhpDocProvider->findClassPhpDoc($reflectionClass->getName()),
+			fn (): ?ResolvedPhpDocBlock => $this->stubPhpDocProvider->findClassPhpDoc($reflectionClass->getName()),
 		);
 	}
 
@@ -233,7 +234,7 @@ final class BetterReflectionProvider implements ReflectionProvider
 			new ReflectionClass($reflectionClass),
 			$scopeFile,
 			null,
-			$this->stubPhpDocProvider->findClassPhpDoc($className),
+			fn (): ?ResolvedPhpDocBlock => $this->stubPhpDocProvider->findClassPhpDoc($className),
 		);
 	}
 

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Reflection;
 
 use Attribute;
+use Closure;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
@@ -140,6 +141,8 @@ final class ClassReflection
 
 	private string|false|null $reflectionDocComment = false;
 
+	private false|ResolvedPhpDocBlock|null $stubPhpDocBlock = false;
+
 	private false|ResolvedPhpDocBlock $resolvedPhpDocBlock = false;
 
 	private false|ResolvedPhpDocBlock $traitContextResolvedPhpDocBlock = false;
@@ -169,6 +172,7 @@ final class ClassReflection
 
 	/**
 	 * @param ReflectionClass|ReflectionEnum $reflection
+	 * @param (Closure(): ?ResolvedPhpDocBlock)|null $stubPhpDocBlockCallback
 	 */
 	public function __construct(
 		private ClassReflectionFactory $classReflectionFactory,
@@ -186,7 +190,7 @@ final class ClassReflection
 		private CoreReflectionClass $reflection,
 		private ?string $anonymousFilename,
 		private ?TemplateTypeMap $resolvedTemplateTypeMap,
-		private ?ResolvedPhpDocBlock $stubPhpDocBlock,
+		private ?Closure $stubPhpDocBlockCallback,
 		private ?string $extraCacheKey = null,
 		private ?TemplateTypeVarianceMap $resolvedCallSiteVarianceMap = null,
 		private ?bool $finalByKeywordOverride = null,
@@ -1932,7 +1936,7 @@ final class ClassReflection
 			$this->reflection,
 			$this->anonymousFilename,
 			$this->typeMapFromList($types),
-			$this->stubPhpDocBlock,
+			$this->stubPhpDocBlockCallback,
 			null,
 			$this->resolvedCallSiteVarianceMap,
 			$this->finalByKeywordOverride,
@@ -1949,7 +1953,7 @@ final class ClassReflection
 			$this->reflection,
 			$this->anonymousFilename,
 			$this->resolvedTemplateTypeMap,
-			$this->stubPhpDocBlock,
+			$this->stubPhpDocBlockCallback,
 			null,
 			$this->varianceMapFromList($variances),
 			$this->finalByKeywordOverride,
@@ -1976,7 +1980,7 @@ final class ClassReflection
 			$this->reflection,
 			$this->anonymousFilename,
 			$this->resolvedTemplateTypeMap,
-			$this->stubPhpDocBlock,
+			$this->stubPhpDocBlockCallback,
 			null,
 			$this->resolvedCallSiteVarianceMap,
 			true,
@@ -2003,7 +2007,7 @@ final class ClassReflection
 			$this->reflection,
 			$this->anonymousFilename,
 			$this->resolvedTemplateTypeMap,
-			$this->stubPhpDocBlock,
+			$this->stubPhpDocBlockCallback,
 			null,
 			$this->resolvedCallSiteVarianceMap,
 			false,
@@ -2012,8 +2016,13 @@ final class ClassReflection
 
 	public function getResolvedPhpDoc(): ?ResolvedPhpDocBlock
 	{
-		if ($this->stubPhpDocBlock !== null) {
-			return $this->stubPhpDocBlock;
+		if ($this->stubPhpDocBlockCallback !== null) {
+			if ($this->stubPhpDocBlock === false) {
+				$this->stubPhpDocBlock = ($this->stubPhpDocBlockCallback)();
+			}
+			if ($this->stubPhpDocBlock !== null) {
+				return $this->stubPhpDocBlock;
+			}
 		}
 
 		$fileName = $this->getFileName();

--- a/src/Reflection/ClassReflectionFactory.php
+++ b/src/Reflection/ClassReflectionFactory.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection;
 
+use Closure;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnum;
 use PHPStan\PhpDoc\ResolvedPhpDocBlock;
@@ -13,14 +14,19 @@ interface ClassReflectionFactory
 {
 
 	/**
+	 * The stub PHPDoc comes in as a callback because asking the StubPhpDocProvider for it parses
+	 * every stub file, which runs the StubFilesExtensions. Those may rely on the bootstrapFiles,
+	 * so the lookup must wait until someone reads ClassReflection::getResolvedPhpDoc().
+	 *
 	 * @param ReflectionClass|ReflectionEnum $reflection
+	 * @param (Closure(): ?ResolvedPhpDocBlock)|null $stubPhpDocBlockCallback
 	 */
 	public function create(
 		string $displayName,
 		CoreReflectionClass $reflection,
 		?string $anonymousFilename,
 		?TemplateTypeMap $resolvedTemplateTypeMap,
-		?ResolvedPhpDocBlock $stubPhpDocBlock,
+		?Closure $stubPhpDocBlockCallback,
 		?string $extraCacheKey = null,
 		?TemplateTypeVarianceMap $resolvedCallSiteVarianceMap = null,
 		?bool $finalByKeywordOverride = null,

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -195,6 +195,26 @@ final class FileTypeMapper
 	}
 
 	/**
+	 * The lexical part of a name scope - the namespace and the uses a PHPDoc's names resolve
+	 * against. Unlike getNameScope() it does not resolve the surrounding @template bounds, which
+	 * goes through TypeNodeResolver and the ReflectionProvider. A caller that only needs to know
+	 * how the names in a PHPDoc text are spelled out should ask for this one.
+	 */
+	public function getIntermediaryNameScope(
+		string $fileName,
+		?string $className,
+		?string $traitName,
+		?string $functionName,
+	): ?IntermediaryNameScope
+	{
+		$fileName = $this->fileHelper->normalizePath($fileName);
+		$nameScopeKey = $this->getNameScopeKey($fileName, $className, $traitName, $functionName);
+		[$nameScopeMap] = $this->getNameScopeMap($fileName);
+
+		return $nameScopeMap[$nameScopeKey] ?? null;
+	}
+
+	/**
 	 * @throws NameScopeAlreadyBeingCreatedException
 	 */
 	public function getNameScope(


### PR DESCRIPTION
#15120 is back on 2.2.10: a larastan project crashes on every run that follows an edit unless the result cache is cleared first.

```
In LarastanStubFilesExtension.php line 25:

  Undefined constant "Larastan\Larastan\LARAVEL_VERSION"
```

#6284 moved every *direct* `StubFilesExtension::getFiles()` call site past the deferred `bootstrapFiles`. This is an indirect one: **restoring the result cache reaches the extensions through the reflection layer.**

`ResultCacheManager::restore()` fetches the exported nodes of every file whose hash changed - which is why it only happens after an edit - and resolving those nodes reads PHPDocs:

```
restore() → exportedNodesChanged() → ExportedNodeFetcher::fetchNodes()
  → ExportedNodeResolver → ReflectionProvider::getClass()
  → StubPhpDocProvider::findClassPhpDoc() → initializeKnownElements()
  → StubFilesProvider::getStubFiles() → the extensions
```

All in the main process, before the bootstrap files have run. Three separate ways in, each reproduced on its own in `e2e/bug-15120b` and each fixed by one commit:

- **Do not look up the stub PHPDoc of a class until it is read** - `BetterReflectionProvider::getClass()` computed it eagerly as a constructor argument, so the first `getClass()` in a process parsed every stub file whether or not anyone read the PHPDoc. It comes in as a callback now. This is the broad trigger: a changed file that uses a trait, which is most files in a Laravel app.
- **Export PHPDoc name scopes without resolving `@template` bounds** - `ExportedNodeResolver` reads only the namespace and the uses out of the name scope, but asked for the fully resolved block; building that resolves the bounds through `TypeNodeResolver`, which reflects the bound's class to learn whether it is generic. `FileTypeMapper::getIntermediaryNameScope()` hands out the lexical scope the name scope map already holds.
- **Read property virtuality off the native reflection** - exporting a non-private property asked `ClassReflection::getNativeProperty()`, which walks the class' interfaces and so reads its `@implements` tags. BetterReflection decides virtuality either way.

With all three in, resolving exported nodes no longer touches PHPStan's PHPDoc layer at all. A probe on `StubFilesProvider::getStubFiles()` that logs any pre-bootstrap call sees **zero** across an incremental analysis of PHPStan's own source with 609 changed files (and the same probe with its flag inverted logs 15, so it does fire).

### Coverage

`e2e/bug-15120b` is the same shape as `e2e/bug-15120` - a bootstrap-defined constant read by a `StubFilesExtension` - but exercises the incremental run: analyse, patch a source file, analyse again. It patches three different files, one per trigger. Each step was verified red before its fix and green after, and each commit is green on its own.

Closes https://github.com/phpstan/phpstan/issues/15120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FA4hJBE4kDNQeReb4yFnAk
