### PR TITLE
Keep the result cache when the turbo extension is switched on or off

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -48,6 +48,7 @@ use function fwrite;
 use function get_loaded_extensions;
 use function hash_file;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_dir;
 use function is_file;
@@ -69,6 +70,16 @@ use const PHP_VERSION_ID;
 #[GenerateFactory(interface: ResultCacheManagerFactory::class)]
 final class ResultCacheManager
 {
+
+	/**
+	 * Loaded PHP extensions that cannot change the analysis result, so switching them on or off
+	 * must not invalidate the whole cache. Profilers do not take part in the analysis at all, and
+	 * phpstan_turbo only replaces PHPStan's own classes with native implementations that behave
+	 * identically, so it cannot change what the cache holds. Keeping it here would make every
+	 * cache built where the extension is available useless everywhere it is not: Windows, a PHP
+	 * version with no distributed binary, or a libc the binaries are not built for.
+	 */
+	private const EXTENSIONS_NOT_INVALIDATING_CACHE = ['xdebug', 'blackfire', 'phpstan_turbo'];
 
 	private const CACHE_VERSION = 'v14-relativePaths';
 
@@ -1457,7 +1468,7 @@ return [
 	 */
 	private function getMeta(array $allAnalysedFiles, ?array $projectConfigArray): array
 	{
-		$extensions = array_values(array_filter(get_loaded_extensions(), static fn (string $extension): bool => $extension !== 'xdebug' && $extension !== 'blackfire'));
+		$extensions = array_values(array_filter(get_loaded_extensions(), static fn (string $extension): bool => !in_array($extension, self::EXTENSIONS_NOT_INVALIDATING_CACHE, true)));
 		sort($extensions);
 
 		if ($projectConfigArray !== null) {


### PR DESCRIPTION
`phpstan_turbo` was part of the result cache key, so a cache written where the extension is available is discarded in full everywhere it is not.

`getMeta()` records `phpExtensions` as sorted `get_loaded_extensions()` minus `xdebug` and `blackfire`. `TurboProcessRestarter` loads the extension into the very process that writes the cache, so PHPStan puts it there itself. Measured on a phar built from `80324fe1a`, toggling only the presence of the binary next to it:

| turbo binary | extensions recorded | second run |
| --- | --- | --- |
| available | 71, including `phpstan_turbo` | cache reused |
| hidden | 70 | `Result cache not used because the metadata do not match: phpExtensions` |
| available again | 71 | same full invalidation, the other way |

The cases where the extension does not load are ordinary rather than exotic: Windows, a PHP version with no distributed binary, a libc the binaries are not built for, a debug build, or `PHP_VERSION_ID < 80300`. That is also the direction that matters for reusing a CI-built cache on a developer machine, which came up in a discussion with @staabm about sharing result caches between machines.

The extension cannot change what the cache holds. It replaces PHPStan's own classes with native implementations that have to behave identically, which is the whole premise of the parity tooling in `turbo-ext/`. I checked that rather than assuming it: analysing the same project twice with the same config, once with the extension active and once without, the resulting `resultCache.php` holds the same content either way. Errors, dependencies, exported nodes and line ignores all match.

On a small single-worker project the two files come out byte-identical. On a 4524-file project with parallel workers they do not, and that is worth spelling out because it is not the extension's doing: the per-file entries under `packageDependencies` are written in worker completion order, so **two identical runs differ the same way** (9544 differing lines between two runs with the extension absent, against 9587 between with and without). Sorted, the with-turbo and without-turbo caches are identical. I had originally written "byte-identical" here on the strength of the single-worker measurement, which was too strong a claim for the parallel case.

This follows 97c30cacf, which did the same for Blackfire.

## Effect on existing caches

One re-analysis for anyone whose cached `phpExtensions` still records the extension, after which it stays stable. `CACHE_VERSION` is deliberately not bumped, since that would force the same re-analysis on everyone else too.

## Checks

`make tests` (21262 tests, 96356 assertions), `make phpstan` and phpcs on the touched file all pass. I also built a phar with the change and confirmed the cache now survives toggling the binary in both directions.

Two notes on what the measurements did and did not cover. The content comparison ran with the extension **active** (binary `dee1d70` against a build expecting it). The phar I built to verify the fix has the extension **loaded but inactive**, because the current tip expects `e598750` and I have no binary for it. That still exercises this code path, since `phpExtensions` reads `get_loaded_extensions()` and does not care whether the extension is active. Everything was measured on macOS with PHP 8.5.

I did not add a test. The two existing exclusions have none, and covering this properly means loading a real extension in CI. Happy to add an e2e if you would rather have one, and equally happy to collapse the constant back into the inline condition if you prefer the shape of 97c30cacf.

