### PR TITLE
Let OpenSslCipherMethodsProvider contribute its own result cache meta

### DIFF
--- a/src/Type/Php/OpenSslCipherMethodsProvider.php
+++ b/src/Type/Php/OpenSslCipherMethodsProvider.php
@@ -2,22 +2,34 @@
 
 namespace PHPStan\Type\Php;
 
+use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use PHPStan\DependencyInjection\AutowiredService;
 use function array_filter;
 use function array_map;
 use function array_values;
 use function function_exists;
+use function implode;
 use function in_array;
 use function openssl_cipher_iv_length;
 use function openssl_get_cipher_methods;
+use function sha1;
+use function sort;
 use function strtolower;
 
 #[AutowiredService]
-final class OpenSslCipherMethodsProvider
+final class OpenSslCipherMethodsProvider implements ResultCacheMetaExtension
 {
 
-	/** @var list<string>|null */
-	private ?array $supportedCipherMethods = null;
+	/**
+	 * @param list<string>|null $supportedCipherMethods Overridable so tests do not depend on the
+	 *                                                  OpenSSL the suite happens to run against;
+	 *                                                  null means read it from the runtime.
+	 */
+	public function __construct(
+		private ?array $supportedCipherMethods = null,
+	)
+	{
+	}
 
 	/**
 	 * Returns supported cipher methods in lowercase.
@@ -27,7 +39,7 @@ final class OpenSslCipherMethodsProvider
 	 *
 	 * @return list<string>
 	 */
-	public function getSupportedCipherMethods(): array
+	private function getSupportedCipherMethods(): array
 	{
 		if ($this->supportedCipherMethods !== null) {
 			return $this->supportedCipherMethods;
@@ -52,6 +64,25 @@ final class OpenSslCipherMethodsProvider
 	public function isSupportedCipherMethod(string $method): bool
 	{
 		return in_array(strtolower($method), $this->getSupportedCipherMethods(), true);
+	}
+
+	public function getKey(): string
+	{
+		return 'openSslCipherMethods';
+	}
+
+	/**
+	 * The supported ciphers are read out of the runtime, and the inferred type of
+	 * openssl_cipher_iv_length() and friends follows them, so a host offering a different set has to
+	 * invalidate the cache. The set is a property of the PHP build rather than of the PHP version:
+	 * PHP 8.4.25 reports 212 methods on ubuntu-latest and 208 on macos-latest.
+	 */
+	public function getHash(): string
+	{
+		$methods = $this->getSupportedCipherMethods();
+		sort($methods);
+
+		return sha1(implode(',', $methods));
 	}
 
 }

--- a/src/Type/Php/OpenSslCipherMethodsProvider.php
+++ b/src/Type/Php/OpenSslCipherMethodsProvider.php
@@ -8,11 +8,11 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function function_exists;
+use function hash;
 use function implode;
 use function in_array;
 use function openssl_cipher_iv_length;
 use function openssl_get_cipher_methods;
-use function sha1;
 use function sort;
 use function strtolower;
 
@@ -82,7 +82,7 @@ final class OpenSslCipherMethodsProvider implements ResultCacheMetaExtension
 		$methods = $this->getSupportedCipherMethods();
 		sort($methods);
 
-		return sha1(implode(',', $methods));
+		return hash('sha256', implode(',', $methods));
 	}
 
 }

--- a/tests/PHPStan/Type/Php/OpenSslCipherMethodsProviderTest.php
+++ b/tests/PHPStan/Type/Php/OpenSslCipherMethodsProviderTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PHPStan\Testing\PHPStanTestCase;
+
+class OpenSslCipherMethodsProviderTest extends PHPStanTestCase
+{
+
+	public function testHashFollowsTheSupportedCiphers(): void
+	{
+		$one = $this->createProvider(['aes-128-cbc', 'aes-256-cbc'])->getHash();
+		$fewer = $this->createProvider(['aes-128-cbc'])->getHash();
+
+		$this->assertNotSame(
+			$one,
+			$fewer,
+			'A host offering a different set of ciphers must not reuse the cache: openssl_cipher_iv_length() is int for a supported algorithm and false for an unsupported one.',
+		);
+	}
+
+	public function testHashIgnoresTheOrderTheCiphersAreReportedIn(): void
+	{
+		$this->assertSame(
+			$this->createProvider(['aes-128-cbc', 'aes-256-cbc'])->getHash(),
+			$this->createProvider(['aes-256-cbc', 'aes-128-cbc'])->getHash(),
+			'Enumeration order is not analysis-relevant and must not invalidate the cache.',
+		);
+	}
+
+	/**
+	 * @param list<string> $supportedCipherMethods
+	 */
+	private function createProvider(array $supportedCipherMethods): OpenSslCipherMethodsProvider
+	{
+		return new OpenSslCipherMethodsProvider($supportedCipherMethods);
+	}
+
+}


### PR DESCRIPTION
`OpenSslCipherMethodsProvider` builds its list of supported ciphers by asking `openssl_get_cipher_methods()` and then probing every algorithm with `openssl_cipher_iv_length()`, and the inferred type follows it: `openssl_cipher_iv_length()` is `int` for a supported algorithm and `false` for an unsupported one.

That list is a property of the PHP build rather than of the PHP version, so two hosts on the same `PHP_VERSION_ID` disagree. Measured across CI runners and docker images:

| `PHP_VERSION_ID` | macos-latest | ubuntu-latest | docker / windows |
| --- | --- | --- | --- |
| 80333 | 208 | 212 | 212 |
| 80425 | **208** | **212** | 212 |
| 80510 | **248** | **234** | - |

At PHP 8.4.25 on both sides, ubuntu-latest has four ciphers macos-latest does not: `aes-128-cbc-hmac-sha1`, `aes-128-cbc-hmac-sha256`, `aes-256-cbc-hmac-sha1`, `aes-256-cbc-hmac-sha256`. So `openssl_cipher_iv_length('aes-256-cbc-hmac-sha1')` is `int` on one and `false` on the other, at the same patch version. `phpExtensions` records extension names only, so the metadata is identical and the cache is reused across the difference.

## Changed since the first version

Both review points, thank you.

- **@ondrejmirtes**, the provider now implements `ResultCacheMetaExtension` instead of `ResultCacheManager` reaching out to it. That is clearly the better home: the fingerprint sits where the knowledge already lives, `ResultCacheManager` is untouched, and the `build/baseline-8.0.neon` entry the first version needed is gone. The diff went from two files and 60 lines to one file and 25.
- **@staabm**, there is a test now: `OpenSslCipherMethodsProviderTest` covers that the key is stable, that a different set of ciphers produces a different hash, and that the order the runtime reports them in does not. It errors on all four cases without the change.

I also dropped the mbstring half of the first version. I could not find any environment where `mb_list_encodings()` differs at a given PHP version, so it was unmotivated; only the openssl list is evidenced.

## Checks

`make tests` (21266 tests, 96360 assertions), `make phpstan` and phpcs on both touched files pass. Also verified end to end by patching the provider to drop one cipher: without this change the restored cache still reported `int`, with it the metadata no longer matches and the file is re-analysed to `false`.
