### PR TITLE
Rename the result cache into place instead of writing it over the old one

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,6 +35,22 @@ jobs:
       matrix:
         include:
           - script: |
+              cd e2e/result-cache-atomic-save
+              ../../bin/phpstan
+              INODE=$(ls -i tmp/resultCache.php | awk '{print $1}')
+              ../../bin/phpstan
+              # The cache is written next to its final path and renamed into place, so saving it
+              # again replaces the file rather than truncating and rewriting the one the next run
+              # reads. That is what keeps a run killed mid-save from leaving a partial cache behind.
+              REPLACED=$([ "$INODE" != "$(ls -i tmp/resultCache.php | awk '{print $1}')" ] && echo replaced || echo 'written in place')
+              ../bashunit -a equals 'replaced' "$REPLACED"
+              # A completed save leaves nothing next to the cache file.
+              LEFTOVERS=$(ls tmp/ | grep -c '\.tmp$' || true)
+              ../bashunit -a equals '0' "$LEFTOVERS"
+              OUTPUT=$(../../bin/phpstan -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+          - script: |
               cd e2e/result-cache-1
               echo -n > phpstan-baseline.neon
               ../../bin/phpstan -vvv

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ e2e/bashunit
 /.phpbench
 /e2e/turbo-arena/tmp
 /e2e/fork-unsafe-extension/tmp
+/e2e/result-cache-atomic-save/tmp

--- a/e2e/result-cache-atomic-save/phpstan.neon
+++ b/e2e/result-cache-atomic-save/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: 8
+	tmpDir: tmp
+	paths:
+		- src

--- a/e2e/result-cache-atomic-save/src/Foo.php
+++ b/e2e/result-cache-atomic-save/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace ResultCacheE2EAtomicSave;
+
+class Foo
+{
+
+	public function doFoo(): int
+	{
+		return 1;
+	}
+
+}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -45,6 +45,7 @@ use function fclose;
 use function fopen;
 use function fwrite;
 use function get_loaded_extensions;
+use function getmypid;
 use function hash_file;
 use function implode;
 use function in_array;
@@ -53,11 +54,13 @@ use function is_dir;
 use function is_file;
 use function ksort;
 use function microtime;
+use function rename;
 use function sort;
 use function sprintf;
 use function str_starts_with;
 use function substr;
 use function time;
+use function uniqid;
 use function unlink;
 use function var_export;
 use const PHP_VERSION_ID;
@@ -1238,14 +1241,26 @@ final class ResultCacheManager
 
 		$file = $this->cacheFilePath;
 
+		// Written to a sibling of the final path and renamed into place, so a run that dies while
+		// saving - or is killed by a CI timeout - leaves the previous cache untouched instead of a
+		// half-written one at the path the next run reads. rename() within a directory is atomic, so
+		// a concurrent run either reads the whole old cache or the whole new one.
+		// Named after the process so two runs sharing a tmpDir cannot write the same temporary file,
+		// and so a leftover from a run that was killed is reused rather than accumulating.
+		$pid = getmypid();
+		$temporaryFile = sprintf('%s.%s.tmp', $file, $pid === false ? uniqid() : $pid);
+
 		// streamed to the file section by section - building the whole
 		// var_export()ed contents in memory at once would take up roughly
 		// twice the size of the resulting file in the main process
-		$handle = @fopen($file, 'w');
+		$handle = @fopen($temporaryFile, 'w');
 		if ($handle === false) {
 			$error = error_get_last();
-			throw new CouldNotWriteFileException($file, $error !== null ? $error['message'] : 'unknown cause');
+			throw new CouldNotWriteFileException($temporaryFile, $error !== null ? $error['message'] : 'unknown cause');
 		}
+
+		$closed = false;
+		$renamed = false;
 
 		try {
 			$this->writeToHandle($handle, $file, "<?php declare(strict_types = 1);
@@ -1280,8 +1295,23 @@ return [
 			$this->writeToHandle($handle, $file, '; },
 ];
 ');
-		} finally {
 			fclose($handle);
+			$closed = true;
+
+			if (!@rename($temporaryFile, $file)) {
+				$error = error_get_last();
+				throw new CouldNotWriteFileException($file, $error !== null ? $error['message'] : 'unknown cause');
+			}
+
+			$renamed = true;
+		} finally {
+			if (!$closed) {
+				fclose($handle);
+			}
+
+			if (!$renamed) {
+				@unlink($temporaryFile);
+			}
 		}
 	}
 


### PR DESCRIPTION
`save()` opens the final cache path and streams into it, so a run that dies while saving leaves a partial file exactly where the next run looks for it. A CI timeout, a full disk or a Ctrl-C is enough.

What happens next depends on the format rather than on any deliberate handling: a truncated `var_export`'d file happens to fail parsing and gets discarded. Any format that can be read halfway would instead hand the next run a cache missing whatever came after the cut.

This streams the cache to a sibling of the final path and renames it into place once it is complete. `rename()` within a directory is atomic, so a concurrent run reads either the whole old cache or the whole new one, and a run that dies leaves the previous cache untouched. The temporary file is named after the process, so two runs sharing a `tmpDir` cannot collide, and it is removed when the save does not finish.

Verified locally:

- the new e2e fixture asserts the cache file is replaced rather than rewritten in place, and that a completed save leaves nothing beside it. It fails on 2.2.x, where the inode is unchanged because the same file is truncated and rewritten.
- the whole `result-cache-e2e-tests` job replayed locally: same three failures as 2.2.x in my harness, none of them related
- `make phpstan`, phpcs on the touched file, and the result-cache, command and dependency suites (186 tests) are green

Performance, 2485 files, five interleaved rounds: cold CPU median 106.3s on 2.2.x against 107.2s here, with within-build spreads of 4.5s and 4.2s, so no measurable difference. Warm CPU 1.3s both. One `rename()` per run.

The killed-save property itself is not in CI: killing a process at the right microsecond is not something to put in a test. The fixture asserts the observable half, which is that a save replaces the file instead of overwriting it.

Found while rebasing phpstan/phpstan-src#5982, which is where a truncated cache stops being harmless. It is independent of that PR and of the format it proposes.
