### PR TITLE
Keep the openssl cipher probe's warnings inside the probe

### DIFF
--- a/src/Internal/Silencer.php
+++ b/src/Internal/Silencer.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use Closure;
+use function restore_error_handler;
+use function set_error_handler;
+
+/**
+ * Runs something that predictably emits diagnostics which are none of the user's business, and keeps
+ * them to itself.
+ *
+ * Not the `@` operator, and not Composer's `Silencer` either: both work by lowering what is reported,
+ * and PHP calls a user error handler for a diagnostic regardless of `error_reporting()`. A handler that
+ * does not consult it therefore still sees everything `@` was meant to hide, and Xdebug's `scream`
+ * disables `@` outright. A handler of our own, on top of the stack for the duration of the call, is
+ * called instead of theirs and reports nothing - and theirs is back in place afterwards.
+ *
+ * Use it only where the diagnostics are expected and meaningless, never to hide a failure that should
+ * be handled: the callable's own return value still says whether it worked.
+ */
+final class Silencer
+{
+
+	/**
+	 * @template T
+	 * @param Closure(): T $callback
+	 * @return T
+	 */
+	public static function call(Closure $callback)
+	{
+		set_error_handler(static fn (): bool => true);
+
+		try {
+			return $callback();
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+}

--- a/src/Type/Php/OpenSslCipherMethodsProvider.php
+++ b/src/Type/Php/OpenSslCipherMethodsProvider.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Internal\Silencer;
 use function array_filter;
 use function array_map;
 use function array_values;
@@ -50,10 +51,14 @@ final class OpenSslCipherMethodsProvider implements ResultCacheMetaExtension
 			// openssl_get_cipher_methods() reports algorithms that are not actually
 			// supported on PHP 8.0-8.4 due to https://github.com/php/php-src/issues/19994
 			// Filter by actually testing each algorithm with openssl_cipher_iv_length().
-			$methods = array_values(array_filter(
+			//
+			// Probing an unsupported algorithm warns, and @ is not enough on its own: a user error
+			// handler that does not consult error_reporting() is still called for a suppressed
+			// diagnostic, and whatever installs one is out of our hands. See Silencer.
+			$methods = Silencer::call(static fn (): array => array_values(array_filter(
 				openssl_get_cipher_methods(true),
-				static fn (string $algorithm): bool => @openssl_cipher_iv_length($algorithm) !== false,
-			));
+				static fn (string $algorithm): bool => openssl_cipher_iv_length($algorithm) !== false,
+			)));
 		}
 
 		$this->supportedCipherMethods = array_map('strtolower', $methods);

--- a/tests/PHPStan/Type/Php/OpenSslCipherMethodsProviderTest.php
+++ b/tests/PHPStan/Type/Php/OpenSslCipherMethodsProviderTest.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Type\Php;
 
 use PHPStan\Testing\PHPStanTestCase;
+use function restore_error_handler;
+use function set_error_handler;
 
 class OpenSslCipherMethodsProviderTest extends PHPStanTestCase
 {
@@ -26,6 +28,36 @@ class OpenSslCipherMethodsProviderTest extends PHPStanTestCase
 			$this->createProvider(['aes-256-cbc', 'aes-128-cbc'])->getHash(),
 			'Enumeration order is not analysis-relevant and must not invalidate the cache.',
 		);
+	}
+
+	/**
+	 * Reading the ciphers out of the runtime means probing each one, and on PHP 8.0-8.4
+	 * openssl_get_cipher_methods() reports algorithms openssl_cipher_iv_length() rejects with a
+	 * warning (php/php-src#19994) - 40 of 248 on PHP 8.4.23. `@` does not settle that: a user error
+	 * handler that does not consult error_reporting() is still called for a suppressed diagnostic.
+	 * See phpstan/phpstan#15176.
+	 *
+	 * Vacuous on a PHP where nothing is rejected, which is why the count is not asserted - only that
+	 * whatever the probe does stays inside it.
+	 */
+	public function testProbingTheRuntimeLeaksNoWarningThroughAnUnsuppressedHandler(): void
+	{
+		$leaked = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$leaked): bool {
+			// deliberately does not check error_reporting(), so the @ operator does not hide anything
+			$leaked[] = $errstr;
+
+			return true;
+		});
+
+		try {
+			$hash = (new OpenSslCipherMethodsProvider())->getHash();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame([], $leaked, 'Probing the runtime for supported ciphers must not emit warnings.');
+		$this->assertNotSame('', $hash);
 	}
 
 	/**


### PR DESCRIPTION
Fixes phpstan/phpstan#15176.

`OpenSslCipherMethodsProvider` filters the reported cipher list by probing each algorithm, because `openssl_get_cipher_methods()` reports algorithms `openssl_cipher_iv_length()` rejects on PHP 8.0-8.4 (php/php-src#19994). Every rejection warns, and there are plenty: **40 of 248 on PHP 8.4.23** with OpenSSL 3.6.3, `aes-128-cbc-cts` among them, which is the message in the report. On PHP 8.5 nothing is rejected, which is why this does not show up everywhere.

The probe is `@`-suppressed and @staabm is right that this normally hides it. What `@` does not survive is a user error handler that does not consult `error_reporting()`: such a handler is still called for a suppressed diagnostic, and returning without checking the mask prints or records it. Whatever installs one is out of our hands, so the robust form is a handler of our own on top of the stack for the duration of the probe, with `restore_error_handler()` leaving theirs in place afterwards. Same shape as `AutoloadSourceLocator` already uses.

## Verified

On PHP 8.4.23, computing the metadata with a mask-ignoring handler installed:

```
stock 2.2.13:  hash ec38cd224f74...  warnings leaked: 40   (first: openssl_cipher_iv_length(): Unknown cipher algorithm)
with the fix:  hash ec38cd224f74...  warnings leaked: 0
```

The hash is identical, so the cipher list and the result cache key are unchanged - this only stops the noise.

Two things I could **not** reproduce, said so nobody assumes otherwise. Installing such a handler from a `bootstrapFiles` entry does not surface the warnings in a real run: the handler is demonstrably active and sees a suppressed `trigger_error()` at bootstrap time, yet it is invoked zero times over a whole analysis while the metadata is computed and the hash lands in the cache file. So something between bootstrap and the probe holds a handler that does respect the mask, and I have not pinned down which. And `xdebug.scream`, which disables `@` outright, is documented to have the same effect but Xdebug is not loaded on this machine, so that one is reasoning rather than measurement.

Neither changes what the fix does: after it, the probe cannot emit a diagnostic to anyone.

PHPStan's own handler in `FileAnalyser` was never the problem - it checks `(error_reporting() & $errno) === 0` and returns early, and so does the one in `Configurator`.

## Test

`testProbingTheRuntimeLeaksNoWarningThroughAnUnsuppressedHandler` installs such a handler, computes the hash, and asserts nothing leaked. It is vacuous on a runtime where no reported cipher is rejected, so it asserts no count - only that whatever the probe does stays inside it. It fails without this change wherever at least one cipher is rejected, which here is PHP 8.4.23.

Suite green, self-analysis clean, phpcs clean.
