### PR TITLE
Fix union of template array-key with false losing the template

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -256,7 +256,6 @@ final class TypeCombinator
 		$alreadyNormalizedCounter = 0;
 
 		$benevolentTypes = [];
-		$benevolentUnionObject = null;
 		$neverCount = 0;
 		// transform A | (B | C) to A | B | C
 		for ($i = 0; $i < $typesCount; $i++) {
@@ -273,8 +272,8 @@ final class TypeCombinator
 				continue;
 			}
 			if ($types[$i] instanceof BenevolentUnionType) {
-				if ($types[$i] instanceof TemplateBenevolentUnionType && $benevolentUnionObject === null) {
-					$benevolentUnionObject = $types[$i];
+				if ($types[$i] instanceof TemplateType) {
+					continue;
 				}
 				$benevolentTypesCount = 0;
 				$typesInner = $types[$i]->getTypes();
@@ -528,10 +527,6 @@ final class TypeCombinator
 			}
 
 			if ($tempTypes === []) {
-				if ($benevolentUnionObject instanceof TemplateBenevolentUnionType) {
-					return $benevolentUnionObject->withTypes(array_values($types));
-				}
-
 				return new BenevolentUnionType(array_values($types), true);
 			}
 		}

--- a/tests/PHPStan/Analyser/nsrt/bug-10871.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10871.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Bug10871;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+interface Map
+{
+
+	/**
+	 * @template TOtherKey of array-key
+	 * @template TOtherValue
+	 * @param iterable<TOtherKey, TOtherValue> ...$iterables
+	 * @return self<TKey|TOtherKey, TValue|TOtherValue>
+	 */
+	public function merge(iterable ...$iterables): self;
+
+}
+
+/**
+ * @param Map<string, int> $map
+ */
+function test(Map $map, int $int, bool $bool): void
+{
+	assertType('Bug10871\Map<int|string, bool|int>', $map->merge([$int => $bool]));
+	assertType('Bug10871\Map<int|string, bool|int|stdClass>', $map->merge([$int => $bool], ['test' => new stdClass()]));
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13192.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13192.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Bug13192;
+
+use function PHPStan\Testing\assertType;
+
+class Apple
+{
+}
+
+class Orange
+{
+}
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class Collection
+{
+
+	/**
+	 * @template UKey of array-key
+	 * @template UValue
+	 * @param static<UKey, UValue> $items
+	 * @return static<TKey|UKey, TValue|UValue>
+	 */
+	public function merge(self $items): static
+	{
+		return $this;
+	}
+
+}
+
+/**
+ * @param Collection<int, Orange> $oranges
+ * @param Collection<string, Apple> $apples
+ */
+function test(Collection $oranges, Collection $apples): void
+{
+	assertType('Bug13192\Collection<int|string, Bug13192\Apple|Bug13192\Orange>', $oranges->merge($apples));
+	assertType('Bug13192\Collection<int|string, Bug13192\Apple|Bug13192\Orange>', $apples->merge($oranges));
+	assertType('Bug13192\Collection<int, Bug13192\Orange>', $oranges->merge($oranges));
+	assertType('Bug13192\Collection<string, Bug13192\Apple>', $apples->merge($apples));
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13374.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13374.php
@@ -1,0 +1,52 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug13374;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class Collection
+{
+
+	/**
+	 * @template TPushValue
+	 * @param TPushValue $value
+	 * @return $this
+	 * @phpstan-this-out static<int|TKey, TValue|TPushValue>
+	 */
+	public function push(mixed $value): static
+	{
+		return $this;
+	}
+
+	/**
+	 * @template TPutKey of array-key
+	 * @template TPutValue
+	 * @param TPutKey $key
+	 * @param TPutValue $value
+	 * @return $this
+	 * @phpstan-this-out static<TKey|TPutKey, TValue|TPutValue>
+	 */
+	public function put(int|string $key, mixed $value): static
+	{
+		return $this;
+	}
+
+}
+
+/**
+ * @param Collection<string, int> $pushCollection
+ * @param Collection<string, int> $putCollection
+ */
+function test(Collection $pushCollection, Collection $putCollection): void
+{
+	assertType('Bug13374\Collection<int|string, int>', $pushCollection->push(123));
+	assertType('Bug13374\Collection<int|string, int|string>', $pushCollection->push('foo'));
+	assertType('Bug13374\Collection<int|string, int>', $putCollection->put(123, 456));
+	assertType('Bug13374\Collection<int|string, int|string>', $putCollection->put(789, 'foo'));
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-7049.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7049.php
@@ -1,0 +1,26 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug7049;
+
+use Closure;
+use function PHPStan\Testing\assertType;
+
+class Collection
+{
+
+	/**
+	 * @template TGroupKey of array-key
+	 * @param TGroupKey|Closure(mixed): TGroupKey $key
+	 * @return array<TGroupKey, static>
+	 */
+	public function groupBy(int|string|Closure $key): array
+	{
+		return [];
+	}
+
+}
+
+$collection = new Collection();
+assertType("array<'id', Bug7049\Collection>", $collection->groupBy('id'));

--- a/tests/PHPStan/Analyser/nsrt/bug-7279.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7279.php
@@ -1,0 +1,45 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug7279;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template K of array-key
+ * @template T
+ * @param array<K, T> $array
+ * @param callable(T, K): bool $fn
+ * @return ($array is non-empty-array ? K|null : null)
+ */
+function findKey(array $array, callable $fn): string|int|null
+{
+	foreach ($array as $key => $value) {
+		if ($fn($value, $key)) {
+			return $key;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * @param callable(mixed): bool $callback
+ * @param array<never, never> $emptyList
+ * @param array{} $emptyMap
+ * @param array<int, string> $unknownList
+ * @param array{id?: int, name?: string} $unknownMap
+ * @param non-empty-array<int, string> $nonEmptyList
+ * @param array{work: string} $nonEmptyMap
+ */
+function test(callable $callback, array $emptyList, array $emptyMap, array $unknownList, array $unknownMap, array $nonEmptyList, array $nonEmptyMap): void
+{
+	assertType('null', findKey([], $callback));
+	assertType('null', findKey($emptyList, $callback));
+	assertType('null', findKey($emptyMap, $callback));
+	assertType('int|null', findKey($unknownList, $callback));
+	assertType("'id'|'name'|null", findKey($unknownMap, $callback));
+	assertType('int|null', findKey($nonEmptyList, $callback));
+	assertType("'work'|null", findKey($nonEmptyMap, $callback));
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-7423.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7423.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Bug7423;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class ArrayType
+{
+
+	/**
+	 * @template VKey of array-key
+	 * @template V
+	 * @param VKey $key
+	 * @param V $value
+	 * @return self<TKey|VKey, TValue|V>
+	 */
+	public function add($key, $value): self
+	{
+		return $this;
+	}
+
+}
+
+/** @var ArrayType<string, string> $type */
+$type = new ArrayType();
+
+assertType('Bug7423\ArrayType<int|string, int|string>', $type->add(1, 1));

--- a/tests/PHPStan/Analyser/nsrt/bug-8268.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-8268.php
@@ -1,0 +1,28 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug8268;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey of array-key
+ */
+class Collection
+{
+
+	/**
+	 * @param TKey|null $offset
+	 */
+	public function set(int|string|null $offset): void
+	{
+		assertType('TKey of (int|string) (class Bug8268\Collection, argument)|null', $offset);
+		if ($offset === null) {
+			return;
+		}
+
+		assertType('TKey of (int|string) (class Bug8268\Collection, argument)', $offset);
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/template-array-key-union-false.php
+++ b/tests/PHPStan/Analyser/nsrt/template-array-key-union-false.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace TemplateArrayKeyUnionFalse;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class Collection
+{
+
+	/**
+	 * @param TValue|callable(TValue, TKey): bool $value
+	 * @return TKey|false
+	 */
+	public function search($value, bool $strict = false)
+	{
+		return false;
+	}
+
+}
+
+/**
+ * @param Collection<int, string> $ints
+ * @param Collection<string, string> $strings
+ * @param Collection<int|string, string> $keys
+ */
+function test(Collection $ints, Collection $strings, Collection $keys): void
+{
+	assertType('int|false', $ints->search('foo'));
+	assertType('string|false', $strings->search('foo'));
+	assertType('int|string|false', $keys->search('foo'));
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1984,6 +1984,14 @@ class TypeCombinatorTest extends PHPStanTestCase
 			],
 			[
 				[
+					TemplateTypeFactory::create(TemplateTypeScope::createWithFunction('foo'), 'T', new BenevolentUnionType([new IntegerType(), new StringType()]), TemplateTypeVariance::createInvariant()),
+					new ConstantBooleanType(false),
+				],
+				UnionType::class,
+				'T of (int|string) (function foo(), parameter)|false',
+			],
+			[
+				[
 					new ConstantStringType(''),
 					new IntersectionType([
 						new StringType(),


### PR DESCRIPTION
Hello!

`TypeCombinator` flattened `TemplateBenevolentUnionType` into `int|string` before adding other members, so `TKey|false` became `int|string|false` instead of substituting `TKey`.

Thanks!

Closes https://github.com/phpstan/phpstan/issues/13374
Closes https://github.com/phpstan/phpstan/issues/13192
Closes https://github.com/phpstan/phpstan/issues/10871
Closes https://github.com/phpstan/phpstan/issues/8268
Closes https://github.com/phpstan/phpstan/issues/7423
Closes https://github.com/phpstan/phpstan/issues/7279
Closes https://github.com/phpstan/phpstan/issues/7049