### PR TITLE
Install the right container before every test and data provider on PHPUnit 9 too

### DIFF
--- a/src/Analyser/ExprHandlerRegistry.php
+++ b/src/Analyser/ExprHandlerRegistry.php
@@ -19,6 +19,18 @@ final class ExprHandlerRegistry
 	private static array $exprHandlersByClass = [];
 
 	/**
+	 * Handlers belong to the container they came from, and spl_object_id() is
+	 * recycled as soon as a container is freed - so ContainerFactory drops the
+	 * memo whenever another container takes over the global state.
+	 *
+	 * @internal
+	 */
+	public static function clearCache(): void
+	{
+		self::$exprHandlersByClass = [];
+	}
+
+	/**
 	 * @return ExprHandler<Expr>|null
 	 */
 	public static function resolve(Expr $expr, Container $container): ?ExprHandler

--- a/src/Analyser/StmtHandlerRegistry.php
+++ b/src/Analyser/StmtHandlerRegistry.php
@@ -24,6 +24,15 @@ final class StmtHandlerRegistry
 	private static array $stmtHandlersByClass = [];
 
 	/**
+	 * @see ExprHandlerRegistry::clearCache()
+	 * @internal
+	 */
+	public static function clearCache(): void
+	{
+		self::$stmtHandlersByClass = [];
+	}
+
+	/**
 	 * @return StmtHandler<Stmt>|null
 	 */
 	public static function resolve(Stmt $stmt, Container $container): ?StmtHandler

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -17,6 +17,8 @@ use Nette\Utils\Strings;
 use Nette\Utils\Validators;
 use Phar;
 use PhpParser\Parser;
+use PHPStan\Analyser\ExprHandlerRegistry;
+use PHPStan\Analyser\StmtHandlerRegistry;
 use PHPStan\BetterReflection\BetterReflection;
 use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
@@ -32,6 +34,7 @@ use PHPStan\Reflection\ReflectionProviderStaticAccessor;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
+use WeakReference;
 use function array_diff_key;
 use function array_intersect;
 use function array_key_exists;
@@ -49,7 +52,6 @@ use function is_array;
 use function is_file;
 use function is_readable;
 use function is_string;
-use function spl_object_id;
 use function sprintf;
 use function str_ends_with;
 use function substr;
@@ -66,7 +68,8 @@ final class ContainerFactory
 
 	private string $configDirectory;
 
-	private static ?int $lastInitializedContainerId = null;
+	/** @var WeakReference<Container>|null */
+	private static ?WeakReference $lastInitializedContainer = null;
 
 	private bool $journalContainer = false;
 
@@ -172,12 +175,22 @@ final class ContainerFactory
 	/** @internal */
 	public static function postInitializeContainer(Container $container): void
 	{
-		$containerId = spl_object_id($container);
-		if ($containerId === self::$lastInitializedContainerId) {
+		// Comparing spl_object_id()s would be wrong: an id is recycled as soon as its
+		// container is freed, so a fresh container could inherit the last initialized
+		// one's id and silently skip installing its own global state.
+		$lastInitializedContainer = self::$lastInitializedContainer !== null ? self::$lastInitializedContainer->get() : null;
+		if ($lastInitializedContainer === $container) {
 			return;
 		}
 
-		self::$lastInitializedContainerId = $containerId;
+		self::$lastInitializedContainer = WeakReference::create($container);
+
+		// Both registries memoize handler instances per container, keyed by the
+		// container's spl_object_id() - a recycled id would otherwise hand this
+		// container the freed one's handlers, which carry the other container's
+		// services and parameters.
+		ExprHandlerRegistry::clearCache();
+		StmtHandlerRegistry::clearCache();
 
 		/** @var SourceLocator $sourceLocator */
 		$sourceLocator = $container->getService('betterReflectionSourceLocator');

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -22,6 +22,7 @@ use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\ReflectionProvider\DirectReflectionProviderProvider;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
+use PHPStan\Testing\PHPUnit\ContainerInitializer;
 use PHPStan\Type\Constant\OversizedArrayBuilder;
 use PHPStan\Type\ExpressionTypeResolverExtension;
 use PHPStan\Type\OperatorTypeSpecifyingExtensionRegistry;
@@ -43,21 +44,29 @@ abstract class PHPStanTestCase extends TestCase
 	use PHPStanTestCaseTrait;
 
 	/**
-	 * Re-register the runtime container as the global static reflection provider before
-	 * every test. Enable this in tests that construct Type objects directly and assert
-	 * PHP-version-dependent reflection results, so a foreign PhpVersion leaked by another
-	 * test can't flake them. See https://github.com/phpstan/phpstan/issues/14860
+	 * Re-register this test class's container as the owner of the global static state
+	 * (the reflection provider, the PhpVersion, the bleeding edge toggle) before every
+	 * test, so a container another test class installed can't flake tests that build
+	 * Type objects directly. See https://github.com/phpstan/phpstan/issues/14860
+	 *
+	 * PHPUnit >= 10 does this through InitContainerBeforeTestSubscriber; PHPUnit 9 -
+	 * which the "Tests with old PHPUnit" jobs run - rejects that extension, so the
+	 * guarantee has to hold here too.
 	 */
-	protected bool $reinitializeContainerBeforeEachTest = false;
-
 	#[Override]
 	protected function setUp(): void
 	{
-		if (!$this->reinitializeContainerBeforeEachTest) {
-			return;
-		}
+		ContainerInitializer::initialize(static::class);
+	}
 
-		self::getContainer();
+	#[Override]
+	public static function tearDownAfterClass(): void
+	{
+		parent::tearDownAfterClass();
+
+		// The next test class's data providers run before any hook this test case has
+		// on PHPUnit 9, in the same ParaTest worker process - see restoreBaseContainer().
+		self::restoreBaseContainer();
 	}
 
 	public static function getParser(): Parser

--- a/src/Testing/PHPStanTestCaseTrait.php
+++ b/src/Testing/PHPStanTestCaseTrait.php
@@ -22,10 +22,40 @@ trait PHPStanTestCaseTrait
 
 	public static function getContainer(): Container
 	{
-		$additionalConfigFiles = [__DIR__ . '/TestCase.neon'];
+		$additionalConfigFiles = [self::getBaseConfigFile()];
 		foreach (static::getAdditionalConfigFiles() as $configFile) {
 			$additionalConfigFiles[] = $configFile;
 		}
+
+		return self::getContainerForConfigFiles($additionalConfigFiles);
+	}
+
+	/**
+	 * Installs the global state of the container built from just the base config -
+	 * the bleeding edge toggle, the static reflection provider, the PhpVersion and
+	 * the type caches all live in static properties that the last initialized
+	 * container owns.
+	 *
+	 * PHPUnit >= 10 initializes the right container before every data provider and
+	 * every test (see PHPStanPHPUnitExtension). PHPUnit 9 - which the "Tests with old
+	 * PHPUnit" jobs run - rejects that extension and has no hook that fires before a
+	 * data provider, while ParaTest reuses one worker process for many test files. A
+	 * class whose container turns on e.g. bleeding edge would therefore leak that
+	 * state into the data providers of the next test file, which build Type objects
+	 * that read the toggle in their constructor. Restoring the base state when a test
+	 * class is done keeps those data providers deterministic on every supported
+	 * PHPUnit version.
+	 */
+	public static function restoreBaseContainer(): void
+	{
+		self::getContainerForConfigFiles([self::getBaseConfigFile()]);
+	}
+
+	/**
+	 * @param string[] $additionalConfigFiles
+	 */
+	private static function getContainerForConfigFiles(array $additionalConfigFiles): Container
+	{
 		$cacheKey = hash('sha256', implode("\n", $additionalConfigFiles));
 
 		if (!isset(self::$containers[$cacheKey])) {
@@ -63,6 +93,11 @@ trait PHPStanTestCaseTrait
 		}
 
 		return self::$containers[$cacheKey];
+	}
+
+	private static function getBaseConfigFile(): string
+	{
+		return __DIR__ . '/TestCase.neon';
 	}
 
 	/**

--- a/tests/PHPStan/Testing/BleedingEdgeContainerStateTest.php
+++ b/tests/PHPStan/Testing/BleedingEdgeContainerStateTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Testing;
+
+use Override;
+use PHPStan\DependencyInjection\BleedingEdgeToggle;
+
+/**
+ * The global state a container installs - here the bleeding edge toggle, which
+ * ConstantArrayType reads in its constructor - has to belong to the test class
+ * that is running, not to whichever class ran before it in the same ParaTest
+ * worker process. On PHPUnit >= 10 InitContainerBeforeTestSubscriber guarantees
+ * that; PHPUnit 9 rejects that extension, so PHPStanTestCase::setUp() does.
+ */
+class BleedingEdgeContainerStateTest extends PHPStanTestCase
+{
+
+	#[Override]
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../conf/bleedingEdge.neon',
+		];
+	}
+
+	public function testThisClassesContainerOwnsTheGlobalState(): void
+	{
+		$this->assertTrue(BleedingEdgeToggle::isBleedingEdge());
+	}
+
+}

--- a/tests/PHPStan/Testing/ContainerStateTest.php
+++ b/tests/PHPStan/Testing/ContainerStateTest.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Testing;
+
+use PHPStan\DependencyInjection\BleedingEdgeToggle;
+
+/**
+ * @see BleedingEdgeContainerStateTest for the same guarantee with a non-base container
+ */
+class ContainerStateTest extends PHPStanTestCase
+{
+
+	public function testThisClassesContainerOwnsTheGlobalState(): void
+	{
+		$this->assertFalse(BleedingEdgeToggle::isBleedingEdge());
+	}
+
+}

--- a/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
@@ -23,11 +23,6 @@ use const PHP_VERSION_ID;
 class HasPropertyTypeTest extends PHPStanTestCase
 {
 
-	// Pin the runtime container so a foreign PhpVersion leaked by another test
-	// can't flake the version-dependent Closure data set below.
-	// See https://github.com/phpstan/phpstan/issues/14860
-	protected bool $reinitializeContainerBeforeEachTest = true;
-
 	public static function dataIsSuperTypeOf(): array
 	{
 		return [

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -32,11 +32,6 @@ use const PHP_VERSION_ID;
 class GenericObjectTypeTest extends PHPStanTestCase
 {
 
-	// Pin the runtime container so a foreign PhpVersion leaked by another test
-	// can't flake the version-dependent data sets (reflected variance of built-in
-	// generics). See https://github.com/phpstan/phpstan/issues/14860
-	protected bool $reinitializeContainerBeforeEachTest = true;
-
 	public static function dataIsSuperTypeOf(): array
 	{
 		return [

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -53,11 +53,6 @@ use const PHP_VERSION_ID;
 class ObjectTypeTest extends PHPStanTestCase
 {
 
-	// Pin the runtime container so a foreign PhpVersion leaked by another test
-	// can't flake the version-dependent Closure data sets (dynamic-property
-	// handling). See https://github.com/phpstan/phpstan/issues/14860
-	protected bool $reinitializeContainerBeforeEachTest = true;
-
 	public static function dataIsIterable(): array
 	{
 		return [

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -74,11 +74,6 @@ use const PHP_VERSION_ID;
 class TypeCombinatorTest extends PHPStanTestCase
 {
 
-	// Pin the runtime container so a foreign PhpVersion leaked by another test
-	// can't flake the version-dependent data sets (dynamic-property handling of
-	// final classes). See https://github.com/phpstan/phpstan/issues/14860
-	protected bool $reinitializeContainerBeforeEachTest = true;
-
 	public static function dataAddNull(): array
 	{
 		return [

--- a/tests/PHPStan/Type/TypeGetFiniteTypesTest.php
+++ b/tests/PHPStan/Type/TypeGetFiniteTypesTest.php
@@ -17,6 +17,12 @@ class TypeGetFiniteTypesTest extends PHPStanTestCase
 
 	public static function dataGetFiniteTypes(): iterable
 	{
+		// The expected ConstantArrayTypes below read the bleeding edge toggle in their
+		// constructor, so this class's container has to be the installed one already
+		// while they are built. On PHPUnit 9 nothing installs it before a data provider
+		// runs - see PHPStanTestCaseTrait::restoreBaseContainer().
+		self::getContainer();
+
 		yield [
 			IntegerRangeType::fromInterval(0, 5),
 			[

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types = 1);
 
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Turbo\TurboExtensionEnabler;
 
 error_reporting(E_ALL);
@@ -24,3 +25,10 @@ eval('trait TraitInEval {
 	}
 
 }');
+
+// A ParaTest worker builds the test suite of the first test file it picks up - and with it
+// runs that file's data providers - before any PHPUnit hook of ours gets a chance to run on
+// PHPUnit 9, which rejects PHPStanPHPUnitExtension. Install the base container's global state
+// (the static reflection provider, the PhpVersion, the bleeding edge toggle) up front so those
+// data providers see the same state as every later one.
+PHPStanTestCase::restoreBaseContainer();


### PR DESCRIPTION
`PHPStanPHPUnitExtension` implements the PHPUnit >= 10 `Runner\Extension\Extension` interface and is registered in `phpunit.xml` as `<extensions><bootstrap class=…/>`. PHPUnit 9 rejects that element outright:

```
Line 4:
  - Element 'bootstrap': This element is not expected. Expected is ( extension ).
```

It only prints that as a config-validation warning and carries on, so the whole **Tests with old PHPUnit** matrix has been running without `InitContainerBeforeDataProviderSubscriber` and `InitContainerBeforeTestSubscriber` — nothing made a data provider or a test see its own test class's container. PHPUnit 9 also has no hook that fires before a data provider at all: providers run while `TestSuiteMapper` builds the suite, before any extension is registered.

ParaTest reuses one worker process for many test files, so whatever container the previous file installed stayed installed. That is where the flakes come from.

### `IntersectionTypeTest::testIsAcceptedBy`

Fails as exactly 3 failures — data sets #2, #3 and #7, the ones expecting `Maybe`, all returning `No` — and only ever on an 8.1 job ([one example](https://github.com/phpstan/phpstan-src/actions/runs/33726961724/job/100558035505)):

1. a bleeding edge test file leaves `BleedingEdgeToggle` on;
2. `dataIsAcceptedBy()` builds its `ConstantArrayType`s **sealed** — the constructor reads that toggle;
3. `dataGetEnumCases()` calls `createReflectionProvider()` mid-provider and switches the toggle back **off**. It only does that on PHP >= 8.1, which is why the 7.4/8.0 jobs never showed this;
4. `accepts()` then compares a sealed array shape against the unsealed ones synthesised during the call, and every `Maybe` becomes `No`.

Reproduced deterministically with a phpunit config that omits `<extensions>` and

```
php tests/vendor/bin/paratest --runner WrapperRunner --no-coverage -p 1 -c <that config>
```

over a bleeding edge test file followed by `IntersectionTypeTest`.

### First file in a worker

The same gap made 30 test files fail with `MissingStaticAccessorInstanceException` whenever they were the first file a ParaTest worker picked up — `VerbosityLevelTest` (which is what a recent 8.0 job hit), `ArrayTypeTest`'s data provider, and others. Running each test file on its own under PHPUnit 9 reproduces all of them.

## The fix

`PHPStanTestCase::setUp()` always installs the test class's own container, `tearDownAfterClass()` restores the base one for the next file's data providers, and `tests/bootstrap.php` installs it for the first file's. That makes `$reinitializeContainerBeforeEachTest` redundant, so it and its four users are gone. A data provider of a class whose container is *not* the base one still has to ask for it itself — `TypeGetFiniteTypesTest` is the only such case and now does.

The second commit fixes an adjacent hazard found on the way: `postInitializeContainer()` identified the last initialized container by `spl_object_id()`, which is recycled as soon as its object is freed — a fresh container could inherit a destroyed one's id and silently skip installing its own reflection provider, PhpVersion and feature toggles. `ExprHandlerRegistry` and `StmtHandlerRegistry` memoize handler instances under that same recycled id, and a handler carries its own container's services, so both memos are dropped when another container takes over.

## Verification

| check | before | after |
| --- | --- | --- |
| deterministic repro (`paratest -p 1`, no extension) | 3 failures | green |
| whole suite in 16 chunks, PHPUnit-9 shape | 13/16 chunks red | 16/16 clean |
| every test file run on its own under PHPUnit 9 | 30 real failures | 0 |
| downgraded 8.1 + PHPUnit 9 + ParaTest 6, full suite | flaky | 20/20 runs green |
| downgraded 8.0 + PHPUnit 9 + ParaTest 6, full suite | flaky | 8/8 runs green |

`ContainerStateTest` / `BleedingEdgeContainerStateTest` are the regression tests; the bleeding edge one fails with the fix reverted. `make tests`, `make phpstan` and `make cs` are clean.

One thing I could **not** reproduce: `ExpressionResultTest::testIsAlwaysTerminating` with data set #15 on the 8.0 job ([here](https://github.com/phpstan/phpstan-src/actions/runs/33726961724/job/100558035542)). It survived 150 solo runs and a full chunk hunt on a downgraded 8.0 build. Both commits remove the ways that test could end up looking at another container's state — the second one in particular fixes a case where an entire test class can run with a dead container's reflection provider and PHP version — but I can't claim it as proven, so that job is worth watching for a few runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019isZYNh3Zms6xGKGGXqxgp
