### PR TITLE
Do not let the exactness of `new Foo()` reach an inferred template argument

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -2002,6 +2002,29 @@ final class ClassReflection
 		);
 	}
 
+	/**
+	 * Back to the finality the class declares. Unlike removeFinalKeywordOverride(),
+	 * which asserts non-finality, this drops the override altogether - a type holding
+	 * such a reflection stops claiming to be exactly this class.
+	 */
+	public function withoutFinalByKeywordOverride(): self
+	{
+		if ($this->finalByKeywordOverride === null) {
+			return $this;
+		}
+
+		return $this->classReflectionFactory->create(
+			$this->displayName,
+			$this->reflection,
+			$this->anonymousFilename,
+			$this->resolvedTemplateTypeMap,
+			$this->stubPhpDocBlockCallback,
+			null,
+			$this->resolvedCallSiteVarianceMap,
+			null,
+		);
+	}
+
 	public function removeFinalKeywordOverride(): self
 	{
 		if ($this->getNativeReflection()->isFinal()) {

--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -413,6 +413,21 @@ class GenericObjectType extends ObjectType
 		return $this->recreate($this->getClassName(), $this->getTypes(), $this->getSubtractedType(), $variances);
 	}
 
+	public function withoutFinalByKeywordOverride(): Type
+	{
+		if ($this->classReflection === null || !$this->classReflection->hasFinalByKeywordOverride()) {
+			return $this;
+		}
+
+		return new self(
+			$this->getClassName(),
+			$this->types,
+			$this->getSubtractedType(),
+			$this->classReflection->withoutFinalByKeywordOverride(),
+			$this->variances,
+		);
+	}
+
 	public function changeSubtractedType(?Type $subtractedType): Type
 	{
 		$result = parent::changeSubtractedType($subtractedType);

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\NonAcceptingNeverType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\VerbosityLevel;
@@ -138,6 +139,24 @@ final class TemplateTypeHelper
 				}
 
 				return $traverse($type->toArgument());
+			}
+
+			return $traverse($type);
+		});
+	}
+
+	/**
+	 * Drops the "exactly this class" flavour of `new Foo()` from every object type inside $type.
+	 *
+	 * An inferred template argument is substituted into written PHPDoc types and compared
+	 * against them. No written type can carry the flavour, so an argument that kept it would
+	 * never match one - https://github.com/phpstan/phpstan/issues/15166.
+	 */
+	public static function removeFinalByKeywordOverrides(Type $type): Type
+	{
+		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+			if ($type instanceof ObjectType) {
+				$type = $type->withoutFinalByKeywordOverride();
 			}
 
 			return $traverse($type);

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -296,6 +296,8 @@ trait TemplateTypeTrait
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
+		$receivedType = TemplateTypeHelper::removeFinalByKeywordOverrides($receivedType);
+
 		if (
 			$receivedType instanceof TemplateType
 			&& $this->getBound()->isSuperTypeOf($receivedType->getBound())->yes()

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1763,6 +1763,23 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $this->changeSubtractedType(null);
 	}
 
+	/**
+	 * Drops the "this is exactly this class" flavour that ClassReflection::asFinal()
+	 * puts on the type of a `new Foo()` expression.
+	 */
+	public function withoutFinalByKeywordOverride(): Type
+	{
+		if ($this->classReflection === null || !$this->classReflection->hasFinalByKeywordOverride()) {
+			return $this;
+		}
+
+		return new self(
+			$this->className,
+			$this->subtractedType,
+			$this->classReflection->withoutFinalByKeywordOverride(),
+		);
+	}
+
 	public function changeSubtractedType(?Type $subtractedType): Type
 	{
 		if ($subtractedType !== null) {

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -4385,4 +4385,13 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.1.0')]
+	public function testBug15166(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-15166.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-15166.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-15166.php
@@ -1,0 +1,95 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace Bug15166;
+
+class Model {}
+class ExtendedModel extends Model {}
+
+/** @template-covariant T of Model */
+class Component {}
+
+/** @extends Component<ExtendedModel> */
+class ExtendedComponent extends Component {}
+
+/** @template M of Model */
+class ComponentBuilder
+{
+	/** @param M $model */
+	public function __construct(public readonly Model $model) {}
+
+	/** @param Component<M> $component */
+	public function accept(Component $component): void {}
+}
+
+function fromParameter(ExtendedModel $model): void
+{
+	$builder = new ComponentBuilder($model);
+	$builder->accept(new ExtendedComponent()); // all good
+}
+
+function fromNew(): void
+{
+	$builder = new ComponentBuilder(new ExtendedModel());
+	$builder->accept(new ExtendedComponent()); // reported
+}
+
+/** @template T of Model */
+class Invariant
+{
+	/** @param T $model */
+	public function __construct(public readonly Model $model) {}
+
+	/** @param Component<T> $component */
+	public function accept(Component $component): void {}
+}
+
+/** @template-contravariant T of Model */
+class Contravariant {}
+
+/** @extends Contravariant<ExtendedModel> */
+class ExtendedContravariant extends Contravariant {}
+
+/** @template T of Model */
+class ContravariantBuilder
+{
+	/** @param T $model */
+	public function __construct(public readonly Model $model) {}
+
+	/** @param Contravariant<T> $component */
+	public function accept(Contravariant $component): void {}
+}
+
+function otherVariances(): void
+{
+	$invariant = new Invariant(new ExtendedModel());
+	$invariant->accept(new ExtendedComponent());
+
+	$contravariant = new ContravariantBuilder(new ExtendedModel());
+	$contravariant->accept(new ExtendedContravariant());
+}
+
+/** @template T */
+class Setter
+{
+	/** @param T $value */
+	public function __construct(private $value) {}
+
+	/** @param T $value */
+	public function set($value): void {}
+}
+
+/** @template-covariant T of Model */
+class ComponentOf
+{
+	/** @param T $model */
+	public function __construct(public readonly Model $model) {}
+}
+
+/** @param ComponentOf<ExtendedModel> $componentOf */
+function nestedInGenericType(ComponentOf $componentOf): void
+{
+	$setter = new Setter(new ComponentOf(new ExtendedModel()));
+	$setter->set($componentOf);
+}

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -1097,4 +1097,10 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.1.0')]
+	public function testBug15166(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-15166.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-15166.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-15166.php
@@ -1,0 +1,36 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace Bug15166Properties;
+
+class Model {}
+class ExtendedModel extends Model {}
+
+/** @template-covariant T of Model */
+class Component {}
+
+/** @extends Component<ExtendedModel> */
+class ExtendedComponent extends Component {}
+
+/** @template M of Model */
+class Holder
+{
+	/** @var Component<M>|null */
+	public ?Component $component = null;
+
+	/** @param M $model */
+	public function __construct(public readonly Model $model) {}
+}
+
+function fromParameter(ExtendedModel $model): void
+{
+	$holder = new Holder($model);
+	$holder->component = new ExtendedComponent();
+}
+
+function fromNew(): void
+{
+	$holder = new Holder(new ExtendedModel());
+	$holder->component = new ExtendedComponent();
+}


### PR DESCRIPTION
The type of a `new Foo()` expression carries a final-by-keyword override (`ClassReflection::asFinal()`, [`3019d39113`](https://github.com/phpstan/phpstan-src/commit/3019d39113)) so that checks know the value cannot be a subclass instance. `TemplateTypeTrait::inferTemplateTypes()` recorded the received type verbatim, so the flavour became the template argument — and there it is unmatchable: no written PHPDoc type can carry it, and `ObjectType::isSuperTypeOf()` answers *maybe* when only one side has the override. A covariant type argument compared against the very same written type therefore failed:

```php
class Model {}
class ExtendedModel extends Model {}

/** @template-covariant T of Model */
class Component {}

/** @extends Component<ExtendedModel> */
class ExtendedComponent extends Component {}

/** @template M of Model */
class ComponentBuilder
{
    /** @param M $model */
    public function __construct(public readonly Model $model) {}

    /** @param Component<M> $component */
    public function accept(Component $component): void {}
}

function fromParameter(ExtendedModel $model): void
{
    $builder = new ComponentBuilder($model);
    $builder->accept(new ExtendedComponent()); // all good
}

function fromNew(): void
{
    $builder = new ComponentBuilder(new ExtendedModel());
    $builder->accept(new ExtendedComponent()); // expects Component<ExtendedModel>, ExtendedComponent given
}
```

The fix strips the override where the argument is inferred, so the `TemplateTypeMap` never carries it and every consumer of the map is covered — including the property shape, where the parameter/property type is resolved from the receiver's class-level map:

```php
$holder = new Holder(new ExtendedModel());
$holder->component = new ExtendedComponent(); // Property Holder<ExtendedModel>::$component ... does not accept ExtendedComponent
```

Notes:

* The strip is deep. The false positive reproduces with the flavour nested inside another generic type (`Setter<ComponentOf<ExtendedModel>>`), so a top-level-only strip would be a half fix. Covered by the test data.
* `ClassReflection::removeFinalKeywordOverride()` could not be reused: it sets the override to `false`, which still answers `hasFinalByKeywordOverride()`. The new `withoutFinalByKeywordOverride()` drops it altogether — back to the class's declared finality — and keeps the rest of the reflection, so anonymous-class identity and `withTypes()` survive.
* Types keep the flavour everywhere else, so `new Foo() instanceof Bar` is still reported as impossible. What is given up is narrowing on a read of a `T`-typed member of a locally constructed generic: `$builder->model instanceof SubExtendedModel` is `bool` now instead of `false`. No existing test depended on it — the full suite passes with no expectation churn.
* Cost is negligible and was measured rather than benchmarked: 2,655 strip calls totalling 2.3 ms in a 22.5 s single-process analysis of `src/Type` (0.01%). An A/B at n=4 per arm showed ±2% in both directions, i.e. noise.
* Adjacent funnels probed and clean: private-property-type-from-constructor inference, inferred return types, array offsets. Template-argument inference was the only path putting the flavour on the expected side of a check.

Closes https://github.com/phpstan/phpstan/issues/15166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxqKZAnAzZMUP1yc4uKTnp
