### PR TITLE
Restart for OPcache even when turbo is already loaded, and keep forked workers off the shared cache

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1019,12 +1019,20 @@ jobs:
       - name: "Build the turbo extension"
         run: make -C turbo-ext -j"$(nproc)"
 
+      - name: "Load the turbo extension through php.ini"
+        # TurboProcessRestarter re-executes the process with the loaded php.ini
+        # to activate OPcache; an extension passed as -d would not survive that,
+        # one from the ini scan dir is loaded again
+        run: |
+          echo "extension=$PWD/turbo-ext/phpstan_turbo.so" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-phpstan-turbo.ini"
+          php -r 'exit(extension_loaded("phpstan_turbo") ? 0 : 1);'
+
       - name: "Verify the arena is actually exercised"
         # Without an active extension ArenaCache is the no-op PHP twin and no
         # shared memory exists at all; without fork the workers do not publish in
         # lockstep. Either would make the test below pass for the wrong reason.
         run: |
-          OUTPUT=$(php -d extension="$PWD/turbo-ext/phpstan_turbo.so" bin/phpstan diagnose -c e2e/turbo-arena/phpstan.neon)
+          OUTPUT=$(php bin/phpstan diagnose -c e2e/turbo-arena/phpstan.neon)
           echo "$OUTPUT"
           e2e/bashunit -a contains 'Turbo extension: enabled' "$OUTPUT"
           e2e/bashunit -a contains 'Mechanism:                 fork (pcntl_fork)' "$OUTPUT"
@@ -1035,7 +1043,7 @@ jobs:
         # extension is now always used, so the variable has to be inert -
         # https://github.com/phpstan/phpstan/issues/15143
         run: |
-          OUTPUT=$(PHPSTAN_TURBO=0 php -d extension="$PWD/turbo-ext/phpstan_turbo.so" bin/phpstan diagnose -c e2e/turbo-arena/phpstan.neon)
+          OUTPUT=$(PHPSTAN_TURBO=0 php bin/phpstan diagnose -c e2e/turbo-arena/phpstan.neon)
           echo "$OUTPUT"
           e2e/bashunit -a contains 'Turbo extension: enabled' "$OUTPUT"
 
@@ -1050,17 +1058,16 @@ jobs:
         # must cost sharing, never results - the analysis has to come out exactly
         # as it does with the runner's normal /dev/shm.
         run: |
-          SO="$PWD/turbo-ext/phpstan_turbo.so"
           cd e2e/turbo-arena
           rm -rf tmp
-          php -d extension="$SO" ../../bin/phpstan analyse --no-progress > "$RUNNER_TEMP/reference.txt" 2>&1 || true
+          php ../../bin/phpstan analyse --no-progress > "$RUNNER_TEMP/reference.txt" 2>&1 || true
           tail -5 "$RUNNER_TEMP/reference.txt"
           # a warm disk cache is the worst case: every worker loads and publishes
           # the same entries at the same moment, so duplicates pile up fastest
-          php -d extension="$SO" ../../bin/phpstan clear-result-cache
+          php ../../bin/phpstan clear-result-cache
           sudo mount -o remount,size=32M /dev/shm
           df -h /dev/shm
-          php -d extension="$SO" ../../bin/phpstan analyse --no-progress > "$RUNNER_TEMP/small-shm.txt" 2>&1 || true
+          php ../../bin/phpstan analyse --no-progress > "$RUNNER_TEMP/small-shm.txt" 2>&1 || true
           tail -40 "$RUNNER_TEMP/small-shm.txt"
           # bashunit takes the haystack as a single argv entry, and execve caps
           # one argument at 128 KB - a few hundred KB of analysis output only
@@ -1114,19 +1121,27 @@ jobs:
           ./configure
           make -j"$(nproc)"
 
+      - name: "Load both extensions through php.ini"
+        # TurboProcessRestarter re-executes the process with the loaded php.ini
+        # to activate OPcache; extensions passed as -d would not survive that,
+        # ones from the ini scan dir are loaded again
+        run: |
+          printf 'extension=%s\nextension=%s\n' "$PWD/turbo-ext/phpstan_turbo.so" "$RUNNER_TEMP/forkunsafe/modules/forkunsafe.so" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-phpstan-turbo.ini"
+          php -r 'exit(extension_loaded("phpstan_turbo") && extension_loaded("forkunsafe") ? 0 : 1);'
+
       - name: "Verify the extension wedges a forked child on its own"
         # a plain exit() in a forked child must hang, or the test below would
         # pass for the wrong reason
         run: |
           set +e
-          timeout 10 php -d extension="$RUNNER_TEMP/forkunsafe/modules/forkunsafe.so" e2e/fork-unsafe-extension/fork-and-exit.php
+          timeout 10 php e2e/fork-unsafe-extension/fork-and-exit.php
           CODE=$?
           set -e
           e2e/bashunit -a equals "124" "$CODE"
 
       - name: "Verify fork mode is actually used"
         run: |
-          OUTPUT=$(php -d extension="$PWD/turbo-ext/phpstan_turbo.so" -d extension="$RUNNER_TEMP/forkunsafe/modules/forkunsafe.so" bin/phpstan diagnose -c e2e/fork-unsafe-extension/phpstan.neon)
+          OUTPUT=$(php bin/phpstan diagnose -c e2e/fork-unsafe-extension/phpstan.neon)
           echo "$OUTPUT"
           e2e/bashunit -a contains 'Turbo extension: enabled' "$OUTPUT"
           e2e/bashunit -a contains 'Mechanism:                 fork (pcntl_fork)' "$OUTPUT"
@@ -1138,7 +1153,7 @@ jobs:
         run: |
           cd e2e/fork-unsafe-extension
           rm -rf tmp
-          OUTPUT=$(../bashunit -a exit_code "0" "timeout 120 php -d extension=$PWD/../../turbo-ext/phpstan_turbo.so -d extension=$RUNNER_TEMP/forkunsafe/modules/forkunsafe.so ../../bin/phpstan analyse --no-progress -vvv")
+          OUTPUT=$(../bashunit -a exit_code "0" "timeout 120 php ../../bin/phpstan analyse --no-progress -vvv")
           echo "$OUTPUT"
           ../bashunit -a contains 'Mechanism:                 fork (pcntl_fork)' "$OUTPUT"
           ../bashunit -a contains '[OK] No errors' "$OUTPUT"

--- a/src/Parallel/ForkedProcess.php
+++ b/src/Parallel/ForkedProcess.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 use Throwable;
 use function fclose;
 use function function_exists;
+use function ini_set;
 use function pcntl_fork;
 use function pcntl_waitpid;
 use function pcntl_wexitstatus;
@@ -101,6 +102,23 @@ final class ForkedProcess extends ProcessBase
 			// Child: drop the inherited listening socket immediately, then run
 			// the worker on its own fresh event loop and never return.
 			$this->server->close();
+			// Leave the shared OPcache alone from here on. What the parent
+			// loaded before forking keeps running from shared memory; this
+			// worker neither stores what it compiles from now on nor loads
+			// what its siblings store. Concurrent population by forked
+			// siblings races on the per-process map_ptr slot table: a process
+			// linking classes privately (once the shared memory is full, or
+			// for any class whose parent is not shared) takes slot offsets
+			// from its own counter, a sibling storing a script takes the same
+			// offsets for the shared copy, and loading that script only ever
+			// bumps the counter upwards - the shared method then runs with a
+			// foreign run-time cache and segfaults on its first cache slot
+			// (intermittent SIGSEGV in workers, 3 of 10 slevomat runs).
+			// Disabling takes effect immediately and is the one OPcache switch
+			// that can be flipped at run time. It costs the sharing of classes
+			// loaded after the fork (0-2% CPU, worker heaps between the
+			// no-OPcache and fully-shared numbers), not the parent's cache.
+			ini_set('opcache.enable', '0');
 			// memory_get_peak_usage() carries over into the child, so without this a
 			// worker would report the main process's peak instead of its own - on an
 			// incremental run, the spike taken while loading the result cache, which

--- a/src/Turbo/TurboProcessRestarter.php
+++ b/src/Turbo/TurboProcessRestarter.php
@@ -2,38 +2,47 @@
 
 namespace PHPStan\Turbo;
 
+use function explode;
 use function extension_loaded;
 use function function_exists;
 use function get_cfg_var;
+use function in_array;
 use function ini_get;
 use function is_string;
 use function max;
 use function pcntl_exec;
 use function php_ini_loaded_file;
+use function strtolower;
+use function trim;
 use const PHP_BINARY;
 
 /**
- * Restarts the main PHPStan process via pcntl_exec() with the distributed
- * turbo extension loaded through -d extension=.
+ * Restarts the main PHPStan process via pcntl_exec() when the process it
+ * was started as is not the one PHPStan wants to run — for either of two
+ * reasons, checked independently.
  *
- * Parallel analysis prefers pcntl_fork()ed workers over spawned ones (see
+ * The distributed turbo extension is available but not loaded. Parallel
+ * analysis prefers pcntl_fork()ed workers over spawned ones (see
  * ForkParallelChecker) — a forked worker inherits the booted process instead
  * of paying a full re-boot. But a forked worker also inherits the parent's
  * loaded extensions: the spawn-time `-d extension=` injection
  * (ProcessHelper) cannot reach it, and dl() cannot load a binary from next
- * to the phar. So when the extension binary is available but not loaded,
- * the whole process is re-executed with it before anything else runs —
- * forked workers then inherit the extension, its stub shadowing, and (when
- * running from a phar) the phar-fork-guard that keeps phar:// reads safe
- * across fork.
+ * to the phar. So the whole process is re-executed with the extension
+ * before anything else runs — forked workers then inherit the extension,
+ * its stub shadowing, and (when running from a phar) the phar-fork-guard
+ * that keeps phar:// reads safe across fork.
  *
- * The restarted process also gets OPcache activated — with JIT pinned off,
- * whatever the user's ini says — so forked workers share the parent's warm
- * opcode cache (see resolveOpcacheArgs()).
+ * The OPcache configuration in effect is not the one PHPStan wants (see
+ * resolveOpcacheArgs()) — usually because OPcache is dormant on CLI, or has
+ * JIT on. The restarted process runs with it activated, JIT pinned off, and
+ * forked workers share the parent's warm opcode cache. This reason stands
+ * on its own so that a php.ini which already loads turbo (a source checkout
+ * with a locally built extension, say) does not leave OPcache dormant just
+ * because there is no extension left to restart for.
  *
- * The restart carries a marker ini entry with the extension path. It doubles
- * as the retry stop (a binary that failed to load leaves the extension
- * unloaded — without the marker the restart would loop) and tells
+ * The restart carries two marker ini entries: RESTARTED_INI is the retry
+ * stop (a binary that failed to load, or an OPcache that could not start,
+ * would otherwise restart forever), and EXTENSION_PATH_INI tells
  * TurboExtensionSelector that spawned workers still need the -d flag
  * (command-line -d flags, unlike php.ini, are not inherited).
  */
@@ -41,6 +50,9 @@ final class TurboProcessRestarter
 {
 
 	public const EXTENSION_PATH_INI = 'phpstan.turboExtensionPath';
+
+	/** Set by the restart so the restarted process never restarts again */
+	public const RESTARTED_INI = 'phpstan.restarted';
 
 	/** Shared memory reserved (not touched) for the opcode cache, in MB — see resolveOpcacheArgs() for the sizing */
 	private const OPCACHE_MEMORY_CONSUMPTION_MB_LIMIT = 256;
@@ -80,11 +92,10 @@ final class TurboProcessRestarter
 	 */
 	public static function restartIfSuitable(array $argv): void
 	{
-		if (extension_loaded('phpstan_turbo')) {
-			return;
-		}
-		if (self::getRestartExtensionPath() !== null) {
-			// already restarted and the extension still did not load
+		if (get_cfg_var(self::RESTARTED_INI) !== false) {
+			// already restarted — whatever did not take effect (a binary that
+			// failed to load, an OPcache that could not start) will not on a
+			// second try either
 			return;
 		}
 		if (
@@ -100,8 +111,12 @@ final class TurboProcessRestarter
 			return;
 		}
 
-		$extensionPath = TurboExtensionSelector::findExtension();
-		if ($extensionPath === null) {
+		$extensionPath = extension_loaded('phpstan_turbo') ? null : TurboExtensionSelector::findExtension();
+		$opcacheArgs = self::getOpcacheArgs();
+		if (
+			$extensionPath === null
+			&& !self::resolveOpcacheRestartNeeded($opcacheArgs, self::getCurrentIniValues($opcacheArgs))
+		) {
 			return;
 		}
 
@@ -113,20 +128,82 @@ final class TurboProcessRestarter
 		}
 		$args[] = '-d';
 		$args[] = 'memory_limit=' . ini_get('memory_limit');
-		foreach (self::getOpcacheArgs() as $opcacheArg) {
+		foreach ($opcacheArgs as $opcacheArg) {
 			$args[] = '-d';
 			$args[] = $opcacheArg;
 		}
+		if ($extensionPath !== null) {
+			$args[] = '-d';
+			$args[] = 'extension=' . $extensionPath;
+			$args[] = '-d';
+			$args[] = self::EXTENSION_PATH_INI . '=' . $extensionPath;
+		}
 		$args[] = '-d';
-		$args[] = 'extension=' . $extensionPath;
-		$args[] = '-d';
-		$args[] = self::EXTENSION_PATH_INI . '=' . $extensionPath;
+		$args[] = self::RESTARTED_INI . '=1';
 		foreach ($argv as $arg) {
 			$args[] = $arg;
 		}
 
 		pcntl_exec(PHP_BINARY, $args);
-		// pcntl_exec() returns only on failure — continue without the extension
+		// pcntl_exec() returns only on failure — continue as we are
+	}
+
+	/**
+	 * Whether the OPcache configuration the restart would set differs from
+	 * the one in effect — the second reason to restart, independent of turbo:
+	 * with the extension already loaded through php.ini there would be
+	 * nothing else to restart for, and OPcache would stay dormant.
+	 *
+	 * @param list<string> $opcacheArgs `name=value` entries, see resolveOpcacheArgs()
+	 * @param array<string, string|false> $currentIniValues ini_get() of each of those names
+	 */
+	public static function resolveOpcacheRestartNeeded(array $opcacheArgs, array $currentIniValues): bool
+	{
+		foreach ($opcacheArgs as $opcacheArg) {
+			[$name, $value] = explode('=', $opcacheArg, 2);
+			$current = $currentIniValues[$name] ?? false;
+			if ($current === false) {
+				// unknown directive on this PHP (opcache.jit before 8.0) — nothing a restart could change
+				continue;
+			}
+			if (self::normalizeIniValue($current) !== self::normalizeIniValue($value)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param list<string> $opcacheArgs
+	 * @return array<string, string|false>
+	 */
+	private static function getCurrentIniValues(array $opcacheArgs): array
+	{
+		$values = [];
+		foreach ($opcacheArgs as $opcacheArg) {
+			$name = explode('=', $opcacheArg, 2)[0];
+			$values[$name] = ini_get($name);
+		}
+
+		return $values;
+	}
+
+	/**
+	 * The ini parser stores booleans as "1" / "" for php.ini and -d values
+	 * alike; ini_set()-style spellings are folded the same way.
+	 */
+	private static function normalizeIniValue(string $value): string
+	{
+		$value = strtolower(trim($value));
+		if (in_array($value, ['', '0', 'off', 'false', 'no', 'none'], true)) {
+			return '0';
+		}
+		if (in_array($value, ['1', 'on', 'true', 'yes'], true)) {
+			return '1';
+		}
+
+		return $value;
 	}
 
 	/**

--- a/tests/PHPStan/Turbo/TurboProcessRestarterTest.php
+++ b/tests/PHPStan/Turbo/TurboProcessRestarterTest.php
@@ -108,4 +108,64 @@ final class TurboProcessRestarterTest extends PHPStanTestCase
 		return $args;
 	}
 
+	/**
+	 * @return iterable<string, array{array<string, string|false>, bool}>
+	 */
+	public static function dataResolveOpcacheRestartNeeded(): iterable
+	{
+		// what the restarted process reads back through ini_get() for the stock args
+		$inEffect = [
+			'opcache.enable' => '1',
+			'opcache.enable_cli' => '1',
+			'opcache.jit' => 'disable',
+			'opcache.jit_buffer_size' => '0',
+			'opcache.validate_timestamps' => '0',
+			'opcache.file_update_protection' => '0',
+			'opcache.max_file_size' => '0',
+			'opcache.file_cache' => '',
+			'opcache.save_comments' => '1',
+			'opcache.memory_consumption' => '256',
+			'opcache.interned_strings_buffer' => '64',
+			'opcache.max_accelerated_files' => '20000',
+		];
+
+		yield 'already in effect' => [$inEffect, false];
+
+		// php.ini spellings the ini parser leaves as-is versus its "1"/"" for booleans
+		yield 'already in effect, php.ini spellings' => [
+			['opcache.enable' => 'On', 'opcache.validate_timestamps' => '', 'opcache.jit' => 'Disable'] + $inEffect,
+			false,
+		];
+
+		yield 'stock CLI: OPcache dormant' => [
+			['opcache.enable_cli' => '', 'opcache.validate_timestamps' => '1', 'opcache.file_update_protection' => '2', 'opcache.memory_consumption' => '128', 'opcache.interned_strings_buffer' => '8', 'opcache.max_accelerated_files' => '10000'] + $inEffect,
+			true,
+		];
+
+		yield 'OPcache active but JIT on' => [
+			['opcache.jit' => 'tracing', 'opcache.jit_buffer_size' => '64M'] + $inEffect,
+			true,
+		];
+
+		yield 'OPcache active with a file cache' => [
+			['opcache.file_cache' => '/tmp/opcache'] + $inEffect,
+			true,
+		];
+
+		// PHP < 8.0 has no JIT directives — nothing a restart could change there
+		yield 'directive unknown on this PHP' => [
+			['opcache.jit' => false, 'opcache.jit_buffer_size' => false] + $inEffect,
+			false,
+		];
+	}
+
+	/**
+	 * @param array<string, string|false> $currentIniValues
+	 */
+	#[DataProvider('dataResolveOpcacheRestartNeeded')]
+	public function testResolveOpcacheRestartNeeded(array $currentIniValues, bool $expected): void
+	{
+		$this->assertSame($expected, TurboProcessRestarter::resolveOpcacheRestartNeeded(self::STOCK_ARGS, $currentIniValues));
+	}
+
 }


### PR DESCRIPTION
Follow-up to #6324.

## Restart for OPcache even when turbo is already loaded

The restart had a single trigger — the distributed turbo binary being available but not loaded — and the OPcache activation only rode along with it. A php.ini that already loads turbo (a source checkout with a locally built extension) therefore never restarted and ran with OPcache dormant, or with JIT on and fork mode declined because of it.

The OPcache configuration is now a trigger of its own: the process restarts whenever the configuration the restart would set differs from the one in effect (`resolveOpcacheRestartNeeded()`), whether or not there is an extension to load. A process whose php.ini already matches, or that was restarted, does not restart again — the retry stop moves from the extension-path marker (which keeps its worker-propagation role) to a generic `phpstan.restarted` marker, since an OPcache-only restart has no extension path to carry. Verified live in a source checkout and with a dist-layout phar: dormant OPcache → restart; turbo via php.ini → OPcache-only restart with turbo reported "loaded via php.ini"; turbo via php.ini with OPcache already configured → no restart; JIT via php.ini → restart with JIT pinned off and fork allowed.

## Keep forked workers off the shared OPcache

While testing the above, an intermittent worker SIGSEGV surfaced on slevomat (3 of 10 fork+OPcache runs, never with OPcache off). Crash reports show `ZEND_ASSIGN_OBJ` running with `EX(run_time_cache) == NULL` inside a lazy-object initializer of a shared (SHM-resident) function — a state every entry path guards against within a single process. The culprit is concurrent population of the shared cache by forked siblings racing on the per-process map_ptr slot table: a process linking classes privately (once the shared memory is full, or for any class whose parent is not shared) takes slot offsets from its own counter (`zend_compile.c:9879`, `zend_inheritance.c:3411`), a sibling storing a script takes the same offsets for the shared copy (`zend_persist.c:734`), and loading that script only ever bumps the counter upwards (`zend_map_ptr_extend`). php-fpm tolerates this because warm workers rarely compile privately mid-request; ten PHPStan workers storing thousands of scripts and then linking privately after exhaustion are the worst case for it.

The worker now disables OPcache right after `pcntl_fork()`, which takes effect immediately: everything the parent loaded stays in shared memory and keeps running from there; the worker compiles privately from then on and never loads what siblings store. No crash in the runs with this change.

Measured cost against the fully shared cache (user CPU, same machine conditions): slevomat 638 → 637/647s, ShipMonk 1371 → 1398s (0–2%); both still −8%/−10% versus OPcache off. Worker heaps land between the no-OPcache and fully shared numbers — slevomat largest worker 1005 / 768 / 886 MB, ShipMonk 1108 / 973 / 1113 MB for off / shared / this — because code compiled after OPcache was active gets no per-request string interning (OPcache replaces the request interning handlers at startup and never restores them), so private compiles cost about twice the heap of plain PHP's. Two php-src follow-ups fall out of this: allocating private map_ptr slots from a range disjoint from the shared ones, and reinstating request-level interning for non-persisted compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ek2A83bWb3Yf4CRmtvBfi4