### PR TITLE
Do not call a cache file that vanished mid-read corrupted

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -328,8 +328,17 @@ final class ResultCacheManager
 		if (!is_array($data)) {
 			@unlink($cacheFilePath);
 
+			// readCacheFile() returns null both for a file it could not read back and for one it could
+			// not open at all, and the second is not a corruption: the file was there for the is_file()
+			// check above and gone by the time it was opened. A concurrent clear-result-cache, a temp
+			// directory being swept, a CI cache artifact expiring mid-run. Calling that corrupt sends
+			// someone looking for a broken disk.
+			$reason = is_file($cacheFilePath)
+				? 'Result cache not used because the cache file is corrupted.'
+				: 'Result cache not used because the cache file disappeared while it was being read.';
+
 			return $this->fullAnalysis(
-				'Result cache not used because the cache file is corrupted.',
+				$reason,
 				$allAnalysedFiles,
 				$this->getMeta($allAnalysedFiles, $projectConfigArray),
 				$currentFileHashes,


### PR DESCRIPTION
`readCacheFile()` returns `null` both for a file it could not read back and for one it could not open at all, and `restore()` reports both as corruption:

```
Result cache not used because the cache file is corrupted.
```

The second case is not corruption. The file was there for the `is_file()` check a few lines above and gone by the time it was opened: a concurrent `clear-result-cache`, a temp directory swept while the run was going, a CI cache artifact expiring mid-run. Telling someone their cache is corrupt sends them looking for a broken disk.

The two are now reported apart, and the corrupt case keeps its existing wording:

```
vanished:  Result cache not used because the cache file disappeared while it was being read.
truncated: Result cache not used because an error occurred while loading the cache file:
           Expected a 49202 byte frame, read 335 bytes.
```

Verified by injecting each: an `unlink()` immediately before the read for the first, and cutting the file to 400 bytes for the second. Behaviour is unchanged either way - the cache is discarded and the analysis is full - only the sentence differs.

This gets more likely rather than less as caches are shared: a directory holding more than one project's cache has more reasons for a file to disappear between the check and the read. Context in phpstan/phpstan#15163.

Suite green, self-analysis clean, phpcs clean.
