### PR TITLE
Cover constant fetch, enum case, static call, instanceof and typehints in checkImportedClassNameCase tests

### DIFF
--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -589,7 +589,15 @@ class ClassConstantRuleTest extends RuleTestCase
 		if ($checkImportedClassNameCase) {
 			$expectedErrors[] = [
 				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
-				25,
+				34,
+			];
+			$expectedErrors[] = [
+				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
+				44,
+			];
+			$expectedErrors[] = [
+				'Enum Bug12827Classes\Suit referenced with incorrect case: Bug12827Classes\SUIT.',
+				54,
 			];
 		}
 

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -589,19 +589,33 @@ class ClassConstantRuleTest extends RuleTestCase
 		if ($checkImportedClassNameCase) {
 			$expectedErrors[] = [
 				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
-				34,
+				29,
 			];
 			$expectedErrors[] = [
 				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
-				44,
-			];
-			$expectedErrors[] = [
-				'Enum Bug12827Classes\Suit referenced with incorrect case: Bug12827Classes\SUIT.',
-				54,
+				39,
 			];
 		}
 
 		$this->analyse([__DIR__ . '/data/bug-12827.php'], $expectedErrors);
+	}
+
+	#[DataProvider('dataBug12827')]
+	#[RequiresPhp('>= 8.1.0')]
+	public function testBug12827Enum(bool $checkImportedClassNameCase): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->checkImportedClassNameCase = $checkImportedClassNameCase;
+
+		$expectedErrors = [];
+		if ($checkImportedClassNameCase) {
+			$expectedErrors[] = [
+				'Enum Bug12827Enum\Suit referenced with incorrect case: Bug12827Enum\SUIT.',
+				17,
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-12827-enum.php'], $expectedErrors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/ExistingClassInInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInInstanceOfRuleTest.php
@@ -67,6 +67,16 @@ class ExistingClassInInstanceOfRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testBug12827(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12827-instanceof.php'], [
+			[
+				'Class Bug12827InstanceOf\Post referenced with incorrect case: Bug12827InstanceOf\POST.',
+				15,
+			],
+		]);
+	}
+
 	public function testClassExists(): void
 	{
 		$this->analyse([__DIR__ . '/data/instanceof-class-exists.php'], []);

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -759,7 +759,7 @@ class InstantiationRuleTest extends RuleTestCase
 		if ($checkImportedClassNameCase) {
 			$expectedErrors[] = [
 				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
-				15,
+				24,
 			];
 		}
 

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -344,7 +344,7 @@ class InstantiationRuleTest extends RuleTestCase
 			],
 			[
 				'Instantiated class Bug4471\Foo is abstract.',
-				24,
+				19,
 			],
 			[
 				'Cannot instantiate interface Bug4471\Bar.',
@@ -438,7 +438,7 @@ class InstantiationRuleTest extends RuleTestCase
 			],
 			[
 				'Missing parameter $start (string) in call to DatePeriod constructor.',
-				24,
+				19,
 			],
 			[
 				'Parameter #3 $end of class DatePeriod constructor expects int|TEnd of DateTimeInterface, string given.',
@@ -462,7 +462,7 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3311a.php'], [
 			[
 				'Parameter #1 $bar of class Bug3311a\Foo constructor expects list<string>, array{1: \'baz\'} given.',
-				24,
+				19,
 				"array{1: 'baz'} is not a list.",
 			],
 		]);
@@ -759,7 +759,7 @@ class InstantiationRuleTest extends RuleTestCase
 		if ($checkImportedClassNameCase) {
 			$expectedErrors[] = [
 				'Class Bug12827Classes\Post referenced with incorrect case: Bug12827Classes\POST.',
-				24,
+				19,
 			];
 		}
 

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -344,7 +344,7 @@ class InstantiationRuleTest extends RuleTestCase
 			],
 			[
 				'Instantiated class Bug4471\Foo is abstract.',
-				19,
+				24,
 			],
 			[
 				'Cannot instantiate interface Bug4471\Bar.',
@@ -438,7 +438,7 @@ class InstantiationRuleTest extends RuleTestCase
 			],
 			[
 				'Missing parameter $start (string) in call to DatePeriod constructor.',
-				19,
+				24,
 			],
 			[
 				'Parameter #3 $end of class DatePeriod constructor expects int|TEnd of DateTimeInterface, string given.',
@@ -462,7 +462,7 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3311a.php'], [
 			[
 				'Parameter #1 $bar of class Bug3311a\Foo constructor expects list<string>, array{1: \'baz\'} given.',
-				19,
+				24,
 				"array{1: 'baz'} is not a list.",
 			],
 		]);

--- a/tests/PHPStan/Rules/Classes/data/bug-12827-enum.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-12827-enum.php
@@ -1,0 +1,26 @@
+<?php // lint >= 8.1
+
+namespace Bug12827Enum {
+	enum Suit {
+		case Hearts;
+	}
+}
+
+namespace Bug12827EnumConsumer {
+	use Bug12827Enum\Suit;
+
+	class Consumer
+	{
+
+		public function doFoo(): Suit
+		{
+			return SUIT::Hearts;
+		}
+
+		public function doBar(): Suit
+		{
+			return Suit::Hearts;
+		}
+
+	}
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-12827-instanceof.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-12827-instanceof.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12827InstanceOf {
+	class Post {}
+}
+
+namespace Bug12827InstanceOfConsumer {
+	use Bug12827InstanceOf\Post;
+
+	class Consumer
+	{
+
+		public function doFoo(object $o): bool
+		{
+			return $o instanceof POST;
+		}
+
+		public function doBar(object $o): bool
+		{
+			return $o instanceof Post;
+		}
+
+	}
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-12827.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-12827.php
@@ -6,15 +6,10 @@ namespace Bug12827Classes {
 		public const FOO = 'foo';
 
 	}
-
-	enum Suit {
-		case Hearts;
-	}
 }
 
 namespace Bug12827ClassesConsumer {
 	use Bug12827Classes\Post;
-	use Bug12827Classes\Suit;
 
 	class Consumer
 	{
@@ -47,16 +42,6 @@ namespace Bug12827ClassesConsumer {
 		public function doDolor(): string
 		{
 			return Post::FOO;
-		}
-
-		public function doSit(): Suit
-		{
-			return SUIT::Hearts;
-		}
-
-		public function doAmet(): Suit
-		{
-			return Suit::Hearts;
 		}
 
 	}

--- a/tests/PHPStan/Rules/Classes/data/bug-12827.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-12827.php
@@ -1,11 +1,20 @@
 <?php declare(strict_types = 1);
 
 namespace Bug12827Classes {
-	class Post {}
+	class Post {
+
+		public const FOO = 'foo';
+
+	}
+
+	enum Suit {
+		case Hearts;
+	}
 }
 
 namespace Bug12827ClassesConsumer {
 	use Bug12827Classes\Post;
+	use Bug12827Classes\Suit;
 
 	class Consumer
 	{
@@ -28,6 +37,26 @@ namespace Bug12827ClassesConsumer {
 		public function doLorem(): string
 		{
 			return Post::class;
+		}
+
+		public function doIpsum(): string
+		{
+			return POST::FOO;
+		}
+
+		public function doDolor(): string
+		{
+			return Post::FOO;
+		}
+
+		public function doSit(): Suit
+		{
+			return SUIT::Hearts;
+		}
+
+		public function doAmet(): Suit
+		{
+			return Suit::Hearts;
 		}
 
 	}

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -535,4 +535,18 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12827(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12827.php'], [
+			[
+				'Class Bug12827Functions\Post referenced with incorrect case: Bug12827Functions\POST.',
+				10,
+			],
+			[
+				'Class Bug12827Functions\Post referenced with incorrect case: Bug12827Functions\POST.',
+				10,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-12827.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-12827.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12827Functions {
+	class Post {}
+}
+
+namespace Bug12827FunctionsConsumer {
+	use Bug12827Functions\Post;
+
+	function doFoo(POST $post): POST
+	{
+		return $post;
+	}
+
+	function doBar(Post $post): Post
+	{
+		return $post;
+	}
+}

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -1067,4 +1067,15 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-15002.php'], []);
 	}
 
+	public function testBug12827(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/bug-12827-static-call.php'], [
+			[
+				'Class Bug12827StaticCall\Post referenced with incorrect case: Bug12827StaticCall\POST.',
+				22,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-12827-static-call.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12827-static-call.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12827StaticCall {
+	class Post {
+
+		public static function create(): self
+		{
+			return new self();
+		}
+
+	}
+}
+
+namespace Bug12827StaticCallConsumer {
+	use Bug12827StaticCall\Post;
+
+	class Consumer
+	{
+
+		public function doFoo(): Post
+		{
+			return POST::create();
+		}
+
+		public function doBar(): Post
+		{
+			return Post::create();
+		}
+
+	}
+}


### PR DESCRIPTION
Follow-up to #6271 (`checkImportedClassNameCase` bleeding-edge toggle). Its fixtures cover `new`, `::class`, `catch` and method attributes. Bumping a large codebase to 2.2.12 hit several other shapes that had no fixture, so this adds them:

- regular class constant fetch (`POST::FOO`) in `ClassConstantRuleTest`
- enum case fetch (`SUIT::Hearts`, reports `enum.nameCase`) in `ClassConstantRuleTest`
- static method call (`POST::create()`) in `CallStaticMethodsRuleTest`
- `instanceof` in `ExistingClassInInstanceOfRuleTest`
- function parameter and return type in `ExistingClassesInTypehintsRuleTest` (`FunctionDefinitionCheck`, which #6271 also rewrote without a test)

Tests only, no source changes.