### PR TITLE
Compare conditional expressions in MutatingScope::equals()

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4647,7 +4647,55 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		if (!$this->compareVariableTypeHolders($this->expressionTypes, $otherScope->expressionTypes)) {
 			return false;
 		}
-		return $this->compareVariableTypeHolders($this->nativeExpressionTypes, $otherScope->nativeExpressionTypes);
+		if (!$this->compareVariableTypeHolders($this->nativeExpressionTypes, $otherScope->nativeExpressionTypes)) {
+			return false;
+		}
+
+		return $this->compareConditionalExpressions($this->conditionalExpressions, $otherScope->conditionalExpressions);
+	}
+
+	/**
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 * @param array<string, ConditionalExpressionHolder[]> $otherConditionalExpressions
+	 */
+	private function compareConditionalExpressions(array $conditionalExpressions, array $otherConditionalExpressions): bool
+	{
+		if (count($conditionalExpressions) !== count($otherConditionalExpressions)) {
+			return false;
+		}
+		foreach ($conditionalExpressions as $exprString => $holders) {
+			if (!isset($otherConditionalExpressions[$exprString])) {
+				return false;
+			}
+			$otherHolders = $otherConditionalExpressions[$exprString];
+			if (count($holders) !== count($otherHolders)) {
+				return false;
+			}
+			foreach ($holders as $key => $holder) {
+				if (!isset($otherHolders[$key])) {
+					return false;
+				}
+				$otherHolder = $otherHolders[$key];
+				if (!$holder->getTypeHolder()->equals($otherHolder->getTypeHolder())) {
+					return false;
+				}
+				$conditions = $holder->getConditionExpressionTypeHolders();
+				$otherConditions = $otherHolder->getConditionExpressionTypeHolders();
+				if (count($conditions) !== count($otherConditions)) {
+					return false;
+				}
+				foreach ($conditions as $conditionExprString => $conditionHolder) {
+					if (!isset($otherConditions[$conditionExprString])) {
+						return false;
+					}
+					if (!$conditionHolder->equals($otherConditions[$conditionExprString])) {
+						return false;
+					}
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/loop-fixpoint-conditional-expressions.php
+++ b/tests/PHPStan/Analyser/nsrt/loop-fixpoint-conditional-expressions.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace LoopFixpointConditionalExpressions;
+
+use LogicException;
+use function PHPStan\Testing\assertType;
+
+final class Item
+{
+
+	public function assign(): void
+	{
+	}
+
+}
+
+abstract class Foo
+{
+
+	/** @return list<Item> */
+	abstract public function getItems(): array;
+
+	public function run(int $quantityToAllocate, int $unitsThatFit): void
+	{
+		$items = $this->getItems();
+		if ($quantityToAllocate <= 0) {
+			return;
+		}
+		if ($unitsThatFit <= 0) {
+			return;
+		}
+
+		do {
+			$unitsAdded = min($unitsThatFit, $quantityToAllocate);
+			$toCurrent = 0;
+			if ($items !== []) {
+				$unitsAdded = min($unitsAdded, count($items));
+				$toCurrent = $unitsAdded;
+			}
+
+			while ($toCurrent > 0) {
+				assertType('list<LoopFixpointConditionalExpressions\Item>', $items);
+				$item = array_shift($items);
+				assertType('LoopFixpointConditionalExpressions\Item|null', $item);
+				if ($item === null) {
+					throw new LogicException();
+				}
+				$item->assign();
+				$toCurrent--;
+			}
+
+			$quantityToAllocate -= $unitsAdded;
+		} while ($quantityToAllocate > 0);
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/loop-fixpoint-conditional-expressions.php
+++ b/tests/PHPStan/Analyser/nsrt/loop-fixpoint-conditional-expressions.php
@@ -2,55 +2,32 @@
 
 namespace LoopFixpointConditionalExpressions;
 
-use LogicException;
 use function PHPStan\Testing\assertType;
 
 final class Item
 {
 
-	public function assign(): void
-	{
-	}
-
 }
 
-abstract class Foo
+class Foo
 {
 
-	/** @return list<Item> */
-	abstract public function getItems(): array;
-
-	public function run(int $quantityToAllocate, int $unitsThatFit): void
+	/** @param list<Item> $items */
+	public function run(array $items): void
 	{
-		$items = $this->getItems();
-		if ($quantityToAllocate <= 0) {
-			return;
-		}
-		if ($unitsThatFit <= 0) {
-			return;
-		}
-
-		do {
-			$unitsAdded = min($unitsThatFit, $quantityToAllocate);
+		foreach ([1, 2] as $_) {
 			$toCurrent = 0;
 			if ($items !== []) {
-				$unitsAdded = min($unitsAdded, count($items));
-				$toCurrent = $unitsAdded;
+				$toCurrent = count($items);
 			}
 
 			while ($toCurrent > 0) {
 				assertType('list<LoopFixpointConditionalExpressions\Item>', $items);
 				$item = array_shift($items);
 				assertType('LoopFixpointConditionalExpressions\Item|null', $item);
-				if ($item === null) {
-					throw new LogicException();
-				}
-				$item->assign();
 				$toCurrent--;
 			}
-
-			$quantityToAllocate -= $unitsAdded;
-		} while ($quantityToAllocate > 0);
+		}
 	}
 
 }


### PR DESCRIPTION
Since 2.2.10 the loop handlers skip a verification pass when the entry scope is unchanged, and they replay the recorded pass instead of the final walk. Both shortcuts compare entry scopes with `MutatingScope::equals()`, which ignored conditional expressions. Two scopes with equal expression types but different conditional expressions do not walk identically, because a later condition narrows through them.

Reproducer: a `while` nested in another loop. The first pass enters with `if $toCurrent is int<1, max> then $items is non-empty-list` from the preceding `if/else` merge. The body invalidates it, so the second entry lacks it, but the two entries compare equal. The first pass is replayed, and `array_shift($items)` inside the loop is reported as never `null` (`identical.alwaysFalse`).

Bisected to 31a36041d ("Replay the recorded fixpoint pass instead of repeating the final loop walk"). 2.2.9 infers `list<Item>` and `Item|null` here.

`equals()` now also compares the conditional expressions. Full test suite passes.

Closes https://github.com/phpstan/phpstan/issues/15157
