### PR TITLE
Group the atomic-save e2e entry with the other result-cache ones

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,22 +35,6 @@ jobs:
       matrix:
         include:
           - script: |
-              cd e2e/result-cache-atomic-save
-              ../../bin/phpstan
-              INODE=$(ls -i tmp/resultCache.php | awk '{print $1}')
-              ../../bin/phpstan
-              # The cache is written next to its final path and renamed into place, so saving it
-              # again replaces the file rather than truncating and rewriting the one the next run
-              # reads. That is what keeps a run killed mid-save from leaving a partial cache behind.
-              REPLACED=$([ "$INODE" != "$(ls -i tmp/resultCache.php | awk '{print $1}')" ] && echo replaced || echo 'written in place')
-              ../bashunit -a equals 'replaced' "$REPLACED"
-              # A completed save leaves nothing next to the cache file.
-              LEFTOVERS=$(ls tmp/ | grep -c '\.tmp$' || true)
-              ../bashunit -a equals '0' "$LEFTOVERS"
-              OUTPUT=$(../../bin/phpstan -vvv 2>&1)
-              echo "$OUTPUT"
-              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
-          - script: |
               cd e2e/result-cache-1
               echo -n > phpstan-baseline.neon
               ../../bin/phpstan -vvv
@@ -140,6 +124,22 @@ jobs:
               mv src/Foo.php.orig src/Foo.php
               echo -n > phpstan-baseline.neon
               ../../bin/phpstan -vvv
+          - script: |
+              cd e2e/result-cache-atomic-save
+              ../../bin/phpstan
+              INODE=$(ls -i tmp/resultCache.php | awk '{print $1}')
+              ../../bin/phpstan
+              # The cache is written next to its final path and renamed into place, so saving it
+              # again replaces the file rather than truncating and rewriting the one the next run
+              # reads. That is what keeps a run killed mid-save from leaving a partial cache behind.
+              REPLACED=$([ "$INODE" != "$(ls -i tmp/resultCache.php | awk '{print $1}')" ] && echo replaced || echo 'written in place')
+              ../bashunit -a equals 'replaced' "$REPLACED"
+              # A completed save leaves nothing next to the cache file.
+              LEFTOVERS=$(ls tmp/ | grep -c '\.tmp$' || true)
+              ../bashunit -a equals '0' "$LEFTOVERS"
+              OUTPUT=$(../../bin/phpstan -vvv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
           - script: |
               cd e2e/bug-14514
               composer install


### PR DESCRIPTION
Following up on @staabm's note on phpstan/phpstan-src#6349: the entry went in as the **first** item of the matrix, which is the position every branch reaches for. An entry there has to be reconciled on every merge of 2.2.x into 2.3.x, and 2.3.x is where the single-pass work will be adding scenarios of its own.

Moved next to `result-cache-10`, where its siblings are.

Pure move, verified rather than eyeballed: the matrix holds the same 70 scripts before and after when compared as a set, and the scenario still passes locally (`replaced`, no `.tmp` leftovers, cache restored with 0 files reanalysed).

Right now 2.2.x is exactly one commit ahead of 2.3.x and that commit is #6349, so this costs nothing to do today.