### PR TITLE
Stop interning TypeCombinator results in the turbo extension

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1182,6 +1182,23 @@ jobs:
           echo "$OUTPUT"
           e2e/bashunit -a contains 'Turbo extension: enabled' "$OUTPUT"
 
+      - name: "Verify conditional types leave interned types equal to a resolved subject alone"
+        # With the extension active TypeCombinator's results are interned, so equal
+        # types share one instance. ConditionalType used to narrow the types in its
+        # branches identical to the subject even once the subject had resolved to a
+        # concrete type, and interning made that hit unrelated types - the `mixed`
+        # value type of an `array` branch for a `mixed` subject -
+        # https://github.com/phpstan/phpstan/issues/15151
+        run: |
+          cd e2e/bug-15151
+          OUTPUT=$(php ../../bin/phpstan analyse --no-progress --error-format=raw 2>&1 || true)
+          echo "$OUTPUT"
+          ../bashunit -a contains 'reception_formulaire.php:20:Dumped type: mixed' "$OUTPUT"
+          ../bashunit -a contains 'webservice.php:25:Dumped type: mixed' "$OUTPUT"
+          ../bashunit -a not_contains 'Dumped type: array' "$OUTPUT"
+          # the two dumps are the only errors: count the file:line:message lines
+          ../bashunit -a equals '2' "$(echo "$OUTPUT" | grep -Ec '^/.+:[0-9]+:')"
+
       - name: "Test"
         # The arena is a per-run POSIX shared-memory object: shm_open() plus an
         # ftruncate() to 256 MB that tmpfs honours sparsely, committing pages on

--- a/e2e/bug-15151/functions.php
+++ b/e2e/bug-15151/functions.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MyApp;
+
+
+/**
+ * Note. The bug disappears if I remove this function or if I edit it in certain ways.
+ *
+ * @param ?int $quote_style
+ * @param array{string, string}|bool|null ...$substitutions_list
+ * @return ($string is null ? null : ($string is '' ? '' : ($string is non-empty-string ? non-empty-string : string)))
+ */
+function htmlentities2(string|int|float|\BackedEnum|null $string, ?int $quote_style = \ENT_QUOTES, array|bool|null ...$substitutions_list): string|null {
+    if ($string instanceof \BackedEnum)
+        $string = validate_string($string->value);
+    if ($string === null)
+        return null;
+    $string = validate_string($string) ?? throw new \ValueError('Incompatible value');
+    $sortie = \htmlspecialchars($string, ($quote_style ?? \ENT_QUOTES) | \ENT_HTML401 | \ENT_SUBSTITUTE, 'utf-8');
+    foreach ($substitutions_list as $substitutions) {
+        if ($substitutions) {
+            if ($substitutions === true)
+                $substitutions = [ [ "\n", "\r" ], [ '<br/>', '' ] ];
+            $sortie = \str_replace($substitutions[0], $substitutions[1], $sortie);
+        }
+    }
+    return $sortie;
+}
+
+
+
+/**
+ * @template T
+ * @param T $val
+ * @return (T is array ? T : null)
+ */
+function validate_array(mixed $val): ?array {
+    return \is_array($val) ? $val : null;
+}
+
+
+/**
+ * @template T of mixed
+ * @param T $val
+ * @return ($val is string ? T&string : ($val is int ? decimal-int-string : ($val is float ? ?numeric-string : null)))
+ */
+function validate_string(mixed $val): ?string {
+    if (\is_string($val)) {
+        return $val;
+    }
+    elseif (\is_int($val)) {
+        return (string) $val;
+    }
+    elseif (\is_float($val)) {
+        return (string) $val;
+    }
+    return null;
+}

--- a/e2e/bug-15151/phpstan.neon
+++ b/e2e/bug-15151/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 8
+	paths:
+		- .

--- a/e2e/bug-15151/reception_formulaire.php
+++ b/e2e/bug-15151/reception_formulaire.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MyApp;
+
+class reception_formulaire {
+
+    /** @var list<array{valeur: string, affichage: string}> */
+    public array $liste_genre_pers = [ ];
+
+
+    // @phpstan-ignore missingType.iterableValue (a phpstan error seems useful in order to trigger the bug)
+    final function __construct(
+        protected readonly array $params
+    ) { }
+
+
+    public function foo(): void {
+        $liste_genre = [ ];
+        foreach (validate_array($this->params['Genre_Admis'] ?? null) ?? [ ] as $_) {
+            \PHPStan\dumpType($_); // ### should be: mixed, sometimes incorrectly: array
+            if (in_array($_, [ 'Cli', 'Emp', 'Fou', 'Pct', 'Pre', 'Self' ], true))
+                $liste_genre[] = $_;
+        }
+        $liste_genre_pers = [ ];
+        foreach ($liste_genre as $ce_genre) {
+            $liste_genre_pers[] = [ 'valeur' => $ce_genre, 'affichage' => '['.$ce_genre.']' ];
+        }
+        $this->liste_genre_pers = $liste_genre_pers;
+
+    }
+
+
+}

--- a/e2e/bug-15151/webservice.php
+++ b/e2e/bug-15151/webservice.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MyApp;
+
+class webservice {
+
+    /**
+     * @param array{limit_defaut: positive-int, limit_max: positive-int} $opt
+     * @return array{positive-int, non-negative-int, list<non-empty-string>}
+     * @phpstan-ignore missingType.iterableValue (a phpstan error seems useful in order to trigger the bug)
+     */
+    public static function get_limit_offset_sort(array $par, array $opt): array {
+        $limit = isset($par['limit']) ? (int) $par['limit'] : $opt['limit_defaut'];
+        if ($limit < 1)
+            $limit = 1;
+        if ($limit > $opt['limit_max'])
+            $limit = $opt['limit_max'];
+
+        $offset = isset($par['offset']) ? (int) $par['offset'] : 0;
+        if ($offset < 0)
+            $offset = 0;
+
+        $sort = [ ];
+        foreach (validate_array($par['sort'] ?? null) ?? [ ] as $_) {
+            \PHPStan\dumpType($_); // ### should be: mixed, sometimes incorrectly: array
+            $_ = validate_string($_);
+            if ($_ !== null && $_ !== '')
+                $sort[] = $_;
+        }
+
+        return [ $limit, $offset, $sort ];
+
+    }
+
+
+}

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -22,7 +22,7 @@ final class TurboExtensionEnabler
 	 * version is the short SHA of the last commit touching turbo-ext/src/,
 	 * enforced by the phar.yml turbo-version job.
 	 */
-	public const EXPECTED_EXTENSION_VERSION = 'e598750';
+	public const EXPECTED_EXTENSION_VERSION = '0829b8e';
 
 	private static bool $typeCombinatorCacheEnabled = false;
 

--- a/src/Type/TypeCombinatorCache.php
+++ b/src/Type/TypeCombinatorCache.php
@@ -10,10 +10,10 @@ use PHPStan\Turbo\ShadowedByTurboExtension;
  * This PHP implementation performs no caching at all — it delegates straight to
  * TypeCombinator. The native implementation memoizes each operation on a
  * structural key of its arguments; roughly 91% of the calls in a
- * self-analysis run repeat an argument tuple that was already computed. It also
- * interns the results, keeping one canonical instance per distinct type value,
- * so operations reaching the same value by different routes return the same
- * object and identity checks can stand in for structural comparison.
+ * self-analysis run repeat an argument tuple that was already computed. It does
+ * not intern the results: equal types reached by different routes stay distinct
+ * objects, as they do here, because code comparing Type objects by identity
+ * relies on that.
  *
  * The cache is scoped to a single container: it hands back shared Type
  * instances, and Type objects carry a lazily resolved ClassReflection tied to the

--- a/tests/PHPStan/Analyser/nsrt/bug-15151.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-15151.php
@@ -1,0 +1,29 @@
+<?php // lint >= 8.1
+
+namespace Bug15151;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ * @param T $val
+ * @return (T is array ? T : null)
+ */
+function validate_array(mixed $val): ?array {
+    return \is_array($val) ? $val : null;
+}
+
+class reception_formulaire {
+
+    // @phpstan-ignore missingType.iterableValue
+    final function __construct(
+        protected readonly array $params
+    ) { }
+
+    public function foo(): void {
+        foreach (validate_array($this->params['Genre_Admis'] ?? null) ?? [ ] as $_) {
+            assertType('mixed', $_);
+        }
+    }
+
+}

--- a/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template-bound.php
+++ b/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template-bound.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace ConditionalTypeForParameterTemplateBound;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TData
+ */
+interface FormTypeInterface
+{
+
+}
+
+/**
+ * @template TData
+ */
+interface FormInterface
+{
+
+	/**
+	 * @return TData
+	 */
+	public function getData();
+
+}
+
+class DataClass
+{
+
+}
+
+/**
+ * @implements FormTypeInterface<DataClass>
+ */
+class DataClassType implements FormTypeInterface
+{
+
+}
+
+class Controller
+{
+
+	/**
+	 * @template TFormType of FormTypeInterface<TData>
+	 * @template TData
+	 *
+	 * @param class-string<TFormType> $type
+	 * @param TData                   $data
+	 * @param array<string, mixed>    $options
+	 *
+	 * @phpstan-return ($data is null ? FormInterface<null|TData> : FormInterface<TData>)
+	 */
+	protected function createForm(string $type, $data = null, array $options = []): FormInterface
+	{
+		throw new \Exception();
+	}
+
+	public function doSomethingNullable(): void
+	{
+		$form = $this->createForm(DataClassType::class);
+		assertType('ConditionalTypeForParameterTemplateBound\DataClass|null', $form->getData());
+	}
+
+	public function doSomething(): void
+	{
+		$form = $this->createForm(DataClassType::class, new DataClass());
+		assertType('ConditionalTypeForParameterTemplateBound\DataClass', $form->getData());
+	}
+
+	public function doSomethingNull(): void
+	{
+		$form = $this->createForm(DataClassType::class, null);
+		assertType('ConditionalTypeForParameterTemplateBound\DataClass|null', $form->getData());
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template.php
+++ b/tests/PHPStan/Analyser/nsrt/conditional-type-for-parameter-template.php
@@ -1,0 +1,115 @@
+<?php // lint >= 8.0
+
+namespace ConditionalTypeForParameterTemplate;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+class A
+{
+
+	/**
+	 * @template T
+	 * @param T $result
+	 * @return ($result is false ? never : T)
+	 */
+	public function throwOnFailure($result)
+	{
+		if ($result === false) {
+			throw new \Exception();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @template T
+	 * @param T $result
+	 * @return ($result is not false ? T : never)
+	 */
+	public function negated($result)
+	{
+		if ($result === false) {
+			throw new \Exception();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @template T
+	 * @param T $a
+	 * @param T $b
+	 * @return ($a is false ? never : T)
+	 */
+	public function boundByTwoParameters($a, $b)
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @template T
+	 * @param T $a
+	 * @param list<T> $others
+	 * @return ($a is false ? never : T)
+	 */
+	public function boundByAnotherParameter($a, array $others)
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @template T
+	 * @param T|null $value
+	 * @return ($value is null ? never : T)
+	 */
+	public function nullable($value)
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @template T
+	 * @param T $val
+	 * @return ($val is array ? T : null)
+	 */
+	public function validateArray(mixed $val): ?array
+	{
+		return \is_array($val) ? $val : null;
+	}
+
+}
+
+/**
+ * @template T
+ * @param T $result
+ * @return ($result is false ? never : T)
+ */
+function throwOnFailure($result)
+{
+	if ($result === false) {
+		throw new \Exception();
+	}
+
+	return $result;
+}
+
+/**
+ * @param stdClass|false $v
+ * @param array{a: int}|string $as
+ */
+function test(A $a, $v, $as, mixed $m, ?stdClass $n): void
+{
+	assertType('stdClass', $a->throwOnFailure($v));
+	assertType('stdClass', throwOnFailure($v));
+	assertType('stdClass', $a->negated($v));
+	assertType("'str'|stdClass|false", $a->boundByTwoParameters($v, 'str'));
+	assertType('stdClass|false', $a->boundByAnotherParameter($v, []));
+	assertType('stdClass', $a->nullable($n));
+	assertType('array|null', $a->validateArray($as));
+
+	foreach ($a->validateArray($m) ?? [] as $x) {
+		assertType('mixed', $x);
+		assertType('array|null', $a->validateArray($x));
+	}
+}

--- a/turbo-ext/src/TypeCombinatorCache.cpp
+++ b/turbo-ext/src/TypeCombinatorCache.cpp
@@ -8,28 +8,18 @@
  * on a structural key of its arguments; a miss calls back into the PHP twin
  * (TypeCombinator::doUnion() and friends), which stays the reference implementation.
  *
- * On top of that the results are *interned*: one canonical instance is kept per
- * distinct type value, so operations that arrive at the same value by different
- * routes hand back the same object. In a self-analysis run 60% of the results the
- * memo does not already cover turn out to be values that already exist (110k of
- * 184k). Sharing them makes `$a === $b` a common outcome for equal types, which
- * is what the identity fast paths already sitting on the hot paths —
- * pt_types_identical_or_equal() on scope merges, `$a === $b` in
- * TypeCombinator::doUnion() — then collect on: -3.1% user CPU on a serial
- * self-analysis, measured over three interleaved rounds. Peak RSS is unchanged;
- * the results being deduplicated are short-lived, and peak RSS is set by
- * reflection and parser state instead.
+ * The results are NOT interned: no canonical instance per type value is kept, and
+ * operations that arrive at the same value by different routes hand back
+ * different objects, exactly as the PHP implementation does. Interning (tried in
+ * 873ede9b0a, reverted) made equal types share one instance across unrelated
+ * call sites, and every place in the analyser comparing Type objects by identity
+ * - a proxy for "the same reference" that only holds while equal values stay
+ * distinct objects - then narrowed or resolved types it never meant to
+ * (phpstan/phpstan#15151). The memo only hands one result to the structurally
+ * equal argument tuples of the same operation, which is the sharing
+ * TypeCombinator itself produces when it returns an operand.
  *
- * PRECONDITION: TypeCombinator::doUnion() must return the same type for equal
- * operands as it does for identical ones, since interning decides which of the
- * two an operand pair is. Its two-operand fast path covers equal array operands
- * for exactly this reason — without it, processArrayTypes() rebuilds such a pair
- * through ArrayType::getIterableKeyType() and drops a subtracted key type, so
- * union(array<mixed~'User', mixed>, <equal>) would widen to array here and stay
- * precise under interning, breaking the rule that analysis output is identical
- * with the extension on and off.
- *
- * Three structures back this:
+ * Two structures back this:
  *
  *  - a per-object 128-bit structural hash of every Type, cached in a *weak* map so
  *    the entry disappears with the object: the cache retains nothing and an object
@@ -47,17 +37,14 @@
  *    cost ~100MB of summed worker peaks on parallel runs, while the entries
  *    that die are the cheap ones: recomputing them is CPU-neutral even at a
  *    hit rate drop from ~90% to ~70%.
- *  - the intern table: the same flat table, keyed by a type's own structural
- *    hash and holding the canonical instance for that value, borrowed the same
- *    way (weak pt_intern_objs, whose dtor releases the slot).
  *
- * The hash is 128 bits precisely so a key can be trusted without keeping the
+ * The hash is 128 bits precisely so the key can be trusted without keeping the
  * arguments alive to re-verify a hit: over the ~10^5 distinct keys of a run the
  * collision probability is ~10^-28. A 64-bit key would be ~10^-9 per run, which
  * across a user base is a silently wrong analysis result — not acceptable.
  *
- * Both tables are cleared whenever a container is created (TypeCombinator::clearCache()).
- * They hand back *shared* Type instances, and a Type lazily resolves a
+ * The memo is cleared whenever a container is created (TypeCombinator::clearCache()).
+ * Memoization hands back *shared* Type instances, and a Type lazily resolves a
  * ClassReflection belonging to the container that created it — so entries must not
  * outlive their container. Production runs one container per process; the test
  * suite does not.
@@ -101,12 +88,8 @@ static constexpr uint32_t HASH_DEPTH_LIMIT = 64;
  * self-analysis run peaks at ~3.5e4 live entries. */
 static constexpr uint32_t MEMO_ENTRIES_LIMIT = 1 << 19;
 
-/* Same safety net for the intern table. Distinct type *values* are far fewer
- * than distinct argument tuples, so this is never reached in practice. */
-static constexpr uint32_t INTERN_ENTRIES_LIMIT = 1 << 19;
-
-/* Initial slot count of a table; must be a power of two. */
-static constexpr uint32_t TABLE_INITIAL_CAPACITY_LIMIT = 1 << 13;
+/* Initial slot count of the memo table; must be a power of two. */
+static constexpr uint32_t MEMO_INITIAL_CAPACITY_LIMIT = 1 << 13;
 
 struct Hash128
 {
@@ -114,157 +97,16 @@ struct Hash128
 	uint64_t b;
 };
 
-/* An occupied slot borrows its object; obj == NULL marks an empty slot,
- * obj == SLOT_TOMBSTONE a deleted one (the probe chain must stay intact, so
- * deletion cannot empty a slot). */
-struct Slot
+/* An occupied memo slot borrows its result; result == NULL marks an empty
+ * slot, result == MEMO_TOMBSTONE a deleted one (the probe chain must stay
+ * intact, so deletion cannot empty a slot). */
+struct MemoSlot
 {
 	Hash128 key;
-	zend_object *obj;
+	zend_object *result;
 };
 
-#define SLOT_TOMBSTONE ((zend_object *) 1)
-
-/* Flat open-addressing table from a 128-bit structural key to a borrowed
- * object, backing both the memo (key = operation + arguments) and the intern
- * table (key = the value itself). Linear probing, 24 bytes per slot; the
- * live+tombstone load never reaches 1 (grow() keeps it at 3/4 at most), so
- * every probe terminates on an empty slot. */
-struct SlotTable
-{
-	Slot *slots;
-	uint32_t mask;
-	uint32_t count;
-	uint32_t tombstones;
-
-	void init()
-	{
-		slots = (Slot *) ecalloc(TABLE_INITIAL_CAPACITY_LIMIT, sizeof(Slot));
-		mask = TABLE_INITIAL_CAPACITY_LIMIT - 1;
-		count = 0;
-		tombstones = 0;
-	}
-
-	void destroy()
-	{
-		efree(slots);
-		slots = NULL;
-		mask = 0;
-		count = 0;
-		tombstones = 0;
-	}
-
-	/* Drop every entry, shrinking an overgrown table back to its initial size. */
-	void reset()
-	{
-		if (mask + 1 > TABLE_INITIAL_CAPACITY_LIMIT) {
-			efree(slots);
-			slots = (Slot *) ecalloc(TABLE_INITIAL_CAPACITY_LIMIT, sizeof(Slot));
-			mask = TABLE_INITIAL_CAPACITY_LIMIT - 1;
-		} else {
-			memset(slots, 0, (size_t) (mask + 1) * sizeof(Slot));
-		}
-		count = 0;
-		tombstones = 0;
-	}
-
-	/* FNV-1a's low bits mix worst; fold the high half in before masking. */
-	zend_always_inline uint32_t start(Hash128 key) const
-	{
-		return (uint32_t) (key.a ^ (key.a >> 32)) & mask;
-	}
-
-	/* The occupied slot holding the key, or NULL. */
-	zend_always_inline Slot *lookup(Hash128 key) const
-	{
-		uint32_t idx = start(key);
-		for (;;) {
-			Slot *slot = &slots[idx];
-			if (slot->obj == NULL) {
-				return NULL;
-			}
-			if (slot->obj != SLOT_TOMBSTONE && slot->key.a == key.a && slot->key.b == key.b) {
-				return slot;
-			}
-			idx = (idx + 1) & mask;
-		}
-	}
-
-	/* Slot to insert the key into: the occupied slot already holding it, else
-	 * the first tombstone on its probe path, else the terminating empty slot. */
-	zend_always_inline Slot *insertPos(Hash128 key) const
-	{
-		uint32_t idx = start(key);
-		Slot *tombstone = NULL;
-		for (;;) {
-			Slot *slot = &slots[idx];
-			if (slot->obj == NULL) {
-				return tombstone != NULL ? tombstone : slot;
-			}
-			if (slot->obj == SLOT_TOMBSTONE) {
-				if (tombstone == NULL) {
-					tombstone = slot;
-				}
-			} else if (slot->key.a == key.a && slot->key.b == key.b) {
-				return slot;
-			}
-			idx = (idx + 1) & mask;
-		}
-	}
-
-	void grow()
-	{
-		uint32_t oldCapacity = mask + 1;
-		Slot *oldSlots = slots;
-
-		/* Tombstones are dropped by the rehash; only grow the table when live
-		 * entries alone justify it, otherwise rehash at the same size. */
-		uint32_t newCapacity = ((uint64_t) count * 4 > (uint64_t) oldCapacity * 2) ? oldCapacity * 2 : oldCapacity;
-		slots = (Slot *) ecalloc(newCapacity, sizeof(Slot));
-		mask = newCapacity - 1;
-		tombstones = 0;
-		for (uint32_t i = 0; i < oldCapacity; i++) {
-			if (oldSlots[i].obj != NULL && oldSlots[i].obj != SLOT_TOMBSTONE) {
-				*insertPos(oldSlots[i].key) = oldSlots[i];
-			}
-		}
-		efree(oldSlots);
-	}
-
-	/* Takes a slot returned by insertPos() that is empty or a tombstone. */
-	void occupy(Slot *slot, Hash128 key, zend_object *obj)
-	{
-		if (slot->obj == SLOT_TOMBSTONE) {
-			tombstones--;
-		}
-		slot->key = key;
-		slot->obj = obj;
-		count++;
-
-		if ((uint64_t) (count + tombstones) * 4 > (uint64_t) (mask + 1) * 3) {
-			grow();
-		}
-	}
-
-	/* Deletes the entry mapping key to obj, if it is still the one present. */
-	void release(Hash128 key, const zend_object *obj)
-	{
-		uint32_t idx = start(key);
-		for (;;) {
-			Slot *slot = &slots[idx];
-			if (slot->obj == NULL) {
-				return;
-			}
-			if (slot->obj == obj && slot->key.a == key.a && slot->key.b == key.b) {
-				slot->obj = SLOT_TOMBSTONE;
-				count--;
-				tombstones++;
-				return;
-			}
-			idx = (idx + 1) & mask;
-		}
-	}
-};
+#define MEMO_TOMBSTONE ((zend_object *) 1)
 
 /* Each memoized result object carries this list of the memo keys mapping to
  * it (several keys can produce the same shared instance), held as IS_PTR in
@@ -278,21 +120,14 @@ struct KeyList
 	Hash128 keys[4]; /* inline head; grown by erealloc */
 };
 
-/* The intern-table counterpart of KeyList: a canonical instance is canonical
- * for exactly one key — its own structural hash. */
-struct InternEntry
-{
-	zend_object *obj;
-	Hash128 key;
-};
-
 static HashTable pt_type_hashes;   /* weak: zend_object* -> Hash128 packed in the bucket zval */
 static HashTable pt_ce_kinds;      /* zend_class_entry* -> kind|slots */
 static HashTable pt_obj_serials;   /* weak: zend_object* -> IS_LONG serial (identity-hashed objects) */
 static HashTable pt_memo_results;  /* weak: zend_object* -> IS_PTR KeyList */
-static HashTable pt_intern_objs;   /* weak: zend_object* -> IS_PTR InternEntry */
-static SlotTable pt_memo;
-static SlotTable pt_intern;
+static MemoSlot *pt_memo_slots = NULL;
+static uint32_t pt_memo_mask = 0;
+static uint32_t pt_memo_count = 0;
+static uint32_t pt_memo_tombstones = 0;
 static uint64_t pt_next_serial = 1;
 static bool pt_cache_inited = false;
 static bool pt_invalidate_active = false;
@@ -607,7 +442,88 @@ static void typeHashDtor(zval *zv)
 
 /* {{{ the memo */
 
+/* Occupied slot holding the key, or NULL. The table's live+tombstone load
+ * never reaches 1 (memoGrow() keeps it at 3/4 at most), so the probe always
+ * terminates. */
+static zend_always_inline MemoSlot *memoLookup(Hash128 key)
+{
+	/* FNV-1a's low bits mix worst; fold the high half in before masking. */
+	uint32_t idx = (uint32_t) (key.a ^ (key.a >> 32)) & pt_memo_mask;
+	for (;;) {
+		MemoSlot *slot = &pt_memo_slots[idx];
+		if (slot->result == NULL) {
+			return NULL;
+		}
+		if (slot->result != MEMO_TOMBSTONE && slot->key.a == key.a && slot->key.b == key.b) {
+			return slot;
+		}
+		idx = (idx + 1) & pt_memo_mask;
+	}
+}
+
+/* Slot to insert the key into: the occupied slot already holding it, else the
+ * first tombstone on its probe path, else the terminating empty slot. */
+static zend_always_inline MemoSlot *memoInsertPos(Hash128 key)
+{
+	uint32_t idx = (uint32_t) (key.a ^ (key.a >> 32)) & pt_memo_mask;
+	MemoSlot *tombstone = NULL;
+	for (;;) {
+		MemoSlot *slot = &pt_memo_slots[idx];
+		if (slot->result == NULL) {
+			return tombstone != NULL ? tombstone : slot;
+		}
+		if (slot->result == MEMO_TOMBSTONE) {
+			if (tombstone == NULL) {
+				tombstone = slot;
+			}
+		} else if (slot->key.a == key.a && slot->key.b == key.b) {
+			return slot;
+		}
+		idx = (idx + 1) & pt_memo_mask;
+	}
+}
+
+static void memoGrow()
+{
+	uint32_t oldCapacity = pt_memo_mask + 1;
+	MemoSlot *oldSlots = pt_memo_slots;
+
+	/* Tombstones are dropped by the rehash; only grow the table when live
+	 * entries alone justify it, otherwise rehash at the same size. */
+	uint32_t newCapacity = ((uint64_t) pt_memo_count * 4 > (uint64_t) oldCapacity * 2) ? oldCapacity * 2 : oldCapacity;
+	pt_memo_slots = (MemoSlot *) ecalloc(newCapacity, sizeof(MemoSlot));
+	pt_memo_mask = newCapacity - 1;
+	pt_memo_tombstones = 0;
+	for (uint32_t i = 0; i < oldCapacity; i++) {
+		if (oldSlots[i].result != NULL && oldSlots[i].result != MEMO_TOMBSTONE) {
+			*memoInsertPos(oldSlots[i].key) = oldSlots[i];
+		}
+	}
+	efree(oldSlots);
+}
+
 /* {{{ weak-result mode: invalidation on result death + key-list upkeep */
+
+static void memoInvalidate(const KeyList *list)
+{
+	for (uint32_t i = 0; i < list->count; i++) {
+		Hash128 key = list->keys[i];
+		uint32_t idx = (uint32_t) (key.a ^ (key.a >> 32)) & pt_memo_mask;
+		for (;;) {
+			MemoSlot *slot = &pt_memo_slots[idx];
+			if (slot->result == NULL) {
+				break;
+			}
+			if (slot->result == list->obj && slot->key.a == key.a && slot->key.b == key.b) {
+				slot->result = MEMO_TOMBSTONE;
+				pt_memo_count--;
+				pt_memo_tombstones++;
+				break;
+			}
+			idx = (idx + 1) & pt_memo_mask;
+		}
+	}
+}
 
 /* Value dtor of pt_memo_results: runs when a memoized result object dies (and
  * on bulk cleanup, where pt_invalidate_active is off and the memo is reset
@@ -616,9 +532,7 @@ static void memoResultDtor(zval *zv)
 {
 	KeyList *list = (KeyList *) Z_PTR_P(zv);
 	if (pt_invalidate_active) {
-		for (uint32_t i = 0; i < list->count; i++) {
-			pt_memo.release(list->keys[i], list->obj);
-		}
+		memoInvalidate(list);
 	}
 	efree(list);
 }
@@ -649,92 +563,21 @@ static void memoTrackResult(zend_object *obj, Hash128 key)
 	}
 }
 
-/* Purge every weak entry of a table without touching the slot tables (the
- * caller resets those wholesale). On 8.4 the unregister loop is spelled out,
- * as in pt_weakrefs_hash_destroy. */
-static void weakResultsClean(HashTable *ht)
+/* Purge every key list without touching the memo slots (the caller resets
+ * those wholesale). On 8.4 the unregister loop is spelled out, as in
+ * pt_weakrefs_hash_destroy. */
+static void memoResultsClean()
 {
+	pt_invalidate_active = false;
 #if PHP_VERSION_ID < 80500
 	zend_ulong objKey;
-	ZEND_HASH_MAP_FOREACH_NUM_KEY(ht, objKey) {
-		zend_weakrefs_hash_del(ht, zend_weakref_key_to_object(objKey));
+	ZEND_HASH_MAP_FOREACH_NUM_KEY(&pt_memo_results, objKey) {
+		zend_weakrefs_hash_del(&pt_memo_results, zend_weakref_key_to_object(objKey));
 	} ZEND_HASH_FOREACH_END();
 #else
-	zend_weakrefs_hash_clean(ht);
+	zend_weakrefs_hash_clean(&pt_memo_results);
 #endif
-}
-
-/* }}} */
-
-/* {{{ interning
-
- * The memo deduplicates *calls*; interning deduplicates *values*. Countless
- * different argument tuples converge on the same result — `int|string` is
- * produced by unions of wildly different operands — and each one otherwise
- * materializes its own object graph. Keeping one canonical instance per
- * structural hash and handing that back means equal types are usually the
- * *same* type, so the identity checks the hot paths already perform decide the
- * comparison instead of recursing into the two graphs.
- *
- * Substituting is sound because the hash covers every declared property: two
- * objects hashing alike are indistinguishable to any reader of their value.
- * Lazily populated memo properties (ObjectType::$classReflection and friends)
- * are part of the hash too, so a populated instance simply hashes differently
- * from a bare one — never a false merge, only a missed one.
- *
- * Entries are borrowed exactly like the memo's: pt_intern_objs is a weak map
- * whose dtor releases the slot, so a canonical instance is retained only as
- * long as some live scope holds it anyway. */
-
-static void internEntryDtor(zval *zv)
-{
-	InternEntry *entry = (InternEntry *) Z_PTR_P(zv);
-	if (pt_invalidate_active) {
-		pt_intern.release(entry->key, entry->obj);
-	}
-	efree(entry);
-}
-
-/* Replaces a freshly computed result with the canonical instance of its value,
- * or makes it the canonical one. */
-static void internResult(zval *return_value)
-{
-	zend_object *obj = Z_OBJ_P(return_value);
-	Hash128 hash;
-	if (!hashObject(obj, hash, 0)) {
-		return;
-	}
-
-	Slot *slot = pt_intern.lookup(hash);
-	if (slot != NULL) {
-		zend_object *canonical = slot->obj;
-		if (canonical == obj) {
-			return;
-		}
-		GC_ADDREF(canonical);
-		/* Dropping the fresh graph can run internEntryDtor/memoResultDtor for
-		 * its children, which only tombstone slots — no table ever rehashes
-		 * under a borrowed Slot pointer. */
-		zval_ptr_dtor(return_value);
-		ZVAL_OBJ(return_value, canonical);
-		return;
-	}
-
-	if (pt_intern.count >= INTERN_ENTRIES_LIMIT) {
-		return;
-	}
-
-	InternEntry *entry = (InternEntry *) emalloc(sizeof(InternEntry));
-	entry->obj = obj;
-	entry->key = hash;
-	zval value;
-	ZVAL_PTR(&value, entry);
-	if (zend_weakrefs_hash_add(&pt_intern_objs, obj, &value) == NULL) {
-		efree(entry); /* unreachable: the lookup above showed no entry */
-		return;
-	}
-
-	pt_intern.occupy(pt_intern.insertPos(hash), hash, obj);
+	pt_invalidate_active = true;
 }
 
 /* }}} */
@@ -752,10 +595,7 @@ public:
 	static void run(INTERNAL_FUNCTION_PARAMETERS, Op op, zend_function *fn, zval *args, uint32_t argc)
 	{
 		Hash128 key = { FNV_OFFSET_A, FNV_OFFSET_B };
-		/* Both tables are only fed and read while no recursion guard is active,
-		 * where the operations are pure functions of their arguments. */
-		bool pure = !guardActive();
-		bool memoizable = argc > 0 && argc <= MEMO_ARGS_LIMIT && pure;
+		bool memoizable = argc > 0 && argc <= MEMO_ARGS_LIMIT && !guardActive();
 
 		if (memoizable) {
 			mixByte(key, (uint8_t) op);
@@ -774,10 +614,10 @@ public:
 		}
 
 		if (memoizable) {
-			Slot *slot = pt_memo.lookup(key);
+			MemoSlot *slot = memoLookup(key);
 			if (slot != NULL) {
-				GC_ADDREF(slot->obj);
-				RETVAL_OBJ(slot->obj);
+				GC_ADDREF(slot->result);
+				RETVAL_OBJ(slot->result);
 				return;
 			}
 		}
@@ -791,18 +631,22 @@ public:
 			return;
 		}
 
-		if (pure) {
-			internResult(return_value);
-		}
-
-		if (memoizable && pt_memo.count < MEMO_ENTRIES_LIMIT) {
+		if (memoizable && pt_memo_count < MEMO_ENTRIES_LIMIT) {
 			/* Fresh lookup: the callback re-enters these operations for nested
 			 * types, which may have inserted this very key or grown the table. */
-			Slot *slot = pt_memo.insertPos(key);
-			if (slot->obj == NULL || slot->obj == SLOT_TOMBSTONE) {
-				zend_object *result = Z_OBJ_P(return_value);
-				memoTrackResult(result, key);
-				pt_memo.occupy(slot, key, result);
+			MemoSlot *slot = memoInsertPos(key);
+			if (slot->result == NULL || slot->result == MEMO_TOMBSTONE) {
+				if (slot->result == MEMO_TOMBSTONE) {
+					pt_memo_tombstones--;
+				}
+				slot->key = key;
+				slot->result = Z_OBJ_P(return_value);
+				pt_memo_count++;
+				memoTrackResult(slot->result, key);
+
+				if ((uint64_t) (pt_memo_count + pt_memo_tombstones) * 4 > (uint64_t) (pt_memo_mask + 1) * 3) {
+					memoGrow();
+				}
 			}
 		}
 	}
@@ -812,12 +656,16 @@ public:
 		if (!pt_cache_inited) {
 			return;
 		}
-		pt_invalidate_active = false;
-		weakResultsClean(&pt_memo_results);
-		weakResultsClean(&pt_intern_objs);
-		pt_invalidate_active = true;
-		pt_memo.reset();
-		pt_intern.reset();
+		memoResultsClean();
+		if (pt_memo_mask + 1 > MEMO_INITIAL_CAPACITY_LIMIT) {
+			efree(pt_memo_slots);
+			pt_memo_slots = (MemoSlot *) ecalloc(MEMO_INITIAL_CAPACITY_LIMIT, sizeof(MemoSlot));
+			pt_memo_mask = MEMO_INITIAL_CAPACITY_LIMIT - 1;
+		} else {
+			memset(pt_memo_slots, 0, (size_t) (pt_memo_mask + 1) * sizeof(MemoSlot));
+		}
+		pt_memo_count = 0;
+		pt_memo_tombstones = 0;
 	}
 };
 
@@ -829,9 +677,9 @@ using phpstanturbo::pt_ce_kinds;
 using phpstanturbo::pt_fn_do_intersect;
 using phpstanturbo::pt_fn_do_remove;
 using phpstanturbo::pt_fn_do_union;
-using phpstanturbo::pt_intern;
-using phpstanturbo::pt_intern_objs;
-using phpstanturbo::pt_memo;
+using phpstanturbo::pt_memo_slots;
+using phpstanturbo::pt_memo_mask;
+using phpstanturbo::pt_memo_count;
 using phpstanturbo::pt_memo_results;
 using phpstanturbo::pt_obj_serials;
 using phpstanturbo::pt_next_serial;
@@ -840,6 +688,7 @@ using phpstanturbo::pt_guard_resolved;
 using phpstanturbo::pt_guard_unavailable;
 using phpstanturbo::pt_type_hashes;
 using phpstanturbo::typeHashDtor;
+using phpstanturbo::MEMO_INITIAL_CAPACITY_LIMIT;
 
 /* {{{ engine ABI glue: parameter parsing + registration */
 
@@ -856,9 +705,10 @@ void pt_type_combinator_cache_rinit()
 	zend_hash_init(&pt_ce_kinds, 128, NULL, NULL, 0);
 	zend_hash_init(&pt_obj_serials, 1024, NULL, NULL, 0);
 	zend_hash_init(&pt_memo_results, 4096, NULL, phpstanturbo::memoResultDtor, 0);
-	zend_hash_init(&pt_intern_objs, 4096, NULL, phpstanturbo::internEntryDtor, 0);
-	pt_memo.init();
-	pt_intern.init();
+	pt_memo_slots = (phpstanturbo::MemoSlot *) ecalloc(MEMO_INITIAL_CAPACITY_LIMIT, sizeof(phpstanturbo::MemoSlot));
+	pt_memo_mask = MEMO_INITIAL_CAPACITY_LIMIT - 1;
+	pt_memo_count = 0;
+	phpstanturbo::pt_memo_tombstones = 0;
 	pt_next_serial = 1;
 	pt_guard_ce = NULL;
 	pt_guard_resolved = false;
@@ -875,9 +725,11 @@ void pt_type_combinator_cache_rshutdown()
 	TypeCombinatorCache::clear();
 	phpstanturbo::pt_invalidate_active = false;
 	pt_weakrefs_hash_destroy(&pt_memo_results);
-	pt_weakrefs_hash_destroy(&pt_intern_objs);
-	pt_memo.destroy();
-	pt_intern.destroy();
+	efree(pt_memo_slots);
+	pt_memo_slots = NULL;
+	pt_memo_mask = 0;
+	pt_memo_count = 0;
+	phpstanturbo::pt_memo_tombstones = 0;
 	pt_weakrefs_hash_destroy(&pt_type_hashes);
 	pt_weakrefs_hash_destroy(&pt_obj_serials);
 	zend_hash_destroy(&pt_ce_kinds);

--- a/turbo-ext/tests/smoke.php
+++ b/turbo-ext/tests/smoke.php
@@ -291,19 +291,13 @@ $explicit = \PHPStanTurbo\TypeCombinatorCache::union(new \PHPStan\Type\MixedType
 $implicit = \PHPStanTurbo\TypeCombinatorCache::union(new \PHPStan\Type\MixedType(false), $intT);
 check($describe($explicit) !== $describe($implicit), 'TCC keeps explicit/implicit mixed apart');
 
-// interning: argument tuples with different memo keys that arrive at the same
-// value hand back one shared instance
+// no interning: argument tuples with different memo keys that arrive at the same
+// value hand back distinct instances, as the PHP implementation does
 $wider = \PHPStanTurbo\TypeCombinatorCache::union($intT, $stringT, new \PHPStan\Type\NeverType());
-check($describe($wider) === $describe($first), 'TCC intern: the extra never collapses to the same value');
-check($wider === $first, 'TCC intern: shared instance across memo keys');
-
-// interning merges on the *structural* hash, so equal values that are built
-// differently are not merged — union() keeps its argument order, and a union
-// listing the same members in another order is a different structure
-check(\PHPStanTurbo\TypeCombinatorCache::union($stringT, $intT) !== $first, 'TCC intern does not merge on equals()');
-
-// distinct values must not be merged
-check(\PHPStanTurbo\TypeCombinatorCache::union($intT, $nullT) !== $first, 'TCC intern keeps distinct values apart');
+check($describe($wider) === $describe($first), 'TCC: the extra never collapses to the same value');
+check($wider !== $first, 'TCC: no shared instance across memo keys');
+check(\PHPStanTurbo\TypeCombinatorCache::union($stringT, $intT) !== $first, 'TCC: another argument order is another memo key');
+check(\PHPStanTurbo\TypeCombinatorCache::union($intT, $nullT) !== $first, 'TCC: distinct values stay apart');
 
 \PHPStanTurbo\TypeCombinatorCache::clearCache();
 $afterClear = \PHPStanTurbo\TypeCombinatorCache::union($intT, $stringT);


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/15151

Reverts the interning of TypeCombinator results in the turbo extension (873ede9b0a); the memo stays. Interning kept one canonical instance per type value, so equal types reached by unrelated routes became the same object, and every place in the analyser comparing Type objects by identity then narrowed or resolved types it never meant to — with the extension `(T is array ? T : null)` came out as `array<array>|null`. The native cache goes back to exactly its pre-interning state plus a note on why there is no interning; the PHP-side `doUnion()` fix for equal array operands (5d393265dc) stays, the memo relies on it just the same.

**Benchmark (fork mode, turbo in the phar, cold result cache, ABBA/BAAB blocks, paired user CPU; the machine was busy, so wall is noise):**

| Project | Pairs | User CPU, no-interning vs 2.2.x | Memory |
|---|---|---|---|
| Slevomat (~600 s user) | 6 | +1.05 %, sd 2.62, wins 2/6, t=1.0 | `-vv` peaks identical per block; maxrss +1.4 % (sd 9.7) |
| ShipMonk (~1330 s user) | 4 | +0.44 %, sd 1.40, wins 1/4, t=0.6 | main 2.93–2.97 GB, worker ~1 GB, maxrss 3.29 GB, both arms |

Analysis output is identical between the arms on both projects. Interning is worth at most about half a percent of user CPU on these workloads, statistically indistinguishable from zero, with no memory effect.

**Tests.** The reporter's files run as an E2E test in the turbo E2E job, and the nsrt fixtures cover the reported shape plus the parameter conditionals on template-typed parameters. Full suite passes with and without the extension. Two cases from the earlier attempt (#6350) are not included because they document identity-based defects this PR does not touch: the variance lookup in `resolveTemplateTypes()` (wrong with and without the extension) and a class-level template type in a parameter conditional, which the memo alone still narrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuKACbcMfZeRgpvHJrHvqw
