### PR TITLE
Fix result cache invalidation with @var referenced classes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -141,6 +141,16 @@ jobs:
               echo "$OUTPUT"
               ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
           - script: |
+              cd e2e/result-cache-11
+              echo -n > phpstan-baseline.neon
+              ../../bin/phpstan -vvv
+              patch -b src/Coll.php < patch-1.patch
+              cat baseline-1.neon > phpstan-baseline.neon
+              ../../bin/phpstan -vvv
+              mv src/Coll.php.orig src/Coll.php
+              echo -n > phpstan-baseline.neon
+              ../../bin/phpstan -vvv
+          - script: |
               cd e2e/bug-14514
               composer install
               ../../bin/phpstan analyze bug-14515.php

--- a/e2e/result-cache-11/baseline-1.neon
+++ b/e2e/result-cache-11/baseline-1.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Cannot call method name\(\) on TestResultCache11\\Item\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/consumer.php

--- a/e2e/result-cache-11/patch-1.patch
+++ b/e2e/result-cache-11/patch-1.patch
@@ -1,0 +1,13 @@
+diff --git a/e2e/result-cache-11/src/Coll.php b/e2e/result-cache-11/src/Coll.php
+index 9a6395d..773bb21 100644
+--- a/e2e/result-cache-11/src/Coll.php
++++ b/e2e/result-cache-11/src/Coll.php
+@@ -4,7 +4,7 @@ namespace TestResultCache11;
+ 
+ /**
+  * @template TValue of object
+- * @extends \Iterator<int, TValue>
++ * @extends \Iterator<int, TValue|false>
+  */
+ interface Coll extends \Iterator
+ {

--- a/e2e/result-cache-11/phpstan.neon
+++ b/e2e/result-cache-11/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+	level: 8
+	paths:
+		- src
+

--- a/e2e/result-cache-11/src/Coll.php
+++ b/e2e/result-cache-11/src/Coll.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace TestResultCache11;
+
+/**
+ * @template TValue of object
+ * @extends \Iterator<int, TValue>
+ */
+interface Coll extends \Iterator
+{
+}
+

--- a/e2e/result-cache-11/src/Item.php
+++ b/e2e/result-cache-11/src/Item.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TestResultCache11;
+
+final class Item
+{
+
+	public function name(): string
+	{
+		return 'x';
+	}
+
+}
+

--- a/e2e/result-cache-11/src/consumer.php
+++ b/e2e/result-cache-11/src/consumer.php
@@ -1,0 +1,13 @@
+<?php
+
+// The inline @var below is this file's ONLY reference to TestResultCache11\Coll.
+// The result cache has to record the dependency edge from it, otherwise a change
+// to Coll's @extends signature does not re-analyse this file.
+
+/** @var \TestResultCache11\Coll<\TestResultCache11\Item> $coll */
+$coll = $GLOBALS['coll'];
+
+foreach ($coll as $item) {
+	echo $item->name();
+}
+

--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Dependency;
 
+use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
@@ -23,6 +24,7 @@ use PHPStan\Node\InPropertyHookNode;
 use PHPStan\Node\InstantiationCallableNode;
 use PHPStan\Node\MethodCallableNode;
 use PHPStan\Node\StaticMethodCallableNode;
+use PHPStan\Node\VirtualNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ConstantReflection;
 use PHPStan\Reflection\ExtendedParameterReflection;
@@ -59,6 +61,19 @@ final class DependencyResolver
 	{
 		$dependenciesReflections = [];
 		$dependenciesFilePaths = [];
+
+		if (
+			$node instanceof Node\Stmt
+			&& !$node instanceof VirtualNode
+			&& !$node instanceof Node\Stmt\ClassLike
+			&& !$node instanceof Node\Stmt\ClassMethod
+			&& !$node instanceof Node\Stmt\Function_
+			&& !$node instanceof Node\Stmt\Property
+			&& !$node instanceof Node\Stmt\ClassConst
+			&& !$node instanceof Node\Stmt\Const_
+		) {
+			$this->extractStmtVarTags($node, $scope, $dependenciesReflections);
+		}
 
 		if ($node instanceof Node\Stmt\Class_) {
 			if (isset($node->namespacedName)) {
@@ -578,6 +593,40 @@ final class DependencyResolver
 		}
 
 		return $classNames;
+	}
+
+	/**
+	 * Extracts the classes referenced from a variable-level var-tag PHPDoc attached to a statement.
+	 *
+	 * @param array<int, ClassReflection|FunctionReflection|ConstantReflection> $dependenciesReflections
+	 */
+	private function extractStmtVarTags(Node\Stmt $stmt, Scope $scope, array &$dependenciesReflections): void
+	{
+		$comments = $stmt->getComments();
+		if (count($comments) === 0) {
+			return;
+		}
+
+		$function = $scope->getFunction();
+		foreach ($comments as $comment) {
+			if (!$comment instanceof Doc) {
+				continue;
+			}
+
+			$resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+				$scope->getFile(),
+				$scope->isInClass() ? $scope->getClassReflection()->getName() : null,
+				$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
+				$function !== null ? $function->getName() : null,
+				$comment->getText(),
+			);
+
+			foreach ($resolvedPhpDoc->getVarTags() as $varTag) {
+				foreach ($varTag->getType()->getReferencedClasses() as $referencedClass) {
+					$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
My project started encountering stale result cache entries after updating to lvl7. Found that the result cache does not register a file dependency for a class that is only referenced by `@var` PHPDoc, like how phtml template files commonly do.

Not sure if there's more elegant way to do this?