### PR TITLE
Keep the pre-autoloader turbo code polyfill-free and skip the extension lookup on PHP < 8.3

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -1097,6 +1097,56 @@ jobs:
           fi
           eval "$SCRIPT"
 
+  phar-run:
+    name: "Run PHAR on PHP ${{ matrix.php-version }}"
+    needs: compiler-tests
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: "Checkout"
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: "Install PHP"
+        # Deliberately without `ini-file: development`: that ini lists the
+        # pcntl functions in disable_functions, and TurboProcessRestarter then
+        # returns before TurboExtensionSelector ever runs. With pcntl available
+        # the phar boots through the turbo restart code, which bin/phpstan
+        # loads before the Composer autoloader - on PHP < 8.0 without the
+        # symfony polyfills (https://github.com/phpstan/phpstan/issues/15137).
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2.37.2
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: "Download PHAR"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: phar-file
+          path: tmp
+
+      - name: "Verify the turbo restart path is reachable"
+        run: |
+          php -r 'exit(function_exists("pcntl_exec") && function_exists("pcntl_fork") ? 0 : 1);'
+
+      - name: "Run PHAR"
+        run: |
+          php tmp/phpstan.phar --version
+          cd e2e/phar-run
+          php ../../tmp/phpstan.phar analyse -vvv
+
   integration-tests:
     if: github.event_name == 'pull_request'
     needs:

--- a/build/PHPStan/Build/SkipTestsWithRequiresPhpAttributeRule.php
+++ b/build/PHPStan/Build/SkipTestsWithRequiresPhpAttributeRule.php
@@ -52,6 +52,14 @@ final class SkipTestsWithRequiresPhpAttributeRule implements Rule
 			return [];
 		}
 
+		if (!$firstStmt->cond->left instanceof Node\Expr\ConstFetch || $firstStmt->cond->left->name->toString() !== 'PHP_VERSION_ID') {
+			return [];
+		}
+
+		if (!$firstStmt->cond->right instanceof Node\Scalar\Int_) {
+			return [];
+		}
+
 		switch (get_class($firstStmt->cond)) {
 			case Node\Expr\BinaryOp\SmallerOrEqual::class:
 				$inverseBinaryOpSigil = '>';
@@ -73,14 +81,6 @@ final class SkipTestsWithRequiresPhpAttributeRule implements Rule
 				break;
 			default:
 				throw new ShouldNotHappenException('No inverse comparison specified for ' . get_class($firstStmt->cond));
-		}
-
-		if (!$firstStmt->cond->left instanceof Node\Expr\ConstFetch || $firstStmt->cond->left->name->toString() !== 'PHP_VERSION_ID') {
-			return [];
-		}
-
-		if (!$firstStmt->cond->right instanceof Node\Scalar\Int_) {
-			return [];
 		}
 
 		if (count($firstStmt->stmts) !== 1) {

--- a/e2e/phar-run/phpstan.neon
+++ b/e2e/phar-run/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 8
+	paths:
+		- src

--- a/e2e/phar-run/src/Foo.php
+++ b/e2e/phar-run/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PharRun;
+
+final class Foo
+{
+
+	public function doFoo(string $s): int
+	{
+		return strlen($s);
+	}
+
+}

--- a/src/Turbo/TurboDiagnoseExtension.php
+++ b/src/Turbo/TurboDiagnoseExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Turbo;
 use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Diagnose\DiagnoseExtension;
+use PHPStan\Php\PhpVersion;
 use function php_uname;
 use function phpversion;
 use function sprintf;
@@ -12,6 +13,7 @@ use const PHP_DEBUG;
 use const PHP_MAJOR_VERSION;
 use const PHP_MINOR_VERSION;
 use const PHP_OS_FAMILY;
+use const PHP_VERSION_ID;
 use const PHP_ZTS;
 
 #[AutowiredService]
@@ -48,8 +50,15 @@ final class TurboDiagnoseExtension implements DiagnoseExtension
 			} else {
 				$workerBinaryLine = 'loaded via php.ini, workers inherit it';
 			}
+		} elseif ($workerBinary !== null) {
+			$workerBinaryLine = $workerBinary;
+		} elseif (PHP_VERSION_ID < TurboExtensionSelector::MINIMUM_PHP_VERSION_ID) {
+			$workerBinaryLine = sprintf(
+				'none built for PHP < %s',
+				(new PhpVersion(TurboExtensionSelector::MINIMUM_PHP_VERSION_ID))->getVersionString(),
+			);
 		} else {
-			$workerBinaryLine = $workerBinary ?? 'none found';
+			$workerBinaryLine = 'none found';
 		}
 		$output->writeLineFormatted(sprintf(
 			'<info>Turbo worker binary:</info> %s',

--- a/src/Turbo/TurboExtensionSelector.php
+++ b/src/Turbo/TurboExtensionSelector.php
@@ -13,6 +13,7 @@ use const PHP_DEBUG;
 use const PHP_MAJOR_VERSION;
 use const PHP_MINOR_VERSION;
 use const PHP_OS_FAMILY;
+use const PHP_VERSION_ID;
 use const PHP_ZTS;
 
 /**
@@ -26,7 +27,8 @@ use const PHP_ZTS;
  * Windows) by the phar.yml commit job, so they only exist for phar-based
  * installations —
  * a source checkout loads its locally built extension through php.ini
- * instead. Only non-debug builds are shipped; ZTS variants (-zts filename
+ * instead. Only non-debug builds for PHP >= MINIMUM_PHP_VERSION_ID are
+ * shipped; ZTS variants (-zts filename
  * suffix) exist for linux-gnu and Windows so hosts with a thread-safe PHP
  * (like PMMP's bundled build) are covered too. Workers run the regular
  * entrypoint, so TurboExtensionEnabler still gates activation on the
@@ -38,6 +40,13 @@ use const PHP_ZTS;
  */
 final class TurboExtensionSelector
 {
+
+	/**
+	 * The oldest PHP the extension is built for — the phar.yml turbo-compile
+	 * matrix. Older runtimes have no binary to find, so they skip the lookup
+	 * (and with it the process restart) entirely.
+	 */
+	public const MINIMUM_PHP_VERSION_ID = 80300;
 
 	public static function findExtensionForWorkers(): ?string
 	{
@@ -63,6 +72,9 @@ final class TurboExtensionSelector
 	 */
 	public static function findExtension(): ?string
 	{
+		if (PHP_VERSION_ID < self::MINIMUM_PHP_VERSION_ID) {
+			return null;
+		}
 		if ((bool) PHP_DEBUG) {
 			return null;
 		}

--- a/src/Turbo/TurboExtensionSelector.php
+++ b/src/Turbo/TurboExtensionSelector.php
@@ -8,7 +8,7 @@ use function file_get_contents;
 use function is_file;
 use function php_uname;
 use function sprintf;
-use function str_contains;
+use function strpos;
 use const PHP_DEBUG;
 use const PHP_MAJOR_VERSION;
 use const PHP_MINOR_VERSION;
@@ -31,6 +31,10 @@ use const PHP_ZTS;
  * (like PMMP's bundled build) are covered too. Workers run the regular
  * entrypoint, so TurboExtensionEnabler still gates activation on the
  * expected extension version.
+ *
+ * bin/phpstan loads this class before the Composer autoloader (for the
+ * process restart), so it must only call functions native to PHP 7.4 - the
+ * symfony polyfills are not registered yet. PreAutoloadFilesTest guards this.
  */
 final class TurboExtensionSelector
 {
@@ -124,7 +128,10 @@ final class TurboExtensionSelector
 	public static function resolveIsMusl(string|false $selfMaps, bool $hasAlpineRelease): bool
 	{
 		if ($selfMaps !== false) {
-			return str_contains($selfMaps, '/ld-musl-');
+			// strpos() rather than str_contains(): this runs before the Composer
+			// autoloader, so the symfony polyfill is not loaded yet and
+			// str_contains() does not exist on PHP < 8.0
+			return strpos($selfMaps, '/ld-musl-') !== false;
 		}
 
 		// no procfs to inspect (non-Linux, or a sandboxed container without

--- a/tests/PHPStan/Build/PreAutoloadFilesTest.php
+++ b/tests/PHPStan/Build/PreAutoloadFilesTest.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Build;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Include_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+use function dirname;
+use function file_get_contents;
+use function realpath;
+use function sprintf;
+use function str_ends_with;
+use function str_replace;
+use function strlen;
+use function strtolower;
+use function substr;
+
+/**
+ * bin/phpstan loads the turbo restart classes before the Composer autoloader,
+ * so the symfony polyfills are not registered yet when they run. A call to a
+ * polyfilled function there (str_contains(), ...) is a fatal error on every
+ * PHP version lacking it natively - and the phar supports PHP 7.4
+ * (https://github.com/phpstan/phpstan/issues/15137).
+ */
+final class PreAutoloadFilesTest extends TestCase
+{
+
+	/**
+	 * bin/phpstan itself up to the autoloader require, plus every file it
+	 * requires before it.
+	 *
+	 * @return iterable<string, array{string, int|null}>
+	 */
+	public static function dataPreAutoloadFiles(): iterable
+	{
+		$root = realpath(__DIR__ . '/../../..');
+		self::assertNotFalse($root);
+		$root = str_replace('\\', '/', $root);
+		$binPath = $root . '/bin/phpstan';
+
+		$autoloadLine = null;
+		$files = [];
+		foreach ((new NodeFinder())->findInstanceOf(self::parse($binPath), Include_::class) as $include) {
+			$path = self::resolveIncludePath($include->expr, dirname($binPath));
+			if ($path === null) {
+				continue;
+			}
+			if (str_ends_with($path, '/vendor/autoload.php')) {
+				$autoloadLine = $include->getStartLine();
+				break;
+			}
+
+			$files[] = $path;
+		}
+
+		self::assertNotNull($autoloadLine, 'bin/phpstan does not require vendor/autoload.php');
+		self::assertNotSame([], $files, 'bin/phpstan requires nothing before vendor/autoload.php');
+
+		yield 'bin/phpstan' => [$binPath, $autoloadLine];
+		foreach ($files as $file) {
+			yield substr($file, strlen($root) + 1) => [$file, null];
+		}
+	}
+
+	/**
+	 * @param int|null $beforeLine Only calls above this line run before the autoloader
+	 */
+	#[DataProvider('dataPreAutoloadFiles')]
+	public function testCallsOnlyNativeFunctions(string $file, ?int $beforeLine): void
+	{
+		$polyfilled = self::polyfilledFunctions();
+
+		$violations = [];
+		foreach ((new NodeFinder())->findInstanceOf(self::parse($file), FuncCall::class) as $call) {
+			if (!$call->name instanceof Name) {
+				continue;
+			}
+			if ($beforeLine !== null && $call->getStartLine() >= $beforeLine) {
+				continue;
+			}
+
+			$function = strtolower($call->name->getLast());
+			if (!isset($polyfilled[$function])) {
+				continue;
+			}
+
+			$violations[] = sprintf('%s() on line %d', $function, $call->getStartLine());
+		}
+
+		self::assertSame([], $violations, sprintf(
+			'%s runs before the Composer autoloader registers the symfony polyfills, so it must only call functions native to PHP 7.4.',
+			$file,
+		));
+	}
+
+	private static function resolveIncludePath(Expr $expr, string $dir): ?string
+	{
+		if (
+			!$expr instanceof Concat
+			|| !$expr->left instanceof Dir
+			|| !$expr->right instanceof String_
+		) {
+			return null;
+		}
+
+		$path = realpath($dir . $expr->right->value);
+		if ($path === false) {
+			return null;
+		}
+
+		return str_replace('\\', '/', $path);
+	}
+
+	/**
+	 * Every function the bundled symfony polyfills declare, i.e. every function
+	 * missing natively on some PHP version PHPStan runs on.
+	 *
+	 * @return array<string, true>
+	 */
+	private static function polyfilledFunctions(): array
+	{
+		$functions = [];
+		$finder = new Finder();
+		foreach ($finder->files()->name('bootstrap*.php')->depth(0)->in(__DIR__ . '/../../../vendor/symfony/polyfill-*') as $fileInfo) {
+			foreach ((new NodeFinder())->findInstanceOf(self::parse($fileInfo->getPathname()), Function_::class) as $function) {
+				$functions[$function->name->toLowerString()] = true;
+			}
+		}
+
+		self::assertArrayHasKey('str_contains', $functions);
+
+		return $functions;
+	}
+
+	/**
+	 * @return Node\Stmt[]
+	 */
+	private static function parse(string $file): array
+	{
+		$code = file_get_contents($file);
+		self::assertNotFalse($code, sprintf('Could not read %s', $file));
+
+		$ast = (new ParserFactory())->createForNewestSupportedVersion()->parse($code);
+		self::assertNotNull($ast, sprintf('Could not parse %s', $file));
+
+		return $ast;
+	}
+
+}

--- a/tests/PHPStan/Build/SkipTestsWithRequiresPhpAttributeRuleTest.php
+++ b/tests/PHPStan/Build/SkipTestsWithRequiresPhpAttributeRuleTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Build;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<SkipTestsWithRequiresPhpAttributeRule>
+ */
+class SkipTestsWithRequiresPhpAttributeRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new SkipTestsWithRequiresPhpAttributeRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/skip-tests-requires-php.php'], [
+			[
+				'Skip tests with #[RequiresPhp] attribute instead.',
+				13,
+			],
+		]);
+	}
+
+	public function testFix(): void
+	{
+		$this->fix(__DIR__ . '/data/skip-tests-requires-php.php', __DIR__ . '/data/skip-tests-requires-php.php.fixed');
+	}
+
+}

--- a/tests/PHPStan/Build/data/skip-tests-requires-php.php
+++ b/tests/PHPStan/Build/data/skip-tests-requires-php.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace SkipTestsWithRequiresPhpAttributeRule;
+
+use PHPUnit\Framework\TestCase;
+use const PHP_VERSION_ID;
+
+class FooTest extends TestCase
+{
+
+	public function testVersionCheck(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped();
+		}
+	}
+
+	public function testVersionCheckWithoutSkip(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			return;
+		}
+	}
+
+	public function testUnrelatedCondition(bool $a, bool $b): void
+	{
+		if ($a || $b) {
+			return;
+		}
+	}
+
+	public function testUnrelatedComparison(int $a): void
+	{
+		if ($a < 80000) {
+			return;
+		}
+	}
+
+}

--- a/tests/PHPStan/Build/data/skip-tests-requires-php.php.fixed
+++ b/tests/PHPStan/Build/data/skip-tests-requires-php.php.fixed
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace SkipTestsWithRequiresPhpAttributeRule;
+
+use PHPUnit\Framework\TestCase;
+use const PHP_VERSION_ID;
+
+class FooTest extends TestCase
+{
+
+	#[\PHPUnit\Framework\Attributes\RequiresPhp('>= 8.0')]
+	public function testVersionCheck(): void
+	{
+	}
+
+	public function testVersionCheckWithoutSkip(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			return;
+		}
+	}
+
+	public function testUnrelatedCondition(bool $a, bool $b): void
+	{
+		if ($a || $b) {
+			return;
+		}
+	}
+
+	public function testUnrelatedComparison(int $a): void
+	{
+		if ($a < 80000) {
+			return;
+		}
+	}
+
+}


### PR DESCRIPTION
`bin/phpstan` requires the turbo restart classes and calls `TurboProcessRestarter::restartIfSuitable()` before `vendor/autoload.php`, so the symfony polyfills are not registered yet when they run. 51d272f6af put `str_contains()` into `TurboExtensionSelector::resolveIsMusl()`, which fatals the phar on PHP 7.4 hosts with pcntl — reached on Linux only, where `/proc/self/maps` exists:

```
PHP Fatal error:  Uncaught Error: Call to undefined function str_contains() in phar:///.../phpstan.phar/src/Turbo/TurboExtensionSelector.php:113
```

Nothing in CI caught it: the phpstan/phpstan e2e jobs that run the phar on 7.4 use setup-php's `ini-file: development`, which lists the pcntl functions in `disable_functions`, so the restarter returned before ever calling `findExtension()`.

- `TurboExtensionSelector::findExtension()` returns early on PHP < 8.3 (`MINIMUM_PHP_VERSION_ID`, the turbo-compile matrix floor): there is no binary to find, so neither the restart nor worker spawning probes the filesystem there, and `diagnose` says so.
- `resolveIsMusl()` uses `strpos()`; `PreAutoloadFilesTest` derives the files `bin/phpstan` loads before the autoloader and fails on any call to a function declared by `vendor/symfony/polyfill-*` — the same class of crash would hit PHP 8.3 with the extension loaded for a polyfill-php84/85 function, which no e2e run exercises.
- New `phar-run` job in phar.yml runs the compiled phar (`--version` + `analyse -vvv` on `e2e/phar-run`) on PHP 7.4–8.5 with pcntl available, asserting `pcntl_exec` exists so it cannot pass vacuously. Reproduced locally in Docker `php:7.4-cli` + pcntl: the unfixed phar fatals exactly as above; a phar with only the version gate passes, as does the full change.
- `SkipTestsWithRequiresPhpAttributeRule` threw `ShouldNotHappenException` for a test method whose first statement is `if ($a || $b)`; the `PHP_VERSION_ID` checks now precede the operator switch (with a test).

Closes https://github.com/phpstan/phpstan/issues/15137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bBnhEMLHeUbbAENSRYK6u
