### PR TITLE
Narrow conditional type branches through NarrowedSubjectType instead of by identity

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1169,6 +1169,23 @@ jobs:
           echo "$OUTPUT"
           e2e/bashunit -a contains 'Turbo extension: enabled' "$OUTPUT"
 
+      - name: "Verify conditional types leave interned types equal to a resolved subject alone"
+        # With the extension active TypeCombinator's results are interned, so equal
+        # types share one instance. ConditionalType used to narrow the types in its
+        # branches identical to the subject even once the subject had resolved to a
+        # concrete type, and interning made that hit unrelated types - the `mixed`
+        # value type of an `array` branch for a `mixed` subject -
+        # https://github.com/phpstan/phpstan/issues/15151
+        run: |
+          cd e2e/bug-15151
+          OUTPUT=$(php ../../bin/phpstan analyse --no-progress --error-format=raw 2>&1 || true)
+          echo "$OUTPUT"
+          ../bashunit -a contains 'reception_formulaire.php:20:Dumped type: mixed' "$OUTPUT"
+          ../bashunit -a contains 'webservice.php:25:Dumped type: mixed' "$OUTPUT"
+          ../bashunit -a not_contains 'Dumped type: array' "$OUTPUT"
+          # the two dumps are the only errors: count the file:line:message lines
+          ../bashunit -a equals '2' "$(echo "$OUTPUT" | grep -Ec '^/.+:[0-9]+:')"
+
       - name: "Test"
         # The arena is a per-run POSIX shared-memory object: shm_open() plus an
         # ftruncate() to 256 MB that tmpfs honours sparsely, committing pages on

--- a/e2e/bug-15151/functions.php
+++ b/e2e/bug-15151/functions.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MyApp;
+
+
+/**
+ * Note. The bug disappears if I remove this function or if I edit it in certain ways.
+ *
+ * @param ?int $quote_style
+ * @param array{string, string}|bool|null ...$substitutions_list
+ * @return ($string is null ? null : ($string is '' ? '' : ($string is non-empty-string ? non-empty-string : string)))
+ */
+function htmlentities2(string|int|float|\BackedEnum|null $string, ?int $quote_style = \ENT_QUOTES, array|bool|null ...$substitutions_list): string|null {
+    if ($string instanceof \BackedEnum)
+        $string = validate_string($string->value);
+    if ($string === null)
+        return null;
+    $string = validate_string($string) ?? throw new \ValueError('Incompatible value');
+    $sortie = \htmlspecialchars($string, ($quote_style ?? \ENT_QUOTES) | \ENT_HTML401 | \ENT_SUBSTITUTE, 'utf-8');
+    foreach ($substitutions_list as $substitutions) {
+        if ($substitutions) {
+            if ($substitutions === true)
+                $substitutions = [ [ "\n", "\r" ], [ '<br/>', '' ] ];
+            $sortie = \str_replace($substitutions[0], $substitutions[1], $sortie);
+        }
+    }
+    return $sortie;
+}
+
+
+
+/**
+ * @template T
+ * @param T $val
+ * @return (T is array ? T : null)
+ */
+function validate_array(mixed $val): ?array {
+    return \is_array($val) ? $val : null;
+}
+
+
+/**
+ * @template T of mixed
+ * @param T $val
+ * @return ($val is string ? T&string : ($val is int ? decimal-int-string : ($val is float ? ?numeric-string : null)))
+ */
+function validate_string(mixed $val): ?string {
+    if (\is_string($val)) {
+        return $val;
+    }
+    elseif (\is_int($val)) {
+        return (string) $val;
+    }
+    elseif (\is_float($val)) {
+        return (string) $val;
+    }
+    return null;
+}

--- a/e2e/bug-15151/phpstan.neon
+++ b/e2e/bug-15151/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 8
+	paths:
+		- .

--- a/e2e/bug-15151/reception_formulaire.php
+++ b/e2e/bug-15151/reception_formulaire.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MyApp;
+
+class reception_formulaire {
+
+    /** @var list<array{valeur: string, affichage: string}> */
+    public array $liste_genre_pers = [ ];
+
+
+    // @phpstan-ignore missingType.iterableValue (a phpstan error seems useful in order to trigger the bug)
+    final function __construct(
+        protected readonly array $params
+    ) { }
+
+
+    public function foo(): void {
+        $liste_genre = [ ];
+        foreach (validate_array($this->params['Genre_Admis'] ?? null) ?? [ ] as $_) {
+            \PHPStan\dumpType($_); // ### should be: mixed, sometimes incorrectly: array
+            if (in_array($_, [ 'Cli', 'Emp', 'Fou', 'Pct', 'Pre', 'Self' ], true))
+                $liste_genre[] = $_;
+        }
+        $liste_genre_pers = [ ];
+        foreach ($liste_genre as $ce_genre) {
+            $liste_genre_pers[] = [ 'valeur' => $ce_genre, 'affichage' => '['.$ce_genre.']' ];
+        }
+        $this->liste_genre_pers = $liste_genre_pers;
+
+    }
+
+
+}

--- a/e2e/bug-15151/webservice.php
+++ b/e2e/bug-15151/webservice.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MyApp;
+
+class webservice {
+
+    /**
+     * @param array{limit_defaut: positive-int, limit_max: positive-int} $opt
+     * @return array{positive-int, non-negative-int, list<non-empty-string>}
+     * @phpstan-ignore missingType.iterableValue (a phpstan error seems useful in order to trigger the bug)
+     */
+    public static function get_limit_offset_sort(array $par, array $opt): array {
+        $limit = isset($par['limit']) ? (int) $par['limit'] : $opt['limit_defaut'];
+        if ($limit < 1)
+            $limit = 1;
+        if ($limit > $opt['limit_max'])
+            $limit = $opt['limit_max'];
+
+        $offset = isset($par['offset']) ? (int) $par['offset'] : 0;
+        if ($offset < 0)
+            $offset = 0;
+
+        $sort = [ ];
+        foreach (validate_array($par['sort'] ?? null) ?? [ ] as $_) {
+            \PHPStan\dumpType($_); // ### should be: mixed, sometimes incorrectly: array
+            $_ = validate_string($_);
+            if ($_ !== null && $_ !== '')
+                $sort[] = $_;
+        }
+
+        return [ $limit, $offset, $sort ];
+
+    }
+
+
+}

--- a/src/Analyser/Traverser/GenericTypeTemplateTraverser.php
+++ b/src/Analyser/Traverser/GenericTypeTemplateTraverser.php
@@ -6,6 +6,7 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\NarrowedSubjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverserCallable;
 
@@ -23,7 +24,7 @@ final class GenericTypeTemplateTraverser implements TypeTraverserCallable
 	 */
 	public function traverse(Type $type, callable $traverse): Type
 	{
-		if ($type instanceof TemplateType && !$type->isArgument()) {
+		if ($type instanceof TemplateType && !$type instanceof NarrowedSubjectType && !$type->isArgument()) {
 			$newType = $this->resolvedTemplateTypeMap->getType($type->getName());
 			if ($newType === null || $newType instanceof ErrorType) {
 				return $type->getDefault() ?? $type->getBound();

--- a/src/Parser/TypeTraverserInstanceofVisitor.php
+++ b/src/Parser/TypeTraverserInstanceofVisitor.php
@@ -6,6 +6,7 @@ use Override;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
+use function in_array;
 
 #[AutowiredService]
 final class TypeTraverserInstanceofVisitor extends NodeVisitorAbstract
@@ -35,7 +36,7 @@ final class TypeTraverserInstanceofVisitor extends NodeVisitorAbstract
 			&& $node->class instanceof Node\Name
 			&& $node->class->toLowerString() === 'phpstan\\type\\typetraverser'
 			&& $node->name instanceof Node\Identifier
-			&& $node->name->toLowerString() === 'map'
+			&& in_array($node->name->toLowerString(), ['map', 'mapwithvariance'], true)
 		) {
 			$this->depth++;
 		}
@@ -51,7 +52,7 @@ final class TypeTraverserInstanceofVisitor extends NodeVisitorAbstract
 			&& $node->class instanceof Node\Name
 			&& $node->class->toLowerString() === 'phpstan\\type\\typetraverser'
 			&& $node->name instanceof Node\Identifier
-			&& $node->name->toLowerString() === 'map'
+			&& in_array($node->name->toLowerString(), ['map', 'mapwithvariance'], true)
 		) {
 			$this->depth--;
 		}

--- a/src/Reflection/ResolvedFunctionVariantWithOriginal.php
+++ b/src/Reflection/ResolvedFunctionVariantWithOriginal.php
@@ -144,7 +144,10 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 	{
 		return $this->returnTypeWithUnresolvableTemplateTypes ??=
 			$this->resolveConditionalTypesForParameter(
-				$this->resolveResolvableTemplateTypes($this->parametersAcceptor->getReturnType(), TemplateTypeVariance::createCovariant()),
+				$this->resolveResolvableTemplateTypes(
+					$this->narrowTemplateTypesInConditionalTypesForParameter($this->parametersAcceptor->getReturnType()),
+					TemplateTypeVariance::createCovariant(),
+				),
 			);
 	}
 
@@ -152,7 +155,10 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 	{
 		return $this->phpDocReturnTypeWithUnresolvableTemplateTypes ??=
 			$this->resolveConditionalTypesForParameter(
-				$this->resolveResolvableTemplateTypes($this->parametersAcceptor->getPhpDocReturnType(), TemplateTypeVariance::createCovariant()),
+				$this->resolveResolvableTemplateTypes(
+					$this->narrowTemplateTypesInConditionalTypesForParameter($this->parametersAcceptor->getPhpDocReturnType()),
+					TemplateTypeVariance::createCovariant(),
+				),
 			);
 	}
 
@@ -288,6 +294,100 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 
 			return $traverse($type);
 		});
+	}
+
+	/**
+	 * `($param is X ? A : B)` narrows the parameter, and when the parameter alone binds the
+	 * template type it is declared with, that template type too: `@param T $param` makes the
+	 * references to T in the branches `T & X` and `T ~ X` (see
+	 * ConditionalTypeForParameter::narrowTemplateType()). Has to happen before the template
+	 * types resolve, while the references are still recognizable.
+	 */
+	private function narrowTemplateTypesInConditionalTypesForParameter(Type $type): Type
+	{
+		if (!$type->hasTemplateOrLateResolvableType()) {
+			return $type;
+		}
+
+		return TypeTraverser::map($type, function (Type $type, callable $traverse): Type {
+			if ($type instanceof ConditionalTypeForParameter) {
+				$templateType = $this->getTemplateTypeBoundOnlyByParameter($type->getParameterName());
+				if ($templateType !== null) {
+					$type = $type->narrowTemplateType($templateType);
+				}
+			}
+
+			return $traverse($type);
+		});
+	}
+
+	/**
+	 * The template type of the function the parameter is declared as, provided no other
+	 * parameter references it - another parameter could bind it to values a condition on
+	 * this parameter says nothing about. A reference through the bound of another template
+	 * type counts too: `@param class-string<TFormType> $type` with
+	 * `@template TFormType of FormTypeInterface<TData>` binds TData.
+	 */
+	private function getTemplateTypeBoundOnlyByParameter(string $parameterName): ?TemplateType
+	{
+		$templateType = null;
+		foreach ($this->parametersAcceptor->getParameters() as $parameter) {
+			if ('$' . $parameter->getName() !== $parameterName) {
+				continue;
+			}
+			if ($parameter->isVariadic()) {
+				return null;
+			}
+
+			$type = $parameter->getType();
+			if (
+				!$type instanceof TemplateType
+				|| $type instanceof NarrowedSubjectType
+				|| $type->getScope()->getFunctionName() === null
+			) {
+				return null;
+			}
+
+			$templateType = $type;
+			break;
+		}
+
+		if ($templateType === null) {
+			return null;
+		}
+
+		foreach ($this->parametersAcceptor->getParameters() as $parameter) {
+			if ('$' . $parameter->getName() === $parameterName) {
+				continue;
+			}
+
+			if (self::referencesTemplateType($parameter->getType(), $templateType)) {
+				return null;
+			}
+		}
+
+		return $templateType;
+	}
+
+	private static function referencesTemplateType(Type $type, TemplateType $templateType): bool
+	{
+		$references = false;
+		TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($templateType, &$references): Type {
+			if (
+				$type instanceof TemplateType
+				&& $type->getName() === $templateType->getName()
+				&& $type->getScope()->equals($templateType->getScope())
+			) {
+				$references = true;
+
+				return $type;
+			}
+
+			// a template type traverses into its bound
+			return $traverse($type);
+		});
+
+		return $references;
 	}
 
 	private function resolveConditionalTypesForParameter(Type $type): Type

--- a/src/Reflection/ResolvedFunctionVariantWithOriginal.php
+++ b/src/Reflection/ResolvedFunctionVariantWithOriginal.php
@@ -12,6 +12,7 @@ use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
+use PHPStan\Type\NarrowedSubjectType;
 use PHPStan\Type\NonAcceptingNeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
@@ -209,6 +210,7 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 		$objectCb = function (Type $type, callable $traverse) use ($references): Type {
 			if (
 				$type instanceof TemplateType
+				&& !$type instanceof NarrowedSubjectType
 				&& !$type->isArgument()
 				&& $type->getScope()->getFunctionName() !== null
 			) {
@@ -252,7 +254,7 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 				return TypeTraverser::map($type, $objectCb);
 			}
 
-			if ($type instanceof TemplateType && !$type->isArgument()) {
+			if ($type instanceof TemplateType && !$type instanceof NarrowedSubjectType && !$type->isArgument()) {
 				$newType = $this->resolvedTemplateTypeMap->getType($type->getName());
 				if ($newType === null || $newType instanceof ErrorType) {
 					return $traverse($type);

--- a/src/Reflection/ResolvedFunctionVariantWithOriginal.php
+++ b/src/Reflection/ResolvedFunctionVariantWithOriginal.php
@@ -211,9 +211,7 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 
 	private function resolveResolvableTemplateTypes(Type $type, TemplateTypeVariance $positionVariance): Type
 	{
-		$references = $type->getReferencedTemplateTypes($positionVariance);
-
-		$objectCb = function (Type $type, callable $traverse) use ($references): Type {
+		$objectCb = function (Type $type, TemplateTypeVariance $variance, callable $traverse): Type {
 			if (
 				$type instanceof TemplateType
 				&& !$type instanceof NarrowedSubjectType
@@ -226,15 +224,6 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 				}
 
 				$newType = TemplateTypeHelper::generalizeInferredTemplateType($type, $newType);
-				$variance = TemplateTypeVariance::createInvariant();
-				foreach ($references as $reference) {
-					// this uses identity to distinguish between different occurrences of the same template type
-					// see https://github.com/phpstan/phpstan-src/pull/2485#discussion_r1328555397 for details
-					if ($reference->getType() === $type) {
-						$variance = $reference->getPositionVariance();
-						break;
-					}
-				}
 
 				$callSiteVariance = $this->callSiteVarianceMap->getVariance($type->getName());
 				if ($callSiteVariance === null || $callSiteVariance->invariant()) {
@@ -255,25 +244,15 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 			return $traverse($type);
 		};
 
-		return TypeTraverser::map($type, function (Type $type, callable $traverse) use ($references, $objectCb): Type {
+		return TypeTraverser::mapWithVariance($type, $positionVariance, function (Type $type, TemplateTypeVariance $variance, callable $traverse) use ($objectCb): Type {
 			if ($type instanceof GenericObjectType || $type instanceof GenericStaticType) {
-				return TypeTraverser::map($type, $objectCb);
+				return TypeTraverser::mapWithVariance($type, $variance, $objectCb);
 			}
 
 			if ($type instanceof TemplateType && !$type instanceof NarrowedSubjectType && !$type->isArgument()) {
 				$newType = $this->resolvedTemplateTypeMap->getType($type->getName());
 				if ($newType === null || $newType instanceof ErrorType) {
 					return $traverse($type);
-				}
-
-				$variance = TemplateTypeVariance::createInvariant();
-				foreach ($references as $reference) {
-					// this uses identity to distinguish between different occurrences of the same template type
-					// see https://github.com/phpstan/phpstan-src/pull/2485#discussion_r1328555397 for details
-					if ($reference->getType() === $type) {
-						$variance = $reference->getPositionVariance();
-						break;
-					}
 				}
 
 				$callSiteVariance = $this->callSiteVarianceMap->getVariance($type->getName());

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -33,6 +33,7 @@ use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
+use PHPStan\Type\Generic\TraversableWithVariance;
 use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
@@ -48,7 +49,7 @@ use function count;
 
 /** @api */
 #[InstanceofDeprecated(insteadUse: 'Type::isCallable() and Type::getCallableParametersAcceptors()')]
-class CallableType implements CompoundType, CallableParametersAcceptor
+class CallableType implements CompoundType, CallableParametersAcceptor, TraversableWithVariance
 {
 
 	use MaybeArrayTypeTrait;
@@ -581,31 +582,51 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 
 	public function traverse(callable $cb): Type
 	{
+		return $this->traverseParts($cb, $cb);
+	}
+
+	public function traverseWithVariance(TemplateTypeVariance $positionVariance, callable $cb): Type
+	{
+		$parameterVariance = $positionVariance->compose(TemplateTypeVariance::createContravariant());
+		$returnVariance = $positionVariance->compose(TemplateTypeVariance::createCovariant());
+
+		return $this->traverseParts(
+			static fn (Type $type): Type => $cb($type, $parameterVariance),
+			static fn (Type $type): Type => $cb($type, $returnVariance),
+		);
+	}
+
+	/**
+	 * @param callable(Type): Type $parameterCb
+	 * @param callable(Type): Type $returnCb Maps the return type and the assertions
+	 */
+	private function traverseParts(callable $parameterCb, callable $returnCb): Type
+	{
 		if ($this->isCommonCallable) {
 			return $this;
 		}
 
-		$parameters = array_map(static function (ParameterReflection $param) use ($cb): NativeParameterReflection {
+		$parameters = array_map(static function (ParameterReflection $param) use ($parameterCb): NativeParameterReflection {
 			$defaultValue = $param->getDefaultValue();
 			return new NativeParameterReflection(
 				$param->getName(),
 				$param->isOptional(),
-				$cb($param->getType()),
+				$parameterCb($param->getType()),
 				$param->passedByReference(),
 				$param->isVariadic(),
-				$defaultValue !== null ? $cb($defaultValue) : null,
+				$defaultValue !== null ? $parameterCb($defaultValue) : null,
 			);
 		}, $this->getParameters());
 
 		return new self(
 			$parameters,
-			$cb($this->getReturnType()),
+			$returnCb($this->getReturnType()),
 			$this->isVariadic(),
 			$this->templateTypeMap,
 			$this->resolvedTemplateTypeMap,
 			$this->templateTags,
 			$this->isPure,
-			$this->assertions->mapTypes($cb),
+			$this->assertions->mapTypes($returnCb),
 		);
 	}
 

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -43,6 +43,7 @@ use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
+use PHPStan\Type\Generic\TraversableWithVariance;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
@@ -55,7 +56,7 @@ use function array_merge;
 use function count;
 
 /** @api */
-class ClosureType implements TypeWithClassName, CallableParametersAcceptor
+class ClosureType implements TypeWithClassName, CallableParametersAcceptor, TraversableWithVariance
 {
 
 	use NonArrayTypeTrait;
@@ -725,23 +726,43 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 
 	public function traverse(callable $cb): Type
 	{
+		return $this->traverseParts($cb, $cb);
+	}
+
+	public function traverseWithVariance(TemplateTypeVariance $positionVariance, callable $cb): Type
+	{
+		$parameterVariance = $positionVariance->compose(TemplateTypeVariance::createContravariant());
+		$returnVariance = $positionVariance->compose(TemplateTypeVariance::createCovariant());
+
+		return $this->traverseParts(
+			static fn (Type $type): Type => $cb($type, $parameterVariance),
+			static fn (Type $type): Type => $cb($type, $returnVariance),
+		);
+	}
+
+	/**
+	 * @param callable(Type): Type $parameterCb
+	 * @param callable(Type): Type $returnCb Maps the return type and the assertions
+	 */
+	private function traverseParts(callable $parameterCb, callable $returnCb): Type
+	{
 		if ($this->isCommonCallable) {
 			return $this;
 		}
 
 		return new self(
-			array_map(static function (ParameterReflection $param) use ($cb): NativeParameterReflection {
+			array_map(static function (ParameterReflection $param) use ($parameterCb): NativeParameterReflection {
 				$defaultValue = $param->getDefaultValue();
 				return new NativeParameterReflection(
 					$param->getName(),
 					$param->isOptional(),
-					$cb($param->getType()),
+					$parameterCb($param->getType()),
 					$param->passedByReference(),
 					$param->isVariadic(),
-					$defaultValue !== null ? $cb($defaultValue) : null,
+					$defaultValue !== null ? $parameterCb($defaultValue) : null,
 				);
 			}, $this->getParameters()),
-			$cb($this->getReturnType()),
+			$returnCb($this->getReturnType()),
 			$this->isVariadic(),
 			$this->templateTypeMap,
 			$this->resolvedTemplateTypeMap,
@@ -753,7 +774,7 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 			$this->usedVariables,
 			$this->acceptsNamedArguments,
 			$this->mustUseReturnValue,
-			$this->assertions->mapTypes($cb),
+			$this->assertions->mapTypes($returnCb),
 			$this->isStatic,
 		);
 	}

--- a/src/Type/ConditionalType.php
+++ b/src/Type/ConditionalType.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\PhpDocParser\Ast\Type\ConditionalTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\LateResolvableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
@@ -195,32 +196,43 @@ final class ConditionalType implements CompoundType, LateResolvableType
 
 	private function getNormalizedIf(): Type
 	{
-		return $this->normalizedIf ??= TypeTraverser::map(
-			$this->if,
-			fn (Type $type, callable $traverse) => $type === $this->subject
-				? (!$this->negated ? $this->getSubjectWithTargetIntersectedType() : $this->getSubjectWithTargetRemovedType())
-				: $traverse($type),
-		);
+		return $this->normalizedIf ??= $this->narrowSubjectIn($this->if, !$this->negated);
 	}
 
 	private function getNormalizedElse(): Type
 	{
-		return $this->normalizedElse ??= TypeTraverser::map(
-			$this->else,
-			fn (Type $type, callable $traverse) => $type === $this->subject
-				? (!$this->negated ? $this->getSubjectWithTargetRemovedType() : $this->getSubjectWithTargetIntersectedType())
+		return $this->normalizedElse ??= $this->narrowSubjectIn($this->else, $this->negated);
+	}
+
+	/**
+	 * Replaces the references to the subject in a branch with what the branch knows about
+	 * it: `subject & target` where the condition holds, `subject ~ target` where it does not
+	 * (see NarrowedSubjectType).
+	 *
+	 * A branch can only reference the subject while it is a template type. Once the subject
+	 * resolves to a concrete type, an equal type inside the branch is not a mention of it -
+	 * the `mixed` value type of an `array` branch has nothing to do with a `mixed` subject -
+	 * so nothing is narrowed here; the references narrowed earlier follow the resolution on
+	 * their own. Matching by identity instead would still hit such unrelated types whenever
+	 * they happen to share an instance, which interned types always do.
+	 */
+	private function narrowSubjectIn(Type $branch, bool $conditionHolds): Type
+	{
+		$subject = $this->subject;
+		if (!$subject instanceof TemplateType) {
+			return $branch;
+		}
+
+		$narrowedSubject = $conditionHolds
+			? ($this->subjectWithTargetIntersectedType ??= NarrowedSubjectType::create($subject, $this->target, true))
+			: ($this->subjectWithTargetRemovedType ??= NarrowedSubjectType::create($subject, $this->target, false));
+
+		return TypeTraverser::map(
+			$branch,
+			static fn (Type $type, callable $traverse) => $subject->equals($type)
+				? $narrowedSubject
 				: $traverse($type),
 		);
-	}
-
-	private function getSubjectWithTargetIntersectedType(): Type
-	{
-		return $this->subjectWithTargetIntersectedType ??= TypeCombinator::intersect($this->subject, $this->target);
-	}
-
-	private function getSubjectWithTargetRemovedType(): Type
-	{
-		return $this->subjectWithTargetRemovedType ??= TypeCombinator::remove($this->subject, $this->target);
 	}
 
 }

--- a/src/Type/ConditionalType.php
+++ b/src/Type/ConditionalType.php
@@ -22,10 +22,6 @@ final class ConditionalType implements CompoundType, LateResolvableType
 
 	private ?Type $normalizedElse = null;
 
-	private ?Type $subjectWithTargetIntersectedType = null;
-
-	private ?Type $subjectWithTargetRemovedType = null;
-
 	public function __construct(
 		private Type $subject,
 		private Type $target,
@@ -218,21 +214,11 @@ final class ConditionalType implements CompoundType, LateResolvableType
 	 */
 	private function narrowSubjectIn(Type $branch, bool $conditionHolds): Type
 	{
-		$subject = $this->subject;
-		if (!$subject instanceof TemplateType) {
+		if (!$this->subject instanceof TemplateType) {
 			return $branch;
 		}
 
-		$narrowedSubject = $conditionHolds
-			? ($this->subjectWithTargetIntersectedType ??= NarrowedSubjectType::create($subject, $this->target, true))
-			: ($this->subjectWithTargetRemovedType ??= NarrowedSubjectType::create($subject, $this->target, false));
-
-		return TypeTraverser::map(
-			$branch,
-			static fn (Type $type, callable $traverse) => $subject->equals($type)
-				? $narrowedSubject
-				: $traverse($type),
-		);
+		return NarrowedSubjectType::narrowReferences($branch, $this->subject, $this->target, $conditionHolds);
 	}
 
 }

--- a/src/Type/ConditionalTypeForParameter.php
+++ b/src/Type/ConditionalTypeForParameter.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\PhpDocParser\Ast\Type\ConditionalTypeForParameterNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\LateResolvableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
@@ -16,6 +17,12 @@ final class ConditionalTypeForParameter implements CompoundType, LateResolvableT
 
 	use LateResolvableTypeTrait;
 	use NonGeneralizableTypeTrait;
+
+	private ?TemplateType $parameterTemplateType = null;
+
+	private ?Type $normalizedIf = null;
+
+	private ?Type $normalizedElse = null;
 
 	public function __construct(
 		private string $parameterName,
@@ -54,13 +61,36 @@ final class ConditionalTypeForParameter implements CompoundType, LateResolvableT
 
 	public function changeParameterName(string $parameterName): self
 	{
-		return new self(
+		$type = new self(
 			$parameterName,
 			$this->target,
 			$this->if,
 			$this->else,
 			$this->negated,
 		);
+		$type->parameterTemplateType = $this->parameterTemplateType;
+
+		return $type;
+	}
+
+	/**
+	 * Narrows the references to the template type the parameter is declared with along with
+	 * the parameter: `@param T $param` makes `($param is X ? A : B)` narrow T to `T & X` in A
+	 * and to `T ~ X` in B, the way `(T is X ? A : B)` does (see NarrowedSubjectType). Only
+	 * sound when nothing but the parameter binds T.
+	 */
+	public function narrowTemplateType(TemplateType $templateType): self
+	{
+		$type = new self(
+			$this->parameterName,
+			$this->target,
+			$this->if,
+			$this->else,
+			$this->negated,
+		);
+		$type->parameterTemplateType = $templateType;
+
+		return $type;
 	}
 
 	public function toConditional(Type $subject): Type
@@ -68,8 +98,8 @@ final class ConditionalTypeForParameter implements CompoundType, LateResolvableT
 		return new ConditionalType(
 			$subject,
 			$this->target,
-			$this->if,
-			$this->else,
+			$this->getNormalizedIf(),
+			$this->getNormalizedElse(),
 			$this->negated,
 		);
 	}
@@ -130,16 +160,20 @@ final class ConditionalTypeForParameter implements CompoundType, LateResolvableT
 
 	protected function getResult(): Type
 	{
-		return TypeCombinator::union($this->if, $this->else);
+		return TypeCombinator::union($this->getNormalizedIf(), $this->getNormalizedElse());
 	}
 
 	public function traverse(callable $cb): Type
 	{
 		$target = $cb($this->target);
-		$if = $cb($this->if);
-		$else = $cb($this->else);
+		$if = $cb($this->getNormalizedIf());
+		$else = $cb($this->getNormalizedElse());
 
-		if ($this->target === $target && $this->if === $if && $this->else === $else) {
+		if (
+			$this->target === $target
+			&& $this->getNormalizedIf() === $if
+			&& $this->getNormalizedElse() === $else
+		) {
 			return $this;
 		}
 
@@ -153,14 +187,32 @@ final class ConditionalTypeForParameter implements CompoundType, LateResolvableT
 		}
 
 		$target = $cb($this->target, $right->target);
-		$if = $cb($this->if, $right->if);
-		$else = $cb($this->else, $right->else);
+		$if = $cb($this->getNormalizedIf(), $right->getNormalizedIf());
+		$else = $cb($this->getNormalizedElse(), $right->getNormalizedElse());
 
-		if ($this->target === $target && $this->if === $if && $this->else === $else) {
+		if (
+			$this->target === $target
+			&& $this->getNormalizedIf() === $if
+			&& $this->getNormalizedElse() === $else
+		) {
 			return $this;
 		}
 
 		return new self($this->parameterName, $target, $if, $else, $this->negated);
+	}
+
+	private function getNormalizedIf(): Type
+	{
+		return $this->normalizedIf ??= $this->parameterTemplateType === null
+			? $this->if
+			: NarrowedSubjectType::narrowReferences($this->if, $this->parameterTemplateType, $this->target, !$this->negated);
+	}
+
+	private function getNormalizedElse(): Type
+	{
+		return $this->normalizedElse ??= $this->parameterTemplateType === null
+			? $this->else
+			: NarrowedSubjectType::narrowReferences($this->else, $this->parameterTemplateType, $this->target, $this->negated);
 	}
 
 	public function toPhpDocNode(): TypeNode

--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -25,6 +25,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use function array_keys;
 use function array_map;
 use function count;
 use function implode;
@@ -32,7 +33,7 @@ use function sprintf;
 
 /** @api */
 #[InstanceofDeprecated]
-class GenericObjectType extends ObjectType
+class GenericObjectType extends ObjectType implements TraversableWithVariance
 {
 
 	/**
@@ -308,23 +309,11 @@ class GenericObjectType extends ObjectType
 
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
-		$classReflection = $this->getClassReflection();
-		if ($classReflection !== null) {
-			$typeList = $classReflection->typeMapToList($classReflection->getTemplateTypeMap());
-		} else {
-			$typeList = [];
-		}
-
+		$variances = $this->getArgumentPositionVariances($positionVariance);
 		$references = [];
 
 		foreach ($this->types as $i => $type) {
-			$effectiveVariance = $this->variances[$i] ?? TemplateTypeVariance::createInvariant();
-			if ($effectiveVariance->invariant() && isset($typeList[$i]) && $typeList[$i] instanceof TemplateType) {
-				$effectiveVariance = $typeList[$i]->getVariance();
-			}
-
-			$variance = $positionVariance->compose($effectiveVariance);
-			foreach ($type->getReferencedTemplateTypes($variance) as $reference) {
+			foreach ($type->getReferencedTemplateTypes($variances[$i]) as $reference) {
 				$references[] = $reference;
 			}
 		}
@@ -332,14 +321,77 @@ class GenericObjectType extends ObjectType
 		return $references;
 	}
 
+	/**
+	 * The variance each type argument stands in when the type itself stands in
+	 * $positionVariance: the one projected onto the argument (`Foo<covariant Bar>`) or,
+	 * without a projection, the one declared for the class template type.
+	 *
+	 * @return array<int, TemplateTypeVariance>
+	 */
+	public function getArgumentPositionVariances(TemplateTypeVariance $positionVariance): array
+	{
+		return self::argumentPositionVariances($this->getClassReflection(), array_keys($this->types), $this->variances, $positionVariance);
+	}
+
+	/**
+	 * @internal Shared with GenericStaticType, see getArgumentPositionVariances()
+	 * @param list<int> $argumentIndexes
+	 * @param array<int, TemplateTypeVariance> $projectedVariances
+	 * @return array<int, TemplateTypeVariance>
+	 */
+	public static function argumentPositionVariances(
+		?ClassReflection $classReflection,
+		array $argumentIndexes,
+		array $projectedVariances,
+		TemplateTypeVariance $positionVariance,
+	): array
+	{
+		if ($classReflection !== null) {
+			$typeList = $classReflection->typeMapToList($classReflection->getTemplateTypeMap());
+		} else {
+			$typeList = [];
+		}
+
+		$variances = [];
+		foreach ($argumentIndexes as $i) {
+			$effectiveVariance = $projectedVariances[$i] ?? TemplateTypeVariance::createInvariant();
+			if ($effectiveVariance->invariant() && isset($typeList[$i]) && $typeList[$i] instanceof TemplateType) {
+				$effectiveVariance = $typeList[$i]->getVariance();
+			}
+
+			$variances[$i] = $positionVariance->compose($effectiveVariance);
+		}
+
+		return $variances;
+	}
+
 	public function traverse(callable $cb): Type
 	{
-		$subtractedType = $this->getSubtractedType() !== null ? $cb($this->getSubtractedType()) : null;
+		return $this->traverseParts($cb, static fn (Type $type): Type => $cb($type));
+	}
+
+	public function traverseWithVariance(TemplateTypeVariance $positionVariance, callable $cb): Type
+	{
+		$variances = $this->getArgumentPositionVariances($positionVariance);
+
+		return $this->traverseParts(
+			static fn (Type $type): Type => $cb($type, $positionVariance),
+			static fn (Type $type, int $i): Type => $cb($type, $variances[$i]),
+		);
+	}
+
+	/**
+	 * @param callable(Type): Type $subtractedTypeCb
+	 * @param callable(Type, int): Type $argumentCb
+	 */
+	private function traverseParts(callable $subtractedTypeCb, callable $argumentCb): Type
+	{
+		$subtractedType = $this->getSubtractedType() !== null ? $subtractedTypeCb($this->getSubtractedType()) : null;
 
 		$typesChanged = false;
 		$types = [];
-		foreach ($this->types as $type) {
-			$newType = $cb($type);
+		foreach ($this->types as $i => $type) {
+			$newType = $argumentCb($type, $i);
 			$types[] = $newType;
 			if ($newType === $type) {
 				continue;

--- a/src/Type/Generic/GenericStaticType.php
+++ b/src/Type/Generic/GenericStaticType.php
@@ -21,7 +21,7 @@ use function array_map;
 use function count;
 
 /** @api */
-class GenericStaticType extends StaticType
+class GenericStaticType extends StaticType implements TraversableWithVariance
 {
 
 	private ?ObjectType $staticObjectType = null;
@@ -157,12 +157,31 @@ class GenericStaticType extends StaticType
 
 	public function traverse(callable $cb): Type
 	{
-		$subtractedType = $this->getSubtractedType() !== null ? $cb($this->getSubtractedType()) : null;
+		return $this->traverseParts($cb, static fn (Type $type): Type => $cb($type));
+	}
+
+	public function traverseWithVariance(TemplateTypeVariance $positionVariance, callable $cb): Type
+	{
+		$variances = GenericObjectType::argumentPositionVariances($this->classReflection, array_keys($this->types), $this->variances, $positionVariance);
+
+		return $this->traverseParts(
+			static fn (Type $type): Type => $cb($type, $positionVariance),
+			static fn (Type $type, int $i): Type => $cb($type, $variances[$i]),
+		);
+	}
+
+	/**
+	 * @param callable(Type): Type $subtractedTypeCb
+	 * @param callable(Type, int): Type $argumentCb
+	 */
+	private function traverseParts(callable $subtractedTypeCb, callable $argumentCb): Type
+	{
+		$subtractedType = $this->getSubtractedType() !== null ? $subtractedTypeCb($this->getSubtractedType()) : null;
 
 		$typesChanged = false;
 		$types = [];
-		foreach ($this->types as $type) {
-			$newType = $cb($type);
+		foreach ($this->types as $i => $type) {
+			$newType = $argumentCb($type, $i);
 			$types[] = $newType;
 			if ($newType === $type) {
 				continue;

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -29,22 +29,9 @@ final class TemplateTypeHelper
 			return $type;
 		}
 
-		$references = $type->getReferencedTemplateTypes($positionVariance);
-
-		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($standins, $references, $callSiteVariances, $keepErrorTypes): Type {
+		return TypeTraverser::mapWithVariance($type, $positionVariance, static function (Type $type, TemplateTypeVariance $variance, callable $traverse) use ($standins, $callSiteVariances, $keepErrorTypes): Type {
 			if ($type instanceof TemplateType && !$type instanceof NarrowedSubjectType && !$type->isArgument()) {
 				$newType = $standins->getType($type->getName());
-
-				$variance = TemplateTypeVariance::createInvariant();
-				foreach ($references as $reference) {
-					// this uses identity to distinguish between different occurrences of the same template type
-					// see https://github.com/phpstan/phpstan-src/pull/2485#discussion_r1328555397 for details
-					if ($reference->getType() === $type) {
-						$variance = $reference->getPositionVariance();
-						break;
-					}
-				}
-
 				if ($newType === null) {
 					return $traverse($type);
 				}

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Generic;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\GeneralizePrecision;
+use PHPStan\Type\NarrowedSubjectType;
 use PHPStan\Type\NonAcceptingNeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
@@ -31,7 +32,7 @@ final class TemplateTypeHelper
 		$references = $type->getReferencedTemplateTypes($positionVariance);
 
 		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($standins, $references, $callSiteVariances, $keepErrorTypes): Type {
-			if ($type instanceof TemplateType && !$type->isArgument()) {
+			if ($type instanceof TemplateType && !$type instanceof NarrowedSubjectType && !$type->isArgument()) {
 				$newType = $standins->getType($type->getName());
 
 				$variance = TemplateTypeVariance::createInvariant();

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -354,6 +354,18 @@ trait TemplateTypeTrait
 		return $this->strategy;
 	}
 
+	/**
+	 * The bound and the default are parts of the template type standing in its own
+	 * variance - overrides what a base class with parts of its own (GenericObjectType)
+	 * would hand out.
+	 *
+	 * @param callable(Type, TemplateTypeVariance): Type $cb
+	 */
+	public function traverseWithVariance(TemplateTypeVariance $positionVariance, callable $cb): Type
+	{
+		return $this->traverse(static fn (Type $type): Type => $cb($type, $positionVariance));
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		$bound = $cb($this->getBound());

--- a/src/Type/Generic/TraversableWithVariance.php
+++ b/src/Type/Generic/TraversableWithVariance.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\Type;
+
+/**
+ * Implemented by the types whose parts stand in a variance of their own: the parameters of
+ * a callable reverse the variance the callable stands in, the arguments of a generic object
+ * take the variance declared for the class template type or projected onto them. Every
+ * other type passes its own variance on to its parts, so the variance-aware traversal
+ * (TypeTraverser::mapWithVariance()) needs nothing but Type::traverse() from it.
+ *
+ * The variances handed to the callback must be the ones getReferencedTemplateTypes()
+ * reports for the same parts.
+ */
+interface TraversableWithVariance
+{
+
+	/**
+	 * @param callable(Type, TemplateTypeVariance): Type $cb
+	 */
+	public function traverseWithVariance(TemplateTypeVariance $positionVariance, callable $cb): Type;
+
+}

--- a/src/Type/NarrowedSubjectType.php
+++ b/src/Type/NarrowedSubjectType.php
@@ -1,0 +1,198 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeStrategy;
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\LateResolvableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
+
+/**
+ * A reference to the template-type subject of a ConditionalType inside one of its
+ * branches, narrowed by what the branch knows: `subject & target` where the condition
+ * holds, `subject ~ target` where it does not.
+ *
+ * The narrowing is computed from the template type right away, and this type behaves
+ * exactly like that narrowed template type as long as the subject stays unresolved.
+ * The narrowing is recomputed from whatever the subject resolves to: it is
+ * `(stdClass|false) ~ false` that gives stdClass for the else branch of
+ * `(T is false ? never : T)` - resolving `T~false` on its own only hands back the type
+ * T resolved to - and `S ~ U` with a template type as the target cannot be narrowed
+ * at all before both resolve. The resolvers of template types therefore traverse into
+ * it instead of substituting it.
+ */
+final class NarrowedSubjectType implements TemplateType, LateResolvableType
+{
+
+	use LateResolvableTypeTrait;
+	use NonGeneralizableTypeTrait;
+
+	private function __construct(
+		private TemplateType $subject,
+		private Type $target,
+		private bool $conditionHolds,
+		private TemplateType $narrowed,
+	)
+	{
+	}
+
+	public static function create(TemplateType $subject, Type $target, bool $conditionHolds): Type
+	{
+		$narrowed = self::narrow($subject, $target, $conditionHolds);
+		if (!$narrowed instanceof TemplateType || $subject->isArgument()) {
+			// nothing to recompute once the template type is gone from the narrowing,
+			// and seen from inside its own function it never resolves
+			return $narrowed;
+		}
+
+		return new self($subject, $target, $conditionHolds, $narrowed);
+	}
+
+	private static function narrow(Type $subject, Type $target, bool $conditionHolds): Type
+	{
+		if ($conditionHolds) {
+			return TypeCombinator::intersect($subject, $target);
+		}
+
+		return TypeCombinator::remove($subject, $target);
+	}
+
+	public function getName(): string
+	{
+		return $this->narrowed->getName();
+	}
+
+	public function getScope(): TemplateTypeScope
+	{
+		return $this->narrowed->getScope();
+	}
+
+	public function getBound(): Type
+	{
+		return $this->narrowed->getBound();
+	}
+
+	public function getDefault(): ?Type
+	{
+		return $this->narrowed->getDefault();
+	}
+
+	public function toArgument(): TemplateType
+	{
+		return $this->narrowed->toArgument();
+	}
+
+	public function isArgument(): bool
+	{
+		return $this->narrowed->isArgument();
+	}
+
+	public function isValidVariance(Type $a, Type $b): IsSuperTypeOfResult
+	{
+		return $this->narrowed->isValidVariance($a, $b);
+	}
+
+	public function getVariance(): TemplateTypeVariance
+	{
+		return $this->narrowed->getVariance();
+	}
+
+	public function getStrategy(): TemplateTypeStrategy
+	{
+		return $this->narrowed->getStrategy();
+	}
+
+	public function getReferencedClasses(): array
+	{
+		return $this->narrowed->getReferencedClasses();
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		return $this->narrowed->getReferencedTemplateTypes($positionVariance);
+	}
+
+	public function equals(Type $type): bool
+	{
+		return $this->narrowed->equals($type instanceof self ? $type->narrowed : $type);
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return $this->narrowed->describe($level);
+	}
+
+	public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
+	{
+		return $this->narrowed->isSuperTypeOf($type);
+	}
+
+	public function isResolvable(): bool
+	{
+		return false;
+	}
+
+	protected function getResult(): Type
+	{
+		return $this->narrowed;
+	}
+
+	/**
+	 * @param callable(Type): Type $cb
+	 */
+	public function traverse(callable $cb): Type
+	{
+		return $this->rebuild($cb($this->subject), $cb($this->target), $cb);
+	}
+
+	public function traverseSimultaneously(Type $right, callable $cb): Type
+	{
+		if (!$right instanceof self) {
+			return $this;
+		}
+
+		return $this->rebuild(
+			$cb($this->subject, $right->subject),
+			$cb($this->target, $right->target),
+			static fn (Type $type): Type => $cb($type, $right->narrowed),
+		);
+	}
+
+	/**
+	 * @param callable(Type): Type $cb
+	 */
+	private function rebuild(Type $subject, Type $target, callable $cb): Type
+	{
+		if (
+			!$subject instanceof TemplateType
+			|| $subject->getName() !== $this->subject->getName()
+			|| !$subject->getScope()->equals($this->subject->getScope())
+		) {
+			// the subject resolved to another type: narrow that one instead
+			return self::narrow($subject, $target, $this->conditionHolds);
+		}
+
+		// still the same template type, at most narrowed by an enclosing conditional
+		// type or turned into an argument: the narrowing stays as computed
+
+		$narrowed = $cb($this->narrowed);
+		if (!$narrowed instanceof TemplateType || $subject->isArgument()) {
+			return $narrowed;
+		}
+
+		if ($subject === $this->subject && $target === $this->target && $narrowed === $this->narrowed) {
+			return $this;
+		}
+
+		return new self($subject, $target, $this->conditionHolds, $narrowed);
+	}
+
+	public function toPhpDocNode(): TypeNode
+	{
+		return $this->narrowed->toPhpDocNode();
+	}
+
+}

--- a/src/Type/NarrowedSubjectType.php
+++ b/src/Type/NarrowedSubjectType.php
@@ -51,6 +51,22 @@ final class NarrowedSubjectType implements TemplateType, LateResolvableType
 		return new self($subject, $target, $conditionHolds, $narrowed);
 	}
 
+	/**
+	 * Replaces the references to $subject in a branch of a conditional type on it with the
+	 * subject as the branch knows it.
+	 */
+	public static function narrowReferences(Type $branch, TemplateType $subject, Type $target, bool $conditionHolds): Type
+	{
+		$narrowedSubject = self::create($subject, $target, $conditionHolds);
+
+		return TypeTraverser::map(
+			$branch,
+			static fn (Type $type, callable $traverse): Type => $subject->equals($type)
+				? $narrowedSubject
+				: $traverse($type),
+		);
+	}
+
 	private static function narrow(Type $subject, Type $target, bool $conditionHolds): Type
 	{
 		if ($conditionHolds) {

--- a/src/Type/TypeTraverser.php
+++ b/src/Type/TypeTraverser.php
@@ -2,6 +2,9 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Generic\TraversableWithVariance;
+
 final class TypeTraverser
 {
 
@@ -38,6 +41,30 @@ final class TypeTraverser
 		$self = new self($cb);
 
 		return $self->mapInternal($type);
+	}
+
+	/**
+	 * map() that tells the callback the variance the type stands in - the variance
+	 * Type::getReferencedTemplateTypes() reports for a template type there: reversed for the
+	 * parameters of a callable, the declared or projected one for the arguments of a generic
+	 * object (see TraversableWithVariance), unchanged for the parts of everything else.
+	 * A template type referenced in several positions of one type is a single object, so
+	 * only the traversal can tell its occurrences apart.
+	 *
+	 * @param callable(Type $type, TemplateTypeVariance $positionVariance, callable(Type): Type $traverse): Type $cb
+	 */
+	public static function mapWithVariance(Type $type, TemplateTypeVariance $positionVariance, callable $cb): Type
+	{
+		return $cb($type, $positionVariance, static function (Type $type) use ($positionVariance, $cb): Type {
+			if ($type instanceof TraversableWithVariance) {
+				return $type->traverseWithVariance(
+					$positionVariance,
+					static fn (Type $part, TemplateTypeVariance $partVariance): Type => self::mapWithVariance($part, $partVariance, $cb),
+				);
+			}
+
+			return $type->traverse(static fn (Type $part): Type => self::mapWithVariance($part, $positionVariance, $cb));
+		});
 	}
 
 	/** @param TypeTraverserCallable|callable(Type $type, callable(Type): Type $traverse): Type $cb */

--- a/tests/PHPStan/Analyser/nsrt/bug-15151.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-15151.php
@@ -1,0 +1,40 @@
+<?php // lint >= 8.1
+
+namespace Bug15151;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ * @param T $val
+ * @return (T is array ? T : null)
+ */
+function validate_array(mixed $val): ?array {
+    return \is_array($val) ? $val : null;
+}
+
+class reception_formulaire {
+
+    // @phpstan-ignore missingType.iterableValue
+    final function __construct(
+        protected readonly array $params
+    ) { }
+
+    public function foo(): void {
+        foreach (validate_array($this->params['Genre_Admis'] ?? null) ?? [ ] as $_) {
+            assertType('mixed', $_);
+        }
+    }
+
+}
+
+function nested(mixed $x): void
+{
+	foreach (validate_array($x) ?? [] as $v) {
+		assertType('mixed', $v);
+		assertType('array|null', validate_array($v));
+		foreach (validate_array($v) ?? [] as $w) {
+			assertType('mixed', $w);
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/call-site-variance-occurrences.php
+++ b/tests/PHPStan/Analyser/nsrt/call-site-variance-occurrences.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types = 1);
+
+namespace CallSiteVarianceOccurrences;
+
+use function PHPStan\Testing\assertType;
+
+class Bar
+{
+
+}
+
+/**
+ * @template T
+ */
+class Foo
+{
+
+	/**
+	 * @return callable(T): T
+	 */
+	public function get(): callable
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @return array{callable(T): void, T}
+	 */
+	public function pair(): array
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @param callable(T): T $cb
+	 */
+	public function set(callable $cb): void
+	{
+	}
+
+}
+
+/**
+ * @param Foo<covariant Bar> $foo
+ */
+function covariant(Foo $foo): void
+{
+	assertType('callable(never): CallSiteVarianceOccurrences\Bar', $foo->get());
+	assertType('array{callable(never): void, CallSiteVarianceOccurrences\Bar}', $foo->pair());
+	$foo->set(function ($x) {
+		assertType('CallSiteVarianceOccurrences\Bar', $x);
+
+		return $x;
+	});
+}
+
+/**
+ * @param Foo<contravariant Bar> $foo
+ */
+function contravariant(Foo $foo): void
+{
+	assertType('callable(CallSiteVarianceOccurrences\Bar): mixed', $foo->get());
+	assertType('array{callable(CallSiteVarianceOccurrences\Bar): void, mixed}', $foo->pair());
+	$foo->set(function ($x) {
+		assertType('mixed', $x);
+
+		return $x;
+	});
+}
+
+/**
+ * @param Foo<*> $foo
+ */
+function bivariant(Foo $foo): void
+{
+	assertType('callable(never): mixed', $foo->get());
+	assertType('array{callable(never): void, mixed}', $foo->pair());
+}

--- a/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template-bound.php
+++ b/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template-bound.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace ConditionalTypeForParameterTemplateBound;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TData
+ */
+interface FormTypeInterface
+{
+
+}
+
+/**
+ * @template TData
+ */
+interface FormInterface
+{
+
+	/**
+	 * @return TData
+	 */
+	public function getData();
+
+}
+
+class DataClass
+{
+
+}
+
+/**
+ * @implements FormTypeInterface<DataClass>
+ */
+class DataClassType implements FormTypeInterface
+{
+
+}
+
+class Controller
+{
+
+	/**
+	 * @template TFormType of FormTypeInterface<TData>
+	 * @template TData
+	 *
+	 * @param class-string<TFormType> $type
+	 * @param TData                   $data
+	 * @param array<string, mixed>    $options
+	 *
+	 * @phpstan-return ($data is null ? FormInterface<null|TData> : FormInterface<TData>)
+	 */
+	protected function createForm(string $type, $data = null, array $options = []): FormInterface
+	{
+		throw new \Exception();
+	}
+
+	public function doSomethingNullable(): void
+	{
+		$form = $this->createForm(DataClassType::class);
+		assertType('ConditionalTypeForParameterTemplateBound\DataClass|null', $form->getData());
+	}
+
+	public function doSomething(): void
+	{
+		$form = $this->createForm(DataClassType::class, new DataClass());
+		assertType('ConditionalTypeForParameterTemplateBound\DataClass', $form->getData());
+	}
+
+	public function doSomethingNull(): void
+	{
+		$form = $this->createForm(DataClassType::class, null);
+		assertType('ConditionalTypeForParameterTemplateBound\DataClass|null', $form->getData());
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template.php
+++ b/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template.php
@@ -1,0 +1,134 @@
+<?php // lint >= 8.0
+
+namespace ConditionalTypeForParameterTemplate;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+class A
+{
+
+	/**
+	 * @template T
+	 * @param T $result
+	 * @return ($result is false ? never : T)
+	 */
+	public function throwOnFailure($result)
+	{
+		if ($result === false) {
+			throw new \Exception();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @template T
+	 * @param T $result
+	 * @return ($result is not false ? T : never)
+	 */
+	public function negated($result)
+	{
+		if ($result === false) {
+			throw new \Exception();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @template T
+	 * @param T $a
+	 * @param T $b
+	 * @return ($a is false ? never : T)
+	 */
+	public function boundByTwoParameters($a, $b)
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @template T
+	 * @param T $a
+	 * @param list<T> $others
+	 * @return ($a is false ? never : T)
+	 */
+	public function boundByAnotherParameter($a, array $others)
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @template T
+	 * @param T|null $value
+	 * @return ($value is null ? never : T)
+	 */
+	public function nullable($value)
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @template T
+	 * @param T $val
+	 * @return ($val is array ? T : null)
+	 */
+	public function validateArray(mixed $val): ?array
+	{
+		return \is_array($val) ? $val : null;
+	}
+
+}
+
+/**
+ * @template T
+ */
+class Generic
+{
+
+	/**
+	 * @param T $x
+	 * @return ($x is null ? never : T)
+	 */
+	public function classTemplate($x)
+	{
+		throw new \Exception();
+	}
+
+}
+
+/**
+ * @template T
+ * @param T $result
+ * @return ($result is false ? never : T)
+ */
+function throwOnFailure($result)
+{
+	if ($result === false) {
+		throw new \Exception();
+	}
+
+	return $result;
+}
+
+/**
+ * @param stdClass|false $v
+ * @param array{a: int}|string $as
+ * @param Generic<stdClass|null> $g
+ */
+function test(A $a, $v, $as, mixed $m, Generic $g, ?stdClass $n): void
+{
+	assertType('stdClass', $a->throwOnFailure($v));
+	assertType('stdClass', throwOnFailure($v));
+	assertType('stdClass', $a->negated($v));
+	assertType("'str'|stdClass|false", $a->boundByTwoParameters($v, 'str'));
+	assertType('stdClass|false', $a->boundByAnotherParameter($v, []));
+	assertType('stdClass', $a->nullable($n));
+	assertType('array|null', $a->validateArray($as));
+	assertType('stdClass|null', $g->classTemplate($n));
+
+	foreach ($a->validateArray($m) ?? [] as $x) {
+		assertType('mixed', $x);
+		assertType('array|null', $a->validateArray($x));
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/15151

Three commits:

1. **Narrow conditional type branches through NarrowedSubjectType instead of by identity** — the reported bug. `ConditionalType` replaced the branch types identical (`===`) to its subject even after the subject had resolved to a concrete type. With the turbo extension interning `TypeCombinator` results, the `mixed` value type of an `array` branch was the very `mixed` the subject had resolved to, so `(T is array ? T : null)` came out as `array<array>|null`; without the extension the same happens whenever the instances coincide by construction (nested `validate_array()` calls, see the nsrt test). The identity pass was load-bearing for template subjects — `T~false` is lost when T resolves, and `S~U` cannot be computed before both resolve (bug-10653, bug-11430) — so the narrowing now lives in an explicit late-resolvable `NarrowedSubjectType` that is recomputed from whatever the subject resolves to. The reporter's files run as an E2E test in the turbo E2E job.
2. **Narrow the template type a conditional type's parameter is declared with** — `@param T $param` with `($param is X ? … : T)` narrowed T only through the same coincidence. Now explicit, and only where nothing but the parameter binds T.
3. **Resolve template types with the variance of each occurrence instead of by identity** — the other identity-based lookup, from the discussion in #2485. One PHPDoc hands out one object per template type, so `callable(T): T` under `Foo<covariant Bar>` resolved to `callable(Bar): Bar` instead of `callable(never): Bar` regardless of the extension. `TypeTraverser::mapWithVariance()` carries the position variance through the traversal; callable/closure parameters and generic object arguments hand out their own variance through `TraversableWithVariance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuKACbcMfZeRgpvHJrHvqw
