### PR TITLE
Report the sampled peak memory of the whole process tree

### DIFF
--- a/src/Command/InceptionResult.php
+++ b/src/Command/InceptionResult.php
@@ -6,6 +6,7 @@ use PHPStan\DependencyInjection\Container;
 use PHPStan\File\PathNotFoundException;
 use PHPStan\Internal\BytesHelper;
 use PHPStan\Parallel\ForkParallelChecker;
+use PHPStan\Process\ProcessTreeMemoryTracker;
 use function floor;
 use function implode;
 use function memory_get_peak_usage;
@@ -140,6 +141,16 @@ final class InceptionResult
 						? sprintf('the %s worker', $mechanism)
 						: sprintf('largest of %d %s workers', $workerCount, $mechanism),
 				));
+
+				// Physical memory of the whole tree at its sampled largest - the
+				// per-process peaks above do not add up to it, see the tracker.
+				$totalPeakBytes = $this->container->getByType(ProcessTreeMemoryTracker::class)->getPeakBytes();
+				if ($totalPeakBytes !== null) {
+					$this->getErrorOutput()->writeLineFormatted(sprintf(
+						'Total peak memory: %s (all processes combined, sampled)',
+						BytesHelper::bytes($totalPeakBytes),
+					));
+				}
 			}
 		}
 

--- a/src/Parallel/ForkedProcess.php
+++ b/src/Parallel/ForkedProcess.php
@@ -46,6 +46,8 @@ final class ForkedProcess extends ProcessBase
 
 	private ?TimerInterface $waitTimer = null;
 
+	private ?int $pid = null;
+
 	/**
 	 * @param string[] $analysedFiles
 	 */
@@ -152,6 +154,7 @@ final class ForkedProcess extends ProcessBase
 		}
 
 		// Parent: poll for the child to exit and report it through $onExit.
+		$this->pid = $pid;
 		$this->waitTimer = $this->loop->addPeriodicTimer(self::WAITPID_POLL_INTERVAL, function () use ($pid, $onExit): void {
 			$status = 0;
 			$result = pcntl_waitpid($pid, $status, WNOHANG);
@@ -197,6 +200,11 @@ final class ForkedProcess extends ProcessBase
 		// child exit; the waitpid poll timer must keep running until then so
 		// the child is actually reaped (otherwise: zombie + hang).
 		$this->endConnection();
+	}
+
+	public function getPid(): ?int
+	{
+		return $this->pid;
 	}
 
 	private function cancelWaitTimer(): void

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -475,18 +475,22 @@ final class ParallelAnalyser
 			$this->processPool->attachProcess($processIdentifier, $process);
 		}
 
-		$childPids = [];
-		foreach ($this->processPool->getAttachedProcesses() as $attachedProcess) {
-			$childPid = $attachedProcess->getPid();
-			if ($childPid === null) {
-				continue;
+		// the sampled number only ever prints at -v and above; a quiet run
+		// should not pay for reading 20 smaps_rollup files twice a second
+		if ($errorOutput !== null && $errorOutput->isVerbose()) {
+			$childPids = [];
+			foreach ($this->processPool->getAttachedProcesses() as $attachedProcess) {
+				$childPid = $attachedProcess->getPid();
+				if ($childPid === null) {
+					continue;
+				}
+
+				$childPids[] = $childPid;
 			}
 
-			$childPids[] = $childPid;
-		}
-
-		if ($childPids !== []) {
-			$this->processTreeMemoryTracker->start($loop, $childPids);
+			if ($childPids !== []) {
+				$this->processTreeMemoryTracker->start($loop, $childPids);
+			}
 		}
 
 		return $deferred->promise();

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -16,6 +16,7 @@ use PHPStan\Dependency\RootExportedNode;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Process\ProcessHelper;
+use PHPStan\Process\ProcessTreeMemoryTracker;
 use PHPStan\Process\TerminationSignal;
 use PHPStan\Reflection\BetterReflection\SourceLocator\PreForkDirectorySymbolScanner;
 use React\EventLoop\LoopInterface;
@@ -59,6 +60,7 @@ final class ParallelAnalyser
 		private ForkParallelChecker $forkParallelChecker,
 		private PreForkDirectorySymbolScanner $preForkDirectorySymbolScanner,
 		private WorkerRunner $workerRunner,
+		private ProcessTreeMemoryTracker $processTreeMemoryTracker,
 	)
 	{
 		$this->processTimeout = max($processTimeout, self::DEFAULT_TIMEOUT);
@@ -132,8 +134,12 @@ final class ParallelAnalyser
 
 		$useFork = $this->forkParallelChecker->isSupported();
 
+		$memoryTracker = $this->processTreeMemoryTracker;
+
 		$server = new TcpServer('127.0.0.1:0', $loop);
-		$this->processPool = new ProcessPool($server, static function () use ($deferred, &$jobs, &$internalErrors, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$packageDependencies, &$exportedNodes, &$peakMemoryUsages, &$allProcessedFiles, $arenaName): void {
+		$this->processPool = new ProcessPool($server, static function () use ($deferred, $loop, $memoryTracker, &$jobs, &$internalErrors, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$packageDependencies, &$exportedNodes, &$peakMemoryUsages, &$allProcessedFiles, $arenaName): void {
+			$memoryTracker->stop($loop);
+
 			if ($arenaName !== null) {
 				ArenaCache::destroy();
 			}
@@ -467,6 +473,20 @@ final class ParallelAnalyser
 				$this->processPool->tryQuitProcess($processIdentifier);
 			});
 			$this->processPool->attachProcess($processIdentifier, $process);
+		}
+
+		$childPids = [];
+		foreach ($this->processPool->getAttachedProcesses() as $attachedProcess) {
+			$childPid = $attachedProcess->getPid();
+			if ($childPid === null) {
+				continue;
+			}
+
+			$childPids[] = $childPid;
+		}
+
+		if ($childPids !== []) {
+			$this->processTreeMemoryTracker->start($loop, $childPids);
 		}
 
 		return $deferred->promise();

--- a/src/Parallel/Process.php
+++ b/src/Parallel/Process.php
@@ -38,4 +38,10 @@ interface Process
 
 	public function bindConnection(ReadableStreamInterface $out, WritableStreamInterface $in): void;
 
+	/**
+	 * The worker's OS process ID, or null before start() or when the process
+	 * failed to come to life.
+	 */
+	public function getPid(): ?int;
+
 }

--- a/src/Parallel/ProcessPool.php
+++ b/src/Parallel/ProcessPool.php
@@ -40,6 +40,14 @@ final class ProcessPool
 		$this->processes[$identifier] = $process;
 	}
 
+	/**
+	 * @return array<string, Process>
+	 */
+	public function getAttachedProcesses(): array
+	{
+		return $this->processes;
+	}
+
 	public function tryQuitProcess(string $identifier): void
 	{
 		if (!array_key_exists($identifier, $this->processes)) {

--- a/src/Parallel/SpawnedProcess.php
+++ b/src/Parallel/SpawnedProcess.php
@@ -76,6 +76,11 @@ final class SpawnedProcess extends ProcessBase
 		});
 	}
 
+	public function getPid(): ?int
+	{
+		return $this->process->getPid();
+	}
+
 	public function quit(): void
 	{
 		$this->cancelTimer();

--- a/src/Process/ProcessTreeMemoryTracker.php
+++ b/src/Process/ProcessTreeMemoryTracker.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use function file_get_contents;
+use function max;
+use function preg_match;
+
+/**
+ * Peak physical memory of the whole process tree - the main process and its
+ * workers combined - measured the only way that number exists: as PSS.
+ *
+ * Per-process figures cannot be added up. A forked worker shares its inherited
+ * pages with the main process and every sibling copy-on-write, so each
+ * process's RSS counts the same physical page again and a sum multiplies it by
+ * the process count. PSS (proportional set size) is the kernel's answer:
+ * every physical page is divided among the processes that share it, so the
+ * PSS of the tree summed across its processes is the tree's actual footprint
+ * at that instant. That covers the turbo arena too - a /dev/shm mapping shared
+ * by all workers is split among them the same way. /proc/<pid>/smaps_rollup
+ * serves the per-process total without walking the full smaps listing, and
+ * reading it needs no privileges for direct children.
+ *
+ * The kernel keeps no PSS high-water mark, so the peak has to be sampled: a
+ * periodic timer on the main process's event loop reads every process's
+ * rollup and keeps the largest sum. Two consequences, both making the result
+ * an understatement, never an exaggeration: a spike between two samples is
+ * missed, and the main process's own late peak - aggregating worker results
+ * and saving the result cache, after the workers are gone and the loop with
+ * them - is not sampled at all. The second gap is closed in getPeakBytes()
+ * with the main process's VmHWM, its lifetime RSS high-water mark: a
+ * process's RSS never exceeds the tree's physical footprint at the same
+ * instant, so VmHWM is itself a lower bound of the tree's peak and taking
+ * the larger of the two bounds only tightens the estimate.
+ *
+ * On platforms without /proc (Windows, macOS) nothing is sampled and
+ * getPeakBytes() returns null; the caller prints nothing.
+ */
+#[AutowiredService]
+final class ProcessTreeMemoryTracker
+{
+
+	private const SAMPLE_INTERVAL_SECONDS = 0.5;
+
+	/** @var list<int> */
+	private array $childPids = [];
+
+	private ?TimerInterface $timer = null;
+
+	private ?int $sampledPeakBytes = null;
+
+	/**
+	 * @param string $filesystemRoot Prefix for every /proc path read, so tests
+	 *                               can run against a fixture tree. Empty means
+	 *                               the real filesystem.
+	 */
+	public function __construct(private string $filesystemRoot = '')
+	{
+	}
+
+	/**
+	 * @param list<int> $childPids
+	 */
+	public function start(LoopInterface $loop, array $childPids): void
+	{
+		if ($this->readPssBytes('self') === null) {
+			return;
+		}
+
+		$this->childPids = $childPids;
+		$this->sample();
+		$this->timer = $loop->addPeriodicTimer(self::SAMPLE_INTERVAL_SECONDS, function (): void {
+			$this->sample();
+		});
+	}
+
+	public function stop(LoopInterface $loop): void
+	{
+		if ($this->timer === null) {
+			return;
+		}
+
+		$loop->cancelTimer($this->timer);
+		$this->timer = null;
+
+		// the workers quit moments ago at most; what is still resident counts
+		$this->sample();
+	}
+
+	/**
+	 * The largest observed footprint of the whole tree, or null when nothing
+	 * was measured - the run was single-process, or the platform has no /proc.
+	 */
+	public function getPeakBytes(): ?int
+	{
+		if ($this->sampledPeakBytes === null) {
+			return null;
+		}
+
+		$ownHighWater = $this->readVmHwmBytes();
+		if ($ownHighWater === null) {
+			return $this->sampledPeakBytes;
+		}
+
+		return max($this->sampledPeakBytes, $ownHighWater);
+	}
+
+	public function sample(): void
+	{
+		$sum = $this->readPssBytes('self');
+		if ($sum === null) {
+			return;
+		}
+
+		foreach ($this->childPids as $pid) {
+			// an exited worker's directory is gone; its pages either moved to a
+			// surviving sharer's PSS or left the footprint with it
+			$pss = $this->readPssBytes((string) $pid);
+			if ($pss === null) {
+				continue;
+			}
+
+			$sum += $pss;
+		}
+
+		if ($this->sampledPeakBytes !== null && $sum <= $this->sampledPeakBytes) {
+			return;
+		}
+
+		$this->sampledPeakBytes = $sum;
+	}
+
+	private function readPssBytes(string $pid): ?int
+	{
+		return $this->readKilobytesLine('/proc/' . $pid . '/smaps_rollup', 'Pss');
+	}
+
+	private function readVmHwmBytes(): ?int
+	{
+		return $this->readKilobytesLine('/proc/self/status', 'VmHWM');
+	}
+
+	private function readKilobytesLine(string $path, string $key): ?int
+	{
+		// the process may have exited, or there is no /proc at all; a warning
+		// from a probe would be worse than not knowing
+		$contents = @file_get_contents($this->filesystemRoot . $path);
+		if ($contents === false) {
+			return null;
+		}
+
+		if (preg_match('~^' . $key . ':\s+(\d+) kB~m', $contents, $matches) !== 1) {
+			return null;
+		}
+
+		return (int) $matches[1] * 1024;
+	}
+
+}

--- a/tests/PHPStan/Process/ProcessTreeMemoryTrackerTest.php
+++ b/tests/PHPStan/Process/ProcessTreeMemoryTrackerTest.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use Override;
+use PHPStan\File\FileWriter;
+use PHPUnit\Framework\TestCase;
+use React\EventLoop\StreamSelectLoop;
+use function dirname;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class ProcessTreeMemoryTrackerTest extends TestCase
+{
+
+	/** @var list<string> */
+	private array $roots = [];
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		foreach ($this->roots as $root) {
+			self::removeDirectory($root);
+		}
+
+		$this->roots = [];
+	}
+
+	public function testPeakIsTheLargestSampledSumOfPssAcrossTheTree(): void
+	{
+		$root = $this->createFixtureRoot([
+			'/proc/self/smaps_rollup' => self::smapsRollup(1000),
+			'/proc/101/smaps_rollup' => self::smapsRollup(300),
+			'/proc/102/smaps_rollup' => self::smapsRollup(200),
+		]);
+		$tracker = new ProcessTreeMemoryTracker($root);
+		$loop = new StreamSelectLoop();
+
+		$tracker->start($loop, [101, 102]);
+		$tracker->stop($loop);
+
+		$this->assertSame(1500 * 1024, $tracker->getPeakBytes());
+	}
+
+	public function testPeakKeepsTheLargestSampleNotTheLast(): void
+	{
+		$root = $this->createFixtureRoot([
+			'/proc/self/smaps_rollup' => self::smapsRollup(1000),
+			'/proc/101/smaps_rollup' => self::smapsRollup(2000),
+		]);
+		$tracker = new ProcessTreeMemoryTracker($root);
+		$loop = new StreamSelectLoop();
+
+		$tracker->start($loop, [101]);
+		FileWriter::write($root . '/proc/101/smaps_rollup', self::smapsRollup(100));
+		$tracker->stop($loop);
+
+		$this->assertSame(3000 * 1024, $tracker->getPeakBytes());
+	}
+
+	public function testExitedChildIsSkippedInsteadOfSpoilingTheSample(): void
+	{
+		$root = $this->createFixtureRoot([
+			'/proc/self/smaps_rollup' => self::smapsRollup(1000),
+			'/proc/101/smaps_rollup' => self::smapsRollup(300),
+		]);
+		$tracker = new ProcessTreeMemoryTracker($root);
+		$loop = new StreamSelectLoop();
+
+		$tracker->start($loop, [101, 999]);
+		$tracker->stop($loop);
+
+		$this->assertSame(1300 * 1024, $tracker->getPeakBytes());
+	}
+
+	public function testMainProcessHighWaterLiftsAPeakTheSamplerMissed(): void
+	{
+		// the main process's own peak comes after the workers are gone - result
+		// aggregation, result cache save - when nothing samples any more; VmHWM
+		// is the kernel's record of it
+		$root = $this->createFixtureRoot([
+			'/proc/self/smaps_rollup' => self::smapsRollup(1000),
+			'/proc/self/status' => "Name:\tphpstan\nVmHWM:\t    5000 kB\nVmRSS:\t    4000 kB\n",
+		]);
+		$tracker = new ProcessTreeMemoryTracker($root);
+		$loop = new StreamSelectLoop();
+
+		$tracker->start($loop, []);
+		$tracker->stop($loop);
+
+		$this->assertSame(5000 * 1024, $tracker->getPeakBytes());
+	}
+
+	public function testNothingIsReportedWithoutProc(): void
+	{
+		$tracker = new ProcessTreeMemoryTracker($this->createFixtureRoot([]));
+		$loop = new StreamSelectLoop();
+
+		$tracker->start($loop, [101]);
+		$tracker->stop($loop);
+
+		$this->assertNull($tracker->getPeakBytes());
+	}
+
+	private static function smapsRollup(int $pssKilobytes): string
+	{
+		return "00400000-7fff9cbe7000 ---p 00000000 00:00 0                          [rollup]\n"
+			. "Rss:\t   99999 kB\n"
+			. "Pss:\t    " . $pssKilobytes . " kB\n"
+			. "Pss_Anon:\t     100 kB\n"
+			. "Private_Dirty:\t     100 kB\n";
+	}
+
+	/**
+	 * @param array<string, string> $files
+	 */
+	private function createFixtureRoot(array $files): string
+	{
+		$root = sys_get_temp_dir() . '/phpstan-process-tree-memory-' . uniqid();
+		$this->roots[] = $root;
+
+		foreach ($files as $path => $contents) {
+			$fullPath = $root . $path;
+			$directory = dirname($fullPath);
+			if (!is_dir($directory)) {
+				mkdir($directory, 0777, true);
+			}
+
+			FileWriter::write($fullPath, $contents);
+		}
+
+		return $root;
+	}
+
+	private static function removeDirectory(string $directory): void
+	{
+		if (!is_dir($directory)) {
+			return;
+		}
+
+		$entries = scandir($directory);
+		if ($entries === false) {
+			return;
+		}
+
+		foreach ($entries as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+
+			$path = $directory . '/' . $entry;
+			if (is_dir($path)) {
+				self::removeDirectory($path);
+				continue;
+			}
+
+			unlink($path);
+		}
+
+		rmdir($directory);
+	}
+
+}


### PR DESCRIPTION
#6297 replaced the summed fiction with two per-process figures that the OS can confirm. This adds the third number people keep asking for — how much memory the whole run took — without bringing the fiction back:

```
Peak memory: 342.5 MB (main process), 220 MB (largest of 20 forked workers)
Total peak memory: 3.67 GB (all processes combined, sampled)
```

## Why the per-process figures cannot just be added up

A forked worker shares its inherited pages with the main process and every sibling copy-on-write. Each process's RSS counts a shared physical page again, so a sum across the tree multiplies it by the process count — that multiplication is exactly what made the old `Used memory` line explode under forking.

The kernel already has the number that adds up: PSS divides every physical page among the processes that share it, so the PSS of the tree summed across its processes is the tree's actual footprint at that instant. That covers the turbo arena too — a `/dev/shm` mapping shared by all workers is split among them the same way. `/proc/<pid>/smaps_rollup` serves the per-process total without walking the full smaps listing, and reading it needs no privileges for direct children — spawned workers included.

## How the peak is taken

The kernel keeps no PSS high-water mark, so the peak has to be sampled: the main process reads every process's rollup twice per second on its existing event loop and keeps the largest sum. Sampling only starts at `-v` and above — the only place the line prints — so a quiet run pays nothing.

Both gaps of sampling understate, never exaggerate:

- A spike between two samples is missed.
- The main process's own late peak — collecting worker results, saving the result cache — comes after the workers are gone and the event loop with them, so no sample sees it. `getPeakBytes()` closes that gap with the main process's `VmHWM`, its lifetime RSS high-water mark: a process's RSS never exceeds the tree's physical footprint at the same instant, so `VmHWM` is itself a lower bound of the tree's peak, and taking the larger of the two bounds only tightens the estimate.

On platforms without `/proc` (Windows, macOS) nothing is sampled and the line is not printed, same as the cgroup-based CPU detection behaves there.

## Checked against the OS

Cold self-analysis of this repository, 20 forked workers, with an external observer polling `smaps_rollup` of the whole process tree at 5 Hz:

| | |
|---|---|
| printed `Total peak memory` | **3.67 GB** |
| observer: max sum of PSS | 3.66 GB |
| observer: max sum of RSS (the naive total) | 4.83 GB |

Spawn mode (pcntl disabled) prints and validates the same way.

The tracker follows the `SystemResources` pattern — a `$filesystemRoot` constructor argument lets the tests run against fixture `/proc` trees; five of them cover the sum, the peak-keeps-the-largest-sample behavior, an exited worker mid-sample, the `VmHWM` lift, and the no-`/proc` platform.

Co-Authored-By: Claude Code
