### PR TITLE
Let the using classes agree before reporting a pointless sort in a trait

### DIFF
--- a/src/Rules/Comparison/ConstantConditionInTraitCollector.php
+++ b/src/Rules/Comparison/ConstantConditionInTraitCollector.php
@@ -11,7 +11,7 @@ use PHPStan\ShouldNotHappenException;
 use function array_key_exists;
 
 /**
- * @implements CollectorWithPaths<never, array{class-string<Rule<covariant Node>>, trait-string, string, null}|array{class-string<Rule<covariant Node>>, trait-string, string, bool, Error|array<mixed>}>
+ * @implements CollectorWithPaths<never, array{class-string<Rule<covariant Node>>, trait-string, string, null}|array{class-string<Rule<covariant Node>>, trait-string, string, bool|string, Error|array<mixed>}>
  */
 final class ConstantConditionInTraitCollector implements CollectorWithPaths
 {
@@ -27,9 +27,9 @@ final class ConstantConditionInTraitCollector implements CollectorWithPaths
 	}
 
 	/**
-	 * @param array{class-string<Rule<covariant Node>>, trait-string, string, null}|array{class-string<Rule<covariant Node>>, trait-string, string, bool, Error|array<mixed>} $data
+	 * @param array{class-string<Rule<covariant Node>>, trait-string, string, null}|array{class-string<Rule<covariant Node>>, trait-string, string, bool|string, Error|array<mixed>} $data
 	 * @param callable(string): string $transformPath
-	 * @return array{class-string<Rule<covariant Node>>, trait-string, string, null}|array{class-string<Rule<covariant Node>>, trait-string, string, bool, Error|array<mixed>}
+	 * @return array{class-string<Rule<covariant Node>>, trait-string, string, null}|array{class-string<Rule<covariant Node>>, trait-string, string, bool|string, Error|array<mixed>}
 	 */
 	public static function transformCollectedDataPaths($data, callable $transformPath)
 	{

--- a/src/Rules/Comparison/ConstantConditionInTraitHelper.php
+++ b/src/Rules/Comparison/ConstantConditionInTraitHelper.php
@@ -54,13 +54,18 @@ final class ConstantConditionInTraitHelper
 	}
 
 	/**
+	 * $value is what the using classes have to agree on for the error to be reported. A condition's
+	 * value is a bool; a rule whose verdict has more than two outcomes passes the outcome itself, so
+	 * that two using classes reaching the same expression for different reasons still counts as
+	 * disagreement.
+	 *
 	 * @param class-string<Rule<covariant Node>> $ruleName
 	 */
 	public function emitError(
 		string $ruleName,
 		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 		Expr $expr,
-		bool $value,
+		bool|string $value,
 		RuleError $ruleError,
 	): void
 	{

--- a/src/Rules/Functions/SortWithoutEffectRule.php
+++ b/src/Rules/Functions/SortWithoutEffectRule.php
@@ -5,10 +5,13 @@ namespace PHPStan\Rules\Functions;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\ArgumentsNormalizer;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -55,6 +58,7 @@ final class SortWithoutEffectRule implements Rule
 
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		private bool $treatPhpDocTypesAsCertain,
 		private bool $treatPhpDocTypesAsCertainTip,
 	)
@@ -66,7 +70,7 @@ final class SortWithoutEffectRule implements Rule
 		return FuncCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if (!($node->name instanceof Node\Name)) {
 			return [];
@@ -93,11 +97,18 @@ final class SortWithoutEffectRule implements Rule
 
 		$normalizedFuncCall = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $node);
 		if ($normalizedFuncCall === null) {
+			// From here on the call is a sort call, so every way out has to be recorded for the
+			// trait collector: a context that reports nothing and says nothing is indistinguishable
+			// from one that was never analysed, and the remaining contexts then look unanimous.
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
+
 			return [];
 		}
 
 		$args = $normalizedFuncCall->getArgs();
 		if (!array_key_exists(0, $args)) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
+
 			return [];
 		}
 
@@ -111,6 +122,8 @@ final class SortWithoutEffectRule implements Rule
 
 		$reason = $this->findNoEffectReason($arrayType, $keyPreserving, $keysAlreadySorted);
 		if ($reason === null) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
+
 			return [];
 		}
 
@@ -127,9 +140,20 @@ final class SortWithoutEffectRule implements Rule
 			}
 		}
 
-		return [
-			$errorBuilder->build(),
-		];
+		$ruleError = $errorBuilder->build();
+
+		// A trait body is analysed once per using class, so self::/static:: in it resolves to a
+		// different type in each of them. A one-element enum makes a generic sortedCases() helper look
+		// pointless in that enum's context while the same line is fine in every other, and reporting it
+		// asks the author to change shared code for one consumer. The collector reports only what all
+		// the using classes agree on, which keeps a call that is pointless whichever class runs it.
+		if ($scope->isInTrait()) {
+			$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, $reason, $ruleError);
+
+			return [];
+		}
+
+		return [$ruleError];
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Functions/SortWithoutEffectRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/SortWithoutEffectRuleTest.php
@@ -2,23 +2,33 @@
 
 namespace PHPStan\Rules\Functions;
 
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitRule;
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<SortWithoutEffectRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class SortWithoutEffectRuleTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule
 	{
-		return new SortWithoutEffectRule(
-			self::createReflectionProvider(),
-			$this->shouldTreatPhpDocTypesAsCertain(),
-			true,
-		);
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new SortWithoutEffectRule(
+				self::createReflectionProvider(),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
+			),
+			// a trait body is analysed once per using class, and this rule is what decides what the
+			// contexts agreed on
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testRule(): void
@@ -183,6 +193,30 @@ class SortWithoutEffectRuleTest extends RuleTestCase
 				$tipText,
 			],
 		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/sort-without-effect-in-trait.php'], [
+			[
+				'Parameter #1 $array (array{1}) of function sort has at most 1 element, call has no effect.',
+				46,
+			],
+			[
+				'Parameter #1 $array (array{}) of function sort is empty, call has no effect.',
+				55,
+			],
+			[
+				'Parameter #1 $array (array{1}) of function sort has at most 1 element, call has no effect.',
+				85,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
+	public function testInTraitWithEnums(): void
+	{
+		$this->analyse([__DIR__ . '/data/sort-without-effect-in-trait-enum.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/data/sort-without-effect-in-trait-enum.php
+++ b/tests/PHPStan/Rules/Functions/data/sort-without-effect-in-trait-enum.php
@@ -1,0 +1,69 @@
+<?php // lint >= 8.1
+
+namespace SortWithoutEffectInTraitEnum;
+
+trait EnumUtils
+{
+
+	/** @return list<static> */
+	public static function sortedCases(): array
+	{
+		$cases = self::cases();
+		// self::cases() is a one-element array in SingleCase and a two-element one in ManyCases:
+		// generic trait code that only looks pointless in one of its consumers
+		usort($cases, static fn (self $a, self $b): int => strcasecmp($a->name, $b->name));
+
+		return $cases;
+	}
+
+}
+
+enum SingleCase: string
+{
+
+	use EnumUtils;
+
+	case ONLY = 'only';
+
+}
+
+enum ManyCases: string
+{
+
+	use EnumUtils;
+
+	case A = 'a';
+	case B = 'b';
+
+}
+
+trait EmptyEnumUtils
+{
+
+	/** @return list<static> */
+	public static function sortedCases(): array
+	{
+		$cases = self::cases();
+		usort($cases, static fn (self $a, self $b): int => strcasecmp($a->name, $b->name));
+
+		return $cases;
+	}
+
+}
+
+enum NoCases
+{
+
+	use EmptyEnumUtils;
+
+}
+
+enum SomeCases
+{
+
+	use EmptyEnumUtils;
+
+	case A;
+	case B;
+
+}

--- a/tests/PHPStan/Rules/Functions/data/sort-without-effect-in-trait.php
+++ b/tests/PHPStan/Rules/Functions/data/sort-without-effect-in-trait.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SortWithoutEffectInTrait;
+
+trait SizeFromUsingClass
+{
+
+	/** @return list<int> */
+	public function doFoo(): array
+	{
+		$a = self::ITEMS;
+		// one element in One, two in Many: pointless in one context and fine in the other,
+		// so the using classes do not agree and nothing is reported
+		sort($a);
+
+		return $a;
+	}
+
+}
+
+class One
+{
+
+	use SizeFromUsingClass;
+
+	public const ITEMS = [1];
+
+}
+
+class Many
+{
+
+	use SizeFromUsingClass;
+
+	public const ITEMS = [1, 2];
+
+}
+
+trait SizeNotFromUsingClass
+{
+
+	/** @return list<int> */
+	public function doFoo(): array
+	{
+		$a = [1];
+		sort($a);
+
+		return $a;
+	}
+
+	/** @return list<int> */
+	public function doBar(): array
+	{
+		$b = [];
+		sort($b);
+
+		return $b;
+	}
+
+}
+
+class UsesIt
+{
+
+	use SizeNotFromUsingClass;
+
+}
+
+class AlsoUsesIt
+{
+
+	use SizeNotFromUsingClass;
+
+}
+
+trait OneUsingClassOnly
+{
+
+	/** @return list<int> */
+	public function doFoo(): array
+	{
+		$a = self::ITEMS;
+		// with a single using class there is no second opinion, so this is reported the same way
+		// the constant-condition rules report it
+		sort($a);
+
+		return $a;
+	}
+
+}
+
+class TheOnlyUser
+{
+
+	use OneUsingClassOnly;
+
+	public const ITEMS = [1];
+
+}


### PR DESCRIPTION
`SortWithoutEffectRule` is new in 2.2.13 behind the `sortWithoutEffect` toggle, and it reports generic trait code in the context of whichever using class happens to pin the array's size.

```php
trait EnumUtils
{
    /** @return static[] */
    public static function sortedCases(): array
    {
        $cases = self::cases();
        usort($cases, static fn (self $a, self $b): int => strcasecmp($a->name, $b->name));

        return $cases;
    }
}

enum SingleCase: string { use EnumUtils; case ONLY = 'only'; }
enum ManyCases: string  { use EnumUtils; case A = 'a'; case B = 'b'; }
```

```
repro.php (in context of class SingleCase):10
Parameter #1 $array (array{SingleCase::ONLY}) of function usort has at most 1 element, call has no effect.
sortArray.noop
```

Nothing in the `ManyCases` context: one line, two verdicts. The helper is correct for every consumer, and the error asks its author to change shared code because one enum has a single case. `sortArray.empty` does the same thing to a zero-case enum.

Reported off a real codebase after a 2.2.12 -> 2.2.13 bump, reproduced here on `d6adcb4ac`.

## What this does

Per-using-class inference is deliberate, so the fix is not to skip traits: in a trait body `self::cases()` really is `array{SingleCase::ONLY}` in one context and `array{ManyCases::A, ManyCases::B}` in another, and `deadCode.unreachable` already reports per using class today.

`ConstantConditionInTraitHelper` already encodes the answer for the 23 constant-condition rules: collect per (rule, trait, expression, value) across every using class, then report only what they agree on, once, at the trait's own line. This rule now goes through it. So:

- the enum helper above is no longer reported, in either context
- a call that is pointless whichever class runs it stays reported, at the trait's line with no `in context of` prefix:
  ```php
  trait GenuineNoop {
      public function f(): array { $a = [1]; usort($a, fn ($x, $y) => $x <=> $y); return $a; }
  }
  ```
  still gives `sortArray.noop`, because `array{1}` does not depend on the using class
- a trait with exactly one using class is still reported, since there is no second opinion to disagree. That is what the constant-condition rules do with the same shape, and the new fixture pins it rather than leaving it to chance.

## The one shared change

`ConstantConditionInTraitHelper::emitError()`'s `$value` widens from `bool` to `bool|string`. A condition has two outcomes; this rule has three (`empty`, `list`, `noop`). Passing a bool would make two using classes that reach one call for different reasons look unanimous, when they should count as disagreement. Existing callers all pass bools and are unaffected, and the collector already keys with `var_export()`.

Everything after the call is identified as a sort call also emits `emitNoError()`, including the two early returns that produce nothing: a context that reports nothing and says nothing is indistinguishable from one that was never analysed, and the remaining contexts then look unanimous.

## Tests

`sort-without-effect-in-trait.php` covers the disagreement, the two size-independent no-ops, and the single-using-class case; `sort-without-effect-in-trait-enum.php` is the reported enum shape plus the zero-case enum, gated on PHP 8.1. The existing test's `getRule()` becomes a `CompositeRule` with `ConstantConditionInTraitRule`, the way `StrictComparisonOfDifferentTypesRuleTest` does it.

Both new tests fail without the `emitError` branch. Suite green (21321), self-analysis clean, phpcs clean.

## Worth a second opinion from you

Reporting in trait context is your call, and I have taken the reading that matches the constant-condition family. If you would rather this rule reported per using class as the dead-code family does, the fixture is the thing to flip. Also note the rule's errors now travel through the collected-data path, which shares whatever `CollectedDataNode` rules do about result-cache staleness.
