### PR TITLE
Reproduce result cache invalidation by paths with parent-directory segments in E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -229,6 +229,21 @@ jobs:
               ../bashunit -a contains 'Result cache not used because the metadata do not match: scannedFiles' "$OUTPUT"
               ../bashunit -a contains 'Instantiated class ResultCacheE2EGenerated\Foo not found.' "$OUTPUT"
           - script: |
+              cd e2e/bug-15125
+              composer install
+              # scanFiles points at vendor/autoload.php through a parent-directory segment in the
+              # middle of an absolute path (%rootDir%/../../../vendor/autoload.php in the issue), and
+              # Composer records every install_path in vendor/composer/installed.php the same way.
+              # Both paths go through the cache normalized while the freshly computed ones keep their
+              # "..", so a second run without any change must still restore the whole cache without
+              # reporting a metadata mismatch.
+              ../../bin/phpstan analyse
+              OUTPUT=$(../../bin/phpstan analyse -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a not_contains 'Result cache not used because the metadata do not match' "$OUTPUT"
+              ../bashunit -a not_contains 'Composer metadata changed but no package versions changed' "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+          - script: |
               cd e2e/result-cache-traits
               ../../bin/phpstan analyse
               patch -b src/FooTrait.php < renameFooTraitMethod.patch

--- a/e2e/bug-15125/.gitignore
+++ b/e2e/bug-15125/.gitignore
@@ -1,0 +1,3 @@
+/tmp
+/vendor
+/composer.lock

--- a/e2e/bug-15125/composer.json
+++ b/e2e/bug-15125/composer.json
@@ -1,0 +1,15 @@
+{
+	"name": "phpstan/bug-15125-e2e",
+	"repositories": [
+		{
+			"type": "path",
+			"url": "./logger",
+			"options": {
+				"symlink": false
+			}
+		}
+	],
+	"require": {
+		"test/logger": "*"
+	}
+}

--- a/e2e/bug-15125/logger/composer.json
+++ b/e2e/bug-15125/logger/composer.json
@@ -1,0 +1,1 @@
+{ "name": "test/logger", "version": "1.0.0", "autoload": { "classmap": ["src"] } }

--- a/e2e/bug-15125/logger/src/Logger.php
+++ b/e2e/bug-15125/logger/src/Logger.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Test\Logger;
+
+class Logger
+{
+
+	public function info(string $message): void
+	{
+	}
+
+}

--- a/e2e/bug-15125/phpstan.neon
+++ b/e2e/bug-15125/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+	level: 8
+	tmpDir: tmp
+	paths:
+		- src
+	scanFiles:
+		- %currentWorkingDirectory%/../bug-15125/vendor/autoload.php

--- a/e2e/bug-15125/src/Bar.php
+++ b/e2e/bug-15125/src/Bar.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bug15125;
+
+use Test\Logger\Logger;
+
+final class Bar
+{
+
+	public function __construct(private Logger $logger)
+	{
+	}
+
+	public function doBar(): void
+	{
+		$this->logger->info('hello');
+	}
+
+}


### PR DESCRIPTION
Reproduction only, no fix yet.

A `scanFiles` entry such as `%rootDir%/../../../vendor/autoload.php` keeps its `..` segments: `NeonAdapter` skips values containing `%`, and nothing normalizes them after parameter expansion. Composer's `install_path` values in `vendor/composer/installed.php` carry `..` the same way. Both go into the result cache through `ResultCachePathTransformer`, which normalizes on the way back, so the restored meta never equals the freshly computed one and every run reports:

```
Result cache not used because the metadata do not match: scannedFiles, composerInstalled
```

The new `e2e/bug-15125` fixture is a Composer project scanning its own `vendor/autoload.php` through a parent-directory segment. The scenario asserts that a second unchanged run restores the whole cache and reports neither a metadata mismatch nor "Composer metadata changed but no package versions changed".

Refs https://github.com/phpstan/phpstan/issues/15125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFe5xF5jTWnvfbsrUz9p2
