### PR TITLE
HashFunctionsReturnTypeExtension: init hash-algorithm list lazily

### DIFF
--- a/src/Type/Php/HashFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashFunctionsReturnTypeExtension.php
@@ -83,12 +83,11 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 		'xxh128',
 	];
 
-	/** @var array<int, non-empty-string> */
-	private array $hashAlgorithms;
+	/** @var array<int, non-empty-string>|null */
+	private ?array $hashAlgorithms = null;
 
 	public function __construct(private PhpVersion $phpVersion)
 	{
-		$this->hashAlgorithms = hash_algos();
 	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
@@ -143,7 +142,8 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 		$returnTypes = array_map(
 			function (ConstantStringType $type) use ($functionData, $stringReturnType, $invalidAlgorithmType) {
 				$algorithm = strtolower($type->getValue());
-				if (!in_array($algorithm, $this->hashAlgorithms, true)) {
+				$algos = $this->hashAlgorithms ??= hash_algos();
+				if (!in_array($algorithm, $algos, true)) {
 					return $invalidAlgorithmType;
 				}
 				if ($functionData['cryptographic'] && in_array($algorithm, self::NON_CRYPTOGRAPHIC_ALGORITHMS, true)) {

--- a/src/Type/Php/HashFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashFunctionsReturnTypeExtension.php
@@ -142,8 +142,8 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 		$returnTypes = array_map(
 			function (ConstantStringType $type) use ($functionData, $stringReturnType, $invalidAlgorithmType) {
 				$algorithm = strtolower($type->getValue());
-				$algos = $this->hashAlgorithms ??= hash_algos();
-				if (!in_array($algorithm, $algos, true)) {
+				$hashAlgorithms = $this->hashAlgorithms ??= hash_algos();
+				if (!in_array($algorithm, $hashAlgorithms, true)) {
 					return $invalidAlgorithmType;
 				}
 				if ($functionData['cryptographic'] && in_array($algorithm, self::NON_CRYPTOGRAPHIC_ALGORITHMS, true)) {


### PR DESCRIPTION
we need this list only when we find one of the supported hash functions with a constant 1st arg.

atm we pay the cost for listing the algos on rule creation, no matter how the analyzed code looks like.
its not that expensive (1-2ms), but its easy to prevent