### PR TITLE
End forked workers with _exit() instead of PHP's full teardown

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1067,3 +1067,78 @@ jobs:
           # fits through the assertion once grep has narrowed it down
           ../bashunit -a not_contains 'parallel worker' "$(grep -F 'parallel worker' "$RUNNER_TEMP/small-shm.txt" || true)"
           diff "$RUNNER_TEMP/reference.txt" "$RUNNER_TEMP/small-shm.txt"
+
+  turbo-fork-unsafe-extension-e2e-tests:
+    name: "Turbo fork-unsafe extension E2E tests"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: "Checkout"
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # the extension bakes its version from `git log -- turbo-ext/src`, and
+          # TurboExtensionEnabler activates only the expected version - a shallow
+          # clone hands us a "dev" build, which would skip the whole test
+          fetch-depth: 0
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
+        with:
+          coverage: "none"
+          php-version: "8.5"
+
+      - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
+
+      - name: "Install bashunit"
+        uses: "TypedDevs/bashunit@94933c088b0719e0c4cf5e3147dad67f713b970d" # 0.44.0
+        with:
+          directory: "e2e"
+
+      - name: "Build the turbo extension"
+        run: make -C turbo-ext -j"$(nproc)"
+
+      - name: "Build the fork-unsafe extension"
+        # a model of ext-grpc without grpc.enable_fork_support: its module
+        # shutdown waits for a thread that a forked child never has. phpize
+        # builds in place, so a copy keeps the build tree out of the checkout.
+        run: |
+          cp -r e2e/fork-unsafe-extension/ext "$RUNNER_TEMP/forkunsafe"
+          cd "$RUNNER_TEMP/forkunsafe"
+          phpize
+          ./configure
+          make -j"$(nproc)"
+
+      - name: "Verify the extension wedges a forked child on its own"
+        # a plain exit() in a forked child must hang, or the test below would
+        # pass for the wrong reason
+        run: |
+          set +e
+          timeout 10 php -d extension="$RUNNER_TEMP/forkunsafe/modules/forkunsafe.so" e2e/fork-unsafe-extension/fork-and-exit.php
+          CODE=$?
+          set -e
+          e2e/bashunit -a equals "124" "$CODE"
+
+      - name: "Verify fork mode is actually used"
+        run: |
+          OUTPUT=$(php -d extension="$PWD/turbo-ext/phpstan_turbo.so" -d extension="$RUNNER_TEMP/forkunsafe/modules/forkunsafe.so" bin/phpstan diagnose -c e2e/fork-unsafe-extension/phpstan.neon)
+          echo "$OUTPUT"
+          e2e/bashunit -a contains 'Turbo extension: enabled' "$OUTPUT"
+          e2e/bashunit -a contains 'Mechanism:                 fork (pcntl_fork)' "$OUTPUT"
+
+      - name: "Test"
+        # https://github.com/phpstan/phpstan/issues/15138 - the forked worker
+        # delivers its result (100%) and then hangs in the inherited extension's
+        # module shutdown; the run must finish instead
+        run: |
+          cd e2e/fork-unsafe-extension
+          rm -rf tmp
+          OUTPUT=$(../bashunit -a exit_code "0" "timeout 120 php -d extension=$PWD/../../turbo-ext/phpstan_turbo.so -d extension=$RUNNER_TEMP/forkunsafe/modules/forkunsafe.so ../../bin/phpstan analyse --no-progress -vvv")
+          echo "$OUTPUT"
+          ../bashunit -a contains 'Mechanism:                 fork (pcntl_fork)' "$OUTPUT"
+          ../bashunit -a contains '[OK] No errors' "$OUTPUT"

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -293,6 +293,9 @@ jobs:
           TURBO_DLL: ${{ runner.temp }}/turbo-ext/modules/phpstan_turbo.so
         run: php -d extension="$RUNNER_TEMP/turbo-ext/modules/phpstan_turbo.so" turbo-ext/tests/arena-smoke.php
 
+      - name: "Forked-worker exit (exitImmediately() ends a child whose teardown would wedge)"
+        run: php -d extension="$RUNNER_TEMP/turbo-ext/modules/phpstan_turbo.so" turbo-ext/tests/exit-immediately.php
+
       - name: "Signature parity (reflect native classes against the PHP twins)"
         run: php -d extension="$RUNNER_TEMP/turbo-ext/modules/phpstan_turbo.so" turbo-ext/tests/signature-parity.php
 
@@ -481,6 +484,9 @@ jobs:
       - name: "Arena smoke test (cross-process shared-memory records)"
         run: php -d extension="$PWD/turbo-ext/phpstan_turbo.so" turbo-ext/tests/arena-smoke.php
 
+      - name: "Forked-worker exit (exitImmediately() ends a child whose teardown would wedge)"
+        run: php -d extension="$PWD/turbo-ext/phpstan_turbo.so" turbo-ext/tests/exit-immediately.php
+
       - name: "Signature parity (reflect native classes against the PHP twins)"
         run: php -d extension="$PWD/turbo-ext/phpstan_turbo.so" turbo-ext/tests/signature-parity.php
 
@@ -590,6 +596,9 @@ jobs:
 
       - name: "Arena smoke test (cross-process shared-memory records)"
         run: docker exec alpine-build php -d extension=/work/turbo-ext/phpstan_turbo.so turbo-ext/tests/arena-smoke.php
+
+      - name: "Forked-worker exit (exitImmediately() ends a child whose teardown would wedge)"
+        run: docker exec alpine-build php -d extension=/work/turbo-ext/phpstan_turbo.so turbo-ext/tests/exit-immediately.php
 
       - name: "Signature parity (reflect native classes against the PHP twins)"
         run: docker exec alpine-build php -d extension=/work/turbo-ext/phpstan_turbo.so turbo-ext/tests/signature-parity.php
@@ -927,6 +936,10 @@ jobs:
       - name: "Arena smoke test (cross-process shared-memory records)"
         shell: bash
         run: php -d extension="$TURBO_DLL" turbo-ext/tests/arena-smoke.php
+
+      - name: "Forked-worker exit (exitImmediately() ends a child whose teardown would wedge)"
+        shell: bash
+        run: php -d extension="$TURBO_DLL" turbo-ext/tests/exit-immediately.php
 
       - name: "Signature parity (reflect native classes against the PHP twins)"
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp/.memory_limit
 e2e/bashunit
 /.phpbench
 /e2e/turbo-arena/tmp
+/e2e/fork-unsafe-extension/tmp

--- a/e2e/fork-unsafe-extension/ext/config.m4
+++ b/e2e/fork-unsafe-extension/ext/config.m4
@@ -1,0 +1,4 @@
+PHP_ARG_ENABLE([forkunsafe], [whether to enable forkunsafe], [AS_HELP_STRING([--enable-forkunsafe], [Enable forkunsafe])], [yes])
+if test "$PHP_FORKUNSAFE" != "no"; then
+  PHP_NEW_EXTENSION([forkunsafe], [forkunsafe.c], [$ext_shared])
+fi

--- a/e2e/fork-unsafe-extension/ext/forkunsafe.c
+++ b/e2e/fork-unsafe-extension/ext/forkunsafe.c
@@ -1,0 +1,79 @@
+/*
+ * forkunsafe - a minimal model of a fork-unsafe PHP extension, the shape of
+ * ext-grpc without grpc.enable_fork_support: RINIT starts a background
+ * thread, MSHUTDOWN asks it to stop and waits on a condition variable until
+ * the running-thread count drops to zero.
+ *
+ * In the process that started the thread this works. In a pcntl_fork()ed
+ * child only the forking thread survives, but the copied counter still says
+ * "one thread running" - so the child's module shutdown waits forever. That
+ * is https://github.com/phpstan/phpstan/issues/15138: a forked worker that
+ * has delivered its results and cannot exit.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include <pthread.h>
+#include <unistd.h>
+
+static pthread_t forkunsafe_thread;
+static pthread_mutex_t forkunsafe_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t forkunsafe_cond = PTHREAD_COND_INITIALIZER;
+static int forkunsafe_running = 0;
+static int forkunsafe_stop = 0;
+
+static void *forkunsafe_worker(void *arg)
+{
+	(void) arg;
+	pthread_mutex_lock(&forkunsafe_lock);
+	while (!forkunsafe_stop) {
+		pthread_mutex_unlock(&forkunsafe_lock);
+		usleep(1000);
+		pthread_mutex_lock(&forkunsafe_lock);
+	}
+	forkunsafe_running = 0;
+	pthread_cond_broadcast(&forkunsafe_cond);
+	pthread_mutex_unlock(&forkunsafe_lock);
+	return NULL;
+}
+
+static PHP_RINIT_FUNCTION(forkunsafe)
+{
+	pthread_mutex_lock(&forkunsafe_lock);
+	if (!forkunsafe_running) {
+		forkunsafe_stop = 0;
+		forkunsafe_running = 1;
+		pthread_create(&forkunsafe_thread, NULL, forkunsafe_worker, NULL);
+	}
+	pthread_mutex_unlock(&forkunsafe_lock);
+	return SUCCESS;
+}
+
+static PHP_MSHUTDOWN_FUNCTION(forkunsafe)
+{
+	pthread_mutex_lock(&forkunsafe_lock);
+	forkunsafe_stop = 1;
+	while (forkunsafe_running) {
+		/* grpc_shutdown()-style: wait for every thread to check out */
+		pthread_cond_wait(&forkunsafe_cond, &forkunsafe_lock);
+	}
+	pthread_mutex_unlock(&forkunsafe_lock);
+	return SUCCESS;
+}
+
+zend_module_entry forkunsafe_module_entry = {
+	STANDARD_MODULE_HEADER,
+	"forkunsafe",
+	NULL,
+	NULL,
+	PHP_MSHUTDOWN(forkunsafe),
+	PHP_RINIT(forkunsafe),
+	NULL,
+	NULL,
+	"0.1",
+	STANDARD_MODULE_PROPERTIES,
+};
+
+ZEND_GET_MODULE(forkunsafe)

--- a/e2e/fork-unsafe-extension/fork-and-exit.php
+++ b/e2e/fork-unsafe-extension/fork-and-exit.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+// A bare pcntl_fork() + exit() with the fork-unsafe extension loaded. The
+// child wedges in the extension's module shutdown, so this script never
+// finishes - the e2e job relies on that to prove the extension models the
+// hang before testing that PHPStan's forked workers survive it.
+
+if (pcntl_fork() === 0) {
+	exit(0);
+}
+
+pcntl_wait($status);
+echo "the forked child exited\n";

--- a/e2e/fork-unsafe-extension/phpstan.neon
+++ b/e2e/fork-unsafe-extension/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: 0
+	tmpDir: tmp
+	paths:
+		- src

--- a/e2e/fork-unsafe-extension/src/Foo.php
+++ b/e2e/fork-unsafe-extension/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace ForkUnsafeExtension;
+
+final class Foo
+{
+
+	public function bar(): int
+	{
+		return 1;
+	}
+
+}

--- a/src/Parallel/ForkParallelChecker.php
+++ b/src/Parallel/ForkParallelChecker.php
@@ -33,6 +33,10 @@ use function sprintf;
  * - OPcache + JIT off — their shared memory is not safe to populate
  *   concurrently from forked children and doing so corrupts analysis
  *   results.
+ *
+ * A forked worker ends with the extension's _exit() instead of PHP's full
+ * teardown (see ForkedChildTerminator): the child inherits every loaded
+ * extension, and a fork-unsafe one wedges its module shutdown.
  */
 #[AutowiredService]
 final class ForkParallelChecker implements DiagnoseExtension

--- a/src/Parallel/ForkedProcess.php
+++ b/src/Parallel/ForkedProcess.php
@@ -4,6 +4,7 @@ namespace PHPStan\Parallel;
 
 use PHPStan\Command\InceptionNotSuccessfulException;
 use PHPStan\Process\ForkedChildCrashReporter;
+use PHPStan\Process\ForkedChildTerminator;
 use PHPStan\ShouldNotHappenException;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
@@ -112,6 +113,8 @@ final class ForkedProcess extends ProcessBase
 			}
 			/** phpcs:enable */
 			ForkedChildCrashReporter::install($tmpStdErr);
+			// after the crash reporter: its shutdown function must run first
+			ForkedChildTerminator::install();
 			$output = new StreamOutput($tmpStdOut);
 			try {
 				$exitCode = $this->workerRunner->run(

--- a/src/Process/ForkedChildTerminator.php
+++ b/src/Process/ForkedChildTerminator.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use PHPStan\Turbo\TurboExtensionEnabler;
+use PHPStanTurbo\Runtime;
+use function register_shutdown_function;
+
+/**
+ * Ends a pcntl_fork()ed worker with _exit() instead of PHP's full teardown.
+ *
+ * A forked child inherits the whole parent process, every loaded extension
+ * with whatever background threads it started included - but fork() copies
+ * only the calling thread. exit() then runs destructors and each extension's
+ * module shutdown, and an extension whose shutdown waits for its threads to
+ * check out (ext-grpc's grpc_shutdown() without grpc.enable_fork_support, for
+ * one) waits forever for threads the child never had: the worker has
+ * delivered its results, the parent keeps polling waitpid(), and the run
+ * hangs at 100%. A forked child that does not exec() must end with _exit(),
+ * leaving the process-wide teardown to the parent.
+ *
+ * install() registers that _exit() as the child's last shutdown function, so
+ * it covers every way out - exit(), a fatal error, an uncaught exception -
+ * and runs after the crash report (ForkedChildCrashReporter) is written.
+ * Everything the parent reads from the child, the results over the socket
+ * and the captured output, has gone through unbuffered fds by then.
+ *
+ * PHP itself has no _exit(); the turbo extension provides it, and fork mode
+ * from a phar requires the extension anyway (see ForkParallelChecker). A
+ * source checkout forking without it keeps the plain exit().
+ */
+final class ForkedChildTerminator
+{
+
+	public static function install(): void
+	{
+		if (!TurboExtensionEnabler::isActive()) {
+			return;
+		}
+
+		register_shutdown_function(static function (): void {
+			Runtime::exitImmediately();
+		});
+	}
+
+}

--- a/src/Process/ForkedProcessPromise.php
+++ b/src/Process/ForkedProcessPromise.php
@@ -114,6 +114,8 @@ final class ForkedProcessPromise implements ProcessPromise
 			// the worker on its own fresh event loop and never return.
 			$this->server->close();
 			ForkedChildCrashReporter::install($tmpStdErr);
+			// after the crash reporter: its shutdown function must run first
+			ForkedChildTerminator::install();
 			// The worker writes its errors into the capture the parent reads,
 			// like a spawned worker whose stderr is the capture itself.
 			$childErrorStream = new StreamOutput($tmpStdErr);

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -21,7 +21,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = '7435abf';
+	public const EXPECTED_EXTENSION_VERSION = 'dee1d70';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/turbo-ext/README.md
+++ b/turbo-ext/README.md
@@ -79,6 +79,15 @@ native code never instantiates its own classes directly: a referenced class
 that is itself shadowed resolves to its stub subclass, and
 factories/singletons instantiate that.
 
+Two more `Runtime` entry points serve fork mode (see `ForkParallelChecker`):
+`enablePharForkGuard()` gives each pcntl_fork()ed worker a private cursor on
+the running phar's fd (`PharForkGuard.cpp`), and `exitImmediately()` —
+`_exit()` with the engine's exit status — is how `ForkedChildTerminator` ends
+a forked worker. A forked child inherits every loaded extension but none of
+their threads, so PHP's full teardown can wedge in a fork-unsafe extension's
+module shutdown (ext-grpc without `grpc.enable_fork_support`); a forked child
+that does not exec() must `_exit()` instead.
+
 The extension is version-pinned (`TurboExtensionEnabler::EXPECTED_EXTENSION_VERSION`);
 a mismatched extension is ignored. There is no runtime kill switch — the only
 way to run without it is not to load it.

--- a/turbo-ext/analysis-stub.php
+++ b/turbo-ext/analysis-stub.php
@@ -23,4 +23,8 @@ final class Runtime
 	{
 	}
 
+	public static function exitImmediately(): never
+	{
+	}
+
 }

--- a/turbo-ext/src/main.cpp
+++ b/turbo-ext/src/main.cpp
@@ -11,6 +11,12 @@
 #include "support.h"
 #include "reg.h"
 
+#ifdef PHP_WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 /* The short SHA of the last commit touching the watched set: baked from git
  * by the Makefile (quoted string passed directly), or from the VERSION.txt
  * the subsplit workflow commits into phpstan/turbo-ext; "dev" with neither,
@@ -74,6 +80,33 @@ static void ZEND_FASTCALL runtimeEnablePharForkGuard(INTERNAL_FUNCTION_PARAMETER
 	pt_phar_fork_guard_register(path);
 }
 
+/* PHPStanTurbo\Runtime::exitImmediately() — _exit() for a pcntl_fork()ed
+ * worker; ForkedChildTerminator registers it as the child's last shutdown
+ * function.
+ *
+ * A forked child inherits the whole parent process, every loaded extension
+ * with whatever background threads it started included — but fork() copies
+ * only the calling thread. PHP's exit() then runs destructors and each
+ * extension's module shutdown, and an extension whose shutdown waits for
+ * its threads to check out (ext-grpc's grpc_shutdown() without
+ * grpc.enable_fork_support, for one) waits forever for threads the child
+ * never had: the worker has delivered its results, the parent keeps
+ * polling waitpid(), and the run hangs at 100%. A forked child that does
+ * not exec() must end with _exit() — no destructors, no module shutdown, no
+ * atexit handlers; that teardown is the parent's. The shutdown functions
+ * have run by then, so the crash report (ForkedChildCrashReporter) is
+ * written, and everything the parent reads — the results over the socket,
+ * the captured output — went through unbuffered fds.
+ *
+ * The status is the engine's: what exit() was given, 255 after a fatal
+ * error, 0 otherwise. */
+static void ZEND_FASTCALL runtimeExitImmediately(INTERNAL_FUNCTION_PARAMETERS)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	_exit(EG(exit_status));
+}
+
 static PHP_MINIT_FUNCTION(phpstan_turbo)
 {
 #ifdef ZTS
@@ -84,6 +117,7 @@ static PHP_MINIT_FUNCTION(phpstan_turbo)
 	runtime.method("configure", reg::PublicStatic, 1, { reg::arrayArg("classMap") }, runtimeConfigure);
 	runtime.method("classRefs", reg::PublicStatic, 0, {}, runtimeClassRefs);
 	runtime.method("enablePharForkGuard", reg::PublicStatic, 1, { reg::stringArg("pharPath") }, runtimeEnablePharForkGuard);
+	runtime.method("exitImmediately", reg::PublicStatic, 0, {}, runtimeExitImmediately);
 	runtime.register_();
 
 	pt_register_trinary_logic();

--- a/turbo-ext/tests/exit-immediately.php
+++ b/turbo-ext/tests/exit-immediately.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test for Runtime::exitImmediately().
+ *
+ * A pcntl_fork()ed child inherits the parent's whole process, and PHP's
+ * exit() runs the full teardown there: destructors, then every extension's
+ * module shutdown. An inherited extension that waits for its threads to
+ * check out at module shutdown (ext-grpc without grpc.enable_fork_support)
+ * waits forever in the child - fork() copies only the calling thread. The
+ * child must end with _exit() right after its shutdown functions instead.
+ *
+ * The teardown that must not run is modelled in userland by a destructor
+ * that never returns: it stands in for the wedged module shutdown, being the
+ * first thing PHP runs after the shutdown functions.
+ *
+ * Two passes over the same child:
+ *   1. control, plain exit() - the child must still be alive at the deadline
+ *      (proves the workload hangs)
+ *   2. exitImmediately() from a shutdown function - the child must be gone
+ *      well within the deadline, with exit()'s status, the earlier shutdown
+ *      function's marker written and the destructor's not
+ *
+ * Run: php -d extension=$PWD/phpstan_turbo.so tests/exit-immediately.php
+ */
+
+const DEADLINE_SECONDS = 3;
+const EXIT_STATUS = 7;
+
+if (!extension_loaded('phpstan_turbo')) {
+	fwrite(STDERR, "phpstan_turbo extension is not loaded\n");
+	exit(1);
+}
+if (!function_exists('pcntl_fork')) {
+	echo "SKIP: pcntl is not available\n";
+	exit(0);
+}
+
+final class WedgedTeardown
+{
+
+	public static ?self $instance = null;
+
+	/** @param resource $markers */
+	public function __construct(private $markers)
+	{
+	}
+
+	public function __destruct()
+	{
+		fwrite($this->markers, "destructor\n");
+		while (true) {
+			sleep(1);
+		}
+	}
+
+}
+
+/**
+ * @return array{exited: bool, status: int|null, markers: string}
+ */
+function forkAndExit(bool $terminate): array
+{
+	$markers = tmpfile();
+	if ($markers === false) {
+		fwrite(STDERR, "tmpfile() failed\n");
+		exit(1);
+	}
+	stream_set_write_buffer($markers, 0);
+
+	$pid = pcntl_fork();
+	if ($pid === -1) {
+		fwrite(STDERR, "fork failed\n");
+		exit(1);
+	}
+	if ($pid === 0) {
+		WedgedTeardown::$instance = new WedgedTeardown($markers);
+		register_shutdown_function(static function () use ($markers): void {
+			fwrite($markers, "shutdown\n");
+		});
+		if ($terminate) {
+			register_shutdown_function(static function (): void {
+				PHPStanTurbo\Runtime::exitImmediately();
+			});
+		}
+		exit(EXIT_STATUS);
+	}
+
+	$exited = false;
+	$status = null;
+	$deadline = microtime(true) + DEADLINE_SECONDS;
+	while (microtime(true) < $deadline) {
+		$result = pcntl_waitpid($pid, $waitStatus, WNOHANG);
+		if ($result === $pid) {
+			$exited = true;
+			$status = pcntl_wifexited($waitStatus) ? pcntl_wexitstatus($waitStatus) : null;
+			break;
+		}
+		usleep(10000);
+	}
+	if (!$exited) {
+		posix_kill($pid, SIGKILL);
+		pcntl_waitpid($pid, $waitStatus);
+	}
+
+	rewind($markers);
+	$written = (string) stream_get_contents($markers);
+	fclose($markers);
+
+	return ['exited' => $exited, 'status' => $status, 'markers' => $written];
+}
+
+$control = forkAndExit(false);
+printf("control (exit):      exited %s, markers %s\n", $control['exited'] ? 'yes' : 'no', json_encode($control['markers']));
+
+$terminated = forkAndExit(true);
+printf("exitImmediately():   exited %s, status %s, markers %s\n", $terminated['exited'] ? 'yes' : 'no', var_export($terminated['status'], true), json_encode($terminated['markers']));
+
+if ($control['exited'] || $control['markers'] !== "shutdown\ndestructor\n") {
+	fwrite(STDERR, "FAIL: the control child did not wedge in its destructor - the workload no longer models the hang\n");
+	exit(1);
+}
+if (!$terminated['exited']) {
+	fwrite(STDERR, "FAIL: the child did not exit\n");
+	exit(1);
+}
+if ($terminated['status'] !== EXIT_STATUS) {
+	fwrite(STDERR, "FAIL: the child exited with the wrong status\n");
+	exit(1);
+}
+if ($terminated['markers'] !== "shutdown\n") {
+	fwrite(STDERR, "FAIL: unexpected teardown ran in the child\n");
+	exit(1);
+}
+
+echo "ALL OK\n";


### PR DESCRIPTION
A `pcntl_fork()`ed worker inherits every loaded extension of the main process but none of its threads. `exit()` runs each extension's module shutdown in the child, and one that waits for its threads to check out there — ext-grpc's `grpc_shutdown()` without `grpc.enable_fork_support`, as sampled by a user in https://github.com/phpstan/phpstan/issues/15131 — waits forever: the worker has delivered its result, the parent keeps polling `waitpid()`, and the run hangs at 100% with no "Result cache is saved". `PHPSTAN_TURBO=0` means spawn mode, which is why it "works"; and the trigger is the machine's php.ini rather than the project, which is why no reproducer repository could show it.

A forked child that does not `exec()` has to end with `_exit()`, which PHP itself cannot do. The turbo extension now provides `Runtime::exitImmediately()` (`_exit()` with the engine's exit status), and `ForkedChildTerminator` registers it as the forked child's last shutdown function — after `ForkedChildCrashReporter`'s — in both `ForkedProcess` and the fixer's `ForkedProcessPromise`. That covers every way out (`exit()`, a fatal error, an uncaught exception), skips the destructors and every extension's module shutdown, and still lets the crash report reach the parent. Fork mode from a phar already requires the extension; a source checkout forking without it keeps the plain `exit()`.

Regression coverage:
- `turbo-ext/tests/exit-immediately.php` models the wedged teardown in userland (a control pass proves the child hangs with plain `exit()`), run in every phar.yml matrix next to the smoke tests.
- A new e2e job builds a minimal fork-unsafe extension with ext-grpc's shape (RINIT starts a thread, MSHUTDOWN waits for it) and runs fork mode with it loaded — after first proving that the extension alone wedges a bare `pcntl_fork()` + `exit()`.

Verified locally with that model extension loaded: the shipped 2.2.11 phar hangs at 100% (the forked worker sampled in `php_module_shutdown → zm_shutdown_* → pthread_cond_wait`), a phar built from this branch completes in the same setup (`symfony php`, restart with the dist `.so`, `fork (pcntl_fork)`), a worker dying of the memory limit still reports "PHPStan process crashed because it reached configured PHP memory limit", the full test suite passes with the extension loaded, and raw analysis output is identical with turbo on and off.

Closes https://github.com/phpstan/phpstan/issues/15138
Closes https://github.com/phpstan/phpstan/issues/15142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7847gqpkLK9hdBztahv8c
