### PR TITLE
Cap the detected CPU core count by the cgroup CPU quota

### DIFF
--- a/src/Diagnose/SystemResourcesDiagnoseExtension.php
+++ b/src/Diagnose/SystemResourcesDiagnoseExtension.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Diagnose;
+
+use PHPStan\Command\Output;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Process\CpuCoreCounter;
+use PHPStan\Process\SystemResources;
+use function sprintf;
+
+/**
+ * Reports what PHPStan believes about the machine, so a user who disagrees with the
+ * number of workers it chose can see which input was wrong.
+ */
+#[AutowiredService]
+final class SystemResourcesDiagnoseExtension implements DiagnoseExtension
+{
+
+	public function __construct(
+		private CpuCoreCounter $cpuCoreCounter,
+		private SystemResources $systemResources,
+	)
+	{
+	}
+
+	public function print(Output $output): void
+	{
+		$output->writeLineFormatted('<info>System resources:</info>');
+		$output->writeLineFormatted(sprintf('Detected CPU cores:        %d', $this->cpuCoreCounter->getDetectedNumberOfCpuCores()));
+
+		$quota = $this->systemResources->getCpuQuota();
+		$output->writeLineFormatted(sprintf(
+			'cgroup CPU quota:          %s',
+			$quota === null ? 'none' : sprintf('%d cores', $quota),
+		));
+
+		$output->writeLineFormatted(sprintf('Usable CPU cores:          %d', $this->cpuCoreCounter->getNumberOfCpuCores()));
+		$output->writeLineFormatted('');
+	}
+
+}

--- a/src/Diagnose/SystemResourcesDiagnoseExtension.php
+++ b/src/Diagnose/SystemResourcesDiagnoseExtension.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Diagnose;
 
 use PHPStan\Command\Output;
+use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Process\CpuCoreCounter;
 use PHPStan\Process\SystemResources;
@@ -19,6 +20,8 @@ final class SystemResourcesDiagnoseExtension implements DiagnoseExtension
 	public function __construct(
 		private CpuCoreCounter $cpuCoreCounter,
 		private SystemResources $systemResources,
+		#[AutowiredParameter(ref: '%parallel.loadLimit%')]
+		private ?float $loadLimit,
 	)
 	{
 	}
@@ -27,6 +30,14 @@ final class SystemResourcesDiagnoseExtension implements DiagnoseExtension
 	{
 		$output->writeLineFormatted('<info>System resources:</info>');
 		$output->writeLineFormatted(sprintf('Detected CPU cores:        %d', $this->cpuCoreCounter->getDetectedNumberOfCpuCores()));
+		$output->writeLineFormatted(sprintf('Load limit:                %s', $this->loadLimit === null ? 'none' : (string) $this->loadLimit));
+
+		$kubernetesLimit = $this->cpuCoreCounter->getKubernetesCpuLimit();
+		$output->writeLineFormatted(sprintf(
+			'KUBERNETES_CPU_LIMIT:      %s',
+			$kubernetesLimit === null ? 'none' : sprintf('%d cores', $kubernetesLimit),
+		));
+		$output->writeLineFormatted(sprintf('Available after limits:    %d', $this->cpuCoreCounter->getNumberOfCpuCoresAfterLimits()));
 
 		$quota = $this->systemResources->getCpuQuota();
 		$output->writeLineFormatted(sprintf(

--- a/src/Process/CpuCoreCounter.php
+++ b/src/Process/CpuCoreCounter.php
@@ -6,6 +6,7 @@ use Fidry\CpuCoreCounter\CpuCoreCounter as FidryCpuCoreCounter;
 use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
+use function min;
 
 #[AutowiredService]
 final class CpuCoreCounter
@@ -13,26 +14,53 @@ final class CpuCoreCounter
 
 	private ?int $count = null;
 
+	private ?int $detectedCount = null;
+
 	public function __construct(
 		#[AutowiredParameter(ref: '%parallel.loadLimit%')]
 		private ?float $loadLimit,
+		private SystemResources $systemResources,
 	)
 	{
 	}
 
+	/**
+	 * Cores PHPStan may actually use: what the machine reports, capped by the CPU
+	 * quota of the cgroup it runs in.
+	 */
 	public function getNumberOfCpuCores(): int
 	{
 		if ($this->count !== null) {
 			return $this->count;
 		}
 
-		try {
-			$this->count = (new FidryCpuCoreCounter())->getAvailableForParallelisation(0, null, $this->loadLimit)->availableCpus;
-		} catch (NumberOfCpuCoreNotFound) {
-			$this->count = 1;
+		$count = $this->getDetectedNumberOfCpuCores();
+
+		// fidry/cpu-core-counter has no cgroup finder, and its nproc-based default
+		// honours a cpuset affinity mask but not a CFS bandwidth quota, so inside a
+		// `docker run --cpus=2` container it reports the host's core count
+		$quota = $this->systemResources->getCpuQuota();
+		if ($quota !== null) {
+			$count = min($count, $quota);
 		}
 
-		return $this->count;
+		return $this->count = $count;
+	}
+
+	/** What the machine reports before any cgroup quota is applied. */
+	public function getDetectedNumberOfCpuCores(): int
+	{
+		if ($this->detectedCount !== null) {
+			return $this->detectedCount;
+		}
+
+		try {
+			$this->detectedCount = (new FidryCpuCoreCounter())->getAvailableForParallelisation(0, null, $this->loadLimit)->availableCpus;
+		} catch (NumberOfCpuCoreNotFound) {
+			$this->detectedCount = 1;
+		}
+
+		return $this->detectedCount;
 	}
 
 }

--- a/src/Process/CpuCoreCounter.php
+++ b/src/Process/CpuCoreCounter.php
@@ -14,7 +14,13 @@ final class CpuCoreCounter
 
 	private ?int $count = null;
 
-	private ?int $detectedCount = null;
+	/**
+	 * What fidry/cpu-core-counter found: the raw count, the count left after the
+	 * load limit and KUBERNETES_CPU_LIMIT were applied, and that environment limit.
+	 *
+	 * @var array{int, int, int|null}|null
+	 */
+	private ?array $detected = null;
 
 	public function __construct(
 		#[AutowiredParameter(ref: '%parallel.loadLimit%')]
@@ -25,8 +31,8 @@ final class CpuCoreCounter
 	}
 
 	/**
-	 * Cores PHPStan may actually use: what the machine reports, capped by the CPU
-	 * quota of the cgroup it runs in.
+	 * Cores PHPStan may actually use: what the machine reports, reduced by the load
+	 * limit and capped by the CPU quota of the cgroup it runs in.
 	 */
 	public function getNumberOfCpuCores(): int
 	{
@@ -34,7 +40,7 @@ final class CpuCoreCounter
 			return $this->count;
 		}
 
-		$count = $this->getDetectedNumberOfCpuCores();
+		$count = $this->getNumberOfCpuCoresAfterLimits();
 
 		// fidry/cpu-core-counter has no cgroup finder, and its nproc-based default
 		// honours a cpuset affinity mask but not a CFS bandwidth quota, so inside a
@@ -47,20 +53,38 @@ final class CpuCoreCounter
 		return $this->count = $count;
 	}
 
-	/** What the machine reports before any cgroup quota is applied. */
+	/** What the machine reports, before any limit is applied. */
 	public function getDetectedNumberOfCpuCores(): int
 	{
-		if ($this->detectedCount !== null) {
-			return $this->detectedCount;
+		return $this->detect()[0];
+	}
+
+	/** The detected count after the load limit and KUBERNETES_CPU_LIMIT, before any cgroup quota. */
+	public function getNumberOfCpuCoresAfterLimits(): int
+	{
+		return $this->detect()[1];
+	}
+
+	public function getKubernetesCpuLimit(): ?int
+	{
+		return $this->detect()[2];
+	}
+
+	/** @return array{int, int, int|null} */
+	private function detect(): array
+	{
+		if ($this->detected !== null) {
+			return $this->detected;
 		}
 
 		try {
-			$this->detectedCount = (new FidryCpuCoreCounter())->getAvailableForParallelisation(0, null, $this->loadLimit)->availableCpus;
+			$result = (new FidryCpuCoreCounter())->getAvailableForParallelisation(0, null, $this->loadLimit);
+			$this->detected = [$result->totalCoresCount, $result->availableCpus, $result->correctedCountLimit];
 		} catch (NumberOfCpuCoreNotFound) {
-			$this->detectedCount = 1;
+			$this->detected = [1, 1, null];
 		}
 
-		return $this->detectedCount;
+		return $this->detected;
 	}
 
 }

--- a/src/Process/SystemResources.php
+++ b/src/Process/SystemResources.php
@@ -11,10 +11,10 @@ use function ctype_digit;
 use function explode;
 use function file_get_contents;
 use function implode;
+use function in_array;
 use function is_file;
 use function max;
 use function min;
-use function str_contains;
 use function str_starts_with;
 use function substr;
 use function trim;
@@ -171,11 +171,8 @@ final class SystemResources
 				if ($controllers !== '') {
 					continue;
 				}
-			} elseif (
-				$controllers !== $controller
-				&& !str_starts_with($controllers, $controller . ',')
-				&& !str_contains($controllers, ',' . $controller)
-			) {
+			} elseif (!in_array($controller, explode(',', $controllers), true)) {
+				// a substring match would take cpuset or cpuacct for cpu
 				continue;
 			}
 

--- a/src/Process/SystemResources.php
+++ b/src/Process/SystemResources.php
@@ -90,9 +90,11 @@ final class SystemResources
 		foreach ($this->getAncestorPaths($cgroupPath) as $path) {
 			$cpuMax = $this->readFile('/sys/fs/cgroup' . $path . '/cpu.max');
 			if ($cpuMax === null) {
-				// the cpu controller is not enabled at this depth - the root cgroup
-				// never has the file and a leaf often does not either - which says
-				// nothing about the ancestors that may still carry a quota
+				// the cpu controller is not enabled at this depth - a host's root
+				// cgroup has no cpu.max and a leaf often does not either - which says
+				// nothing about the ancestors that may still carry a quota. Inside a
+				// cgroup namespace the root is the container's own cgroup and does
+				// carry it, which is why the walk starts there.
 				continue;
 			}
 

--- a/src/Process/SystemResources.php
+++ b/src/Process/SystemResources.php
@@ -1,0 +1,246 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use function array_key_exists;
+use function array_slice;
+use function ceil;
+use function count;
+use function ctype_digit;
+use function explode;
+use function file_get_contents;
+use function implode;
+use function is_file;
+use function max;
+use function min;
+use function str_contains;
+use function str_starts_with;
+use function substr;
+use function trim;
+
+/**
+ * CPU resources the current process may actually use.
+ *
+ * The count can be constrained by a cgroup. A container limited with
+ * `docker run --cpus=2` or a Kubernetes `limits.cpu: 2` gets a CFS bandwidth
+ * quota while all of the host's CPUs stay visible and unmasked, so nproc, lscpu
+ * and /proc/cpuinfo all report the host's core count - see fidry/cpu-core-counter,
+ * which has no cgroup finder at all. Spawning one worker per "detected" core in
+ * such a container would result in 64 workers fighting over 2-CPU cores on a CI job.
+ *
+ * Returns null when no cgroup limits CPU bandwidth (or the platform cannot say),
+ * never a guess: the caller falls back to the detected core count.
+ */
+#[AutowiredService]
+final class SystemResources
+{
+
+	/**
+	 * Which cgroup the process belongs to cannot change while it runs, unlike the values
+	 * read out of that cgroup - so the path is memoized and nothing else is.
+	 *
+	 * @var array<string, string|null>
+	 */
+	private array $cgroupPaths = [];
+
+	/**
+	 * @param string $filesystemRoot Prefix for every /proc and /sys path read, so tests
+	 *                               can run against a fixture tree. Empty means the real
+	 *                               filesystem.
+	 */
+	public function __construct(private string $filesystemRoot = '')
+	{
+	}
+
+	/**
+	 * Number of CPU cores the current cgroup's CFS quota allows, or null when no
+	 * cgroup limits CPU bandwidth.
+	 *
+	 * @return positive-int|null
+	 */
+	public function getCpuQuota(): ?int
+	{
+		$quotas = [];
+		foreach ([$this->getCgroupV2CpuQuota(), $this->getCgroupV1CpuQuota()] as $quota) {
+			if ($quota === null) {
+				continue;
+			}
+
+			$quotas[] = $quota;
+		}
+
+		if (count($quotas) === 0) {
+			return null;
+		}
+
+		// a sub-core quota still lets a single worker run, just throttled
+		return max(1, min($quotas));
+	}
+
+	/** @return positive-int|null */
+	private function getCgroupV2CpuQuota(): ?int
+	{
+		$cgroupPath = $this->getCgroupPath('');
+		if ($cgroupPath === null) {
+			return null;
+		}
+
+		$quotas = [];
+		foreach ($this->getAncestorPaths($cgroupPath) as $path) {
+			$cpuMax = $this->readFile('/sys/fs/cgroup' . $path . '/cpu.max');
+			if ($cpuMax === null) {
+				// the cpu controller is not enabled at this depth - the root cgroup
+				// never has the file and a leaf often does not either - which says
+				// nothing about the ancestors that may still carry a quota
+				continue;
+			}
+
+			$parts = explode(' ', trim($cpuMax));
+			if (count($parts) !== 2 || !ctype_digit($parts[0]) || !ctype_digit($parts[1])) {
+				// "max <period>" is how an unlimited cgroup states it
+				continue;
+			}
+
+			$period = (int) $parts[1];
+			if ($period <= 0) {
+				continue;
+			}
+
+			$quotas[] = (int) ceil((int) $parts[0] / $period);
+		}
+
+		return count($quotas) === 0 ? null : max(1, min($quotas));
+	}
+
+	/** @return positive-int|null */
+	private function getCgroupV1CpuQuota(): ?int
+	{
+		$cgroupPath = $this->getCgroupPath('cpu');
+		if ($cgroupPath === null) {
+			return null;
+		}
+
+		$quotas = [];
+		foreach ($this->getAncestorPaths($cgroupPath) as $path) {
+			foreach (['cpu', 'cpu,cpuacct'] as $controllerDir) {
+				$base = '/sys/fs/cgroup/' . $controllerDir . $path;
+				$quota = $this->readIntFile($base . '/cpu.cfs_quota_us');
+				$period = $this->readIntFile($base . '/cpu.cfs_period_us');
+				if ($quota === null || $period === null || $quota <= 0 || $period <= 0) {
+					// -1 means unlimited
+					continue;
+				}
+
+				$quotas[] = (int) ceil($quota / $period);
+			}
+		}
+
+		return count($quotas) === 0 ? null : max(1, min($quotas));
+	}
+
+	/**
+	 * The current process' path within a cgroup hierarchy, or null when it is not in
+	 * one. An empty controller asks for the v2 unified hierarchy.
+	 */
+	private function getCgroupPath(string $controller): ?string
+	{
+		if (array_key_exists($controller, $this->cgroupPaths)) {
+			return $this->cgroupPaths[$controller];
+		}
+
+		return $this->cgroupPaths[$controller] = $this->findCgroupPath($controller);
+	}
+
+	private function findCgroupPath(string $controller): ?string
+	{
+		$contents = $this->readFile('/proc/self/cgroup');
+		if ($contents === null) {
+			return null;
+		}
+
+		foreach (explode("\n", $contents) as $line) {
+			// hierarchy-ID:controller-list:path
+			$parts = explode(':', trim($line), 3);
+			if (count($parts) !== 3) {
+				continue;
+			}
+
+			[, $controllers, $path] = $parts;
+			if ($controller === '') {
+				if ($controllers !== '') {
+					continue;
+				}
+			} elseif (
+				$controllers !== $controller
+				&& !str_starts_with($controllers, $controller . ',')
+				&& !str_contains($controllers, ',' . $controller)
+			) {
+				continue;
+			}
+
+			return $path === '/' ? '' : $path;
+		}
+
+		return null;
+	}
+
+	/**
+	 * The cgroup's own path and every ancestor up to the root, because a limit set on
+	 * an ancestor binds the leaf just as tightly - Kubernetes puts the pod's quota on
+	 * the pod slice, not on the container's own cgroup.
+	 *
+	 * @return list<string>
+	 */
+	private function getAncestorPaths(string $path): array
+	{
+		$segments = [];
+		foreach (explode('/', $path) as $segment) {
+			if ($segment === '') {
+				continue;
+			}
+
+			$segments[] = $segment;
+		}
+
+		$paths = [''];
+		for ($i = 1; $i <= count($segments); $i++) {
+			$paths[] = '/' . implode('/', array_slice($segments, 0, $i));
+		}
+
+		return $paths;
+	}
+
+	private function readIntFile(string $path): ?int
+	{
+		$contents = $this->readFile($path);
+		if ($contents === null) {
+			return null;
+		}
+
+		$contents = trim($contents);
+		$negative = str_starts_with($contents, '-');
+		$digits = $negative ? substr($contents, 1) : $contents;
+		if ($digits === '' || !ctype_digit($digits)) {
+			return null;
+		}
+
+		return $negative ? -(int) $digits : (int) $digits;
+	}
+
+	private function readFile(string $path): ?string
+	{
+		$path = $this->filesystemRoot . $path;
+
+		// container filesystems routinely have these present but unreadable, and a
+		// warning from a probe would be worse than not knowing
+		if (!@is_file($path)) {
+			return null;
+		}
+
+		$contents = @file_get_contents($path);
+
+		return $contents === false ? null : $contents;
+	}
+
+}

--- a/tests/PHPStan/Process/SystemResourcesTest.php
+++ b/tests/PHPStan/Process/SystemResourcesTest.php
@@ -137,6 +137,23 @@ class SystemResourcesTest extends TestCase
 			2,
 		];
 
+		yield 'v2, docker container in its own cgroup namespace: the root is the container cgroup' => [
+			[
+				'/proc/self/cgroup' => "0::/\n",
+				'/sys/fs/cgroup/cpu.max' => "200000 100000\n",
+			],
+			2,
+		];
+
+		yield 'v1, docker container in the host cgroup namespace: the mount is rooted at the container cgroup' => [
+			[
+				'/proc/self/cgroup' => "4:cpu,cpuacct:/docker/0123abcd\n",
+				'/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us' => "400000\n",
+				'/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us' => "100000\n",
+			],
+			4,
+		];
+
 		yield 'no cgroup filesystem at all' => [[], null];
 
 		yield 'in the root cgroup, which has no cpu.max' => [

--- a/tests/PHPStan/Process/SystemResourcesTest.php
+++ b/tests/PHPStan/Process/SystemResourcesTest.php
@@ -1,0 +1,208 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use Override;
+use PHPStan\File\FileWriter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use function dirname;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class SystemResourcesTest extends TestCase
+{
+
+	/** @var list<string> */
+	private array $roots = [];
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		foreach ($this->roots as $root) {
+			self::removeDirectory($root);
+		}
+
+		$this->roots = [];
+	}
+
+	/**
+	 * @return iterable<string, array{array<string, string>, int|null}>
+	 */
+	public static function dataCpuQuota(): iterable
+	{
+		yield 'v2, quota on the leaf' => [
+			[
+				'/proc/self/cgroup' => "0::/foo\n",
+				'/sys/fs/cgroup/foo/cpu.max' => "200000 100000\n",
+			],
+			2,
+		];
+
+		yield 'v2, quota only on an ancestor' => [
+			[
+				'/proc/self/cgroup' => "0::/foo/bar\n",
+				'/sys/fs/cgroup/foo/cpu.max' => "200000 100000\n",
+			],
+			2,
+		];
+
+		yield 'v2, nested with a tighter ancestor' => [
+			[
+				'/proc/self/cgroup' => "0::/foo/bar\n",
+				'/sys/fs/cgroup/foo/cpu.max' => "100000 100000\n",
+				'/sys/fs/cgroup/foo/bar/cpu.max' => "400000 100000\n",
+			],
+			1,
+		];
+
+		yield 'v2, unlimited' => [
+			[
+				'/proc/self/cgroup' => "0::/foo\n",
+				'/sys/fs/cgroup/foo/cpu.max' => "max 100000\n",
+			],
+			null,
+		];
+
+		yield 'v2, cpu controller not enabled at any level' => [
+			[
+				'/proc/self/cgroup' => "0::/foo\n",
+				'/sys/fs/cgroup/foo/memory.max' => "4294967296\n",
+			],
+			null,
+		];
+
+		yield 'v2, quota is not a whole number of cores' => [
+			[
+				'/proc/self/cgroup' => "0::/foo\n",
+				'/sys/fs/cgroup/foo/cpu.max' => "250000 100000\n",
+			],
+			3,
+		];
+
+		yield 'v2, quota below a single core' => [
+			[
+				'/proc/self/cgroup' => "0::/foo\n",
+				'/sys/fs/cgroup/foo/cpu.max' => "50000 100000\n",
+			],
+			1,
+		];
+
+		yield 'v2, malformed' => [
+			[
+				'/proc/self/cgroup' => "0::/foo\n",
+				'/sys/fs/cgroup/foo/cpu.max' => "garbage\n",
+			],
+			null,
+		];
+
+		yield 'v1, quota' => [
+			[
+				'/proc/self/cgroup' => "4:cpu,cpuacct:/foo\n",
+				'/sys/fs/cgroup/cpu/foo/cpu.cfs_quota_us' => "200000\n",
+				'/sys/fs/cgroup/cpu/foo/cpu.cfs_period_us' => "100000\n",
+			],
+			2,
+		];
+
+		yield 'v1, unlimited' => [
+			[
+				'/proc/self/cgroup' => "4:cpu,cpuacct:/foo\n",
+				'/sys/fs/cgroup/cpu/foo/cpu.cfs_quota_us' => "-1\n",
+				'/sys/fs/cgroup/cpu/foo/cpu.cfs_period_us' => "100000\n",
+			],
+			null,
+		];
+
+		yield 'v1, controller mounted as cpu,cpuacct' => [
+			[
+				'/proc/self/cgroup' => "4:cpu,cpuacct:/foo\n",
+				'/sys/fs/cgroup/cpu,cpuacct/foo/cpu.cfs_quota_us' => "400000\n",
+				'/sys/fs/cgroup/cpu,cpuacct/foo/cpu.cfs_period_us' => "100000\n",
+			],
+			4,
+		];
+
+		yield 'no cgroup filesystem at all' => [[], null];
+
+		yield 'in the root cgroup, which has no cpu.max' => [
+			['/proc/self/cgroup' => "0::/\n"],
+			null,
+		];
+	}
+
+	/**
+	 * @param array<string, string> $files
+	 */
+	#[DataProvider('dataCpuQuota')]
+	public function testGetCpuQuota(array $files, ?int $expectedQuota): void
+	{
+		$resources = new SystemResources($this->createFixtureRoot($files));
+
+		$this->assertSame($expectedQuota, $resources->getCpuQuota());
+	}
+
+	public function testUsableCoresNeverExceedDetectedCoresOnThisMachine(): void
+	{
+		// the important regression: whatever this machine turns out to be, applying
+		// its quota must narrow the core count rather than invent capacity or
+		// collapse to zero - a probe that guesses low would throttle every run
+		$counter = new CpuCoreCounter(null, new SystemResources());
+
+		$this->assertGreaterThanOrEqual(1, $counter->getNumberOfCpuCores());
+		$this->assertLessThanOrEqual($counter->getDetectedNumberOfCpuCores(), $counter->getNumberOfCpuCores());
+	}
+
+	/**
+	 * @param array<string, string> $files
+	 */
+	private function createFixtureRoot(array $files): string
+	{
+		$root = sys_get_temp_dir() . '/phpstan-system-resources-' . uniqid();
+		$this->roots[] = $root;
+
+		foreach ($files as $path => $contents) {
+			$fullPath = $root . $path;
+			$directory = dirname($fullPath);
+			if (!is_dir($directory)) {
+				mkdir($directory, 0777, true);
+			}
+
+			FileWriter::write($fullPath, $contents);
+		}
+
+		if (!is_dir($root)) {
+			mkdir($root, 0777, true);
+		}
+
+		return $root;
+	}
+
+	private static function removeDirectory(string $directory): void
+	{
+		if (!is_dir($directory)) {
+			return;
+		}
+
+		foreach (scandir($directory) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+
+			$path = $directory . '/' . $entry;
+			if (is_dir($path)) {
+				self::removeDirectory($path);
+			} else {
+				unlink($path);
+			}
+		}
+
+		rmdir($directory);
+	}
+
+}

--- a/tests/PHPStan/Process/SystemResourcesTest.php
+++ b/tests/PHPStan/Process/SystemResourcesTest.php
@@ -128,6 +128,15 @@ class SystemResourcesTest extends TestCase
 			4,
 		];
 
+		yield 'v1, a hierarchy whose controller name merely starts with cpu is listed first' => [
+			[
+				'/proc/self/cgroup' => "7:net_cls,cpuset:/other\n4:cpu,cpuacct:/foo\n",
+				'/sys/fs/cgroup/cpu/foo/cpu.cfs_quota_us' => "200000\n",
+				'/sys/fs/cgroup/cpu/foo/cpu.cfs_period_us' => "100000\n",
+			],
+			2,
+		];
+
 		yield 'no cgroup filesystem at all' => [[], null];
 
 		yield 'in the root cgroup, which has no cpu.max' => [


### PR DESCRIPTION
Split out of #6256 — the cgroup half only, so it can be judged and merged on its own; the `auto` worker default stays in #6256 (now rebased on top of this branch).

fidry/cpu-core-counter honours a cpuset affinity mask and the `KUBERNETES_CPU_LIMIT` env variable, but not a CFS bandwidth quota. Inside `docker run --cpus=2` or a Kubernetes container with `limits.cpu` it reports the host's core count, so PHPStan spawns up to 8 workers that fight over 2 cores. @AJenbo's measurements in #6256 for `--cpus=1/2/4`: −23 % / −17 % / −9 % wall time, peak memory 1.66 GB → 0.59 / 0.79 / 1.12 GB.

Commits:
- **Cap the detected CPU core count by the cgroup CPU quota** — @AJenbo's `SystemResources` + `CpuCoreCounter` + diagnose extension, verbatim from #6256, authored as him.
- **Match cgroup controllers as a list, not as a substring** — `str_contains($controllers, ',cpu')` also matched `,cpuset` and `,cpuacct`; `/proc/self/cgroup` lists hierarchies by descending id, so a `net_cls,cpuset` hierarchy above `cpu,cpuacct` won the lookup and the quota silently became "none". Regression fixture included.
- **Report each input to the usable core count separately in diagnose** — "Detected CPU cores" was the count after `loadLimit` and `KUBERNETES_CPU_LIMIT` had already been applied; now each input is on its own line.
- **Cover the Docker cgroup layouts the quota lookup is for** — tests for Docker on cgroup v2 (own namespace, `0::/`, quota at the tree root) and Docker/Kubernetes on v1 (host namespace, mount rooted at the container cgroup); both depend on the ancestor walk starting at the root.

Worker count with this PR alone (jobSize 20, ≥2 jobs per process, maximum 8):

| Scenario | before | after |
|---|---|---|
| `docker --cpus=2` on a 64-thread host, 2000 files | 8 | 2 |
| `docker --cpus=4` | 8 | 4 |
| `docker --cpus=16` | 8 | 8 |
| Kubernetes `limits.cpu: 3` | 8 | 3 |
| bare 32-thread workstation | 8 | 8 |
| macOS / Windows / no cgroup | 8 | 8 |

`phpstan diagnose` now prints:

```
System resources:
Detected CPU cores:        32
Load limit:                1
KUBERNETES_CPU_LIMIT:      none
Available after limits:    32
cgroup CPU quota:          4 cores
Usable CPU cores:          4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRfhXECP8wuY7qyLqRaXk3
