### PR TITLE
Normalize result cache meta paths and expand known placeholders in NeonAdapter

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -243,6 +243,13 @@ jobs:
               ../bashunit -a not_contains 'Result cache not used because the metadata do not match' "$OUTPUT"
               ../bashunit -a not_contains 'Composer metadata changed but no package versions changed' "$OUTPUT"
               ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+              # --autoload-file is recorded in executedFilesHashes under the path it was given with;
+              # a './' segment must not keep the cache from being reused either.
+              ../../bin/phpstan analyse -a ./vendor/autoload.php
+              OUTPUT=$(../../bin/phpstan analyse -a ./vendor/autoload.php -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a not_contains 'Result cache not used because the metadata do not match' "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
           - script: |
               cd e2e/result-cache-traits
               ../../bin/phpstan analyse

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -34,7 +34,6 @@ use function array_fill_keys;
 use function array_filter;
 use function array_key_exists;
 use function array_keys;
-use function array_map;
 use function array_merge;
 use function array_unique;
 use function array_values;
@@ -1469,7 +1468,14 @@ return [
 			ksort($projectConfigArray);
 		}
 
-		return [
+		// The cached meta comes back through absolutizeMeta(), which normalizes every path, and
+		// isMetaDifferent() compares with !==. The paths below are spelled by their sources, not by
+		// PHPStan: a config entry through a %placeholder% NeonAdapter could not expand keeps its '..'
+		// segments (and mixes separators on Windows), Composer records install_path as
+		// __DIR__ . '/../x', --autoload-file may be given as ./vendor/autoload.php. Normalizing them
+		// here makes the comparison one of paths, not of spellings - otherwise such an entry reads
+		// as a metadata change on every run and the whole cache is discarded every time.
+		return $this->getPathTransformer()->normalizeMeta([
 			'cacheVersion' => self::CACHE_VERSION,
 			'phpstanVersion' => ComposerHelper::getPhpStanVersion(),
 			'metaExtensions' => $this->getMetaFromPhpStanExtensions(),
@@ -1486,9 +1492,9 @@ return [
 			// extensions may only run after the bootstrapFiles. This entry catches a changed
 			// list in any config file, including the included ones that are not part of the
 			// projectConfig entry above.
-			'configStubFiles' => array_map(fn (string $stubFile): string => $this->fileHelper->normalizePath($stubFile), $this->configStubFiles),
+			'configStubFiles' => $this->configStubFiles,
 			'level' => $this->usedLevel,
-		];
+		]);
 	}
 
 	private function getFileHash(string $path): string

--- a/src/Analyser/ResultCache/ResultCachePathTransformer.php
+++ b/src/Analyser/ResultCache/ResultCachePathTransformer.php
@@ -26,7 +26,11 @@ use const DIRECTORY_SEPARATOR;
  *
  * Only paths under (or reachable from) the anchor become relative; a path with no shared prefix is
  * left absolute, following ccache's CCACHE_BASEDIR rule. absolutizePath() is the inverse: an already
- * absolute path is passed through unchanged, so relative and absolute entries can coexist in one cache.
+ * absolute path resolves to itself, so relative and absolute entries can coexist in one cache.
+ *
+ * absolutizePath() hands back a normalized path, so the round trip relativizePath() -> absolutizePath()
+ * only returns what went in when that was normalized to begin with. normalizeMeta() puts a freshly
+ * computed meta into that form before ResultCacheManager compares it against the restored one.
  *
  * @phpstan-import-type CollectorData from CollectedData
  */
@@ -60,7 +64,18 @@ final class ResultCachePathTransformer
 	{
 		[$scheme, $filesystemPath] = $this->splitScheme($path);
 
-		return $scheme . $this->anchorFileHelper->normalizePath($this->anchorFileHelper->absolutizePath($filesystemPath));
+		return $this->normalizePath($scheme . $this->anchorFileHelper->absolutizePath($filesystemPath));
+	}
+
+	/**
+	 * The canonical spelling of a path - the form absolutizePath() hands back for it: '.' and '..'
+	 * segments collapsed, the platform separator throughout. A path built by concatenation (Composer
+	 * records install_path as __DIR__ . '/../x', a %placeholder%/dir mixes separators on Windows)
+	 * equals its restored twin only after going through this.
+	 */
+	public function normalizePath(string $path): string
+	{
+		return $this->anchorFileHelper->normalizePath($path);
 	}
 
 	/**
@@ -263,7 +278,7 @@ final class ResultCachePathTransformer
 	 */
 	public function relativizeMeta(array $meta): array
 	{
-		return $this->transformMeta($meta, false);
+		return $this->transformMeta($meta, fn (string $path): string => $this->relativizePath($path));
 	}
 
 	/**
@@ -272,7 +287,21 @@ final class ResultCachePathTransformer
 	 */
 	public function absolutizeMeta(array $meta): array
 	{
-		return $this->transformMeta($meta, true);
+		return $this->transformMeta($meta, fn (string $path): string => $this->absolutizePath($path));
+	}
+
+	/**
+	 * Puts every path of a freshly computed meta into the canonical form absolutizePath() produces, so
+	 * comparing it against a restored meta compares paths, not the accidental shape their sources built
+	 * them in. Without it a restored key can never equal a non-canonical current one, and the cache is
+	 * discarded on every run.
+	 *
+	 * @param mixed[] $meta
+	 * @return mixed[]
+	 */
+	public function normalizeMeta(array $meta): array
+	{
+		return $this->transformMeta($meta, fn (string $path): string => $this->normalizePath($path));
 	}
 
 	/**
@@ -303,26 +332,27 @@ final class ResultCachePathTransformer
 
 	/**
 	 * @param mixed[] $meta
+	 * @param callable(string): string $transformPath
 	 * @return mixed[]
 	 */
-	private function transformMeta(array $meta, bool $absolutize): array
+	private function transformMeta(array $meta, callable $transformPath): array
 	{
 		foreach (['analysedPaths', 'configStubFiles'] as $listKey) {
 			if (!array_key_exists($listKey, $meta) || !is_array($meta[$listKey])) {
 				continue;
 			}
-			$meta[$listKey] = $this->transformList($meta[$listKey], $absolutize);
+			$meta[$listKey] = $this->transformList($meta[$listKey], $transformPath);
 		}
 
 		foreach (['scannedFiles', 'composerLocks', 'executedFilesHashes', 'stubFiles'] as $key) {
 			if (!array_key_exists($key, $meta) || !is_array($meta[$key])) {
 				continue;
 			}
-			$meta[$key] = $this->transformKeys($meta[$key], $absolutize);
+			$meta[$key] = $this->transformKeys($meta[$key], $transformPath);
 		}
 
 		if (array_key_exists('composerInstalled', $meta) && is_array($meta['composerInstalled'])) {
-			$meta['composerInstalled'] = $this->transformComposerInstalled($meta['composerInstalled'], $absolutize);
+			$meta['composerInstalled'] = $this->transformComposerInstalled($meta['composerInstalled'], $transformPath);
 		}
 
 		return $meta;
@@ -330,9 +360,10 @@ final class ResultCachePathTransformer
 
 	/**
 	 * @param mixed[] $composerInstalled
+	 * @param callable(string): string $transformPath
 	 * @return array<string, mixed>
 	 */
-	private function transformComposerInstalled(array $composerInstalled, bool $absolutize): array
+	private function transformComposerInstalled(array $composerInstalled, callable $transformPath): array
 	{
 		$result = [];
 		foreach ($composerInstalled as $file => $installed) {
@@ -341,29 +372,25 @@ final class ResultCachePathTransformer
 					if (!is_array($packageData) || !array_key_exists('install_path', $packageData) || !is_string($packageData['install_path'])) {
 						continue;
 					}
-					$installed['versions'][$package]['install_path'] = $this->transformPath($packageData['install_path'], $absolutize);
+					$installed['versions'][$package]['install_path'] = $transformPath($packageData['install_path']);
 				}
 			}
-			$result[$this->transformPath((string) $file, $absolutize)] = $installed;
+			$result[$transformPath((string) $file)] = $installed;
 		}
 
 		return $result;
 	}
 
-	private function transformPath(string $path, bool $absolutize): string
-	{
-		return $absolutize ? $this->absolutizePath($path) : $this->relativizePath($path);
-	}
-
 	/**
 	 * @param mixed[] $paths
+	 * @param callable(string): string $transformPath
 	 * @return list<string>
 	 */
-	private function transformList(array $paths, bool $absolutize): array
+	private function transformList(array $paths, callable $transformPath): array
 	{
 		$result = [];
 		foreach ($paths as $path) {
-			$result[] = $this->transformPath((string) $path, $absolutize);
+			$result[] = $transformPath((string) $path);
 		}
 
 		return $result;
@@ -375,7 +402,7 @@ final class ResultCachePathTransformer
 	 */
 	private function relativizeList(array $paths): array
 	{
-		return $this->transformList($paths, false);
+		return $this->transformList($paths, fn (string $path): string => $this->relativizePath($path));
 	}
 
 	/**
@@ -384,18 +411,19 @@ final class ResultCachePathTransformer
 	 */
 	private function absolutizeList(array $paths): array
 	{
-		return $this->transformList($paths, true);
+		return $this->transformList($paths, fn (string $path): string => $this->absolutizePath($path));
 	}
 
 	/**
 	 * @param mixed[] $byKey
+	 * @param callable(string): string $transformPath
 	 * @return array<string, mixed>
 	 */
-	private function transformKeys(array $byKey, bool $absolutize): array
+	private function transformKeys(array $byKey, callable $transformPath): array
 	{
 		$result = [];
 		foreach ($byKey as $key => $value) {
-			$result[$this->transformPath((string) $key, $absolutize)] = $value;
+			$result[$transformPath((string) $key)] = $value;
 		}
 
 		return $result;

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -181,7 +181,7 @@ final class CommandHelper
 		$autoloadFunctionsBefore = spl_autoload_functions();
 
 		if ($autoloadFile !== null) {
-			$autoloadFile = $currentWorkingDirectoryFileHelper->absolutizePath($autoloadFile);
+			$autoloadFile = $currentWorkingDirectoryFileHelper->normalizePath($currentWorkingDirectoryFileHelper->absolutizePath($autoloadFile));
 			if (!is_file($autoloadFile)) {
 				$errorOutput->writeLineFormatted(sprintf('Autoload file "%s" not found.', $autoloadFile));
 				throw new InceptionNotSuccessfulException();
@@ -209,7 +209,7 @@ final class CommandHelper
 				}
 			}
 		} else {
-			$projectConfigFile = $currentWorkingDirectoryFileHelper->absolutizePath($projectConfigFile);
+			$projectConfigFile = $currentWorkingDirectoryFileHelper->normalizePath($currentWorkingDirectoryFileHelper->absolutizePath($projectConfigFile));
 		}
 
 		if ($generateBaselineFile !== null) {

--- a/src/DependencyInjection/LoaderFactory.php
+++ b/src/DependencyInjection/LoaderFactory.php
@@ -24,16 +24,19 @@ final class LoaderFactory
 
 	public function createLoader(): Loader
 	{
-		$neonAdapter = new NeonCachedFileReader($this->expandRelativePaths);
+		// known before the container is compiled, so the adapter can expand them in path entries
+		// and the loader in included file names
+		$parameters = [
+			'rootDir' => $this->rootDir,
+			'currentWorkingDirectory' => $this->currentWorkingDirectory,
+			'env' => Environment::getCleanedArray(),
+		];
+		$neonAdapter = new NeonCachedFileReader($this->expandRelativePaths, $parameters);
 
 		$loader = new NeonLoader($this->fileHelper, $this->generateBaselineFile);
 		$loader->addAdapter('dist', $neonAdapter);
 		$loader->addAdapter('neon', $neonAdapter);
-		$loader->setParameters([
-			'rootDir' => $this->rootDir,
-			'currentWorkingDirectory' => $this->currentWorkingDirectory,
-			'env' => Environment::getCleanedArray(),
-		]);
+		$loader->setParameters($parameters);
 
 		return $loader;
 	}

--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -13,15 +13,18 @@ use Override;
 use PHPStan\DependencyInjection\Neon\OptionalPath;
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
+use function array_key_exists;
 use function array_values;
 use function count;
 use function dirname;
+use function explode;
 use function implode;
 use function in_array;
 use function is_array;
 use function is_int;
 use function is_string;
 use function ltrim;
+use function preg_replace_callback;
 use function sprintf;
 use function str_contains;
 use function str_starts_with;
@@ -30,7 +33,7 @@ use function substr;
 final class NeonAdapter implements Adapter
 {
 
-	public const CACHE_KEY = 'v32-deferred-autowired-parameters';
+	public const CACHE_KEY = 'v33-known-placeholders-expanded';
 
 	private const PREVENT_MERGING_SUFFIX = '!';
 
@@ -39,8 +42,10 @@ final class NeonAdapter implements Adapter
 
 	/**
 	 * @param list<string> $expandRelativePaths
+	 * @param array<string, mixed> $parameters the parameters already known when the config is loaded
+	 *                                         (rootDir, currentWorkingDirectory, env), see LoaderFactory
 	 */
-	public function __construct(private array $expandRelativePaths)
+	public function __construct(private array $expandRelativePaths, private array $parameters = [])
 	{
 	}
 
@@ -105,20 +110,9 @@ final class NeonAdapter implements Adapter
 					}
 					$val = $tmp;
 				} else {
-					if (
-						in_array($keyToResolve, [
-							'[parameters][excludePaths][]',
-							'[parameters][excludePaths][analyse][]',
-							'[parameters][excludePaths][analyseAndScan][]',
-						], true)
-						&& count($val->attributes) === 1
-						&& $val->attributes[0] === '?'
-						&& is_string($val->value)
-						&& !str_contains($val->value, '%')
-						&& !str_starts_with($val->value, '*')
-					) {
-						$fileHelper = $this->createFileHelperByFile($file);
-						$val = new OptionalPath($fileHelper->normalizePath($fileHelper->absolutizePath($val->value)));
+					$optionalPath = $this->createOptionalPath($keyToResolve, $val, $file);
+					if ($optionalPath !== null) {
+						$val = $optionalPath;
 					} else {
 						$tmp = $this->process([$val->value], $fileKeyToPass, $file);
 						$val = new Statement($tmp[0], $this->process($val->attributes, $fileKeyToPass, $file));
@@ -126,9 +120,12 @@ final class NeonAdapter implements Adapter
 				}
 			}
 
-			if (in_array($keyToResolve, $this->expandRelativePaths, true) && is_string($val) && !str_contains($val, '%') && !str_starts_with($val, '*')) {
-				$fileHelper = $this->createFileHelperByFile($file);
-				$val = $fileHelper->normalizePath($fileHelper->absolutizePath($val));
+			if (in_array($keyToResolve, $this->expandRelativePaths, true) && is_string($val) && !str_starts_with($val, '*')) {
+				$path = $this->expandKnownParameters($val);
+				if ($path !== null) {
+					$fileHelper = $this->createFileHelperByFile($file);
+					$val = $fileHelper->normalizePath($fileHelper->absolutizePath($path));
+				}
 			}
 
 			if (
@@ -142,6 +139,84 @@ final class NeonAdapter implements Adapter
 			$res[$key] = $val;
 		}
 		return $res;
+	}
+
+	/**
+	 * `- path (?)` in excludePaths marks the path optional. It becomes an OptionalPath when it can be
+	 * resolved right here, like a plain path entry; otherwise the entity is processed as a statement.
+	 */
+	private function createOptionalPath(string $keyToResolve, Entity $entity, string $file): ?OptionalPath
+	{
+		if (
+			!in_array($keyToResolve, [
+				'[parameters][excludePaths][]',
+				'[parameters][excludePaths][analyse][]',
+				'[parameters][excludePaths][analyseAndScan][]',
+			], true)
+			|| count($entity->attributes) !== 1
+			|| $entity->attributes[0] !== '?'
+			|| !is_string($entity->value)
+			|| str_starts_with($entity->value, '*')
+		) {
+			return null;
+		}
+
+		$path = $this->expandKnownParameters($entity->value);
+		if ($path === null) {
+			return null;
+		}
+
+		$fileHelper = $this->createFileHelperByFile($file);
+
+		return new OptionalPath($fileHelper->normalizePath($fileHelper->absolutizePath($path)));
+	}
+
+	/**
+	 * Expands the placeholders whose values are known before the container is compiled - rootDir,
+	 * currentWorkingDirectory and env - so a path written through them is absolutized and normalized
+	 * like a plain one. Returns null for a value with a placeholder this cannot resolve (a parameter
+	 * the config defines itself, an unset env variable, the %% escape): that one is left to the DI
+	 * compiler as written.
+	 */
+	private function expandKnownParameters(string $value): ?string
+	{
+		if (!str_contains($value, '%')) {
+			return $value;
+		}
+
+		$unresolved = false;
+		$expanded = preg_replace_callback('~%([\w.-]*)%~', function (array $matches) use (&$unresolved): string {
+			$parameter = $this->getKnownParameter($matches[1]);
+			if ($parameter === null) {
+				$unresolved = true;
+
+				return $matches[0];
+			}
+
+			return $parameter;
+		}, $value);
+
+		if ($unresolved || $expanded === null) {
+			return null;
+		}
+
+		return $expanded;
+	}
+
+	/**
+	 * @param string $name a parameter name as written between the percent signs, `env.HOME` for a nested one
+	 */
+	private function getKnownParameter(string $name): ?string
+	{
+		$value = $this->parameters;
+		foreach (explode('.', $name) as $key) {
+			if (!is_array($value) || !array_key_exists($key, $value)) {
+				return null;
+			}
+			$value = $value[$key];
+		}
+
+		return is_string($value) ? $value : null;
 	}
 
 	private function createFileHelperByFile(string $file): FileHelper

--- a/src/DependencyInjection/NeonCachedFileReader.php
+++ b/src/DependencyInjection/NeonCachedFileReader.php
@@ -19,10 +19,11 @@ final class NeonCachedFileReader implements Adapter
 
 	/**
 	 * @param list<string> $expandRelativePaths
+	 * @param array<string, mixed> $parameters
 	 */
-	public function __construct(private array $expandRelativePaths)
+	public function __construct(private array $expandRelativePaths, array $parameters = [])
 	{
-		$this->adapter = new NeonAdapter($this->expandRelativePaths);
+		$this->adapter = new NeonAdapter($this->expandRelativePaths, $parameters);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/ResultCache/ResultCachePathTransformerTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/ResultCachePathTransformerTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ResultCache;
+
+use PHPUnit\Framework\TestCase;
+use function str_replace;
+use const DIRECTORY_SEPARATOR;
+
+class ResultCachePathTransformerTest extends TestCase
+{
+
+	/**
+	 * ResultCacheManager compares the meta restored from the cache (absolutizeMeta() of what was stored
+	 * with relativizeMeta()) against the freshly computed one with !==. The round trip normalizes, so
+	 * the freshly computed side has to be normalized as well: normalizeMeta() must be the fixed point of
+	 * the round trip, and it must map the shapes the meta sources hand over onto that fixed point.
+	 */
+	public function testNormalizeMetaIsTheRoundTripFixedPoint(): void
+	{
+		$transformer = new ResultCachePathTransformer(self::raw('/opt/project/vendor/phpstan/phpstan'));
+
+		$raw = [
+			'cacheVersion' => 'v14-relativePaths',
+			// config paths through a %placeholder% keep the '.' and '..' segments they were written with
+			'analysedPaths' => [
+				self::raw('/opt/project/./src'),
+				self::raw('/opt/project/app/../lib'),
+			],
+			'scannedFiles' => [
+				self::raw('/opt/project/../project/vendor/autoload.php') => 'hash-autoload',
+			],
+			// composerAutoloaderProjectPaths . '/composer.lock': mixed separators on Windows
+			'composerLocks' => [
+				self::canonical('/opt/project') . '/composer.lock' => 'hash-lock',
+			],
+			'composerInstalled' => [
+				self::canonical('/opt/project') . '/vendor/composer/installed.php' => [
+					'versions' => [
+						// Composer records install_path as __DIR__ . '/../acme/dep'
+						'acme/dep' => [
+							'version' => '1.0.0.0',
+							'install_path' => self::canonical('/opt/project/vendor/composer') . '/../acme/dep',
+						],
+					],
+				],
+			],
+			'executedFilesHashes' => [
+				// --autoload-file ./vendor/autoload.php
+				self::raw('/opt/project/./vendor/autoload.php') => 'hash-cli-autoload',
+				// a bootstrapFile inside a phar, written through a placeholder
+				'phar://' . self::raw('/opt/project/boot/../boot.phar/boot.php') => 'hash-boot',
+			],
+			'configStubFiles' => [
+				self::raw('/opt/project/stubs/../stubs/Foo.stub'),
+			],
+			'stubFiles' => [
+				self::raw('/opt/project/stubs/../stubs/Foo.stub') => 'hash-stub',
+			],
+			'level' => '8',
+		];
+		$canonical = [
+			'cacheVersion' => 'v14-relativePaths',
+			'analysedPaths' => [
+				self::canonical('/opt/project/src'),
+				self::canonical('/opt/project/lib'),
+			],
+			'scannedFiles' => [
+				self::canonical('/opt/project/vendor/autoload.php') => 'hash-autoload',
+			],
+			'composerLocks' => [
+				self::canonical('/opt/project/composer.lock') => 'hash-lock',
+			],
+			'composerInstalled' => [
+				self::canonical('/opt/project/vendor/composer/installed.php') => [
+					'versions' => [
+						'acme/dep' => [
+							'version' => '1.0.0.0',
+							'install_path' => self::canonical('/opt/project/vendor/acme/dep'),
+						],
+					],
+				],
+			],
+			'executedFilesHashes' => [
+				self::canonical('/opt/project/vendor/autoload.php') => 'hash-cli-autoload',
+				'phar://' . self::canonical('/opt/project/boot.phar/boot.php') => 'hash-boot',
+			],
+			'configStubFiles' => [
+				self::canonical('/opt/project/stubs/Foo.stub'),
+			],
+			'stubFiles' => [
+				self::canonical('/opt/project/stubs/Foo.stub') => 'hash-stub',
+			],
+			'level' => '8',
+		];
+
+		$this->assertSame($canonical, $transformer->normalizeMeta($raw));
+
+		// the restored meta equals the normalized current one
+		$this->assertSame($canonical, $transformer->absolutizeMeta($transformer->relativizeMeta($canonical)));
+
+		// and the round trip is what canonicalizes: a cache written from the raw meta restores to the
+		// same canonical form, so a cache from before the normalization is still reused
+		$this->assertSame($canonical, $transformer->absolutizeMeta($transformer->relativizeMeta($raw)));
+	}
+
+	/**
+	 * The path as its source spells it: '/'-separated, with a drive letter on Windows.
+	 */
+	private static function raw(string $unixPath): string
+	{
+		return DIRECTORY_SEPARATOR === '\\' ? 'C:' . $unixPath : $unixPath;
+	}
+
+	/**
+	 * The path as FileHelper::normalizePath() spells it on the running platform.
+	 */
+	private static function canonical(string $unixPath): string
+	{
+		return DIRECTORY_SEPARATOR === '\\' ? 'C:' . str_replace('/', '\\', $unixPath) : $unixPath;
+	}
+
+}

--- a/tests/PHPStan/Command/CommandHelperTest.php
+++ b/tests/PHPStan/Command/CommandHelperTest.php
@@ -319,4 +319,35 @@ class CommandHelperTest extends TestCase
 		}
 	}
 
+	/**
+	 * --autoload-file lands in the result cache meta (executedFilesHashes) and --configuration in
+	 * additionalConfigFiles; both are normalized like every other path given on the command line, so
+	 * './' and '../' segments never reach the container.
+	 *
+	 * @throws InceptionNotSuccessfulException
+	 */
+	public function testAutoloadFileAndConfigurationAreNormalized(): void
+	{
+		$result = CommandHelper::begin(
+			new StringInput(''),
+			new NullOutput(),
+			[__DIR__],
+			null,
+			__DIR__ . '/relative-paths/nested/../here.php',
+			[],
+			__DIR__ . '/relative-paths/nested/../root.neon',
+			null,
+			'0',
+			false,
+			false,
+			null,
+			null,
+			false,
+		);
+		$parameters = $result->getContainer()->getParameters();
+		$relativePaths = __DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR;
+		$this->assertSame($relativePaths . 'here.php', $parameters['cliAutoloadFile']);
+		$this->assertContains($relativePaths . 'root.neon', $parameters['additionalConfigFiles']);
+	}
+
 }

--- a/tests/PHPStan/Command/CommandHelperTest.php
+++ b/tests/PHPStan/Command/CommandHelperTest.php
@@ -179,7 +179,7 @@ class CommandHelperTest extends TestCase
 					'scanDirectories' => [
 						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'src',
 						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths',
-						realpath(__DIR__ . '/../../../') . '/conf',
+						realpath(__DIR__ . '/../../../') . DIRECTORY_SEPARATOR . 'conf',
 					],
 					'paths' => [
 						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'src',
@@ -213,6 +213,49 @@ class CommandHelperTest extends TestCase
 							'paths' => [
 								__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'aaa.php',
 								__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'nested' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'bbb.php',
+							],
+						],
+					],
+				],
+			],
+			[
+				// every path written through %rootDir% and a '.' or '..' segment: NeonAdapter expands the
+				// placeholder itself and normalizes the result like a plain relative entry
+				__DIR__ . '/relative-paths/placeholders.neon',
+				[
+					'bootstrapFiles' => [
+						realpath(__DIR__ . '/../../../stubs/runtime/ReflectionUnionType.php'),
+						realpath(__DIR__ . '/../../../stubs/runtime/ReflectionAttribute.php'),
+						realpath(__DIR__ . '/../../../stubs/runtime/Attribute85.php'),
+						realpath(__DIR__ . '/../../../stubs/runtime/ReflectionIntersectionType.php'),
+						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'here.php',
+					],
+					'scanFiles' => [
+						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR . 'there.php',
+						__DIR__ . DIRECTORY_SEPARATOR . 'up.php',
+					],
+					'scanDirectories' => [
+						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths',
+					],
+					'paths' => [
+						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'src',
+					],
+					'excludePaths' => [
+						'analyseAndScan' => [
+							__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR . 'data',
+							__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'nonexistent',
+						],
+						'analyse' => [],
+					],
+					'ignoreErrors' => [
+						[
+							'message' => '#aaa#',
+							'path' => __DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'nested' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'aaa.php',
+						],
+						[
+							'message' => '#bbb#',
+							'paths' => [
+								__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'aaa.php',
 							],
 						],
 					],

--- a/tests/PHPStan/Command/relative-paths/placeholders.neon
+++ b/tests/PHPStan/Command/relative-paths/placeholders.neon
@@ -1,0 +1,22 @@
+parameters:
+	bootstrapFiles:
+		- %rootDir%/tests/PHPStan/Command/relative-paths/nested/../here.php
+	scanFiles:
+		- %rootDir%/tests/PHPStan/Command/relative-paths/./test/there.php
+		- %rootDir%/tests/PHPStan/Command/relative-paths/../up.php
+	scanDirectories:
+		- %rootDir%/tests/PHPStan/Command/relative-paths/src/..
+	paths:
+		- %rootDir%/tests/PHPStan/Command/relative-paths/nested/../src
+	excludePaths:
+		- %rootDir%/tests/PHPStan/Command/relative-paths/nested/../src/*/data
+		- %rootDir%/tests/PHPStan/Command/relative-paths/nested/../nonexistent (?)
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+		-
+			message: '#aaa#'
+			path: %rootDir%/tests/PHPStan/Command/relative-paths/nested/../nested/src/aaa.php
+		-
+			message: '#bbb#'
+			paths:
+				- %rootDir%/tests/PHPStan/Command/relative-paths/src/../src/aaa.php


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/15125
Closes https://github.com/phpstan/phpstan/issues/15152

Turns the three red E2E legs on 2.2.x green: `bug-15125` on Linux, and `phar bootstrap file` + `paths through the currentWorkingDirectory placeholder` on Windows (#6339, #6342).

## Root cause

Both issues are one defect. Since 2.2.9 the result cache stores its meta relative to the PHPStan install and re-absolutizes it on load, and `ResultCachePathTransformer::absolutizePath()` normalizes. The freshly computed meta in `ResultCacheManager::getMeta()` was built from whatever string the source handed over, and `isMetaDifferent()` compares with `!==`. Any meta path spelled non-canonically on the current side mismatched on every run. Before 2.2.9 both sides were the same raw string, so the spelling never mattered.

| Meta key | Current-side source | Non-canonical when |
|---|---|---|
| `analysedPaths` | config `paths` through `Helpers::expand` only | value contains a `%placeholder%` |
| `scannedFiles` | `scanFiles` parameter verbatim | value contains a `%placeholder%` |
| `executedFilesHashes` | `bootstrapFiles` verbatim, `--autoload-file` absolutized but not normalized | `%placeholder%` in config; `-a ./x` or `-a ../x` on any OS, any `-a` on Windows |
| `composerLocks`, `composerInstalled` keys | project path with `/composer.lock` appended | always on Windows (mixed separators) |
| `composerInstalled[*]['install_path']` | Composer's `__DIR__ . '/../x'` | **always, every OS, every Composer project** |

The last row was invisible: the changed-packages fallback absorbed it, so every warm run in every Composer project printed `Composer metadata changed but no package versions changed; keeping the result cache.` and resolved the package set for nothing.

#15125 is the `..` flavour (Linux), #15152 the separator flavour (`%currentWorkingDirectory%` expands to `D:\a\...` and the literal `/src` follows). The real PHAR was never affected: `NeonAdapter` normalizes PHPStan's own runtime stubs on both sides, which the Windows PHAR legs of #6342 confirmed. The reporter's mismatching keys come from placeholder-bearing entries in their own config.

## Changes

**1. Normalize the result cache meta before comparing it with the restored one**

- `ResultCachePathTransformer::normalizeMeta()` walks the same keys `relativizeMeta()`/`absolutizeMeta()` do (`transformMeta()` now takes the path callable). `absolutizePath()` runs through the new `normalizePath()`, so the round trip is the identity on a normalized meta by construction.
- `ResultCacheManager::getMeta()` returns `normalizeMeta([...])`. The one-off `configStubFiles` normalization from 79d9db8e91 is subsumed.
- `CommandHelper` normalizes `--autoload-file` and `--configuration` like every other path given on the command line.
- No `CACHE_VERSION` bump: a cache written before this change already restores to the canonical form, so it is reused as-is (verified locally).

**2. Expand the known placeholders in `NeonAdapter`**

`NeonAdapter` skipped absolutizing and normalizing any `expandRelativePaths` value containing a `%`, because the DI compiler expands placeholders later. `rootDir`, `currentWorkingDirectory` and `env` are known before the container is compiled (`LoaderFactory` already hands them to the Nette loader for `includes`), so the adapter now expands those itself and normalizes the result like a plain relative entry. A value with a placeholder it cannot resolve (a parameter the config defines, an unset env variable) is left to the DI compiler as written. This keeps one spelling of every configured path in the container for every consumer, not just the cache, and fixes a side crash: an optional exclude path written with a placeholder (`%rootDir%/x (?)`) used to reach `ValidateExcludePathsExtension` as a `Statement` and die with a `TypeError`. `NeonAdapter::CACHE_KEY` is bumped so cached containers are regenerated.

Left alone on purpose: `FileHelper::normalizePath()` (an `@api` method) keeps writing the platform separator behind a `phar://` scheme. With both sides normalized the same way that spelling is irrelevant to the cache, and changing it would alter `@api` output on Windows.

## Tests

- `ResultCachePathTransformerTest` (new): `normalizeMeta()` maps the shapes the meta sources produce (`.`/`..` segments, `/`-joined Windows paths, Composer `install_path`, a `phar://` bootstrap file, `./vendor/autoload.php`) onto the canonical form, that form is the fixed point of `relativizeMeta()` → `absolutizeMeta()`, and a cache written from the raw meta restores to the same canonical form. Runs on Windows too (drive-letter paths). Fails before the change with `Call to undefined method normalizeMeta()`.
- `CommandHelperTest::testAutoloadFileAndConfigurationAreNormalized` (new): fails before the change with `.../relative-paths/nested/../here.php`.
- `CommandHelperTest::dataParameters` gets `relative-paths/placeholders.neon`: `bootstrapFiles`, `scanFiles`, `scanDirectories`, `paths`, both `excludePaths` forms and both `ignoreErrors` path forms written through `%rootDir%` and a `.`/`..` segment; every container parameter must be normalized. Fails before the change (raw `..` values, and the `TypeError` for the optional path). The existing `%rootDir%/conf` expectation now uses `DIRECTORY_SEPARATOR`, which is what the Windows unit-test leg will see.
- E2E: the `bug-15125` step also reuses the cache across two runs with `-a ./vendor/autoload.php`. The Windows legs from #6342 and the `bug-15125` leg from #6339 are the acceptance tests for the two issues.

Verified locally on macOS: the `bug-15125`, `result-cache-placeholder-paths` and `result-cache-phar-bootstrap` fixtures, a placeholder-free Composer project (no more `Composer metadata changed` on warm runs), `paths`/`bootstrapFiles` through `..`, `-a ./vendor/autoload.php`, and reuse of a cache written before the fix all restore `0 files will be reanalysed`. `make phpstan` and phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzuqvNMEzugXUEXVogMsMJ
