### PR TITLE
Read the cached collected data only when the rules on CollectedDataNode run

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use Closure;
+use PHPStan\Analyser\ResultCache\LazyCollectedData;
 use PHPStan\Collectors\CollectedData;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\DependencyInjection\AutowiredParameter;
@@ -140,7 +141,7 @@ final class Analyser
 			linesToIgnore: $linesToIgnore,
 			unmatchedLineIgnores: $unmatchedLineIgnores,
 			internalErrors: [],
-			collectedData: $collectedData,
+			collectedData: LazyCollectedData::fromArray($collectedData),
 			dependencies: $internalErrorsCount === 0 ? $dependencies : null,
 			usedTraitDependencies: $internalErrorsCount === 0 ? $usedTraitDependencies : null,
 			packageDependencies: $internalErrorsCount === 0 ? $packageDependencies : null,

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -17,8 +17,6 @@ final class AnalyserResult
 	/** @var list<Error>|null */
 	private ?array $errors = null;
 
-	private LazyCollectedData $collectedData;
-
 	/**
 	 * @param list<Error> $unorderedErrors
 	 * @param list<Error> $filteredPhpErrors
@@ -26,7 +24,6 @@ final class AnalyserResult
 	 * @param list<Error> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param CollectorData|LazyCollectedData $collectedData
 	 * @param list<InternalError> $internalErrors
 	 * @param array<string, array<string>>|null $dependencies
 	 * @param array<string, array<string>>|null $usedTraitDependencies
@@ -42,7 +39,7 @@ final class AnalyserResult
 		private array $linesToIgnore,
 		private array $unmatchedLineIgnores,
 		private array $internalErrors,
-		array|LazyCollectedData $collectedData,
+		private LazyCollectedData $collectedData,
 		private ?array $dependencies,
 		private ?array $usedTraitDependencies,
 		private ?array $packageDependencies,
@@ -53,9 +50,6 @@ final class AnalyserResult
 		private int $workerCount = 0,
 	)
 	{
-		$this->collectedData = $collectedData instanceof LazyCollectedData
-			? $collectedData
-			: LazyCollectedData::fromArray($collectedData);
 	}
 
 	/**

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -142,8 +142,7 @@ final class AnalyserResult
 	}
 
 	/**
-	 * Decodes the collected data that came from the result cache. Prefer getLazyCollectedData()
-	 * unless the whole array is needed - after a cached run this is the biggest section of the cache.
+	 * Decodes what came from the result cache; getLazyCollectedData() passes it on undecoded.
 	 *
 	 * @return CollectorData
 	 */

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser;
 
+use PHPStan\Analyser\ResultCache\LazyCollectedData;
 use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 use function usort;
@@ -16,6 +17,8 @@ final class AnalyserResult
 	/** @var list<Error>|null */
 	private ?array $errors = null;
 
+	private LazyCollectedData $collectedData;
+
 	/**
 	 * @param list<Error> $unorderedErrors
 	 * @param list<Error> $filteredPhpErrors
@@ -23,7 +26,7 @@ final class AnalyserResult
 	 * @param list<Error> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param CollectorData $collectedData
+	 * @param CollectorData|LazyCollectedData $collectedData
 	 * @param list<InternalError> $internalErrors
 	 * @param array<string, array<string>>|null $dependencies
 	 * @param array<string, array<string>>|null $usedTraitDependencies
@@ -39,7 +42,7 @@ final class AnalyserResult
 		private array $linesToIgnore,
 		private array $unmatchedLineIgnores,
 		private array $internalErrors,
-		private array $collectedData,
+		array|LazyCollectedData $collectedData,
 		private ?array $dependencies,
 		private ?array $usedTraitDependencies,
 		private ?array $packageDependencies,
@@ -50,6 +53,9 @@ final class AnalyserResult
 		private int $workerCount = 0,
 	)
 	{
+		$this->collectedData = $collectedData instanceof LazyCollectedData
+			? $collectedData
+			: LazyCollectedData::fromArray($collectedData);
 	}
 
 	/**
@@ -142,9 +148,17 @@ final class AnalyserResult
 	}
 
 	/**
+	 * Decodes the collected data that came from the result cache. Prefer getLazyCollectedData()
+	 * unless the whole array is needed - after a cached run this is the biggest section of the cache.
+	 *
 	 * @return CollectorData
 	 */
 	public function getCollectedData(): array
+	{
+		return $this->collectedData->toArray();
+	}
+
+	public function getLazyCollectedData(): LazyCollectedData
 	{
 		return $this->collectedData;
 	}

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\AnalysedCodeException;
+use PHPStan\Analyser\ResultCache\LazyCollectedData;
 use PHPStan\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
 use PHPStan\BetterReflection\Reflection\Exception\CircularReference;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
@@ -49,10 +50,20 @@ final class AnalyserResultFinalizer
 			return $this->addUnmatchedIgnoredErrors($this->mergeFilteredPhpErrors($analyserResult), [], []);
 		}
 
+		try {
+			$collectedData = $analyserResult->getCollectedData();
+		} catch (Throwable $t) {
+			if ($debug) {
+				throw $t;
+			}
+
+			return $this->addUnmatchedIgnoredErrors($this->mergeFilteredPhpErrors($this->withUnreadableCollectedData($analyserResult, $t)), [], []);
+		}
+
 		$nodeType = CollectedDataNode::class;
-		// The only point where the cached collected data is decoded. It lives as long as this node,
-		// which the result below does not hold on to.
-		$node = new CollectedDataNode($analyserResult->getCollectedData(), $onlyFiles);
+		// Decoded here and released with this node; the result below carries the lazy form on.
+		$node = new CollectedDataNode($collectedData, $onlyFiles);
+		unset($collectedData);
 
 		$file = 'N/A';
 		$scope = $this->scopeFactory->create(ScopeContext::create($file));
@@ -160,6 +171,41 @@ final class AnalyserResultFinalizer
 			processedFiles: $analyserResult->getProcessedFiles(),
 			workerCount: $analyserResult->getWorkerCount(),
 		), $collectorErrors, $locallyIgnoredCollectorErrors);
+	}
+
+	/**
+	 * The result cache was discarded by the reader, so the run reports the failure and the collector
+	 * rules do not run; the next run analyses everything and starts a new cache.
+	 */
+	private function withUnreadableCollectedData(AnalyserResult $analyserResult, Throwable $t): AnalyserResult
+	{
+		$internalErrors = $analyserResult->getInternalErrors();
+		$internalErrors[] = new InternalError(
+			$t->getMessage(),
+			'reading the collected data from the result cache',
+			InternalError::prepareTrace($t),
+			$t->getTraceAsString(),
+			shouldReportBug: false,
+		);
+
+		return new AnalyserResult(
+			unorderedErrors: $analyserResult->getUnorderedErrors(),
+			filteredPhpErrors: $analyserResult->getFilteredPhpErrors(),
+			allPhpErrors: $analyserResult->getAllPhpErrors(),
+			locallyIgnoredErrors: $analyserResult->getLocallyIgnoredErrors(),
+			linesToIgnore: $analyserResult->getLinesToIgnore(),
+			unmatchedLineIgnores: $analyserResult->getUnmatchedLineIgnores(),
+			internalErrors: $internalErrors,
+			collectedData: LazyCollectedData::fromArray([]),
+			dependencies: $analyserResult->getDependencies(),
+			usedTraitDependencies: $analyserResult->getUsedTraitDependencies(),
+			packageDependencies: $analyserResult->getPackageDependencies(),
+			exportedNodes: $analyserResult->getExportedNodes(),
+			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
+			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
+			processedFiles: $analyserResult->getProcessedFiles(),
+			workerCount: $analyserResult->getWorkerCount(),
+		);
 	}
 
 	private function mergeFilteredPhpErrors(AnalyserResult $analyserResult): AnalyserResult

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -61,7 +61,7 @@ final class AnalyserResultFinalizer
 		}
 
 		$nodeType = CollectedDataNode::class;
-		// Decoded here and released with this node; the result below carries the lazy form on.
+		// Released with this node; the result below carries the lazy form on.
 		$node = new CollectedDataNode($collectedData, $onlyFiles);
 		unset($collectedData);
 

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -40,7 +40,7 @@ final class AnalyserResultFinalizer
 
 	public function finalize(AnalyserResult $analyserResult, bool $onlyFiles, bool $debug): FinalizerResult
 	{
-		if (count($analyserResult->getCollectedData()) === 0) {
+		if ($analyserResult->getLazyCollectedData()->isEmpty()) {
 			return $this->addUnmatchedIgnoredErrors($this->mergeFilteredPhpErrors($analyserResult), [], []);
 		}
 
@@ -50,6 +50,8 @@ final class AnalyserResultFinalizer
 		}
 
 		$nodeType = CollectedDataNode::class;
+		// The only point where the cached collected data is decoded. It lives as long as this node,
+		// which the result below does not hold on to.
 		$node = new CollectedDataNode($analyserResult->getCollectedData(), $onlyFiles);
 
 		$file = 'N/A';
@@ -148,7 +150,7 @@ final class AnalyserResultFinalizer
 			linesToIgnore: $allLinesToIgnore,
 			unmatchedLineIgnores: $allUnmatchedLineIgnores,
 			internalErrors: $internalErrors,
-			collectedData: $analyserResult->getCollectedData(),
+			collectedData: $analyserResult->getLazyCollectedData(),
 			dependencies: $analyserResult->getDependencies(),
 			usedTraitDependencies: $analyserResult->getUsedTraitDependencies(),
 			packageDependencies: $analyserResult->getPackageDependencies(),
@@ -170,7 +172,7 @@ final class AnalyserResultFinalizer
 			linesToIgnore: $analyserResult->getLinesToIgnore(),
 			unmatchedLineIgnores: $analyserResult->getUnmatchedLineIgnores(),
 			internalErrors: $analyserResult->getInternalErrors(),
-			collectedData: $analyserResult->getCollectedData(),
+			collectedData: $analyserResult->getLazyCollectedData(),
 			dependencies: $analyserResult->getDependencies(),
 			usedTraitDependencies: $analyserResult->getUsedTraitDependencies(),
 			packageDependencies: $analyserResult->getPackageDependencies(),
@@ -237,7 +239,7 @@ final class AnalyserResultFinalizer
 				linesToIgnore: $analyserResult->getLinesToIgnore(),
 				unmatchedLineIgnores: $analyserResult->getUnmatchedLineIgnores(),
 				internalErrors: $analyserResult->getInternalErrors(),
-				collectedData: $analyserResult->getCollectedData(),
+				collectedData: $analyserResult->getLazyCollectedData(),
 				dependencies: $analyserResult->getDependencies(),
 				usedTraitDependencies: $analyserResult->getUsedTraitDependencies(),
 				packageDependencies: $analyserResult->getPackageDependencies(),

--- a/src/Analyser/ResultCache/LazyCollectedData.php
+++ b/src/Analyser/ResultCache/LazyCollectedData.php
@@ -11,11 +11,10 @@ use function count;
 /**
  * Collected data that is read from the result cache file only when something asks for it.
  *
- * The cached part is an index of where each analysed file's entry sits in the cache file. The
- * fresh part is what this run's analysis produced and holds the actual values. toArray() reads the
- * cached entries and lays the fresh ones over them - the only point where the cached values exist
- * in memory. Until then, the main process holds a few bytes per file, which is what the forked
- * workers inherit; restore() used to hand them the whole decoded section.
+ * The cached part is an index of where each analysed file's entry sits in the cache file; the
+ * fresh part is what this run's analysis produced. toArray() reads the cached entries and lays the
+ * fresh ones over them. Until then, the main process holds a few bytes per file, which is all the
+ * forked workers inherit.
  *
  * @phpstan-import-type CollectorData from CollectedData
  */

--- a/src/Analyser/ResultCache/LazyCollectedData.php
+++ b/src/Analyser/ResultCache/LazyCollectedData.php
@@ -4,6 +4,8 @@ namespace PHPStan\Analyser\ResultCache;
 
 use Closure;
 use PHPStan\Collectors\CollectedData;
+use PHPStan\ShouldNotHappenException;
+use function array_key_exists;
 use function count;
 
 /**
@@ -41,11 +43,16 @@ final class LazyCollectedData
 		return new self([], null, $data);
 	}
 
+	/**
+	 * Editor mode analyses a temporary copy of a file and reports it under the file's own path. Only
+	 * the fresh side can hold the temporary path: ResultCacheManager::mergeCollectedData() takes both
+	 * paths out of the cached index, and a cached entry is verified against its file on reading, so it
+	 * could not be renamed anyway.
+	 */
 	public function withRenamedFile(string $from, string $to): self
 	{
-		$cachedIndex = [];
-		foreach ($this->cachedIndex as $file => $position) {
-			$cachedIndex[$file === $from ? $to : $file] = $position;
+		if (array_key_exists($from, $this->cachedIndex)) {
+			throw new ShouldNotHappenException();
 		}
 
 		$fresh = [];
@@ -53,7 +60,7 @@ final class LazyCollectedData
 			$fresh[$file === $from ? $to : $file] = $data;
 		}
 
-		return new self($cachedIndex, $this->cachedReader, $fresh);
+		return new self($this->cachedIndex, $this->cachedReader, $fresh);
 	}
 
 	/**

--- a/src/Analyser/ResultCache/LazyCollectedData.php
+++ b/src/Analyser/ResultCache/LazyCollectedData.php
@@ -24,12 +24,12 @@ final class LazyCollectedData
 
 	/**
 	 * @param array<string, array{int, int}> $cachedIndex analysed file => [offset, length] of its entry in the cache file
-	 * @param (Closure(array<string, array{int, int}>): CollectorData)|null $cachedReader
+	 * @param Closure(array<string, array{int, int}>): CollectorData $cachedReader
 	 * @param CollectorData $fresh
 	 */
 	public function __construct(
 		private array $cachedIndex,
-		private ?Closure $cachedReader,
+		private Closure $cachedReader,
 		private array $fresh,
 	)
 	{
@@ -40,7 +40,7 @@ final class LazyCollectedData
 	 */
 	public static function fromArray(array $data): self
 	{
-		return new self([], null, $data);
+		return new self([], static fn (): array => [], $data);
 	}
 
 	/**
@@ -93,7 +93,7 @@ final class LazyCollectedData
 	 */
 	public function toArray(): array
 	{
-		if (count($this->cachedIndex) === 0 || $this->cachedReader === null) {
+		if (count($this->cachedIndex) === 0) {
 			return $this->fresh;
 		}
 

--- a/src/Analyser/ResultCache/LazyCollectedData.php
+++ b/src/Analyser/ResultCache/LazyCollectedData.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ResultCache;
+
+use Closure;
+use PHPStan\Collectors\CollectedData;
+use function count;
+
+/**
+ * Collected data that is read from the result cache file only when something asks for it.
+ *
+ * The cached part is an index of where each analysed file's entry sits in the cache file. The
+ * fresh part is what this run's analysis produced and holds the actual values. toArray() reads the
+ * cached entries and lays the fresh ones over them - the only point where the cached values exist
+ * in memory. Until then, the main process holds a few bytes per file, which is what the forked
+ * workers inherit; restore() used to hand them the whole decoded section.
+ *
+ * @phpstan-import-type CollectorData from CollectedData
+ */
+final class LazyCollectedData
+{
+
+	/**
+	 * @param array<string, array{int, int}> $cachedIndex analysed file => [offset, length] of its entry in the cache file
+	 * @param (Closure(array<string, array{int, int}>): CollectorData)|null $cachedReader
+	 * @param CollectorData $fresh
+	 */
+	private function __construct(
+		private array $cachedIndex,
+		private ?Closure $cachedReader,
+		private array $fresh,
+	)
+	{
+	}
+
+	/**
+	 * @param CollectorData $data
+	 */
+	public static function fromArray(array $data): self
+	{
+		return new self([], null, $data);
+	}
+
+	/**
+	 * @param array<string, array{int, int}> $cachedIndex
+	 * @param Closure(array<string, array{int, int}>): CollectorData $cachedReader
+	 * @param CollectorData $fresh
+	 */
+	public static function fromCache(array $cachedIndex, Closure $cachedReader, array $fresh = []): self
+	{
+		return new self($cachedIndex, $cachedReader, $fresh);
+	}
+
+	/**
+	 * @param array<string, array{int, int}> $cachedIndex
+	 * @param CollectorData $fresh
+	 */
+	public function with(array $cachedIndex, array $fresh): self
+	{
+		return new self($cachedIndex, $this->cachedReader, $fresh);
+	}
+
+	public function withRenamedFile(string $from, string $to): self
+	{
+		$cachedIndex = [];
+		foreach ($this->cachedIndex as $file => $position) {
+			$cachedIndex[$file === $from ? $to : $file] = $position;
+		}
+
+		$fresh = [];
+		foreach ($this->fresh as $file => $data) {
+			$fresh[$file === $from ? $to : $file] = $data;
+		}
+
+		return new self($cachedIndex, $this->cachedReader, $fresh);
+	}
+
+	/**
+	 * @return array<string, array{int, int}>
+	 */
+	public function getCachedIndex(): array
+	{
+		return $this->cachedIndex;
+	}
+
+	/**
+	 * @return CollectorData
+	 */
+	public function getFresh(): array
+	{
+		return $this->fresh;
+	}
+
+	public function isEmpty(): bool
+	{
+		return count($this->cachedIndex) === 0 && count($this->fresh) === 0;
+	}
+
+	/**
+	 * Cached entries first, in the order of the index, then the fresh ones; a fresh entry replaces
+	 * a cached one for the same file. Reads the cache file every time: nothing is kept, so the
+	 * caller decides how long the decoded data lives.
+	 *
+	 * @return CollectorData
+	 */
+	public function toArray(): array
+	{
+		if (count($this->cachedIndex) === 0 || $this->cachedReader === null) {
+			return $this->fresh;
+		}
+
+		$result = ($this->cachedReader)($this->cachedIndex);
+		foreach ($this->fresh as $file => $data) {
+			$result[$file] = $data;
+		}
+
+		return $result;
+	}
+
+}

--- a/src/Analyser/ResultCache/LazyCollectedData.php
+++ b/src/Analyser/ResultCache/LazyCollectedData.php
@@ -25,7 +25,7 @@ final class LazyCollectedData
 	 * @param (Closure(array<string, array{int, int}>): CollectorData)|null $cachedReader
 	 * @param CollectorData $fresh
 	 */
-	private function __construct(
+	public function __construct(
 		private array $cachedIndex,
 		private ?Closure $cachedReader,
 		private array $fresh,
@@ -39,25 +39,6 @@ final class LazyCollectedData
 	public static function fromArray(array $data): self
 	{
 		return new self([], null, $data);
-	}
-
-	/**
-	 * @param array<string, array{int, int}> $cachedIndex
-	 * @param Closure(array<string, array{int, int}>): CollectorData $cachedReader
-	 * @param CollectorData $fresh
-	 */
-	public static function fromCache(array $cachedIndex, Closure $cachedReader, array $fresh = []): self
-	{
-		return new self($cachedIndex, $cachedReader, $fresh);
-	}
-
-	/**
-	 * @param array<string, array{int, int}> $cachedIndex
-	 * @param CollectorData $fresh
-	 */
-	public function with(array $cachedIndex, array $fresh): self
-	{
-		return new self($cachedIndex, $this->cachedReader, $fresh);
 	}
 
 	public function withRenamedFile(string $from, string $to): self
@@ -97,9 +78,9 @@ final class LazyCollectedData
 	}
 
 	/**
-	 * Cached entries first, in the order of the index, then the fresh ones; a fresh entry replaces
-	 * a cached one for the same file. Reads the cache file every time: nothing is kept, so the
-	 * caller decides how long the decoded data lives.
+	 * Cached entries first, then the fresh ones; a fresh entry replaces a cached one for the same
+	 * file. Reads the cache file every time: nothing is kept, so the caller decides how long the
+	 * decoded data lives.
 	 *
 	 * @return CollectorData
 	 */

--- a/src/Analyser/ResultCache/ResultCache.php
+++ b/src/Analyser/ResultCache/ResultCache.php
@@ -4,12 +4,10 @@ namespace PHPStan\Analyser\ResultCache;
 
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\FileAnalyserResult;
-use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 
 /**
  * @phpstan-import-type LinesToIgnore from FileAnalyserResult
- * @phpstan-import-type CollectorData from CollectedData
  */
 final class ResultCache
 {
@@ -21,7 +19,6 @@ final class ResultCache
 	 * @param array<string, list<Error>> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param CollectorData $collectedData
 	 * @param array<string, array<string>> $dependencies
 	 * @param array<string, array<string>> $usedTraitDependencies
 	 * @param array<string, array<string>> $packageDependencies
@@ -39,7 +36,7 @@ final class ResultCache
 		private array $locallyIgnoredErrors,
 		private array $linesToIgnore,
 		private array $unmatchedLineIgnores,
-		private array $collectedData,
+		private LazyCollectedData $collectedData,
 		private array $dependencies,
 		private array $usedTraitDependencies,
 		private array $packageDependencies,
@@ -117,10 +114,7 @@ final class ResultCache
 		return $this->unmatchedLineIgnores;
 	}
 
-	/**
-	 * @return CollectorData
-	 */
-	public function getCollectedData(): array
+	public function getCollectedData(): LazyCollectedData
 	{
 		return $this->collectedData;
 	}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -1763,7 +1763,7 @@ final class ResultCacheManager
 	 * entry over to the next cache file unchanged.
 	 *
 	 * @param resource $handle
-	 * @return array<int|string, array{int, int}>
+	 * @return array<string, array{int, int}>
 	 */
 	private function indexEntryFrames($handle, int $count, int $fileSize, string $name): array
 	{

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -148,17 +148,6 @@ final class ResultCacheManager
 	 */
 	private const LAZY_SECTIONS = ['errors', 'locallyIgnoredErrors', 'exportedNodes'];
 
-	/**
-	 * The section that is never decoded as a whole. Collected data is by far the largest part of the
-	 * cache on a project using collectors (a dead code detector stores every member usage there), and
-	 * only the rules that run on CollectedDataNode need it - after the analysis, in the main process.
-	 * readCacheFile() records where each file's entry is and restore() hands that index out as
-	 * LazyCollectedData; save() copies the entries that stay valid byte for byte from the old file.
-	 * Nothing decodes the section before AnalyserResultFinalizer asks for it, so the forked workers
-	 * never inherit it.
-	 */
-	private const INDEXED_SECTION = 'collectedData';
-
 	/** @var array<string, string> */
 	private array $fileHashes = [];
 
@@ -366,15 +355,12 @@ final class ResultCacheManager
 		$data['unmatchedLineIgnores'] = $transformer->absolutizeCompoundKeyed($data['unmatchedLineIgnores']);
 		$data['dependencies'] = $transformer->absolutizeDependencies($data['dependencies']);
 		$data['packageDependencies'] = $transformer->absolutizeFileKeyed($data['packageDependencies'] ?? []);
+		$data['collectedDataIndex'] = $transformer->absolutizeFileKeyed($data['collectedDataIndex']);
 
 		$errorsCallback = $data['errorsCallback'];
 		$data['errorsCallback'] = static fn (): array => $transformer->absolutizeErrors($errorsCallback());
 		$locallyIgnoredErrorsCallback = $data['locallyIgnoredErrorsCallback'];
 		$data['locallyIgnoredErrorsCallback'] = static fn (): array => $transformer->absolutizeErrors($locallyIgnoredErrorsCallback());
-		$collectedDataIndex = [];
-		foreach ($data['collectedDataIndex'] as $relativeFile => $position) {
-			$collectedDataIndex[$transformer->absolutizePath($relativeFile)] = $position;
-		}
 		$exportedNodesCallback = $data['exportedNodesCallback'];
 		$data['exportedNodesCallback'] = static fn (): array => $transformer->absolutizeFileKeyed($exportedNodesCallback());
 
@@ -619,6 +605,7 @@ final class ResultCacheManager
 		$invertedUsedTraitDependenciesToReturn = [];
 		$linesToIgnore = $data['linesToIgnore'];
 		$unmatchedLineIgnores = $data['unmatchedLineIgnores'];
+		$collectedDataIndex = $data['collectedDataIndex'];
 
 		try {
 			// The cached objects are reconstructed here, and a cache written by a PHPStan whose classes
@@ -884,7 +871,7 @@ final class ResultCacheManager
 			locallyIgnoredErrors: $filteredLocallyIgnoredErrors,
 			linesToIgnore: $filteredLinesToIgnore,
 			unmatchedLineIgnores: $filteredUnmatchedLineIgnores,
-			collectedData: LazyCollectedData::fromCache($filteredCollectedDataIndex, $this->createCollectedDataReader($cacheFilePath)),
+			collectedData: new LazyCollectedData($filteredCollectedDataIndex, $this->createCollectedDataReader(), []),
 			dependencies: $invertedDependenciesToReturn,
 			usedTraitDependencies: $invertedUsedTraitDependenciesToReturn,
 			packageDependencies: $packageDependencies,
@@ -1137,11 +1124,9 @@ final class ResultCacheManager
 				}
 			}
 			$savedCollectedData = $doSave($errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedData, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles);
-			if ($savedCollectedData !== null) {
-				// The old file is gone after the rename, so the entries are read back from the new one.
-				$collectedData = $savedCollectedData;
-				$saved = true;
-			}
+			$saved = $savedCollectedData !== null;
+			// The old file is gone after the rename, so the cached entries are read back from the new one.
+			$collectedData = $savedCollectedData ?? $collectedData;
 		}
 
 		$flatErrors = [];
@@ -1240,7 +1225,7 @@ final class ResultCacheManager
 			$mergedFresh[$file] = $freshCollectedDataByFile[$file];
 		}
 
-		return $resultCache->getCollectedData()->with($cachedIndex, $mergedFresh);
+		return new LazyCollectedData($cachedIndex, $this->createCollectedDataReader(), $mergedFresh);
 	}
 
 	/**
@@ -1569,7 +1554,7 @@ final class ResultCacheManager
 			}
 		}
 
-		return LazyCollectedData::fromCache($savedCollectedDataIndex, $this->createCollectedDataReader($file), $collectedData->getFresh());
+		return new LazyCollectedData($savedCollectedDataIndex, $this->createCollectedDataReader(), $collectedData->getFresh());
 	}
 
 	/**
@@ -1578,60 +1563,46 @@ final class ResultCacheManager
 	 * every other section is, so the file does not depend on which files were re-analysed.
 	 *
 	 * @param resource $handle
-	 * @return array<string, array{int, int}> The position of every copied entry in the new file
+	 * @return array<string, array{int, int}> Where every copied entry is in the new file
 	 */
 	private function writeCollectedDataFrame($handle, string $file, LazyCollectedData $collectedData): array
 	{
 		$transformer = $this->getPathTransformer();
 		$cachedIndex = $collectedData->getCachedIndex();
 		$fresh = $collectedData->getFresh();
-		foreach ($fresh as & $collectedDataPerFile) {
-			ksort($collectedDataPerFile);
-		}
-		unset($collectedDataPerFile);
-
 		$files = array_keys($cachedIndex + $fresh);
 		sort($files);
-
-		$this->writeToHandle($handle, $file, self::INDEXED_SECTION . '* ' . count($files) . "\n");
+		$this->writeToHandle($handle, $file, 'collectedData* ' . count($files) . "\n");
 
 		$sourceHandle = null;
 		$savedIndex = [];
-		try {
-			foreach ($files as $analysedFile) {
-				if (array_key_exists($analysedFile, $fresh)) {
-					foreach ($transformer->relativizeCollectedData([$analysedFile => $fresh[$analysedFile]]) as $relativeFile => $data) {
-						$this->writeEntryFrame($handle, $file, $relativeFile, $data);
-					}
-
-					continue;
+		foreach ($files as $analysedFile) {
+			if (array_key_exists($analysedFile, $fresh)) {
+				$collectedDataPerFile = $fresh[$analysedFile];
+				ksort($collectedDataPerFile);
+				foreach ($transformer->relativizeCollectedData([$analysedFile => $collectedDataPerFile]) as $relativeFile => $data) {
+					$this->writeEntryFrame($handle, $file, $relativeFile, $data);
 				}
 
-				[$offset, $length] = $cachedIndex[$analysedFile];
-				if ($sourceHandle === null) {
-					$openedHandle = @fopen($this->cacheFilePath, 'r');
-					if ($openedHandle === false) {
-						throw new RuntimeException(sprintf('Cannot open the result cache file %s to copy the collected data from.', $this->cacheFilePath));
-					}
-					$sourceHandle = $openedHandle;
-				}
-
-				$position = ftell($handle);
-				if ($position === false) {
-					throw new CouldNotWriteFileException($file, 'cannot tell the position in the file');
-				}
-
-				$copied = stream_copy_to_stream($sourceHandle, $handle, $length, $offset);
-				if ($copied !== $length) {
-					throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $this->cacheFilePath, $analysedFile));
-				}
-
-				$savedIndex[$analysedFile] = [$position, $length];
+				continue;
 			}
-		} finally {
-			if ($sourceHandle !== null) {
-				fclose($sourceHandle);
+
+			$sourceHandle ??= $this->openCacheFile();
+			$position = ftell($handle);
+			if ($position === false) {
+				throw new CouldNotWriteFileException($file, 'cannot tell the position in the file');
 			}
+
+			[$offset, $length] = $cachedIndex[$analysedFile];
+			if (stream_copy_to_stream($sourceHandle, $handle, $length, $offset) !== $length) {
+				throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $this->cacheFilePath, $analysedFile));
+			}
+
+			$savedIndex[$analysedFile] = [$position, $length];
+		}
+
+		if ($sourceHandle !== null) {
+			fclose($sourceHandle);
 		}
 
 		return $savedIndex;
@@ -1717,7 +1688,7 @@ final class ResultCacheManager
 
 			$data = [];
 			$lazy = array_fill_keys(self::LAZY_SECTIONS, false);
-			$data[self::INDEXED_SECTION . 'Index'] = [];
+			$data['collectedDataIndex'] = [];
 			while (($header = fgets($handle)) !== false) {
 				$header = rtrim($header, "\n");
 				if ($header === '') {
@@ -1738,8 +1709,12 @@ final class ResultCacheManager
 
 				$name = substr($name, 0, -1);
 				$count = (int) $size;
-				if ($name === self::INDEXED_SECTION) {
-					$data[$name . 'Index'] = $this->indexEntryFrames($handle, $count, $fileSize, $name);
+				// Never decoded as a whole: it is by far the largest section on a project using collectors,
+				// and only the rules on CollectedDataNode need it - after the analysis, in the main process.
+				// restore() hands the index out as LazyCollectedData, which reads the entries on demand,
+				// and save() copies the ones that stay valid from this file byte for byte.
+				if ($name === 'collectedData') {
+					$data['collectedDataIndex'] = $this->indexEntryFrames($handle, $count, $fileSize, $name);
 
 					continue;
 				}
@@ -1792,19 +1767,14 @@ final class ResultCacheManager
 	 */
 	private function indexEntryFrames($handle, int $count, int $fileSize, string $name): array
 	{
+		$offset = ftell($handle);
+		if ($offset === false) {
+			throw new RuntimeException(sprintf('Cannot tell the position of section "%s".', $name));
+		}
+
 		$index = [];
 		for ($i = 0; $i < $count; $i++) {
-			$offset = ftell($handle);
-			if ($offset === false) {
-				throw new RuntimeException(sprintf('Cannot tell the position of entry %d of section "%s".', $i, $name));
-			}
-
-			$entry = sprintf('entry %d of %d in section "%s"', $i, $count, $name);
-			[$keyLength, $valueLength] = $this->readEntryHeader($handle, $entry);
-			$key = $this->readFrame($handle, $keyLength);
-			if (!is_int($key) && !is_string($key)) {
-				throw new RuntimeException(sprintf('The key of %s is not an array key.', $entry));
-			}
+			[$key, $valueLength] = $this->readEntryKey($handle);
 
 			// fseek() past the end of a file succeeds, so the position is what catches a section the
 			// file does not actually hold.
@@ -1818,90 +1788,97 @@ final class ResultCacheManager
 			}
 
 			$index[$key] = [$offset, $position - $offset];
+			$offset = $position;
 		}
 
 		return $index;
 	}
 
 	/**
+	 * The header and key of an entry frame, leaving the handle at its value.
+	 *
 	 * @param resource $handle
-	 * @param string $entry What the entry is, for the error message
-	 * @return array{int, int} The lengths of the key and value payloads
+	 * @return array{int|string, int} The key and the length of the value payload
 	 */
-	private function readEntryHeader($handle, string $entry): array
+	private function readEntryKey($handle): array
 	{
 		$header = fgets($handle);
 		if ($header === false) {
-			throw new RuntimeException(sprintf('The cache file ended before %s.', $entry));
+			throw new RuntimeException('The cache file ended inside an array section.');
 		}
 
-		$parts = explode(' ', rtrim($header, "\n"), 2);
-		if (count($parts) !== 2) {
-			throw new RuntimeException(sprintf('Malformed header "%s" of %s.', rtrim($header, "\n"), $entry));
+		$lengths = explode(' ', rtrim($header, "\n"));
+		if (count($lengths) !== 2 || (int) $lengths[1] <= 0) {
+			throw new RuntimeException(sprintf('Malformed entry header "%s".', rtrim($header, "\n")));
 		}
 
-		[$keyLength, $valueLength] = [(int) $parts[0], (int) $parts[1]];
-		if ($keyLength <= 0 || $valueLength <= 0) {
-			throw new RuntimeException(sprintf('A frame length of %s is not positive.', $entry));
+		$key = $this->readFrame($handle, (int) $lengths[0]);
+		if (!is_int($key) && !is_string($key)) {
+			throw new RuntimeException('An entry key is not an array key.');
 		}
 
-		return [$keyLength, $valueLength];
+		return [$key, (int) $lengths[1]];
 	}
 
 	/**
-	 * Reads the collected data entries the index points at, in the order of the index. The file is
-	 * opened for the duration of the call only: an open handle would be inherited by the forked
-	 * workers, and a rename over the file (the next save) must not find it open on Windows.
-	 *
 	 * @return Closure(array<string, array{int, int}>): CollectorData
 	 */
-	private function createCollectedDataReader(string $cacheFilePath): Closure
+	private function createCollectedDataReader(): Closure
 	{
-		return function (array $index) use ($cacheFilePath): array {
-			$handle = @fopen($cacheFilePath, 'r');
-			if ($handle === false) {
-				throw new RuntimeException(sprintf('Cannot open the result cache file %s to read the collected data from.', $cacheFilePath));
+		return fn (array $index): array => $this->readCollectedData($index);
+	}
+
+	/**
+	 * Reads the collected data entries the index points at. The file is opened for the duration of
+	 * the call only: an open handle would be inherited by the forked workers, and a rename over the
+	 * file (the next save) must not find it open on Windows.
+	 *
+	 * @param array<string, array{int, int}> $index
+	 * @return CollectorData
+	 */
+	private function readCollectedData(array $index): array
+	{
+		// Read front to back: the entries are stored in the order of their paths and the index
+		// usually is too, but a seek backwards on a file this size is what makes reading it slow.
+		uasort($index, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
+
+		$transformer = $this->getPathTransformer();
+		$handle = $this->openCacheFile();
+		$data = [];
+		foreach ($index as $file => [$offset]) {
+			if (fseek($handle, $offset) !== 0) {
+				throw new RuntimeException(sprintf('Cannot seek to the collected data of %s.', $file));
 			}
 
-			$transformer = $this->getPathTransformer();
-
-			// Read front to back: the entries are stored in the order of their paths and the index
-			// usually is too, but a seek backwards on a file this size is what makes reading it slow.
-			$byOffset = $index;
-			uasort($byOffset, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
-
-			$relativeData = [];
-			try {
-				foreach ($byOffset as $file => [$offset, $length]) {
-					if (fseek($handle, $offset) !== 0) {
-						throw new RuntimeException(sprintf('Cannot seek to the collected data of %s.', $file));
-					}
-
-					[$keyLength, $valueLength] = $this->readEntryHeader($handle, sprintf('the collected data of %s', $file));
-					$key = $this->readFrame($handle, $keyLength);
-					if (!is_string($key) || $transformer->absolutizePath($key) !== $file) {
-						throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $cacheFilePath, $file));
-					}
-
-					$value = $this->readFrame($handle, $valueLength);
-					if (!is_array($value)) {
-						throw new RuntimeException(sprintf('The collected data of %s is not an array.', $file));
-					}
-
-					$relativeData[$key] = $value;
-				}
-			} finally {
-				fclose($handle);
+			[$key, $valueLength] = $this->readEntryKey($handle);
+			if (!is_string($key) || $transformer->absolutizePath($key) !== $file) {
+				throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $this->cacheFilePath, $file));
 			}
 
-			$absoluteData = $transformer->absolutizeCollectedData($relativeData);
-			$result = [];
-			foreach (array_keys($index) as $file) {
-				$result[$file] = $absoluteData[$file];
+			$value = $this->readFrame($handle, $valueLength);
+			if (!is_array($value)) {
+				throw new RuntimeException(sprintf('The collected data of %s is not an array.', $file));
 			}
 
-			return $result;
-		};
+			$data[$key] = $value;
+		}
+
+		fclose($handle);
+
+		return $transformer->absolutizeCollectedData($data);
+	}
+
+	/**
+	 * @return resource
+	 */
+	private function openCacheFile()
+	{
+		$handle = @fopen($this->cacheFilePath, 'r');
+		if ($handle === false) {
+			throw new RuntimeException(sprintf('Cannot open the result cache file %s.', $this->cacheFilePath));
+		}
+
+		return $handle;
 	}
 
 	/**
@@ -1925,13 +1902,7 @@ final class ResultCacheManager
 	{
 		$entries = [];
 		for ($i = 0; $i < $count; $i++) {
-			$entry = sprintf('entry %d of %d', $i, $count);
-			[$keyLength, $valueLength] = $this->readEntryHeader($handle, $entry);
-			$key = $this->readFrame($handle, $keyLength);
-			if (!is_int($key) && !is_string($key)) {
-				throw new RuntimeException(sprintf('The key of %s is not an array key.', $entry));
-			}
-
+			[$key, $valueLength] = $this->readEntryKey($handle);
 			$entries[$key] = $this->readFrame($handle, $valueLength);
 		}
 

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -1065,7 +1065,18 @@ final class ResultCacheManager
 				}
 			}
 
-			$savedCollectedData = $this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedData, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles, $resultCache->getCurrentFileHashes(), $meta);
+			try {
+				$savedCollectedData = $this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedData, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles, $resultCache->getCurrentFileHashes(), $meta);
+			} catch (RuntimeException $e) {
+				// Only the copy of the cached collected data throws this: the file it was restored from
+				// no longer holds the entries where the index says, so another run sharing the tmpDir
+				// replaced it. Its cache stays; the rules on CollectedDataNode discard it when they find
+				// the same, and the next run analyses everything.
+				if ($output->isVeryVerbose()) {
+					$output->writeLineFormatted(sprintf('Result cache was not saved because the previous cache file changed during the analysis: %s', $e->getMessage()));
+				}
+				return null;
+			}
 
 			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache is saved.');
@@ -1593,7 +1604,11 @@ final class ResultCacheManager
 				throw new CouldNotWriteFileException($file, 'cannot tell the position in the file');
 			}
 
+			// Nothing holds the file open between restore() and here, so another run sharing the tmpDir
+			// may have renamed a different cache over it. The key at the offset says whether the bytes
+			// about to be copied are still the entry the index was built for.
 			[$offset, $length] = $cachedIndex[$analysedFile];
+			$this->seekToEntry($sourceHandle, $offset, $analysedFile);
 			if (stream_copy_to_stream($sourceHandle, $handle, $length, $offset) !== $length) {
 				throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $this->cacheFilePath, $analysedFile));
 			}
@@ -1886,15 +1901,7 @@ final class ResultCacheManager
 		$data = [];
 		try {
 			foreach ($index as $file => [$offset]) {
-				if (fseek($handle, $offset) !== 0) {
-					throw new RuntimeException(sprintf('Cannot seek to the collected data of %s.', $file));
-				}
-
-				[$key, $valueLength] = $this->readEntryKey($handle);
-				if (!is_string($key) || $transformer->absolutizePath($key) !== $file) {
-					throw new RuntimeException(sprintf('The entry of %s is not where it was.', $file));
-				}
-
+				[$key, $valueLength] = $this->seekToEntry($handle, $offset, $file);
 				$value = $this->readFrame($handle, $valueLength);
 				if (!is_array($value)) {
 					throw new RuntimeException(sprintf('The collected data of %s is not an array.', $file));
@@ -1916,6 +1923,27 @@ final class ResultCacheManager
 		fclose($handle);
 
 		return $transformer->absolutizeCollectedData($data);
+	}
+
+	/**
+	 * Moves to an entry of the collected data section and past its key, refusing an entry that is
+	 * not the one the index was built for.
+	 *
+	 * @param resource $handle
+	 * @return array{string, int} The key as stored and the length of the value payload
+	 */
+	private function seekToEntry($handle, int $offset, string $file): array
+	{
+		if (fseek($handle, $offset) !== 0) {
+			throw new RuntimeException(sprintf('Cannot seek to the collected data of %s.', $file));
+		}
+
+		[$key, $valueLength] = $this->readEntryKey($handle);
+		if (!is_string($key) || $this->getPathTransformer()->absolutizePath($key) !== $file) {
+			throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $this->cacheFilePath, $file));
+		}
+
+		return [$key, $valueLength];
 	}
 
 	/**

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -1884,22 +1884,33 @@ final class ResultCacheManager
 		$transformer = $this->getPathTransformer();
 		$handle = $this->openCacheFile();
 		$data = [];
-		foreach ($index as $file => [$offset]) {
-			if (fseek($handle, $offset) !== 0) {
-				throw new RuntimeException(sprintf('Cannot seek to the collected data of %s.', $file));
-			}
+		try {
+			foreach ($index as $file => [$offset]) {
+				if (fseek($handle, $offset) !== 0) {
+					throw new RuntimeException(sprintf('Cannot seek to the collected data of %s.', $file));
+				}
 
-			[$key, $valueLength] = $this->readEntryKey($handle);
-			if (!is_string($key) || $transformer->absolutizePath($key) !== $file) {
-				throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $this->cacheFilePath, $file));
-			}
+				[$key, $valueLength] = $this->readEntryKey($handle);
+				if (!is_string($key) || $transformer->absolutizePath($key) !== $file) {
+					throw new RuntimeException(sprintf('The entry of %s is not where it was.', $file));
+				}
 
-			$value = $this->readFrame($handle, $valueLength);
-			if (!is_array($value)) {
-				throw new RuntimeException(sprintf('The collected data of %s is not an array.', $file));
-			}
+				$value = $this->readFrame($handle, $valueLength);
+				if (!is_array($value)) {
+					throw new RuntimeException(sprintf('The collected data of %s is not an array.', $file));
+				}
 
-			$data[$key] = $value;
+				$data[$key] = $value;
+			}
+		} catch (Throwable $e) {
+			// The walk in readCacheFile() validated the framing, not the values, so this is the first
+			// point where a damaged value shows, and save() has already carried it over into the new
+			// file. Left in place it would fail every run from now on; restore() discards a cache it
+			// cannot read back the same way.
+			fclose($handle);
+			@unlink($this->cacheFilePath);
+
+			throw new RuntimeException(sprintf('The result cache file %s could not be read back and was discarded, so the next run analyses everything: %s', $this->cacheFilePath, $e->getMessage()), previous: $e);
 		}
 
 		fclose($handle);

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser\ResultCache;
 
+use Closure;
 use Nette\Neon\Neon;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
@@ -61,6 +62,8 @@ use function in_array;
 use function is_array;
 use function is_dir;
 use function is_file;
+use function is_int;
+use function is_string;
 use function ksort;
 use function microtime;
 use function rename;
@@ -70,9 +73,11 @@ use function sort;
 use function sprintf;
 use function str_ends_with;
 use function str_starts_with;
+use function stream_copy_to_stream;
 use function strlen;
 use function substr;
 use function time;
+use function uasort;
 use function uniqid;
 use function unlink;
 use function unserialize;
@@ -97,7 +102,7 @@ final class ResultCacheManager
 	 */
 	private const EXTENSIONS_NOT_INVALIDATING_CACHE = ['xdebug', 'blackfire', 'phpstan_turbo'];
 
-	private const CACHE_VERSION = 'v18-missingFileDependencies';
+	private const CACHE_VERSION = 'v19-lazyCollectedData';
 
 	/**
 	 * The recorded hash of a dependency that does not exist. A rule can depend on a path rather than on
@@ -136,12 +141,23 @@ final class ResultCacheManager
 	 * remember where it starts and walk past its entries.
 	 *
 	 * Nothing closure-shaped is written: a frame holds the plain serialized payload
-	 * (`a:1:{s:9:"file.php";a:1:{i:0;O:22:"PHPStan\Analyser\Error"...`), and readCacheFile() builds
-	 * the callback in PHP around the open handle and that offset, which is only the shape restore()
-	 * expects. The var_export format writes a real `static function (): array` into the file instead,
-	 * and PHP still compiles the array literal inside it.
+	 * (`s:8:"file.php";` followed by `a:1:{i:0;O:22:"PHPStan\Analyser\Error"...`), and
+	 * readCacheFile() builds the callback in PHP around the open handle and that offset, which is only
+	 * the shape restore() expects. The var_export format writes a real `static function (): array`
+	 * into the file instead, and PHP still compiles the array literal inside it.
 	 */
-	private const LAZY_SECTIONS = ['errors', 'locallyIgnoredErrors', 'collectedData', 'exportedNodes'];
+	private const LAZY_SECTIONS = ['errors', 'locallyIgnoredErrors', 'exportedNodes'];
+
+	/**
+	 * The section that is never decoded as a whole. Collected data is by far the largest part of the
+	 * cache on a project using collectors (a dead code detector stores every member usage there), and
+	 * only the rules that run on CollectedDataNode need it - after the analysis, in the main process.
+	 * readCacheFile() records where each file's entry is and restore() hands that index out as
+	 * LazyCollectedData; save() copies the entries that stay valid byte for byte from the old file.
+	 * Nothing decodes the section before AnalyserResultFinalizer asks for it, so the forked workers
+	 * never inherit it.
+	 */
+	private const INDEXED_SECTION = 'collectedData';
 
 	/** @var array<string, string> */
 	private array $fileHashes = [];
@@ -252,7 +268,7 @@ final class ResultCacheManager
 			locallyIgnoredErrors: [],
 			linesToIgnore: [],
 			unmatchedLineIgnores: [],
-			collectedData: [],
+			collectedData: LazyCollectedData::fromArray([]),
 			dependencies: [],
 			usedTraitDependencies: [],
 			packageDependencies: [],
@@ -355,8 +371,10 @@ final class ResultCacheManager
 		$data['errorsCallback'] = static fn (): array => $transformer->absolutizeErrors($errorsCallback());
 		$locallyIgnoredErrorsCallback = $data['locallyIgnoredErrorsCallback'];
 		$data['locallyIgnoredErrorsCallback'] = static fn (): array => $transformer->absolutizeErrors($locallyIgnoredErrorsCallback());
-		$collectedDataCallback = $data['collectedDataCallback'];
-		$data['collectedDataCallback'] = static fn (): array => $transformer->absolutizeCollectedData($collectedDataCallback());
+		$collectedDataIndex = [];
+		foreach ($data['collectedDataIndex'] as $relativeFile => $position) {
+			$collectedDataIndex[$transformer->absolutizePath($relativeFile)] = $position;
+		}
 		$exportedNodesCallback = $data['exportedNodesCallback'];
 		$data['exportedNodesCallback'] = static fn (): array => $transformer->absolutizeFileKeyed($exportedNodesCallback());
 
@@ -611,7 +629,6 @@ final class ResultCacheManager
 			// that cannot be reconstructed is discarded like any other unusable one.
 			$errors = $data['errorsCallback']();
 			$locallyIgnoredErrors = $data['locallyIgnoredErrorsCallback']();
-			$collectedData = $data['collectedDataCallback']();
 			$exportedNodes = $data['exportedNodesCallback']();
 		} catch (Throwable $e) {
 			@unlink($cacheFilePath);
@@ -628,7 +645,7 @@ final class ResultCacheManager
 		$filteredLocallyIgnoredErrors = [];
 		$filteredLinesToIgnore = [];
 		$filteredUnmatchedLineIgnores = [];
-		$filteredCollectedData = [];
+		$filteredCollectedDataIndex = [];
 		$filteredExportedNodes = [];
 		$newFileAppeared = false;
 
@@ -653,8 +670,8 @@ final class ResultCacheManager
 			if (array_key_exists($analysedFile, $unmatchedLineIgnores)) {
 				$filteredUnmatchedLineIgnores[$analysedFile] = $unmatchedLineIgnores[$analysedFile];
 			}
-			if (array_key_exists($analysedFile, $collectedData)) {
-				$filteredCollectedData[$analysedFile] = $collectedData[$analysedFile];
+			if (array_key_exists($analysedFile, $collectedDataIndex)) {
+				$filteredCollectedDataIndex[$analysedFile] = $collectedDataIndex[$analysedFile];
 			}
 			if (array_key_exists($analysedFile, $exportedNodes)) {
 				$filteredExportedNodes[$analysedFile] = $exportedNodes[$analysedFile];
@@ -867,7 +884,7 @@ final class ResultCacheManager
 			locallyIgnoredErrors: $filteredLocallyIgnoredErrors,
 			linesToIgnore: $filteredLinesToIgnore,
 			unmatchedLineIgnores: $filteredUnmatchedLineIgnores,
-			collectedData: $filteredCollectedData,
+			collectedData: LazyCollectedData::fromCache($filteredCollectedDataIndex, $this->createCollectedDataReader($cacheFilePath)),
 			dependencies: $invertedDependenciesToReturn,
 			usedTraitDependencies: $invertedUsedTraitDependenciesToReturn,
 			packageDependencies: $packageDependencies,
@@ -997,7 +1014,7 @@ final class ResultCacheManager
 			$freshLocallyIgnoredErrorsByFile[$error->getFilePath()][] = $error;
 		}
 
-		$freshCollectedDataByFile = $analyserResult->getCollectedData();
+		$freshCollectedData = $analyserResult->getLazyCollectedData();
 
 		$meta = $resultCache->getMeta();
 		$projectConfigArray = $meta['projectConfig'];
@@ -1005,44 +1022,46 @@ final class ResultCacheManager
 			$projectConfigArray = $this->getPathTransformer()->relativizeProjectConfig($projectConfigArray);
 			$meta['projectConfig'] = Neon::encode($projectConfigArray);
 		}
-		$doSave = function (array $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, ?array $dependencies, ?array $usedTraitDependencies, ?array $packageDependencies, array $exportedNodes, array $projectExtensionFiles) use ($internalErrors, $resultCache, $output, $onlyFiles, $meta): bool {
+		// Returns the collected data as it can be read back from the saved file, or null when nothing
+		// was saved.
+		$doSave = function (array $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, LazyCollectedData $collectedData, ?array $dependencies, ?array $usedTraitDependencies, ?array $packageDependencies, array $exportedNodes, array $projectExtensionFiles) use ($internalErrors, $resultCache, $output, $onlyFiles, $meta): ?LazyCollectedData {
 			if ($onlyFiles) {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because only files were passed as analysed paths.');
 				}
-				return false;
+				return null;
 			}
 			if ($dependencies === null) {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of error in dependencies.');
 				}
-				return false;
+				return null;
 			}
 			if ($usedTraitDependencies === null) {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of error in used trait dependencies.');
 				}
-				return false;
+				return null;
 			}
 			if ($packageDependencies === null) {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of error in package dependencies.');
 				}
-				return false;
+				return null;
 			}
 
 			if (count($internalErrors) > 0) {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of internal errors.');
 				}
-				return false;
+				return null;
 			}
 
 			if (count($this->fileReplacements) > 0) {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of --tmp-file and --instead-of CLI options passed (editor mode).');
 				}
-				return false;
+				return null;
 			}
 
 			foreach ($errorsByFile as $errors) {
@@ -1055,17 +1074,17 @@ final class ResultCacheManager
 						$output->writeLineFormatted(sprintf('Result cache was not saved because of non-ignorable exception: %s', $error->getMessage()));
 					}
 
-					return false;
+					return null;
 				}
 			}
 
-			$this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles, $resultCache->getCurrentFileHashes(), $meta);
+			$savedCollectedData = $this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedData, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles, $resultCache->getCurrentFileHashes(), $meta);
 
 			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache is saved.');
 			}
 
-			return true;
+			return $savedCollectedData;
 		};
 
 		if ($resultCache->isFullAnalysis()) {
@@ -1075,7 +1094,7 @@ final class ResultCacheManager
 				if ($analyserResult->getDependencies() !== null) {
 					$projectExtensionFiles = $this->getProjectExtensionFiles($projectConfigArray, $analyserResult->getDependencies());
 				}
-				$saved = $doSave($freshErrorsByFile, $freshLocallyIgnoredErrorsByFile, $analyserResult->getLinesToIgnore(), $analyserResult->getUnmatchedLineIgnores(), $freshCollectedDataByFile, $analyserResult->getDependencies(), $analyserResult->getUsedTraitDependencies(), $analyserResult->getPackageDependencies(), $this->addNonAnalysedExportedNodes($analyserResult->getExportedNodes(), $analyserResult->getDependencies(), $analyserResult->getUsedTraitDependencies()), $projectExtensionFiles);
+				$saved = $doSave($freshErrorsByFile, $freshLocallyIgnoredErrorsByFile, $analyserResult->getLinesToIgnore(), $analyserResult->getUnmatchedLineIgnores(), $freshCollectedData, $analyserResult->getDependencies(), $analyserResult->getUsedTraitDependencies(), $analyserResult->getPackageDependencies(), $this->addNonAnalysedExportedNodes($analyserResult->getExportedNodes(), $analyserResult->getDependencies(), $analyserResult->getUsedTraitDependencies()), $projectExtensionFiles) !== null;
 			} else {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because it was not requested.');
@@ -1087,7 +1106,7 @@ final class ResultCacheManager
 
 		$errorsByFile = $this->mergeErrors($resultCache, $freshErrorsByFile);
 		$locallyIgnoredErrorsByFile = $this->mergeLocallyIgnoredErrors($resultCache, $freshLocallyIgnoredErrorsByFile);
-		$collectedDataByFile = $this->mergeCollectedData($resultCache, $freshCollectedDataByFile);
+		$collectedData = $this->mergeCollectedData($resultCache, $freshCollectedData->getFresh());
 		$dependencies = $this->mergeDependencies($resultCache->getDependencies(), $resultCache->getFilesToAnalyse(), $analyserResult->getDependencies());
 		$usedTraitDependencies = $this->mergeDependencies($resultCache->getUsedTraitDependencies(), $resultCache->getFilesToAnalyse(), $analyserResult->getUsedTraitDependencies());
 		$packageDependencies = $this->mergePackageDependencies($resultCache->getPackageDependencies(), $resultCache->getFilesToAnalyse(), $analyserResult->getPackageDependencies());
@@ -1117,7 +1136,12 @@ final class ResultCacheManager
 					$projectExtensionFiles[$file] = [$hash, true, $className];
 				}
 			}
-			$saved = $doSave($errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles);
+			$savedCollectedData = $doSave($errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedData, $dependencies, $usedTraitDependencies, $packageDependencies, $exportedNodes, $projectExtensionFiles);
+			if ($savedCollectedData !== null) {
+				// The old file is gone after the rename, so the entries are read back from the new one.
+				$collectedData = $savedCollectedData;
+				$saved = true;
+			}
 		}
 
 		$flatErrors = [];
@@ -1142,7 +1166,7 @@ final class ResultCacheManager
 			linesToIgnore: $linesToIgnore,
 			unmatchedLineIgnores: $unmatchedLineIgnores,
 			internalErrors: $internalErrors,
-			collectedData: $collectedDataByFile,
+			collectedData: $collectedData,
 			dependencies: $dependencies,
 			usedTraitDependencies: $usedTraitDependencies,
 			packageDependencies: $packageDependencies,
@@ -1199,24 +1223,24 @@ final class ResultCacheManager
 
 	/**
 	 * @param CollectorData $freshCollectedDataByFile
-	 * @return CollectorData
 	 */
-	private function mergeCollectedData(ResultCache $resultCache, array $freshCollectedDataByFile): array
+	private function mergeCollectedData(ResultCache $resultCache, array $freshCollectedDataByFile): LazyCollectedData
 	{
-		$collectedDataByFile = $resultCache->getCollectedData();
+		$cachedIndex = $resultCache->getCollectedData()->getCachedIndex();
+		$mergedFresh = [];
 		foreach ($resultCache->getFilesToAnalyse() as $file) {
 			if (array_key_exists($file, $this->fileReplacements)) {
-				unset($collectedDataByFile[$file]);
+				unset($cachedIndex[$file]);
 				$file = $this->fileReplacements[$file];
 			}
+			unset($cachedIndex[$file]);
 			if (!array_key_exists($file, $freshCollectedDataByFile)) {
-				unset($collectedDataByFile[$file]);
 				continue;
 			}
-			$collectedDataByFile[$file] = $freshCollectedDataByFile[$file];
+			$mergedFresh[$file] = $freshCollectedDataByFile[$file];
 		}
 
-		return $collectedDataByFile;
+		return $resultCache->getCollectedData()->with($cachedIndex, $mergedFresh);
 	}
 
 	/**
@@ -1377,7 +1401,6 @@ final class ResultCacheManager
 	 * @param array<string, list<Error>> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param CollectorData $collectedData
 	 * @param array<string, array<string>> $dependencies
 	 * @param array<string, array<string>> $usedTraitDependencies
 	 * @param array<string, array<string>> $packageDependencies
@@ -1385,6 +1408,7 @@ final class ResultCacheManager
 	 * @param array<string, array{string, bool, string}> $projectExtensionFiles
 	 * @param array<string, string> $currentFileHashes
 	 * @param mixed[] $meta
+	 * @return LazyCollectedData The same collected data, with the cached entries indexed in the saved file
 	 */
 	private function save(
 		int $lastFullAnalysisTime,
@@ -1392,7 +1416,7 @@ final class ResultCacheManager
 		array $locallyIgnoredErrors,
 		array $linesToIgnore,
 		array $unmatchedLineIgnores,
-		array $collectedData,
+		LazyCollectedData $collectedData,
 		array $dependencies,
 		array $usedTraitDependencies,
 		array $packageDependencies,
@@ -1400,7 +1424,7 @@ final class ResultCacheManager
 		array $projectExtensionFiles,
 		array $currentFileHashes,
 		array $meta,
-	): void
+	): LazyCollectedData
 	{
 		$invertedDependencies = [];
 		$filesNoOneIsDependingOn = array_fill_keys(array_keys($dependencies), true);
@@ -1450,12 +1474,7 @@ final class ResultCacheManager
 		ksort($locallyIgnoredErrors);
 		ksort($linesToIgnore);
 		ksort($unmatchedLineIgnores);
-		ksort($collectedData);
 		ksort($invertedDependencies);
-
-		foreach ($collectedData as & $collectedDataPerFile) {
-			ksort($collectedDataPerFile);
-		}
 
 		foreach ($invertedDependencies as $file => $fileData) {
 			$dependentFiles = $fileData['dependentFiles'];
@@ -1488,7 +1507,6 @@ final class ResultCacheManager
 		$locallyIgnoredErrors = $transformer->relativizeErrors($locallyIgnoredErrors);
 		$linesToIgnore = $transformer->relativizeCompoundKeyed($linesToIgnore);
 		$unmatchedLineIgnores = $transformer->relativizeCompoundKeyed($unmatchedLineIgnores);
-		$collectedData = $transformer->relativizeCollectedData($collectedData);
 		$invertedDependencies = $transformer->relativizeDependencies($invertedDependencies);
 		$packageDependencies = $transformer->relativizeFileKeyed($packageDependencies);
 		$exportedNodes = $transformer->relativizeFileKeyed($exportedNodes);
@@ -1528,7 +1546,7 @@ final class ResultCacheManager
 			$this->writeArrayFrame($handle, $file, 'locallyIgnoredErrors', $locallyIgnoredErrors);
 			$this->writeArrayFrame($handle, $file, 'linesToIgnore', $linesToIgnore);
 			$this->writeArrayFrame($handle, $file, 'unmatchedLineIgnores', $unmatchedLineIgnores);
-			$this->writeArrayFrame($handle, $file, 'collectedData', $collectedData);
+			$savedCollectedDataIndex = $this->writeCollectedDataFrame($handle, $file, $collectedData);
 			$this->writeArrayFrame($handle, $file, 'dependencies', $invertedDependencies);
 			$this->writeArrayFrame($handle, $file, 'packageDependencies', $packageDependencies);
 			$this->writeArrayFrame($handle, $file, 'exportedNodes', $exportedNodes);
@@ -1550,6 +1568,73 @@ final class ResultCacheManager
 				@unlink($temporaryFile);
 			}
 		}
+
+		return LazyCollectedData::fromCache($savedCollectedDataIndex, $this->createCollectedDataReader($file), $collectedData->getFresh());
+	}
+
+	/**
+	 * The collected data section: the cached entries are copied byte for byte from the file they
+	 * were restored from, the fresh ones are serialized. Written in the order of the file paths, as
+	 * every other section is, so the file does not depend on which files were re-analysed.
+	 *
+	 * @param resource $handle
+	 * @return array<string, array{int, int}> The position of every copied entry in the new file
+	 */
+	private function writeCollectedDataFrame($handle, string $file, LazyCollectedData $collectedData): array
+	{
+		$transformer = $this->getPathTransformer();
+		$cachedIndex = $collectedData->getCachedIndex();
+		$fresh = $collectedData->getFresh();
+		foreach ($fresh as & $collectedDataPerFile) {
+			ksort($collectedDataPerFile);
+		}
+		unset($collectedDataPerFile);
+
+		$files = array_keys($cachedIndex + $fresh);
+		sort($files);
+
+		$this->writeToHandle($handle, $file, self::INDEXED_SECTION . '* ' . count($files) . "\n");
+
+		$sourceHandle = null;
+		$savedIndex = [];
+		try {
+			foreach ($files as $analysedFile) {
+				if (array_key_exists($analysedFile, $fresh)) {
+					foreach ($transformer->relativizeCollectedData([$analysedFile => $fresh[$analysedFile]]) as $relativeFile => $data) {
+						$this->writeEntryFrame($handle, $file, $relativeFile, $data);
+					}
+
+					continue;
+				}
+
+				[$offset, $length] = $cachedIndex[$analysedFile];
+				if ($sourceHandle === null) {
+					$openedHandle = @fopen($this->cacheFilePath, 'r');
+					if ($openedHandle === false) {
+						throw new RuntimeException(sprintf('Cannot open the result cache file %s to copy the collected data from.', $this->cacheFilePath));
+					}
+					$sourceHandle = $openedHandle;
+				}
+
+				$position = ftell($handle);
+				if ($position === false) {
+					throw new CouldNotWriteFileException($file, 'cannot tell the position in the file');
+				}
+
+				$copied = stream_copy_to_stream($sourceHandle, $handle, $length, $offset);
+				if ($copied !== $length) {
+					throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $this->cacheFilePath, $analysedFile));
+				}
+
+				$savedIndex[$analysedFile] = [$position, $length];
+			}
+		} finally {
+			if ($sourceHandle !== null) {
+				fclose($sourceHandle);
+			}
+		}
+
+		return $savedIndex;
 	}
 
 	/**
@@ -1576,10 +1661,7 @@ final class ResultCacheManager
 	}
 
 	/**
-	 * An array, as `name* count\n` followed by one length-prefixed frame per entry.
-	 *
-	 * Each entry is serialized as a single-element array so its key travels with it, which keeps string
-	 * and integer keys distinct without a second frame for the key.
+	 * An array, as `name* count\n` followed by one entry frame per element.
 	 *
 	 * @param resource $handle
 	 * @param array<mixed> $values
@@ -1588,10 +1670,24 @@ final class ResultCacheManager
 	{
 		$this->writeToHandle($handle, $file, $name . '* ' . count($values) . "\n");
 		foreach ($values as $key => $value) {
-			$blob = serialize([$key => $value]);
-			$this->writeToHandle($handle, $file, strlen($blob) . "\n");
-			$this->writeToHandle($handle, $file, $blob);
+			$this->writeEntryFrame($handle, $file, $key, $value);
 		}
+	}
+
+	/**
+	 * One element of an array frame: `keyLength valueLength\n`, the serialized key, the serialized
+	 * value. The key has its own payload so a reader can index the entries without decoding the
+	 * values, and serializing it keeps string and integer keys distinct.
+	 *
+	 * @param resource $handle
+	 */
+	private function writeEntryFrame($handle, string $file, int|string $key, mixed $value): void
+	{
+		$keyBlob = serialize($key);
+		$valueBlob = serialize($value);
+		$this->writeToHandle($handle, $file, strlen($keyBlob) . ' ' . strlen($valueBlob) . "\n");
+		$this->writeToHandle($handle, $file, $keyBlob);
+		$this->writeToHandle($handle, $file, $valueBlob);
 	}
 
 	/**
@@ -1621,6 +1717,7 @@ final class ResultCacheManager
 
 			$data = [];
 			$lazy = array_fill_keys(self::LAZY_SECTIONS, false);
+			$data[self::INDEXED_SECTION . 'Index'] = [];
 			while (($header = fgets($handle)) !== false) {
 				$header = rtrim($header, "\n");
 				if ($header === '') {
@@ -1641,6 +1738,12 @@ final class ResultCacheManager
 
 				$name = substr($name, 0, -1);
 				$count = (int) $size;
+				if ($name === self::INDEXED_SECTION) {
+					$data[$name . 'Index'] = $this->indexEntryFrames($handle, $count, $fileSize, $name);
+
+					continue;
+				}
+
 				if (!array_key_exists($name, $lazy)) {
 					$data[$name] = $this->readEntryFrames($handle, $count);
 
@@ -1655,7 +1758,7 @@ final class ResultCacheManager
 					throw new RuntimeException(sprintf('Cannot tell the position of section "%s".', $name));
 				}
 
-				$this->skipEntryFrames($handle, $count, $fileSize, $name);
+				$this->indexEntryFrames($handle, $count, $fileSize, $name);
 				$lazy[$name] = true;
 				$data[$name . 'Callback'] = fn (): array => $this->readEntryFramesAt($handle, $offset, $count, $name);
 			}
@@ -1679,27 +1782,33 @@ final class ResultCacheManager
 	}
 
 	/**
-	 * Walks past an array frame's entries without unserializing them, checking as it goes that the
-	 * file really holds them.
+	 * Walks past an array frame's entries decoding only their keys, checking as it goes that the
+	 * file really holds them. Returns where each entry is: the offset of its header line and the
+	 * length up to the end of its value, which is what stream_copy_to_stream() needs to carry the
+	 * entry over to the next cache file unchanged.
 	 *
 	 * @param resource $handle
+	 * @return array<int|string, array{int, int}>
 	 */
-	private function skipEntryFrames($handle, int $count, int $fileSize, string $name): void
+	private function indexEntryFrames($handle, int $count, int $fileSize, string $name): array
 	{
+		$index = [];
 		for ($i = 0; $i < $count; $i++) {
-			$length = fgets($handle);
-			if ($length === false) {
-				throw new RuntimeException(sprintf('Section "%s" ended after %d of %d entries.', $name, $i, $count));
+			$offset = ftell($handle);
+			if ($offset === false) {
+				throw new RuntimeException(sprintf('Cannot tell the position of entry %d of section "%s".', $i, $name));
 			}
 
-			$length = (int) rtrim($length, "\n");
-			if ($length <= 0) {
-				throw new RuntimeException(sprintf('Frame length %d is not positive.', $length));
+			$entry = sprintf('entry %d of %d in section "%s"', $i, $count, $name);
+			[$keyLength, $valueLength] = $this->readEntryHeader($handle, $entry);
+			$key = $this->readFrame($handle, $keyLength);
+			if (!is_int($key) && !is_string($key)) {
+				throw new RuntimeException(sprintf('The key of %s is not an array key.', $entry));
 			}
 
 			// fseek() past the end of a file succeeds, so the position is what catches a section the
 			// file does not actually hold.
-			if (fseek($handle, $length, SEEK_CUR) !== 0) {
+			if (fseek($handle, $valueLength, SEEK_CUR) !== 0) {
 				throw new RuntimeException(sprintf('Cannot skip entry %d of section "%s".', $i, $name));
 			}
 
@@ -1707,7 +1816,92 @@ final class ResultCacheManager
 			if ($position === false || $position > $fileSize) {
 				throw new RuntimeException(sprintf('Section "%s" is truncated at entry %d of %d.', $name, $i, $count));
 			}
+
+			$index[$key] = [$offset, $position - $offset];
 		}
+
+		return $index;
+	}
+
+	/**
+	 * @param resource $handle
+	 * @param string $entry What the entry is, for the error message
+	 * @return array{int, int} The lengths of the key and value payloads
+	 */
+	private function readEntryHeader($handle, string $entry): array
+	{
+		$header = fgets($handle);
+		if ($header === false) {
+			throw new RuntimeException(sprintf('The cache file ended before %s.', $entry));
+		}
+
+		$parts = explode(' ', rtrim($header, "\n"), 2);
+		if (count($parts) !== 2) {
+			throw new RuntimeException(sprintf('Malformed header "%s" of %s.', rtrim($header, "\n"), $entry));
+		}
+
+		[$keyLength, $valueLength] = [(int) $parts[0], (int) $parts[1]];
+		if ($keyLength <= 0 || $valueLength <= 0) {
+			throw new RuntimeException(sprintf('A frame length of %s is not positive.', $entry));
+		}
+
+		return [$keyLength, $valueLength];
+	}
+
+	/**
+	 * Reads the collected data entries the index points at, in the order of the index. The file is
+	 * opened for the duration of the call only: an open handle would be inherited by the forked
+	 * workers, and a rename over the file (the next save) must not find it open on Windows.
+	 *
+	 * @return Closure(array<string, array{int, int}>): CollectorData
+	 */
+	private function createCollectedDataReader(string $cacheFilePath): Closure
+	{
+		return function (array $index) use ($cacheFilePath): array {
+			$handle = @fopen($cacheFilePath, 'r');
+			if ($handle === false) {
+				throw new RuntimeException(sprintf('Cannot open the result cache file %s to read the collected data from.', $cacheFilePath));
+			}
+
+			$transformer = $this->getPathTransformer();
+
+			// Read front to back: the entries are stored in the order of their paths and the index
+			// usually is too, but a seek backwards on a file this size is what makes reading it slow.
+			$byOffset = $index;
+			uasort($byOffset, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
+
+			$relativeData = [];
+			try {
+				foreach ($byOffset as $file => [$offset, $length]) {
+					if (fseek($handle, $offset) !== 0) {
+						throw new RuntimeException(sprintf('Cannot seek to the collected data of %s.', $file));
+					}
+
+					[$keyLength, $valueLength] = $this->readEntryHeader($handle, sprintf('the collected data of %s', $file));
+					$key = $this->readFrame($handle, $keyLength);
+					if (!is_string($key) || $transformer->absolutizePath($key) !== $file) {
+						throw new RuntimeException(sprintf('The result cache file %s changed while it was being read: the entry of %s is not where it was.', $cacheFilePath, $file));
+					}
+
+					$value = $this->readFrame($handle, $valueLength);
+					if (!is_array($value)) {
+						throw new RuntimeException(sprintf('The collected data of %s is not an array.', $file));
+					}
+
+					$relativeData[$key] = $value;
+				}
+			} finally {
+				fclose($handle);
+			}
+
+			$absoluteData = $transformer->absolutizeCollectedData($relativeData);
+			$result = [];
+			foreach (array_keys($index) as $file) {
+				$result[$file] = $absoluteData[$file];
+			}
+
+			return $result;
+		};
 	}
 
 	/**
@@ -1731,19 +1925,14 @@ final class ResultCacheManager
 	{
 		$entries = [];
 		for ($i = 0; $i < $count; $i++) {
-			$length = fgets($handle);
-			if ($length === false) {
-				throw new RuntimeException(sprintf('Cache file ended after %d of %d entries.', $i, $count));
+			$entry = sprintf('entry %d of %d', $i, $count);
+			[$keyLength, $valueLength] = $this->readEntryHeader($handle, $entry);
+			$key = $this->readFrame($handle, $keyLength);
+			if (!is_int($key) && !is_string($key)) {
+				throw new RuntimeException(sprintf('The key of %s is not an array key.', $entry));
 			}
 
-			$entry = $this->readFrame($handle, (int) rtrim($length, "\n"));
-			if (!is_array($entry)) {
-				throw new RuntimeException('An entry frame did not contain an array.');
-			}
-
-			foreach ($entry as $key => $value) {
-				$entries[$key] = $value;
-			}
+			$entries[$key] = $this->readFrame($handle, $valueLength);
 		}
 
 		return $entries;

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -1733,7 +1733,7 @@ final class ResultCacheManager
 					throw new RuntimeException(sprintf('Cannot tell the position of section "%s".', $name));
 				}
 
-				$this->indexEntryFrames($handle, $count, $fileSize, $name);
+				$this->skipEntryFrames($handle, $count, $fileSize, $name);
 				$lazy[$name] = true;
 				$data[$name . 'Callback'] = fn (): array => $this->readEntryFramesAt($handle, $offset, $count, $name);
 			}
@@ -1800,12 +1800,34 @@ final class ResultCacheManager
 	}
 
 	/**
-	 * The header and key of an entry frame, leaving the handle at its value.
+	 * Walks past an array frame's entries without decoding anything, checking as it goes that the
+	 * file really holds them.
 	 *
 	 * @param resource $handle
-	 * @return array{int|string, int} The key and the length of the value payload
 	 */
-	private function readEntryKey($handle): array
+	private function skipEntryFrames($handle, int $count, int $fileSize, string $name): void
+	{
+		for ($i = 0; $i < $count; $i++) {
+			[$keyLength, $valueLength] = $this->readEntryHeader($handle);
+
+			// fseek() past the end of a file succeeds, so the position is what catches a section the
+			// file does not actually hold.
+			if (fseek($handle, $keyLength + $valueLength, SEEK_CUR) !== 0) {
+				throw new RuntimeException(sprintf('Cannot skip entry %d of section "%s".', $i, $name));
+			}
+
+			$position = ftell($handle);
+			if ($position === false || $position > $fileSize) {
+				throw new RuntimeException(sprintf('Section "%s" is truncated at entry %d of %d.', $name, $i, $count));
+			}
+		}
+	}
+
+	/**
+	 * @param resource $handle
+	 * @return array{int, int} The lengths of the key and value payloads
+	 */
+	private function readEntryHeader($handle): array
 	{
 		$header = fgets($handle);
 		if ($header === false) {
@@ -1813,16 +1835,28 @@ final class ResultCacheManager
 		}
 
 		$lengths = explode(' ', rtrim($header, "\n"));
-		if (count($lengths) !== 2 || (int) $lengths[1] <= 0) {
+		if (count($lengths) !== 2 || (int) $lengths[0] <= 0 || (int) $lengths[1] <= 0) {
 			throw new RuntimeException(sprintf('Malformed entry header "%s".', rtrim($header, "\n")));
 		}
 
-		$key = $this->readFrame($handle, (int) $lengths[0]);
+		return [(int) $lengths[0], (int) $lengths[1]];
+	}
+
+	/**
+	 * The header and key of an entry frame, leaving the handle at its value.
+	 *
+	 * @param resource $handle
+	 * @return array{int|string, int} The key and the length of the value payload
+	 */
+	private function readEntryKey($handle): array
+	{
+		[$keyLength, $valueLength] = $this->readEntryHeader($handle);
+		$key = $this->readFrame($handle, $keyLength);
 		if (!is_int($key) && !is_string($key)) {
 			throw new RuntimeException('An entry key is not an array key.');
 		}
 
-		return [$key, (int) $lengths[1]];
+		return [$key, $valueLength];
 	}
 
 	/**

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -1775,6 +1775,11 @@ final class ResultCacheManager
 		$index = [];
 		for ($i = 0; $i < $count; $i++) {
 			[$key, $valueLength] = $this->readEntryKey($handle);
+			// The sections are keyed by file path. restore() absolutizes the keys outside the guard that
+			// turns a damaged file into a full analysis, so anything else has to be refused here.
+			if (!is_string($key)) {
+				throw new RuntimeException(sprintf('Entry %d of section "%s" is not keyed by a path.', $i, $name));
+			}
 
 			// fseek() past the end of a file succeeds, so the position is what catches a section the
 			// file does not actually hold.

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -224,7 +224,7 @@ final class AnalyseApplication
 				linesToIgnore: [],
 				unmatchedLineIgnores: [],
 				internalErrors: [],
-				collectedData: [],
+				collectedData: LazyCollectedData::fromArray([]),
 				dependencies: [],
 				usedTraitDependencies: [],
 				packageDependencies: [],

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\AnalyserResultFinalizer;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
+use PHPStan\Analyser\ResultCache\LazyCollectedData;
 use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
 use PHPStan\Collectors\CollectedData;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -78,7 +79,7 @@ final class AnalyseApplication
 		if (count($ignoredErrorHelperResult->getErrors()) > 0) {
 			$notFileSpecificErrors = $ignoredErrorHelperResult->getErrors();
 			$internalErrors = [];
-			$collectedData = [];
+			$collectedData = LazyCollectedData::fromArray([]);
 			$savedResultCache = false;
 			$memoryUsageBytes = 0;
 			$workerCount = 0;
@@ -117,7 +118,7 @@ final class AnalyseApplication
 					linesToIgnore: $intermediateAnalyserResult->getLinesToIgnore(),
 					unmatchedLineIgnores: $intermediateAnalyserResult->getUnmatchedLineIgnores(),
 					internalErrors: $intermediateAnalyserResult->getInternalErrors(),
-					collectedData: $intermediateAnalyserResult->getCollectedData(),
+					collectedData: $intermediateAnalyserResult->getLazyCollectedData(),
 					dependencies: $intermediateAnalyserResult->getDependencies(),
 					usedTraitDependencies: $intermediateAnalyserResult->getUsedTraitDependencies(),
 					packageDependencies: $intermediateAnalyserResult->getPackageDependencies(),
@@ -150,7 +151,7 @@ final class AnalyseApplication
 			$ignoredErrorHelperProcessedResult = $ignoredErrorHelperResult->process($errors, $onlyFiles, $files, $hasInternalErrors);
 			$fileSpecificErrors = $ignoredErrorHelperProcessedResult->getNotIgnoredErrors();
 			$notFileSpecificErrors = $ignoredErrorHelperProcessedResult->getOtherIgnoreMessages();
-			$collectedData = $analyserResult->getCollectedData();
+			$collectedData = $analyserResult->getLazyCollectedData();
 			$savedResultCache = $resultCacheResult->isSaved();
 		}
 
@@ -159,7 +160,7 @@ final class AnalyseApplication
 			$notFileSpecificErrors,
 			$internalErrors,
 			[],
-			$this->mapCollectedData($collectedData),
+			fn (): array => $this->mapCollectedData($collectedData->toArray()),
 			$defaultLevelUsed,
 			$projectConfigFile,
 			$savedResultCache,
@@ -297,15 +298,6 @@ final class AnalyseApplication
 			return $analyserResult;
 		}
 
-		$newCollectedData = [];
-		foreach ($analyserResult->getCollectedData() as $file => $data) {
-			if ($file === $tmpFile) {
-				$file = $insteadOfFile;
-			}
-
-			$newCollectedData[$file] = $data;
-		}
-
 		$dependencies = null;
 		if ($analyserResult->getDependencies() !== null) {
 			$dependencies = $this->switchTmpFileInDependencies($analyserResult->getDependencies(), $insteadOfFile, $tmpFile);
@@ -336,7 +328,7 @@ final class AnalyseApplication
 			linesToIgnore: $this->switchTmpFileInLinesToIgnore($analyserResult->getLinesToIgnore(), $insteadOfFile, $tmpFile),
 			unmatchedLineIgnores: $this->switchTmpFileInLinesToIgnore($analyserResult->getUnmatchedLineIgnores(), $insteadOfFile, $tmpFile),
 			internalErrors: $analyserResult->getInternalErrors(),
-			collectedData: $newCollectedData,
+			collectedData: $analyserResult->getLazyCollectedData()->withRenamedFile($tmpFile, $insteadOfFile),
 			dependencies: $dependencies,
 			usedTraitDependencies: $usedTraitDependencies,
 			packageDependencies: $packageDependencies,

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command;
 use Closure;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\AnalyserResult;
+use PHPStan\Analyser\ResultCache\LazyCollectedData;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Parallel\ParallelAnalyser;
 use PHPStan\Parallel\Scheduler;
@@ -65,7 +66,7 @@ final class AnalyserRunner
 				linesToIgnore: [],
 				unmatchedLineIgnores: [],
 				internalErrors: [],
-				collectedData: [],
+				collectedData: LazyCollectedData::fromArray([]),
 				dependencies: [],
 				usedTraitDependencies: [],
 				packageDependencies: [],

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Command;
 
+use Closure;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\InternalError;
 use PHPStan\Collectors\CollectedData;
@@ -22,7 +23,7 @@ final class AnalysisResult
 	 * @param list<string> $notFileSpecificErrors
 	 * @param list<InternalError> $internalErrors
 	 * @param list<string> $warnings
-	 * @param list<CollectedData> $collectedData
+	 * @param list<CollectedData>|(Closure(): list<CollectedData>) $collectedData A closure defers building the list, which after a cached run means decoding the biggest section of the result cache
 	 * @param list<string> $processedFiles
 	 */
 	public function __construct(
@@ -30,7 +31,7 @@ final class AnalysisResult
 		private array $notFileSpecificErrors,
 		private array $internalErrors,
 		private array $warnings,
-		private array $collectedData,
+		private array|Closure $collectedData,
 		private bool $defaultLevelUsed,
 		private ?string $projectConfigFile,
 		private bool $savedResultCache,
@@ -109,6 +110,10 @@ final class AnalysisResult
 	 */
 	public function getCollectedData(): array
 	{
+		if ($this->collectedData instanceof Closure) {
+			$this->collectedData = ($this->collectedData)();
+		}
+
 		return $this->collectedData;
 	}
 

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -23,7 +23,7 @@ final class AnalysisResult
 	 * @param list<string> $notFileSpecificErrors
 	 * @param list<InternalError> $internalErrors
 	 * @param list<string> $warnings
-	 * @param list<CollectedData>|(Closure(): list<CollectedData>) $collectedData A closure defers building the list, which after a cached run means decoding the biggest section of the result cache
+	 * @param list<CollectedData>|(Closure(): list<CollectedData>) $collectedData A closure defers decoding the result cache until asked
 	 * @param list<string> $processedFiles
 	 */
 	public function __construct(

--- a/src/Command/FixerWorkerRunner.php
+++ b/src/Command/FixerWorkerRunner.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\Error;
 use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
 use PHPStan\Analyser\Ignore\IgnoredErrorHelperResult;
 use PHPStan\Analyser\InternalError;
+use PHPStan\Analyser\ResultCache\LazyCollectedData;
 use PHPStan\Analyser\ResultCache\ResultCacheManager;
 use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -342,7 +343,7 @@ final class FixerWorkerRunner
 				linesToIgnore: [],
 				unmatchedLineIgnores: [],
 				internalErrors: [],
-				collectedData: [],
+				collectedData: LazyCollectedData::fromArray([]),
 				dependencies: [],
 				usedTraitDependencies: [],
 				packageDependencies: [],

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -9,6 +9,7 @@ use Nette\Utils\Random;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\InternalError;
+use PHPStan\Analyser\ResultCache\LazyCollectedData;
 use PHPStan\Cache\ArenaCache;
 use PHPStan\Command\CommandHelper;
 use PHPStan\Command\Output;
@@ -157,7 +158,7 @@ final class ParallelAnalyser
 				linesToIgnore: $linesToIgnore,
 				unmatchedLineIgnores: $unmatchedLineIgnores,
 				internalErrors: $internalErrors,
-				collectedData: $collectedData,
+				collectedData: LazyCollectedData::fromArray($collectedData),
 				dependencies: $internalErrorsCount === 0 ? $dependencies : null,
 				usedTraitDependencies: $internalErrorsCount === 0 ? $usedTraitDependencies : null,
 				packageDependencies: $internalErrorsCount === 0 ? $packageDependencies : null,

--- a/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
@@ -4,10 +4,10 @@ namespace PHPStan\Analyser\ResultCache;
 
 use PHPStan\Rules\DeadCode\MethodWithoutImpurePointsCollector;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\TestCase;
 use function array_keys;
 
-class LazyCollectedDataTest extends PHPStanTestCase
+class LazyCollectedDataTest extends TestCase
 {
 
 	private int $reads = 0;

--- a/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
@@ -34,7 +34,7 @@ class LazyCollectedDataTest extends PHPStanTestCase
 			return $result;
 		};
 
-		$lazy = LazyCollectedData::fromCache(['b.php' => [10, 20], 'a.php' => [30, 40]], $reader);
+		$lazy = new LazyCollectedData(['b.php' => [10, 20], 'a.php' => [30, 40]], $reader, []);
 		$this->assertFalse($lazy->isEmpty());
 		$this->assertSame(0, $this->reads);
 
@@ -51,8 +51,7 @@ class LazyCollectedDataTest extends PHPStanTestCase
 	public function testFreshEntriesReplaceCachedOnes(): void
 	{
 		$reader = static fn (array $index): array => ['a.php' => [MethodWithoutImpurePointsCollector::class => ['cached']], 'b.php' => [MethodWithoutImpurePointsCollector::class => ['cached']]];
-		$lazy = LazyCollectedData::fromCache(['a.php' => [0, 1], 'b.php' => [1, 1]], $reader)
-			->with(['a.php' => [0, 1], 'b.php' => [1, 1]], ['b.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']], 'c.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]]);
+		$lazy = new LazyCollectedData(['a.php' => [0, 1], 'b.php' => [1, 1]], $reader, ['b.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']], 'c.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]]);
 
 		$this->assertSame([
 			'a.php' => [MethodWithoutImpurePointsCollector::class => ['cached']],
@@ -64,7 +63,7 @@ class LazyCollectedDataTest extends PHPStanTestCase
 	public function testWithRenamedFile(): void
 	{
 		$reader = static fn (array $index): array => ['renamed.php' => [MethodWithoutImpurePointsCollector::class => ['cached']]];
-		$lazy = LazyCollectedData::fromCache(['tmp.php' => [0, 1]], $reader, ['tmp2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]])
+		$lazy = (new LazyCollectedData(['tmp.php' => [0, 1]], $reader, ['tmp2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]]))
 			->withRenamedFile('tmp.php', 'renamed.php')
 			->withRenamedFile('tmp2.php', 'renamed2.php');
 

--- a/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ResultCache;
+
+use PHPStan\Rules\DeadCode\MethodWithoutImpurePointsCollector;
+use PHPStan\Testing\PHPStanTestCase;
+use function array_keys;
+
+class LazyCollectedDataTest extends PHPStanTestCase
+{
+
+	private int $reads = 0;
+
+	public function testFromArrayIsReturnedAsIs(): void
+	{
+		$data = ['a.php' => [MethodWithoutImpurePointsCollector::class => ['x']]];
+		$lazy = LazyCollectedData::fromArray($data);
+
+		$this->assertFalse($lazy->isEmpty());
+		$this->assertSame($data, $lazy->toArray());
+		$this->assertSame([], $lazy->getCachedIndex());
+		$this->assertTrue(LazyCollectedData::fromArray([])->isEmpty());
+	}
+
+	public function testCachedEntriesAreReadOnlyWhenAsked(): void
+	{
+		$reader = function (array $index): array {
+			$this->reads++;
+			$result = [];
+			foreach (array_keys($index) as $file) {
+				$result[$file] = [MethodWithoutImpurePointsCollector::class => ['cached ' . $file]];
+			}
+
+			return $result;
+		};
+
+		$lazy = LazyCollectedData::fromCache(['b.php' => [10, 20], 'a.php' => [30, 40]], $reader);
+		$this->assertFalse($lazy->isEmpty());
+		$this->assertSame(0, $this->reads);
+
+		$this->assertSame([
+			'b.php' => [MethodWithoutImpurePointsCollector::class => ['cached b.php']],
+			'a.php' => [MethodWithoutImpurePointsCollector::class => ['cached a.php']],
+		], $lazy->toArray());
+		$this->assertSame(1, $this->reads);
+
+		$lazy->toArray();
+		$this->assertSame(2, $this->reads, 'nothing is kept between calls');
+	}
+
+	public function testFreshEntriesReplaceCachedOnes(): void
+	{
+		$reader = static fn (array $index): array => ['a.php' => [MethodWithoutImpurePointsCollector::class => ['cached']], 'b.php' => [MethodWithoutImpurePointsCollector::class => ['cached']]];
+		$lazy = LazyCollectedData::fromCache(['a.php' => [0, 1], 'b.php' => [1, 1]], $reader)
+			->with(['a.php' => [0, 1], 'b.php' => [1, 1]], ['b.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']], 'c.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]]);
+
+		$this->assertSame([
+			'a.php' => [MethodWithoutImpurePointsCollector::class => ['cached']],
+			'b.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']],
+			'c.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']],
+		], $lazy->toArray());
+	}
+
+	public function testWithRenamedFile(): void
+	{
+		$reader = static fn (array $index): array => ['renamed.php' => [MethodWithoutImpurePointsCollector::class => ['cached']]];
+		$lazy = LazyCollectedData::fromCache(['tmp.php' => [0, 1]], $reader, ['tmp2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]])
+			->withRenamedFile('tmp.php', 'renamed.php')
+			->withRenamedFile('tmp2.php', 'renamed2.php');
+
+		$this->assertSame(['renamed.php' => [0, 1]], $lazy->getCachedIndex());
+		$this->assertSame(['renamed2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]], $lazy->getFresh());
+		$this->assertSame([
+			'renamed.php' => [MethodWithoutImpurePointsCollector::class => ['cached']],
+			'renamed2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']],
+		], $lazy->toArray());
+	}
+
+}

--- a/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/LazyCollectedDataTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser\ResultCache;
 
 use PHPStan\Rules\DeadCode\MethodWithoutImpurePointsCollector;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
 use function array_keys;
 
@@ -62,17 +63,23 @@ class LazyCollectedDataTest extends PHPStanTestCase
 
 	public function testWithRenamedFile(): void
 	{
-		$reader = static fn (array $index): array => ['renamed.php' => [MethodWithoutImpurePointsCollector::class => ['cached']]];
-		$lazy = (new LazyCollectedData(['tmp.php' => [0, 1]], $reader, ['tmp2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]]))
-			->withRenamedFile('tmp.php', 'renamed.php')
-			->withRenamedFile('tmp2.php', 'renamed2.php');
+		$reader = static fn (array $index): array => ['cached.php' => [MethodWithoutImpurePointsCollector::class => ['cached']]];
+		$lazy = (new LazyCollectedData(['cached.php' => [0, 1]], $reader, ['tmp.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]]))
+			->withRenamedFile('tmp.php', 'renamed.php');
 
-		$this->assertSame(['renamed.php' => [0, 1]], $lazy->getCachedIndex());
-		$this->assertSame(['renamed2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']]], $lazy->getFresh());
+		$this->assertSame(['cached.php' => [0, 1]], $lazy->getCachedIndex());
 		$this->assertSame([
-			'renamed.php' => [MethodWithoutImpurePointsCollector::class => ['cached']],
-			'renamed2.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']],
+			'cached.php' => [MethodWithoutImpurePointsCollector::class => ['cached']],
+			'renamed.php' => [MethodWithoutImpurePointsCollector::class => ['fresh']],
 		], $lazy->toArray());
+	}
+
+	public function testWithRenamedFileRefusesCachedFile(): void
+	{
+		$lazy = new LazyCollectedData(['cached.php' => [0, 1]], static fn (array $index): array => [], []);
+
+		$this->expectException(ShouldNotHappenException::class);
+		$lazy->withRenamedFile('cached.php', 'renamed.php');
 	}
 
 }

--- a/tests/PHPStan/Analyser/ResultCache/ResultCacheManagerCollectedDataTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/ResultCacheManagerCollectedDataTest.php
@@ -1,0 +1,292 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ResultCache;
+
+use Override;
+use PHPStan\Analyser\AnalyserResult;
+use PHPStan\Command\Output;
+use PHPStan\Command\Symfony\SymfonyOutput;
+use PHPStan\Command\Symfony\SymfonyStyle;
+use PHPStan\Dependency\ExportedNodeFetcher;
+use PHPStan\Dependency\PackageDependencyResolver;
+use PHPStan\File\FileHelper;
+use PHPStan\Php\ComposerPhpVersionFactory;
+use PHPStan\Php\PhpVersion;
+use PHPStan\PhpDoc\StubFilesProvider;
+use PHPStan\Rules\DeadCode\MethodWithoutImpurePointsCollector;
+use PHPStan\Testing\PHPStanTestCase;
+use RuntimeException;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Style\SymfonyStyle as SymfonyConsoleStyle;
+use function array_keys;
+use function count;
+use function file_get_contents;
+use function file_put_contents;
+use function is_file;
+use function md5_file;
+use function mkdir;
+use function rmdir;
+use function str_replace;
+use function strlen;
+use function strpos;
+use function substr;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class ResultCacheManagerCollectedDataTest extends PHPStanTestCase
+{
+
+	private string $directory;
+
+	/** @var list<string> */
+	private array $files = [];
+
+	#[Override]
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->directory = sys_get_temp_dir() . '/phpstan-collected-data-' . uniqid();
+		// the cache file must not be in the analysed directory, or it counts as a scanned file
+		mkdir($this->directory . '/src', 0777, true);
+		foreach (['a', 'b', 'c'] as $name) {
+			$file = $this->directory . '/src/' . $name . '.php';
+			file_put_contents($file, '<?php class Cache' . $name . " {}\n");
+			$this->files[] = $file;
+		}
+	}
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		foreach ($this->files as $file) {
+			@unlink($file);
+		}
+		@unlink($this->cacheFilePath());
+		@rmdir($this->directory . '/src');
+		@rmdir($this->directory);
+	}
+
+	public function testCachedEntriesAreIndexedAndReadBack(): void
+	{
+		$data = $this->collectedData(['a', 'b', 'c']);
+		$this->saveFullAnalysis($data);
+
+		$resultCache = $this->createManager()->restore($this->files, false, false, null, $this->nullOutput());
+		$this->assertFalse($resultCache->isFullAnalysis());
+		$this->assertSame([], $resultCache->getFilesToAnalyse());
+
+		$lazy = $resultCache->getCollectedData();
+		$this->assertSame($this->files, array_keys($lazy->getCachedIndex()));
+		$this->assertSame([], $lazy->getFresh());
+		$this->assertSame($data, $lazy->toArray());
+
+		$contents = file_get_contents($this->cacheFilePath());
+		$this->assertNotFalse($contents);
+		foreach ($lazy->getCachedIndex() as $file => [$offset, $length]) {
+			$entry = substr($contents, $offset, $length);
+			$this->assertStringContainsString('"' . str_replace($this->directory . '/', '', $file) . '"', $entry);
+			$this->assertStringEndsWith('}', $entry);
+		}
+	}
+
+	public function testWarmSaveCopiesEveryEntryByteForByte(): void
+	{
+		$this->saveFullAnalysis($this->collectedData(['a', 'b', 'c']));
+		$before = md5_file($this->cacheFilePath());
+
+		$manager = $this->createManager();
+		$resultCache = $manager->restore($this->files, false, false, null, $this->nullOutput());
+		$processed = $manager->process($this->analyserResult([]), $resultCache, $this->nullOutput(), false, true);
+		$this->assertTrue($processed->isSaved());
+		$this->assertSame($before, md5_file($this->cacheFilePath()));
+		$this->assertSame($this->collectedData(['a', 'b', 'c']), $processed->getAnalyserResult()->getCollectedData());
+	}
+
+	public function testPartialSaveEqualsFreshSaveOfMergedData(): void
+	{
+		$this->saveFullAnalysis($this->collectedData(['a', 'b', 'c']));
+
+		file_put_contents($this->files[1], "<?php class Cacheb { public function m(): void {} }\n");
+		$manager = $this->createManager();
+		$resultCache = $manager->restore($this->files, false, false, null, $this->nullOutput());
+		$this->assertSame([$this->files[1]], $resultCache->getFilesToAnalyse());
+
+		$freshB = [$this->files[1] => [MethodWithoutImpurePointsCollector::class => ['fresh b']]];
+		$processed = $manager->process($this->analyserResult($freshB), $resultCache, $this->nullOutput(), false, true);
+		$this->assertTrue($processed->isSaved());
+
+		// cached entries come first, the re-analysed file after them
+		$expected = $this->collectedData(['a', 'c', 'b']);
+		$expected[$this->files[1]] = $freshB[$this->files[1]];
+		$this->assertSame($expected, $processed->getAnalyserResult()->getCollectedData());
+
+		$partial = md5_file($this->cacheFilePath());
+		$this->saveFullAnalysis($expected);
+		$this->assertSame($partial, md5_file($this->cacheFilePath()));
+	}
+
+	public function testDamagedValueDiscardsTheCacheWhenRead(): void
+	{
+		$this->saveFullAnalysis($this->collectedData(['a', 'b', 'c']));
+		$this->breakFirstCollectedDataValue();
+
+		$resultCache = $this->createManager()->restore($this->files, false, false, null, $this->nullOutput());
+		$this->assertFalse($resultCache->isFullAnalysis(), 'the framing is intact, only a value is damaged');
+
+		try {
+			$resultCache->getCollectedData()->toArray();
+			$this->fail('The damaged value should not decode.');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('could not be read back and was discarded', $e->getMessage());
+		}
+
+		$this->assertFalse(is_file($this->cacheFilePath()));
+	}
+
+	public function testTruncatedSectionIsDiscardedOnRestore(): void
+	{
+		$this->saveFullAnalysis($this->collectedData(['a', 'b', 'c']));
+		$contents = file_get_contents($this->cacheFilePath());
+		$this->assertNotFalse($contents);
+		$position = strpos($contents, "collectedData* 3\n");
+		$this->assertNotFalse($position);
+		file_put_contents($this->cacheFilePath(), substr($contents, 0, $position + strlen("collectedData* 3\n") + 20));
+
+		$resultCache = $this->createManager()->restore($this->files, false, false, null, $this->nullOutput());
+		$this->assertTrue($resultCache->isFullAnalysis());
+		$this->assertFalse(is_file($this->cacheFilePath()));
+	}
+
+	public function testPreviousEntryFramingIsDiscarded(): void
+	{
+		$this->saveFullAnalysis($this->collectedData(['a']));
+		$contents = file_get_contents($this->cacheFilePath());
+		$this->assertNotFalse($contents);
+
+		// the 2.2.13 framing: one length per entry, the key inside the payload
+		$position = strpos($contents, "collectedData* 1\n");
+		$this->assertNotFalse($position);
+		$entryStart = $position + strlen("collectedData* 1\n");
+		$headerEnd = strpos($contents, "\n", $entryStart);
+		$this->assertNotFalse($headerEnd);
+		file_put_contents($this->cacheFilePath(), substr($contents, 0, $entryStart) . '42' . substr($contents, $headerEnd));
+
+		$resultCache = $this->createManager()->restore($this->files, false, false, null, $this->nullOutput());
+		$this->assertTrue($resultCache->isFullAnalysis());
+	}
+
+	/**
+	 * @param list<string> $names
+	 * @return array<string, array<class-string<MethodWithoutImpurePointsCollector>, list<string>>>
+	 */
+	private function collectedData(array $names): array
+	{
+		$data = [];
+		foreach ($names as $name) {
+			$data[$this->directory . '/src/' . $name . '.php'] = [MethodWithoutImpurePointsCollector::class => ['usage in ' . $name]];
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @param array<string, array<class-string<MethodWithoutImpurePointsCollector>, list<string>>> $collectedData
+	 */
+	private function saveFullAnalysis(array $collectedData): void
+	{
+		@unlink($this->cacheFilePath());
+		$manager = $this->createManager();
+		$resultCache = $this->createManager()->restore($this->files, false, false, null, $this->nullOutput());
+		$this->assertTrue($resultCache->isFullAnalysis());
+
+		$processed = $manager->process($this->analyserResult($collectedData), $resultCache, $this->nullOutput(), false, true);
+		$this->assertTrue($processed->isSaved());
+		$this->assertCount(count($collectedData), $processed->getAnalyserResult()->getCollectedData());
+	}
+
+	/**
+	 * @param array<string, array<class-string<MethodWithoutImpurePointsCollector>, list<string>>> $collectedData
+	 */
+	private function analyserResult(array $collectedData): AnalyserResult
+	{
+		$dependencies = [];
+		foreach ($this->files as $file) {
+			$dependencies[$file] = [];
+		}
+
+		return new AnalyserResult(
+			unorderedErrors: [],
+			filteredPhpErrors: [],
+			allPhpErrors: [],
+			locallyIgnoredErrors: [],
+			linesToIgnore: [],
+			unmatchedLineIgnores: [],
+			internalErrors: [],
+			collectedData: LazyCollectedData::fromArray($collectedData),
+			dependencies: $dependencies,
+			usedTraitDependencies: [],
+			packageDependencies: [],
+			exportedNodes: [],
+			reachedInternalErrorsCountLimit: false,
+			peakMemoryUsageBytes: 0,
+			processedFiles: $this->files,
+		);
+	}
+
+	private function breakFirstCollectedDataValue(): void
+	{
+		$contents = file_get_contents($this->cacheFilePath());
+		$this->assertNotFalse($contents);
+		$position = strpos($contents, 's:10:"usage in a"');
+		$this->assertNotFalse($position);
+		// the declared length no longer matches the body, the frame keeps its size
+		file_put_contents($this->cacheFilePath(), substr($contents, 0, $position) . 's:11:' . substr($contents, $position + 5));
+	}
+
+	private function createManager(): ResultCacheManager
+	{
+		$container = self::getContainer();
+
+		return new ResultCacheManager(
+			resultCacheMetaExtensions: $container->getExtensionsCollection(ResultCacheMetaExtension::class),
+			exportedNodeFetcher: $container->getByType(ExportedNodeFetcher::class),
+			scanFileFinder: $container->getService('fileFinderScan'),
+			stubFilesProvider: $container->getByType(StubFilesProvider::class),
+			fileHelper: $container->getByType(FileHelper::class),
+			packageDependencyResolver: $container->getByType(PackageDependencyResolver::class),
+			cacheFilePath: $this->cacheFilePath(),
+			analysedPaths: [$this->directory . '/src'],
+			analysedPathsFromConfig: [],
+			composerAutoloaderProjectPaths: [],
+			usedLevel: '8',
+			cliAutoloadFile: null,
+			bootstrapFiles: [],
+			scanFiles: [],
+			scanDirectories: [],
+			configStubFiles: [],
+			fileReplacements: [],
+			checkDependenciesOfProjectExtensionFiles: false,
+			parametersNotInvalidatingCache: [],
+			skipResultCacheIfOlderThanDays: 7,
+			anchorDirectory: $this->directory,
+			phpVersion: $container->getByType(PhpVersion::class),
+			composerPhpVersionFactory: $container->getByType(ComposerPhpVersionFactory::class),
+		);
+	}
+
+	private function cacheFilePath(): string
+	{
+		return $this->directory . '/resultCache.php';
+	}
+
+	private function nullOutput(): Output
+	{
+		$symfonyOutput = new NullOutput();
+
+		return new SymfonyOutput($symfonyOutput, new SymfonyStyle(new SymfonyConsoleStyle(new StringInput(''), $symfonyOutput)));
+	}
+
+}

--- a/tests/PHPStan/Analyser/ResultCache/ResultCacheManagerCollectedDataTest.php
+++ b/tests/PHPStan/Analyser/ResultCache/ResultCacheManagerCollectedDataTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser\ResultCache;
 
+use Nette\Utils\Strings;
 use Override;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Command\Output;
@@ -20,14 +21,15 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Style\SymfonyStyle as SymfonyConsoleStyle;
 use function array_keys;
+use function basename;
 use function count;
 use function file_get_contents;
 use function file_put_contents;
 use function is_file;
 use function md5_file;
 use function mkdir;
+use function ord;
 use function rmdir;
-use function str_replace;
 use function strlen;
 use function strpos;
 use function substr;
@@ -47,11 +49,12 @@ class ResultCacheManagerCollectedDataTest extends PHPStanTestCase
 	protected function setUp(): void
 	{
 		parent::setUp();
-		$this->directory = sys_get_temp_dir() . '/phpstan-collected-data-' . uniqid();
+		$fileHelper = self::getContainer()->getByType(FileHelper::class);
+		$this->directory = $fileHelper->normalizePath(sys_get_temp_dir() . '/phpstan-collected-data-' . uniqid());
 		// the cache file must not be in the analysed directory, or it counts as a scanned file
 		mkdir($this->directory . '/src', 0777, true);
 		foreach (['a', 'b', 'c'] as $name) {
-			$file = $this->directory . '/src/' . $name . '.php';
+			$file = $fileHelper->normalizePath($this->directory . '/src/' . $name . '.php');
 			file_put_contents($file, '<?php class Cache' . $name . " {}\n");
 			$this->files[] = $file;
 		}
@@ -87,7 +90,7 @@ class ResultCacheManagerCollectedDataTest extends PHPStanTestCase
 		$this->assertNotFalse($contents);
 		foreach ($lazy->getCachedIndex() as $file => [$offset, $length]) {
 			$entry = substr($contents, $offset, $length);
-			$this->assertStringContainsString('"' . str_replace($this->directory . '/', '', $file) . '"', $entry);
+			$this->assertStringContainsString('"src/' . basename($file) . '"', $entry);
 			$this->assertStringEndsWith('}', $entry);
 		}
 	}
@@ -123,9 +126,9 @@ class ResultCacheManagerCollectedDataTest extends PHPStanTestCase
 		$expected[$this->files[1]] = $freshB[$this->files[1]];
 		$this->assertSame($expected, $processed->getAnalyserResult()->getCollectedData());
 
-		$partial = md5_file($this->cacheFilePath());
+		$partial = $this->cacheContentsWithoutTime();
 		$this->saveFullAnalysis($expected);
-		$this->assertSame($partial, md5_file($this->cacheFilePath()));
+		$this->assertSame($partial, $this->cacheContentsWithoutTime());
 	}
 
 	public function testDamagedValueDiscardsTheCacheWhenRead(): void
@@ -186,7 +189,7 @@ class ResultCacheManagerCollectedDataTest extends PHPStanTestCase
 	{
 		$data = [];
 		foreach ($names as $name) {
-			$data[$this->directory . '/src/' . $name . '.php'] = [MethodWithoutImpurePointsCollector::class => ['usage in ' . $name]];
+			$data[$this->files[ord($name) - ord('a')]] = [MethodWithoutImpurePointsCollector::class => ['usage in ' . $name]];
 		}
 
 		return $data;
@@ -234,6 +237,17 @@ class ResultCacheManagerCollectedDataTest extends PHPStanTestCase
 			peakMemoryUsageBytes: 0,
 			processedFiles: $this->files,
 		);
+	}
+
+	/**
+	 * A full analysis records its own time, which a partial save keeps from the previous one.
+	 */
+	private function cacheContentsWithoutTime(): string
+	{
+		$contents = file_get_contents($this->cacheFilePath());
+		$this->assertNotFalse($contents);
+
+		return Strings::replace($contents, '~^lastFullAnalysisTime \d+\ni:\d+;~m', '');
 	}
 
 	private function breakFirstCollectedDataValue(): void


### PR DESCRIPTION
## Problem

`restore()` decodes the whole `collectedData` section into the main process before the analysis starts. Only the rules on `CollectedDataNode` need that data, after the analysis, in the main process. Until then it sits in memory for the whole run, and every forked worker inherits it. On a project with a collector-heavy extension this is the largest section of the cache by far: [Dead Code Detector](https://github.com/shipmonk-rnd/dead-code-detector) stores every member usage in it, hundreds of megabytes on a large codebase. That is why DCD moved its data into its own file store (shipmonk-rnd/dead-code-detector#319) and later optimised that store (shipmonk-rnd/dead-code-detector#427). With 2.2.13 and this change both can go: DCD emits its usages through the collector API again.

## Change

- An array-frame entry carries its key as a separate payload before the value, so a section can be indexed without decoding any value. Cache version bumped.
- `restore()` walks the `collectedData` section into an index (file to offset and length) and hands it out as `LazyCollectedData` together with the run's fresh data. That is all the workers inherit.
- `save()` copies the entries that stay valid byte for byte from the old file, records their positions in the new one, and serializes only the fresh entries. A warm run writes a byte-identical file.
- `AnalyserResultFinalizer` is the only place that decodes the section, and the decoded array lives as long as the `CollectedDataNode`.
- The file is opened per read; no handle survives a fork or blocks a rename on Windows. Both the reader and the copy verify the key at the offset, so a cache replaced by another run sharing the tmpDir is never copied misaligned: the save is skipped and the run reports an internal error once.
- A value that fails to unserialize used to be caught in `restore()`. It now surfaces in the finalizer, after the bytes were copied into the new file, so the reader discards the file and the finalizer reports an internal error (`shouldReportBug: false`) instead of failing on every following run.

`CollectedDataNode` and the `Collector` API are unchanged. `AnalysisResult` (`@api`) accepts the collected data as a closure so a formatter that never asks for it never decodes the section.

## Numbers

phpstan-src self-analysis with DCD data in the result cache (2467 files, 88 MB cache), main process, Linux:

|  | before | after |
|---|---|---|
| `restore()`, warm run | 200 ms, +168 MB | 175 ms, +74 MB |
| partial run of 486 files, main process peak | 486 MB | 440 MB |
| partial run of 486 files, largest forked worker | 368 MB | 276 MB |

The peak during the `CollectedDataNode` rules is unchanged; they still get the whole array. A streaming API for rules would be a separate, additive change.

## Notes

- After a partial run, `CollectedDataNode` lists the cached files first and the re-analysed ones after them. A full run already yields worker-completion order, so nothing can depend on it.
- `ResultCacheManager::process()` drops `workerCount` on the merged result, so cached runs never print the per-worker peak. Not included here; the worker numbers above come from a one-line local fix.
- The CI jobs failing here (mutation testing, Windows PHPStan, extension and integration tests) fail the same way on #6371 and #6372.
