### PR TITLE
Resolve template defaults referencing other templates in composite types

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -55,6 +55,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeAlias;
 use PHPStan\Type\TypehintHelper;
+use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\VerbosityLevel;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException;
@@ -1861,12 +1862,26 @@ final class ClassReflection
 		$className = $this->getName();
 		foreach ($resolvedPhpDoc->getTemplateTags() as $tag) {
 			$type = $types[$i] ?? $tag->getDefault() ?? $tag->getBound();
-			if ($type instanceof TemplateType && $type->getScope()->getClassName() === $className) {
+			// A template default may reference other template types of the same
+			// class, possibly nested inside a composite type like `TValue|null`.
+			// Never descend into a TemplateType's bound - bounds may be
+			// self-referential (`@template T of Foo<T>`).
+			$type = TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($map, $className): Type {
+				if (!$type instanceof TemplateType) {
+					return $traverse($type);
+				}
+
+				if ($type->getScope()->getClassName() !== $className) {
+					return $type;
+				}
+
 				$resolved = $map[$type->getName()] ?? null;
 				if ($resolved !== null && !$resolved instanceof TemplateType) {
-					$type = $resolved;
+					return $resolved;
 				}
-			}
+
+				return $type;
+			});
 			$map[$tag->getName()] = $type;
 			$i++;
 		}

--- a/tests/PHPStan/Analyser/nsrt/template-default-referring-other-nested.php
+++ b/tests/PHPStan/Analyser/nsrt/template-default-referring-other-nested.php
@@ -1,0 +1,60 @@
+<?php // lint >= 8.0
+
+namespace TemplateDefaultReferringOtherNested;
+
+use function PHPStan\Testing\assertType;
+
+class Entity
+{
+
+}
+
+class User extends Entity
+{
+
+}
+
+class Post extends Entity
+{
+
+}
+
+/**
+ * @template TRelated of Entity
+ * @template TDeclaring of Entity
+ * @template TBare = TRelated
+ * @template TResult = TRelated|null
+ * @template TList of array = list<TRelated>
+ * @template TShape of array = array{related: TRelated, declaring: TDeclaring}
+ */
+interface Relation
+{
+
+	/** @return TBare */
+	public function bare(): mixed;
+
+	/** @return TResult */
+	public function getResults(): mixed;
+
+	/** @return TList */
+	public function all(): array;
+
+	/** @return TShape */
+	public function shape(): array;
+
+}
+
+/**
+ * @param Relation<User, Post> $defaulted
+ * @param Relation<User, Post, User, User> $explicit
+ */
+function test(Relation $defaulted, Relation $explicit): void
+{
+	assertType('TemplateDefaultReferringOtherNested\User', $defaulted->bare());
+	assertType('TemplateDefaultReferringOtherNested\User|null', $defaulted->getResults());
+	assertType('list<TemplateDefaultReferringOtherNested\User>', $defaulted->all());
+	assertType('array{related: TemplateDefaultReferringOtherNested\User, declaring: TemplateDefaultReferringOtherNested\Post}', $defaulted->shape());
+
+	assertType('TemplateDefaultReferringOtherNested\User', $explicit->bare());
+	assertType('TemplateDefaultReferringOtherNested\User', $explicit->getResults());
+}


### PR DESCRIPTION
Hello!

`ClassReflection::typeMapFromList()` only substituted a sibling template reference when the default was exactly a bare `TemplateType`. So `@template TResult = TRelated` resolved correctly, but a default that merely contained the reference - `= TRelated|null`, `= list<TRelated>`, or an array shape - kept the unresolved template and leaked it into inferred types.

Traverse the type instead, substituting any nested reference to a template of the same class. Bounds are deliberately not descended into, because they may be self-referential (`@template T of Foo<T>`) and traversing them expands without bound.

The substitution has to apply to explicitly passed arguments as well as to `$tag->getDefault()`, because TypeNodeResolver already pads missing arguments with the raw defaults before this code runs.

Thanks!