### PR TITLE
Do not invalidate the result cache when tmpDir changes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -151,6 +151,17 @@ jobs:
               echo -n > phpstan-baseline.neon
               ../../bin/phpstan -vvv
           - script: |
+              cd e2e/result-cache-moved-tmpdir
+              ../../bin/phpstan
+              # Where the cache is stored cannot change what it holds, so moving it has to keep it
+              # usable: same project, same analysis, cache read from a different tmpDir.
+              mkdir -p tmp-b
+              cp tmp-a/resultCache.php tmp-b/resultCache.php
+              OUTPUT=$(../../bin/phpstan analyse -c moved.neon -vv 2>&1)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'Result cache restored. 0 files will be reanalysed.' "$OUTPUT"
+              ../bashunit -a not_contains 'metadata do not match' "$OUTPUT"
+          - script: |
               cd e2e/bug-14514
               composer install
               ../../bin/phpstan analyze bug-14515.php

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ e2e/bashunit
 /e2e/turbo-arena/tmp
 /e2e/fork-unsafe-extension/tmp
 /e2e/result-cache-atomic-save/tmp
+/e2e/result-cache-moved-tmpdir/tmp-a
+/e2e/result-cache-moved-tmpdir/tmp-b

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -255,6 +255,7 @@ parameters:
 		- [parameters, internalErrorsCountLimit]
 		- [parameters, cache]
 		- [parameters, memoryLimitFile]
+		- [parameters, tmpDir]
 		- [parameters, pro]
 		- parametersSchema
 

--- a/e2e/result-cache-moved-tmpdir/moved.neon
+++ b/e2e/result-cache-moved-tmpdir/moved.neon
@@ -1,0 +1,7 @@
+includes:
+	- phpstan.neon
+
+parameters:
+	# The same analysis, reading the cache from somewhere else. Where the cache is stored cannot
+	# change what it holds, so tmpDir is in parametersNotInvalidatingCache and this must reuse it.
+	tmpDir: tmp-b

--- a/e2e/result-cache-moved-tmpdir/phpstan.neon
+++ b/e2e/result-cache-moved-tmpdir/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: 8
+	tmpDir: tmp-a
+	paths:
+		- src

--- a/e2e/result-cache-moved-tmpdir/src/Foo.php
+++ b/e2e/result-cache-moved-tmpdir/src/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace ResultCacheE2EMovedTmpDir;
+
+class Foo
+{
+
+	public function doFoo(): int
+	{
+		return 1;
+	}
+
+}


### PR DESCRIPTION
`tmpDir` ends up in the `projectConfig` entry of the result cache metadata, so moving the cache directory throws away the cache it contains:

```
Result cache not used because the metadata do not match: projectConfig
```

Where the cache is stored cannot change what it holds.

## Why it is safe to leave out

The only two `%tmpDir%` references in the shipped configuration are the result cache path itself (`resultCachePath: %tmpDir%/resultCache.php`) and the file cache directory (`%tmpDir%/cache/PHPStan`). In `src/` it is read by the path transformer, by `save()` for the temporary file it renames from, and by `CommandHelper` to resolve and create the directory. Nothing reads it for anything but locating those.

A configuration that references `%tmpDir%` inside an analysis-relevant parameter (`scanDirectories`, `excludePaths`, ...) keeps *that* parameter in the metadata with its expanded value, so nothing is hidden by leaving `tmpDir` itself out.

I left the `tmpDir` branch of `ResultCachePathTransformer::relativizeProjectConfig()` in place: `parametersNotInvalidatingCache` is a user-overridable parameter, so it is still reachable.

## Why it matters

Reusing a cache produced somewhere else. The same project analysed by two people, or in CI and then locally, commonly differs only in where the cache lives: a per-user cache directory, a container mount, or one shared directory that several git worktrees point at. Today that difference alone costs a full re-analysis.

It does not make a cache portable between machines on its own, since `phpVersion` and `phpExtensions` still differ; it removes one blocker that carries no information.

## Test

`e2e/result-cache-moved-tmpdir` analyses a project into `tmp-a`, copies `resultCache.php` to `tmp-b`, and asserts the same analysis reuses it with 0 files reanalysed and no metadata mismatch. Without the one-line change that run reports `metadata do not match: projectConfig`, so it fails for the right reason.

Only `resultCache.php` is copied, not `cache/`, because that is all the reuse needs.

## Verified locally

The whole `result-cache-e2e-tests` job replayed with bashunit 0.44.0: one failure, `bug-14718`, which needs a `composer install` my sandbox cannot do and fails the same way on 2.2.x. Result-cache, command and dependency suites: 186 tests, 641 assertions. `make phpstan` clean.

Related but orthogonal: phpstan/phpstan-src#1469 gives each project config its own cache *file*; this is about the key, and two configs sharing one `tmpDir` still differ in the rest of `projectConfig`.
