### PR TITLE
Reduce repeated work when matching ignored errors

### DIFF
--- a/src/Analyser/Ignore/IgnoredErrorHelperResult.php
+++ b/src/Analyser/Ignore/IgnoredErrorHelperResult.php
@@ -69,6 +69,25 @@ final class IgnoredErrorHelperResult
 	}
 
 	/**
+	 * @param array<array{index: int<0, max>, ignoreError: string|ExpandedIgnoredErrorData}> $ignoreErrors
+	 * @return array<array{index: int<0, max>, ignoreError: string|ExpandedIgnoredErrorData}>
+	 */
+	private static function filterIgnoreErrorsByIdentifier(array $ignoreErrors, ?string $identifier): array
+	{
+		$filtered = [];
+		foreach ($ignoreErrors as $ignoreError) {
+			$ignore = $ignoreError['ignoreError'];
+			if (is_array($ignore) && isset($ignore['identifier']) && $ignore['identifier'] !== $identifier) {
+				continue;
+			}
+
+			$filtered[] = $ignoreError;
+		}
+
+		return $filtered;
+	}
+
+	/**
 	 * @param list<Error> $errors
 	 * @param string[] $analysedFiles
 	 */
@@ -88,6 +107,12 @@ final class IgnoredErrorHelperResult
 		// offset writes — otherwise PHPStan widens it to `array<mixed>`.
 		$realCounts = [];
 		$matchedAt = [];
+
+		// Preserve configuration order while filtering out identifier-specific
+		// entries that cannot match, once per distinct error identifier.
+		$otherIgnoreErrorsByIdentifier = [];
+
+		$ignoreErrorsByFileAndIdentifier = [];
 
 		$processIgnoreError = function (Error $error, int $i, $ignore) use (&$unmatchedIgnoredErrors, &$stringErrors, &$realCounts, &$matchedAt): bool {
 			$shouldBeIgnored = false;
@@ -116,22 +141,27 @@ final class IgnoredErrorHelperResult
 						}
 					}
 				} elseif (isset($ignore['paths'])) {
-					foreach ($ignore['paths'] as $j => $ignorePath) {
-						$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, ignoredErrorPattern: $ignore['message'] ?? null, ignoredErrorMessage: $ignore['rawMessage'] ?? null, identifier: $ignore['identifier'] ?? null, path: $ignorePath);
-						if (!$shouldBeIgnored) {
-							continue;
-						}
+					// Message and identifier do not depend on the path. Match them once
+					// instead of repeating the potentially expensive regex for every path.
+					$matchesMessageAndIdentifier = IgnoredError::shouldIgnore($this->fileHelper, $error, ignoredErrorPattern: $ignore['message'] ?? null, ignoredErrorMessage: $ignore['rawMessage'] ?? null, identifier: $ignore['identifier'] ?? null, path: null);
+					if ($matchesMessageAndIdentifier) {
+						foreach ($ignore['paths'] as $j => $ignorePath) {
+							$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, ignoredErrorPattern: null, ignoredErrorMessage: null, identifier: null, path: $ignorePath);
+							if (!$shouldBeIgnored) {
+								continue;
+							}
 
-						if (isset($unmatchedIgnoredErrors[$i])) {
-							if (!is_array($unmatchedIgnoredErrors[$i])) {
-								throw new ShouldNotHappenException();
+							if (isset($unmatchedIgnoredErrors[$i])) {
+								if (!is_array($unmatchedIgnoredErrors[$i])) {
+									throw new ShouldNotHappenException();
+								}
+								unset($unmatchedIgnoredErrors[$i]['paths'][$j]);
+								if (isset($unmatchedIgnoredErrors[$i]['paths']) && count($unmatchedIgnoredErrors[$i]['paths']) === 0) {
+									unset($unmatchedIgnoredErrors[$i]);
+								}
 							}
-							unset($unmatchedIgnoredErrors[$i]['paths'][$j]);
-							if (isset($unmatchedIgnoredErrors[$i]['paths']) && count($unmatchedIgnoredErrors[$i]['paths']) === 0) {
-								unset($unmatchedIgnoredErrors[$i]);
-							}
+							break;
 						}
-						break;
 					}
 				} else {
 					$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, ignoredErrorPattern: $ignore['message'] ?? null, ignoredErrorMessage: $ignore['rawMessage'] ?? null, identifier: $ignore['identifier'] ?? null, path: null);
@@ -161,6 +191,10 @@ final class IgnoredErrorHelperResult
 		$errorQueue = $errors;
 		for ($errorIndex = 0; $errorIndex < count($errorQueue); $errorIndex++) {
 			$error = $errorQueue[$errorIndex];
+			$identifier = $error->getIdentifier();
+			$identifierKey = $identifier ?? '';
+			$matchingOtherIgnoreErrors = $otherIgnoreErrorsByIdentifier[$identifierKey]
+				??= self::filterIgnoreErrorsByIdentifier($this->otherIgnoreErrors, $identifier);
 
 			// An error deduplicated directly into a trait (see ConstantConditionInTraitRule)
 			// stands for one occurrence per using class. An ignoreErrors path pointing at one
@@ -175,7 +209,9 @@ final class IgnoredErrorHelperResult
 					$contextError = $error->asReportedInTraitContext($contextFilePath);
 					$contextIgnored = false;
 					$normalizedContextFilePath = $this->fileHelper->normalizePath($contextFilePath);
-					foreach ($this->ignoreErrorsByFile[$normalizedContextFilePath] ?? [] as $ignoreError) {
+					$matchingFileIgnoreErrors = $ignoreErrorsByFileAndIdentifier[$normalizedContextFilePath][$identifierKey]
+						??= self::filterIgnoreErrorsByIdentifier($this->ignoreErrorsByFile[$normalizedContextFilePath] ?? [], $identifier);
+					foreach ($matchingFileIgnoreErrors as $ignoreError) {
 						$i = $ignoreError['index'];
 						$ignore = $ignoreError['ignoreError'];
 						if (!$processIgnoreError($contextError, $i, $ignore)) {
@@ -185,7 +221,7 @@ final class IgnoredErrorHelperResult
 						}
 					}
 					if (!$contextIgnored) {
-						foreach ($this->otherIgnoreErrors as $ignoreError) {
+						foreach ($matchingOtherIgnoreErrors as $ignoreError) {
 							$i = $ignoreError['index'];
 							$ignore = $ignoreError['ignoreError'];
 							// only entries scoped to a path that does not cover the trait file
@@ -234,7 +270,9 @@ final class IgnoredErrorHelperResult
 
 			$filePath = $this->fileHelper->normalizePath($error->getFilePath());
 			if (!$isStrippedSurvivor && isset($this->ignoreErrorsByFile[$filePath])) {
-				foreach ($this->ignoreErrorsByFile[$filePath] as $ignoreError) {
+				$matchingFileIgnoreErrors = $ignoreErrorsByFileAndIdentifier[$filePath][$identifierKey]
+					??= self::filterIgnoreErrorsByIdentifier($this->ignoreErrorsByFile[$filePath], $identifier);
+				foreach ($matchingFileIgnoreErrors as $ignoreError) {
 					$i = $ignoreError['index'];
 					$ignore = $ignoreError['ignoreError'];
 					$result = $processIgnoreError($error, $i, $ignore);
@@ -249,7 +287,9 @@ final class IgnoredErrorHelperResult
 			if ($traitFilePath !== null) {
 				$normalizedTraitFilePath = $this->fileHelper->normalizePath($traitFilePath);
 				if (isset($this->ignoreErrorsByFile[$normalizedTraitFilePath])) {
-					foreach ($this->ignoreErrorsByFile[$normalizedTraitFilePath] as $ignoreError) {
+					$matchingFileIgnoreErrors = $ignoreErrorsByFileAndIdentifier[$normalizedTraitFilePath][$identifierKey]
+						??= self::filterIgnoreErrorsByIdentifier($this->ignoreErrorsByFile[$normalizedTraitFilePath], $identifier);
+					foreach ($matchingFileIgnoreErrors as $ignoreError) {
 						$i = $ignoreError['index'];
 						$ignore = $ignoreError['ignoreError'];
 						$result = $processIgnoreError($error, $i, $ignore);
@@ -261,7 +301,7 @@ final class IgnoredErrorHelperResult
 				}
 			}
 
-			foreach ($this->otherIgnoreErrors as $ignoreError) {
+			foreach ($matchingOtherIgnoreErrors as $ignoreError) {
 				$i = $ignoreError['index'];
 				$ignore = $ignoreError['ignoreError'];
 

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -166,6 +166,19 @@ class AnalyserTest extends PHPStanTestCase
 		$this->assertSame('Ignored error pattern wrong.identifier was not matched in reported errors.', $result[1]);
 	}
 
+	public function testFileWithAnIgnoredErrorIdentifierAndPathWithWrongIdentifier(): void
+	{
+		$result = $this->runAnalyser([[
+			'identifier' => 'wrong.identifier',
+			'path' => __DIR__ . '/data/bootstrap-error.php',
+		]], true, __DIR__ . '/data/bootstrap-error.php', false);
+		$this->assertCount(2, $result);
+		$this->assertInstanceOf(Error::class, $result[0]);
+		$this->assertSame('Fail.', $result[0]->getMessage());
+		$this->assertInstanceOf(Error::class, $result[1]);
+		$this->assertSame('Ignored error pattern wrong.identifier in path ' . __DIR__ . '/data/bootstrap-error.php was not matched in reported errors.', $result[1]->getMessage());
+	}
+
 	public function testIgnoreErrorByPath(): void
 	{
 		$ignoreErrors = [
@@ -404,6 +417,37 @@ class AnalyserTest extends PHPStanTestCase
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
 		$this->assertNoErrors($result);
+	}
+
+	public function testIgnoreErrorByMessageIdentifierAndSecondPath(): void
+	{
+		$ignoreErrors = [
+			[
+				'message' => '#Fail\.#',
+				'identifier' => 'tests.alwaysFail',
+				'paths' => [
+					__DIR__ . '/data/another-path.php',
+					__DIR__ . '/data/bootstrap-error.php',
+				],
+			],
+		];
+		$result = $this->runAnalyser($ignoreErrors, false, __DIR__ . '/data/bootstrap-error.php', false);
+		$this->assertNoErrors($result);
+	}
+
+	public function testIgnoreErrorByPathsRequiresMatchingIdentifier(): void
+	{
+		$ignoreErrors = [
+			[
+				'message' => '#Fail\.#',
+				'identifier' => 'wrong.identifier',
+				'paths' => [__DIR__ . '/data/bootstrap-error.php'],
+			],
+		];
+		$result = $this->runAnalyser($ignoreErrors, false, __DIR__ . '/data/bootstrap-error.php', false);
+		$this->assertCount(1, $result);
+		$this->assertInstanceOf(Error::class, $result[0]);
+		$this->assertSame('Fail.', $result[0]->getMessage());
 	}
 
 	public function testIgnoreErrorMultiByPaths(): void

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -41,6 +41,7 @@ use function sprintf;
 use function str_replace;
 use function strtoupper;
 use function substr;
+use const DIRECTORY_SEPARATOR;
 use const PHP_OS;
 
 class AnalyserTest extends PHPStanTestCase
@@ -176,7 +177,8 @@ class AnalyserTest extends PHPStanTestCase
 		$this->assertInstanceOf(Error::class, $result[0]);
 		$this->assertSame('Fail.', $result[0]->getMessage());
 		$this->assertInstanceOf(Error::class, $result[1]);
-		$this->assertSame('Ignored error pattern wrong.identifier in path ' . __DIR__ . '/data/bootstrap-error.php was not matched in reported errors.', $result[1]->getMessage());
+		$expectedPath = str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/data/bootstrap-error.php');
+		$this->assertSame('Ignored error pattern wrong.identifier in path ' . $expectedPath . ' was not matched in reported errors.', $result[1]->getMessage());
 	}
 
 	public function testIgnoreErrorByPath(): void


### PR DESCRIPTION
## Summary

This reduces repeated work in `IgnoredErrorHelperResult::process()` in two ways:

- for an `ignoreErrors` entry containing `paths`, the identifier and message/regex are matched once instead of once per path;
- ignore entries with a different identifier are filtered out once per distinct error identifier before processing, while preserving their configured order.

The matching semantics and the behavior of entries using a singular `path` are unchanged.

## Motivation

This was identified while profiling a large project with a warm result cache: https://github.com/phpstan/phpstan/discussions/15174#discussioncomment-18293062

With no files requiring analysis, ignored-error processing was still a significant part of the warm run.

## Benchmark

PHPStan 2.2.13, warm result cache, without the PHP baseline:

| | Before | After matching message once per `paths` entry |
|---|---:|---:|
| Wall-clock median | 5.26 s | 4.38 s |
| Wall-clock mean | 5.24 s | 4.38 s |
| Samples | 10 | 10 |

Matching messages once improved the median wall-clock time by **0.89 s (16.8%)**.

Filtering by identifier provided a further improvement in a bracketed comparison:

| | Before identifier filtering | After identifier filtering |
|---|---:|---:|
| Wall-clock median | 4.55 s | 4.37 s |
| Samples | 6 | 6 |

### SPX profile

| | Stock | Final patch |
|---|---:|---:|
| SPX process wall time | 10.17 s | 8.37 s |
| Total calls | 22.82 M | 16.28 M |
| `IgnoredError::shouldIgnore()` calls | 2.52 M | 0.38 M |
| `Nette\Utils\Strings::match()` calls | 0.93 M | 0.42 M |
| `IgnoredErrorHelperResult::process()` | 3.23 s | 1.13 s |

Full-trace SPX adds substantial overhead, so the unprofiled wall-clock results above are the primary benchmark.

With the large PHP-format baseline enabled, identifier filtering improved the warm median from **5.02 s to 4.715 s** in six samples per variant.

All stock and patched comparisons produced byte-identical output. They reported the same 1000+ errors without the PHP baseline and the same eight errors with it.

## Tests

Regression coverage includes:

- matching a message and identifier against the second configured path;
- requiring the identifier to match when `paths` is used;
- retaining an unmatched identifier-specific entry for an exact file path.

Commands run:

```bash
vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserTest.php
php -d memory_limit=450M bin/phpstan analyse src/Analyser/Ignore/IgnoredErrorHelperResult.php tests/PHPStan/Analyser/AnalyserTest.php --no-progress
```

Results:

- PHPUnit: 62 tests, 204 assertions
- PHPStan: no errors
