### PR TITLE
Watch files through the OS instead of re-hashing them every second

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -81,6 +81,14 @@ parameters:
 		- '#should be contravariant with parameter \$node \(PhpParser\\Node\) of method PHPStan\\Rules\\Rule<PhpParser\\Node>::processNode\(\)$#'
 		- '#Variable property access on PhpParser\\Node#'
 		-
+			# FFI's methods are the C functions declared in the cdef string at
+			# runtime, so no reflection can know them
+			identifier: method.notFound
+			message: '#^Call to an undefined method FFI::#'
+			paths:
+				- ../src/File/FsEventsFileMonitor.php
+				- ../src/File/InotifyFileMonitor.php
+		-
 			identifier: shipmonk.deadMethod
 			message: '#^Unused .*?::__construct#' # likely used in DIC
 			reportUnmatched: false

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -16,6 +16,7 @@ use PHPStan\Analyser\InternalError;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\File\FileMonitor;
+use PHPStan\File\FileMonitorFactory;
 use PHPStan\File\FileMonitorResult;
 use PHPStan\File\FileReader;
 use PHPStan\File\FileWriter;
@@ -75,7 +76,7 @@ final class FixerApplication
 	 * @param string[] $bootstrapFiles
 	 */
 	public function __construct(
-		private FileMonitor $fileMonitor,
+		private FileMonitorFactory $fileMonitorFactory,
 		private IgnoredErrorHelper $ignoredErrorHelper,
 		private StubFilesProvider $stubFilesProvider,
 		#[AutowiredParameter]
@@ -102,6 +103,8 @@ final class FixerApplication
 	)
 	{
 	}
+
+	private ?FileMonitor $fileMonitor = null;
 
 	public function run(
 		InceptionResult $inceptionResult,
@@ -154,7 +157,7 @@ final class FixerApplication
 				}
 			});
 
-			$this->fileMonitor->initialize(array_merge(
+			$this->fileMonitor = $this->fileMonitorFactory->create(array_merge(
 				$this->getComposerLocks(),
 				$this->getComposerInstalled(),
 				$this->getExecutedFiles(),
@@ -404,24 +407,29 @@ final class FixerApplication
 	 */
 	private function monitorFileChanges(LoopInterface $loop, callable $hasChangesCallback): void
 	{
-		$callback = function () use (&$callback, $loop, $hasChangesCallback): void {
+		if ($this->fileMonitor === null) {
+			throw new ShouldNotHappenException();
+		}
+		$fileMonitor = $this->fileMonitor;
+		$interval = $fileMonitor->getPollInterval();
+		$callback = function () use (&$callback, $loop, $hasChangesCallback, $fileMonitor, $interval): void {
 			if (!$this->fileMonitorActive) {
-				$loop->addTimer(1.0, $callback);
+				$loop->addTimer($interval, $callback);
 				return;
 			}
 			if ($this->processInProgress !== null) {
-				$loop->addTimer(1.0, $callback);
+				$loop->addTimer($interval, $callback);
 				return;
 			}
-			$changes = $this->fileMonitor->getChanges();
+			$changes = $fileMonitor->getChanges();
 
 			if ($changes->hasAnyChanges()) {
 				$hasChangesCallback($changes);
 			}
 
-			$loop->addTimer(1.0, $callback);
+			$loop->addTimer($interval, $callback);
 		};
-		$loop->addTimer(1.0, $callback);
+		$loop->addTimer($interval, $callback);
 	}
 
 	private function analyse(

--- a/src/File/FileMonitor.php
+++ b/src/File/FileMonitor.php
@@ -2,146 +2,32 @@
 
 namespace PHPStan\File;
 
-use PHPStan\DependencyInjection\AutowiredParameter;
-use PHPStan\DependencyInjection\AutowiredService;
-use PHPStan\ShouldNotHappenException;
-use function array_diff;
-use function array_key_exists;
-use function array_keys;
-use function array_merge;
-use function array_unique;
-use function hash_file;
-use function is_dir;
-use function is_file;
-
-#[AutowiredService]
-final class FileMonitor
+/**
+ * Watches the analysed and scanned files for changes between PHPStan Pro analyses.
+ *
+ * {@see HashingFileMonitor} is the portable implementation: it re-hashes every
+ * monitored file on every poll. The native implementations
+ * ({@see KqueueFileMonitor}, {@see InotifyFileMonitor}) wrap it and let the
+ * kernel answer "did anything change at all", so an idle poll touches no files;
+ * once the kernel says yes, they delegate to the hashing monitor so the reported
+ * result is identical either way.
+ *
+ * {@see FileMonitorFactory} picks the implementation for the current platform.
+ */
+interface FileMonitor
 {
 
-	/** @var array<string, string>|null */
-	private ?array $fileHashes = null;
+	/**
+	 * @param array<string> $filePaths extra files to monitor besides the analysed and scanned ones
+	 */
+	public function initialize(array $filePaths): void;
 
-	/** @var array<string>|null */
-	private ?array $filePaths = null;
+	public function getChanges(): FileMonitorResult;
 
 	/**
-	 * @param string[] $analysedPaths
-	 * @param string[] $analysedPathsFromConfig
-	 * @param string[] $scanFiles
-	 * @param string[] $scanDirectories
+	 * How often the caller should poll. A monitor whose idle poll is free can
+	 * afford a much shorter interval, which is what makes an edit noticed sooner.
 	 */
-	public function __construct(
-		#[AutowiredParameter(ref: '@fileFinderAnalyse')]
-		private FileFinder $analyseFileFinder,
-		#[AutowiredParameter(ref: '@fileFinderScan')]
-		private FileFinder $scanFileFinder,
-		#[AutowiredParameter]
-		private array $analysedPaths,
-		#[AutowiredParameter]
-		private array $analysedPathsFromConfig,
-		#[AutowiredParameter]
-		private array $scanFiles,
-		#[AutowiredParameter]
-		private array $scanDirectories,
-	)
-	{
-	}
-
-	/**
-	 * @param array<string> $filePaths
-	 */
-	public function initialize(array $filePaths): void
-	{
-		$finderResult = $this->analyseFileFinder->findFiles($this->analysedPaths);
-		$fileHashes = [];
-		foreach (array_unique(array_merge($finderResult->getFiles(), $filePaths, $this->getScannedFiles($finderResult->getFiles()))) as $filePath) {
-			$fileHashes[$filePath] = $this->getFileHash($filePath);
-		}
-
-		$this->fileHashes = $fileHashes;
-		$this->filePaths = $filePaths;
-	}
-
-	public function getChanges(): FileMonitorResult
-	{
-		if ($this->fileHashes === null || $this->filePaths === null) {
-			throw new ShouldNotHappenException();
-		}
-		$finderResult = $this->analyseFileFinder->findFiles($this->analysedPaths);
-		$oldFileHashes = $this->fileHashes;
-		$fileHashes = [];
-		$newFiles = [];
-		$changedFiles = [];
-		$deletedFiles = [];
-		$filePaths = array_unique(array_merge($finderResult->getFiles(), $this->filePaths, $this->getScannedFiles($finderResult->getFiles())));
-		foreach ($filePaths as $filePath) {
-			if (!array_key_exists($filePath, $oldFileHashes)) {
-				$newFiles[] = $filePath;
-				$fileHashes[$filePath] = $this->getFileHash($filePath);
-				continue;
-			}
-
-			$oldHash = $oldFileHashes[$filePath];
-			unset($oldFileHashes[$filePath]);
-			$newHash = $this->getFileHash($filePath);
-			$fileHashes[$filePath] = $newHash;
-			if ($oldHash === $newHash) {
-				continue;
-			}
-
-			$changedFiles[] = $filePath;
-		}
-
-		$this->fileHashes = $fileHashes;
-
-		foreach (array_keys($oldFileHashes) as $file) {
-			$deletedFiles[] = $file;
-		}
-
-		return new FileMonitorResult(
-			$newFiles,
-			$changedFiles,
-			$deletedFiles,
-		);
-	}
-
-	private function getFileHash(string $filePath): string
-	{
-		$hash = hash_file('sha256', $filePath);
-
-		if ($hash === false) {
-			throw new CouldNotReadFileException($filePath);
-		}
-
-		return $hash;
-	}
-
-	/**
-	 * @param string[] $allAnalysedFiles
-	 * @return array<string>
-	 */
-	private function getScannedFiles(array $allAnalysedFiles): array
-	{
-		$scannedFiles = $this->scanFiles;
-		$analysedDirectories = [];
-		foreach (array_merge($this->analysedPaths, $this->analysedPathsFromConfig) as $analysedPath) {
-			if (is_file($analysedPath)) {
-				continue;
-			}
-
-			if (!is_dir($analysedPath)) {
-				continue;
-			}
-
-			$analysedDirectories[] = $analysedPath;
-		}
-
-		$directories = array_unique(array_merge($analysedDirectories, $this->scanDirectories));
-		foreach ($this->scanFileFinder->findFiles($directories)->getFiles() as $file) {
-			$scannedFiles[] = $file;
-		}
-
-		return array_diff($scannedFiles, $allAnalysedFiles);
-	}
+	public function getPollInterval(): float;
 
 }

--- a/src/File/FileMonitorFactory.php
+++ b/src/File/FileMonitorFactory.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\AutowiredService;
+use function getenv;
+use const PHP_OS_FAMILY;
+
+/**
+ * Picks the {@see FileMonitor} for this platform and hands it back initialized.
+ *
+ * Whether a native monitor can actually run is only known once it has opened
+ * its kernel handle and armed every watch, so the fallback decision belongs
+ * here rather than at the call site: a native monitor that cannot promise to
+ * see every change is discarded whole, and {@see HashingFileMonitor} - correct
+ * everywhere, just slower - answers instead.
+ */
+#[AutowiredService]
+final class FileMonitorFactory
+{
+
+	/** Set to anything to force {@see HashingFileMonitor}. */
+	private const DISABLE_ENV_VARIABLE = 'PHPSTAN_DISABLE_NATIVE_FILE_MONITOR';
+
+	/**
+	 * @param string[] $analysedPaths
+	 * @param string[] $analysedPathsFromConfig
+	 * @param string[] $scanDirectories
+	 */
+	public function __construct(
+		private HashingFileMonitor $hashingFileMonitor,
+		#[AutowiredParameter]
+		private array $analysedPaths,
+		#[AutowiredParameter]
+		private array $analysedPathsFromConfig,
+		#[AutowiredParameter]
+		private array $scanDirectories,
+	)
+	{
+	}
+
+	/**
+	 * @param array<string> $filePaths extra files to monitor besides the analysed and scanned ones
+	 */
+	public function create(array $filePaths): FileMonitor
+	{
+		$native = $this->createNative();
+		if ($native !== null) {
+			try {
+				$native->initialize($filePaths);
+
+				return $native;
+			} catch (FileMonitorNotSupportedException) {
+				// fall through to hashing
+			}
+		}
+
+		$this->hashingFileMonitor->initialize($filePaths);
+
+		return $this->hashingFileMonitor;
+	}
+
+	private function createNative(): ?NativeFileMonitor
+	{
+		// escape hatch: the native monitors depend on FFI and on kernel
+		// facilities a container or a hardened host can take away in ways they
+		// cannot detect
+		if (getenv(self::DISABLE_ENV_VARIABLE) !== false) {
+			return null;
+		}
+
+		if (PHP_OS_FAMILY === 'Darwin') {
+			return new FsEventsFileMonitor(
+				$this->hashingFileMonitor,
+				$this->analysedPaths,
+				$this->analysedPathsFromConfig,
+				$this->scanDirectories,
+			);
+		}
+
+		if (PHP_OS_FAMILY === 'Linux') {
+			return new InotifyFileMonitor(
+				$this->hashingFileMonitor,
+				$this->analysedPaths,
+				$this->analysedPathsFromConfig,
+				$this->scanDirectories,
+			);
+		}
+
+		return null;
+	}
+
+}

--- a/src/File/FileMonitorNotSupportedException.php
+++ b/src/File/FileMonitorNotSupportedException.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use Exception;
+
+/**
+ * A native file monitor cannot run here - no FFI, the kernel refused a watch,
+ * or the project has more directories than we are willing to watch.
+ * {@see FileMonitorFactory} answers with {@see HashingFileMonitor} instead.
+ */
+final class FileMonitorNotSupportedException extends Exception
+{
+
+}

--- a/src/File/FileMonitorResult.php
+++ b/src/File/FileMonitorResult.php
@@ -23,9 +23,25 @@ final class FileMonitorResult
 	/**
 	 * @return string[]
 	 */
+	public function getNewFiles(): array
+	{
+		return $this->newFiles;
+	}
+
+	/**
+	 * @return string[]
+	 */
 	public function getChangedFiles(): array
 	{
 		return $this->changedFiles;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getDeletedFiles(): array
+	{
+		return $this->deletedFiles;
 	}
 
 	public function hasAnyChanges(): bool

--- a/src/File/FsEventsFileMonitor.php
+++ b/src/File/FsEventsFileMonitor.php
@@ -1,0 +1,192 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use Closure;
+use FFI;
+use FFI\CData;
+use PHPStan\ShouldNotHappenException;
+use Throwable;
+use function class_exists;
+use function extension_loaded;
+
+/**
+ * macOS {@see NativeFileMonitor} backed by FSEvents, reached through FFI.
+ *
+ * FSEvents watches whole subtrees, so a project needs a handful of watches
+ * rather than one per directory, and - unlike a kqueue watch on a directory -
+ * it reports a file rewritten in place, which is what an editor save usually
+ * is.
+ *
+ * Events arrive on the run loop of the thread that scheduled the stream, so
+ * they are collected by running that run loop with a zero timeout on each
+ * poll: no blocking, no second thread, and the callback runs on the same
+ * thread that called it.
+ */
+final class FsEventsFileMonitor extends NativeFileMonitor
+{
+
+	private const CDEF = <<<'C'
+typedef void* CFAllocatorRef;
+typedef void* CFArrayRef;
+typedef void* CFStringRef;
+typedef void* FSEventStreamRef;
+typedef void* CFRunLoopRef;
+typedef void (*PHPStanFSEventStreamCallback)(void *stream, void *info, unsigned long numEvents, void *eventPaths, unsigned int *eventFlags, unsigned long long *eventIds);
+CFStringRef CFStringCreateWithCString(CFAllocatorRef alloc, const char *cStr, unsigned int encoding);
+CFArrayRef CFArrayCreate(CFAllocatorRef allocator, const void **values, long numValues, const void *callBacks);
+FSEventStreamRef FSEventStreamCreate(CFAllocatorRef allocator, PHPStanFSEventStreamCallback callback, void *context, CFArrayRef pathsToWatch, unsigned long long sinceWhen, double latency, unsigned int flags);
+void FSEventStreamScheduleWithRunLoop(FSEventStreamRef streamRef, CFRunLoopRef runLoop, CFStringRef runLoopMode);
+unsigned char FSEventStreamStart(FSEventStreamRef streamRef);
+void FSEventStreamStop(FSEventStreamRef streamRef);
+void FSEventStreamInvalidate(FSEventStreamRef streamRef);
+void FSEventStreamRelease(FSEventStreamRef streamRef);
+CFRunLoopRef CFRunLoopGetCurrent(void);
+int CFRunLoopRunInMode(CFStringRef mode, double seconds, unsigned char returnAfterSourceHandled);
+C;
+
+	private const FRAMEWORK = '/System/Library/Frameworks/CoreServices.framework/CoreServices';
+
+	private const KCF_STRING_ENCODING_UTF8 = 0x08000100;
+
+	/** kFSEventStreamEventIdSinceNow - all ones, which is -1 as a PHP int */
+	private const SINCE_NOW = -1;
+
+	/** kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer */
+	private const CREATE_FLAGS = 0x10 | 0x02;
+
+	/** Report as soon as the kernel has the event; the poll interval paces us. */
+	private const LATENCY_SECONDS = 0.0;
+
+	private ?FFI $ffi = null;
+
+	/** The CFStringRef for kCFRunLoopDefaultMode. */
+	private ?CData $runLoopMode = null;
+
+	/**
+	 * Streams, and the CF objects they borrow. CFArrayCreate() is given no
+	 * retain callbacks, so nothing but this keeps the paths alive for as long
+	 * as the stream reads them.
+	 *
+	 * @var list<array{mixed, mixed, mixed, mixed}>
+	 */
+	private array $streams = [];
+
+	private bool $changed = false;
+
+	/**
+	 * Kept referenced: an FFI callback must outlive every call into it.
+	 *
+	 * @var (Closure(mixed, mixed, mixed, mixed, mixed, mixed): void)|null
+	 */
+	private ?Closure $callback = null;
+
+	protected function watchesRecursively(): bool
+	{
+		return true;
+	}
+
+	protected function open(): void
+	{
+		if (!extension_loaded('ffi') || !class_exists(FFI::class)) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		try {
+			$ffi = FFI::cdef(self::CDEF, self::FRAMEWORK);
+		} catch (Throwable) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		$this->ffi = $ffi;
+		$this->runLoopMode = $ffi->CFStringCreateWithCString(null, 'kCFRunLoopDefaultMode', self::KCF_STRING_ENCODING_UTF8);
+		$this->callback = function ($stream, $info, $numEvents, $eventPaths, $eventFlags, $eventIds): void {
+			$this->changed = true;
+		};
+	}
+
+	protected function addWatch(string $directory): void
+	{
+		// A stream's path list is fixed once created, and watchesRecursively()
+		// keeps the roots down to a handful, so one stream per root is cheaper
+		// than rebuilding a combined stream whenever a root appears.
+		$this->startStream($directory);
+	}
+
+	protected function drainEvents(): bool
+	{
+		if ($this->ffi === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		// Runs whatever the run loop already has ready and returns immediately;
+		// the callback flips $changed while it does.
+		$this->ffi->CFRunLoopRunInMode($this->runLoopMode, self::LATENCY_SECONDS, 0);
+
+		$changed = $this->changed;
+		$this->changed = false;
+
+		return $changed;
+	}
+
+	public function __destruct()
+	{
+		if ($this->ffi === null) {
+			return;
+		}
+
+		foreach ($this->streams as [$stream]) {
+			$this->ffi->FSEventStreamStop($stream);
+			$this->ffi->FSEventStreamInvalidate($stream);
+			$this->ffi->FSEventStreamRelease($stream);
+		}
+
+		$this->streams = [];
+	}
+
+	/**
+	 * @throws FileMonitorNotSupportedException
+	 */
+	private function startStream(string $directory): void
+	{
+		if ($this->ffi === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		$ffi = $this->ffi;
+		$paths = $ffi->new('void*[1]');
+		$cfString = $ffi->CFStringCreateWithCString(null, $directory, self::KCF_STRING_ENCODING_UTF8);
+		if ($cfString === null) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		$paths[0] = $cfString;
+		$array = $ffi->CFArrayCreate(null, $ffi->cast('const void**', FFI::addr($paths)), 1, null);
+		if ($array === null) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		$stream = $ffi->FSEventStreamCreate(
+			null,
+			$this->callback,
+			null,
+			$array,
+			self::SINCE_NOW,
+			self::LATENCY_SECONDS,
+			self::CREATE_FLAGS,
+		);
+		if ($stream === null) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		$ffi->FSEventStreamScheduleWithRunLoop($stream, $ffi->CFRunLoopGetCurrent(), $this->runLoopMode);
+		if ($ffi->FSEventStreamStart($stream) === 0) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		// CFArrayCreate was given no retain callbacks, so the strings (and the
+		// array) are only alive as long as this holds on to them.
+		$this->streams[] = [$stream, $array, $paths, $cfString];
+	}
+
+}

--- a/src/File/HashingFileMonitor.php
+++ b/src/File/HashingFileMonitor.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\ShouldNotHappenException;
+use function array_diff;
+use function array_key_exists;
+use function array_keys;
+use function array_merge;
+use function array_unique;
+use function hash_file;
+use function is_dir;
+use function is_file;
+
+#[AutowiredService]
+final class HashingFileMonitor implements FileMonitor
+{
+
+	/** Every poll re-hashes every monitored file, so it must stay coarse. */
+	private const POLL_INTERVAL_SECONDS = 1.0;
+
+	/** @var array<string, string>|null */
+	private ?array $fileHashes = null;
+
+	/** @var array<string>|null */
+	private ?array $filePaths = null;
+
+	/**
+	 * @param string[] $analysedPaths
+	 * @param string[] $analysedPathsFromConfig
+	 * @param string[] $scanFiles
+	 * @param string[] $scanDirectories
+	 */
+	public function __construct(
+		#[AutowiredParameter(ref: '@fileFinderAnalyse')]
+		private FileFinder $analyseFileFinder,
+		#[AutowiredParameter(ref: '@fileFinderScan')]
+		private FileFinder $scanFileFinder,
+		#[AutowiredParameter]
+		private array $analysedPaths,
+		#[AutowiredParameter]
+		private array $analysedPathsFromConfig,
+		#[AutowiredParameter]
+		private array $scanFiles,
+		#[AutowiredParameter]
+		private array $scanDirectories,
+	)
+	{
+	}
+
+	/**
+	 * @param array<string> $filePaths
+	 */
+	public function initialize(array $filePaths): void
+	{
+		$finderResult = $this->analyseFileFinder->findFiles($this->analysedPaths);
+		$fileHashes = [];
+		foreach (array_unique(array_merge($finderResult->getFiles(), $filePaths, $this->getScannedFiles($finderResult->getFiles()))) as $filePath) {
+			$fileHashes[$filePath] = $this->getFileHash($filePath);
+		}
+
+		$this->fileHashes = $fileHashes;
+		$this->filePaths = $filePaths;
+	}
+
+	public function getPollInterval(): float
+	{
+		return self::POLL_INTERVAL_SECONDS;
+	}
+
+	/**
+	 * The paths initialize() decided to watch, for a monitor wrapping this one.
+	 *
+	 * @return array<string>
+	 */
+	public function getMonitoredFiles(): array
+	{
+		if ($this->fileHashes === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		return array_keys($this->fileHashes);
+	}
+
+	public function getChanges(): FileMonitorResult
+	{
+		if ($this->fileHashes === null || $this->filePaths === null) {
+			throw new ShouldNotHappenException();
+		}
+		$finderResult = $this->analyseFileFinder->findFiles($this->analysedPaths);
+		$oldFileHashes = $this->fileHashes;
+		$fileHashes = [];
+		$newFiles = [];
+		$changedFiles = [];
+		$deletedFiles = [];
+		$filePaths = array_unique(array_merge($finderResult->getFiles(), $this->filePaths, $this->getScannedFiles($finderResult->getFiles())));
+		foreach ($filePaths as $filePath) {
+			if (!array_key_exists($filePath, $oldFileHashes)) {
+				$newFiles[] = $filePath;
+				$fileHashes[$filePath] = $this->getFileHash($filePath);
+				continue;
+			}
+
+			$oldHash = $oldFileHashes[$filePath];
+			unset($oldFileHashes[$filePath]);
+			$newHash = $this->getFileHash($filePath);
+			$fileHashes[$filePath] = $newHash;
+			if ($oldHash === $newHash) {
+				continue;
+			}
+
+			$changedFiles[] = $filePath;
+		}
+
+		$this->fileHashes = $fileHashes;
+
+		foreach (array_keys($oldFileHashes) as $file) {
+			$deletedFiles[] = $file;
+		}
+
+		return new FileMonitorResult(
+			$newFiles,
+			$changedFiles,
+			$deletedFiles,
+		);
+	}
+
+	private function getFileHash(string $filePath): string
+	{
+		$hash = hash_file('sha256', $filePath);
+
+		if ($hash === false) {
+			throw new CouldNotReadFileException($filePath);
+		}
+
+		return $hash;
+	}
+
+	/**
+	 * @param string[] $allAnalysedFiles
+	 * @return array<string>
+	 */
+	private function getScannedFiles(array $allAnalysedFiles): array
+	{
+		$scannedFiles = $this->scanFiles;
+		$analysedDirectories = [];
+		foreach (array_merge($this->analysedPaths, $this->analysedPathsFromConfig) as $analysedPath) {
+			if (is_file($analysedPath)) {
+				continue;
+			}
+
+			if (!is_dir($analysedPath)) {
+				continue;
+			}
+
+			$analysedDirectories[] = $analysedPath;
+		}
+
+		$directories = array_unique(array_merge($analysedDirectories, $this->scanDirectories));
+		foreach ($this->scanFileFinder->findFiles($directories)->getFiles() as $file) {
+			$scannedFiles[] = $file;
+		}
+
+		return array_diff($scannedFiles, $allAnalysedFiles);
+	}
+
+}

--- a/src/File/InotifyFileMonitor.php
+++ b/src/File/InotifyFileMonitor.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use FFI;
+use FFI\CData;
+use PHPStan\ShouldNotHappenException;
+use Throwable;
+use function class_exists;
+use function extension_loaded;
+
+/**
+ * Linux {@see NativeFileMonitor} backed by inotify, reached through FFI.
+ *
+ * inotify watches a single directory, not a subtree, so every directory below
+ * the analysed paths costs one watch - which is what
+ * `fs.inotify.max_user_watches` bounds, and why {@see self::WATCH_LIMIT} exists.
+ *
+ * The queue is drained rather than parsed: this monitor only has to answer
+ * "did anything change", and the wrapped hashing monitor works out what.
+ */
+final class InotifyFileMonitor extends NativeFileMonitor
+{
+
+	private const CDEF = <<<'C'
+int inotify_init1(int flags);
+int inotify_add_watch(int fd, const char *pathname, unsigned int mask);
+long read(int fd, void *buf, unsigned long count);
+int close(int fd);
+C;
+
+	/** IN_NONBLOCK - a poll must never wait for an event that is not there */
+	private const IN_NONBLOCK = 04000;
+
+	/**
+	 * IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE | IN_MOVED_FROM | IN_MOVED_TO
+	 * | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF - every way a
+	 * file an editor just saved can show up, including the write-and-rename
+	 * that most editors do.
+	 */
+	private const WATCH_MASK = 0x2 | 0x4 | 0x8 | 0x40 | 0x80 | 0x100 | 0x200 | 0x400 | 0x800;
+
+	/** Events are variable length; this only has to be big enough to drain in few reads. */
+	private const READ_BUFFER_BYTES = 65536;
+
+	private ?FFI $ffi = null;
+
+	private int $fd = -1;
+
+	private ?CData $buffer = null;
+
+	protected function watchesRecursively(): bool
+	{
+		return false;
+	}
+
+	protected function open(): void
+	{
+		if (!extension_loaded('ffi') || !class_exists(FFI::class)) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		try {
+			$ffi = FFI::cdef(self::CDEF);
+			$fd = $ffi->inotify_init1(self::IN_NONBLOCK);
+		} catch (Throwable) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		if ($fd < 0) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		$this->ffi = $ffi;
+		$this->fd = $fd;
+		$this->buffer = $ffi->new('char[' . self::READ_BUFFER_BYTES . ']');
+	}
+
+	protected function addWatch(string $directory): void
+	{
+		if ($this->ffi === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		// -1 means the per-user watch limit is exhausted (or the directory went
+		// away between listing and arming) - either way this monitor cannot
+		// promise to see every change, so it must not be used at all.
+		if ($this->ffi->inotify_add_watch($this->fd, $directory, self::WATCH_MASK) < 0) {
+			throw new FileMonitorNotSupportedException();
+		}
+	}
+
+	protected function drainEvents(): bool
+	{
+		if ($this->ffi === null || $this->buffer === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		$changed = false;
+		while ($this->ffi->read($this->fd, $this->buffer, self::READ_BUFFER_BYTES) > 0) {
+			$changed = true;
+		}
+
+		return $changed;
+	}
+
+}

--- a/src/File/NativeFileMonitor.php
+++ b/src/File/NativeFileMonitor.php
@@ -1,0 +1,356 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use FilesystemIterator;
+use PHPStan\ShouldNotHappenException;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use function array_keys;
+use function count;
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function microtime;
+use function rtrim;
+use function stat;
+use function str_starts_with;
+use function strlen;
+use function strpos;
+use function substr;
+use function uniqid;
+use function unlink;
+use function usleep;
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * A {@see FileMonitor} that asks the kernel whether anything changed before
+ * doing any work.
+ *
+ * The kernel only answers the coarse question "was anything touched under these
+ * directories". Deciding *which* files that means - honouring the finder's
+ * exclude rules, and telling a real edit from a touch that left the content
+ * alone - stays with the wrapped {@see HashingFileMonitor}, which runs only on
+ * the polls where the kernel said yes. The reported {@see FileMonitorResult} is
+ * therefore exactly what the hashing monitor alone would have reported; what
+ * changes is that an idle poll no longer reads every analysed file.
+ *
+ * Directories are the unit of watching: watching files individually would cost
+ * a descriptor per file and still miss files that do not exist yet.
+ */
+abstract class NativeFileMonitor implements FileMonitor
+{
+
+	/**
+	 * Watching is cheap per poll but not per watch - a non-recursive backend
+	 * spends one kernel watch per directory, and the kernel bounds those per
+	 * user. A project with more directories than this is served by the hashing
+	 * monitor instead of failing halfway through arming.
+	 */
+	protected const WATCH_LIMIT = 8192;
+
+	/**
+	 * An idle poll is a single non-blocking syscall, so the interval can be far
+	 * below the hashing monitor's - which is where most of the latency win
+	 * comes from, the backends' own delivery delay being a few milliseconds.
+	 */
+	private const POLL_INTERVAL_SECONDS = 0.05;
+
+	/**
+	 * How long {@see self::verifyWatchesDeliver()} waits for the kernel to
+	 * report a file it just created. Both backends deliver in single-digit
+	 * milliseconds when they work at all, so this only has to be generous
+	 * enough for a loaded machine.
+	 */
+	private const PROBE_TIMEOUT_SECONDS = 0.5;
+
+	private const PROBE_POLL_MICROSECONDS = 2000;
+
+	/** @var array<string, true> */
+	private array $watchedDirectories = [];
+
+	/**
+	 * Monitored files that lie outside the watched roots - composer.lock, the
+	 * config files, the phar PHPStan runs from. There are a few dozen of them
+	 * and they are scattered, so they are polled by stat() rather than pulling
+	 * their whole parent directory into a recursive watch: the project root is
+	 * a common parent, and watching it would make every result cache write look
+	 * like a source change.
+	 *
+	 * stat() is enough because this only has to open the gate - the wrapped
+	 * hashing monitor still decides whether the content actually differs.
+	 *
+	 * @var array<string, array{int, int}>|null path => [mtime, size]
+	 */
+	private ?array $unwatchedStats = null;
+
+	/**
+	 * @param string[] $analysedPaths
+	 * @param string[] $analysedPathsFromConfig
+	 * @param string[] $scanDirectories
+	 */
+	public function __construct(
+		private HashingFileMonitor $hashingFileMonitor,
+		private array $analysedPaths,
+		private array $analysedPathsFromConfig,
+		private array $scanDirectories,
+	)
+	{
+	}
+
+	/**
+	 * @throws FileMonitorNotSupportedException
+	 */
+	public function initialize(array $filePaths): void
+	{
+		$this->hashingFileMonitor->initialize($filePaths);
+		$this->open();
+		$this->arm();
+		$this->verifyWatchesDeliver();
+	}
+
+	/**
+	 * Proves the watches actually fire before anyone relies on them.
+	 *
+	 * A watch can be registered successfully and then never deliver anything:
+	 * inotify reports nothing at all for a Docker Desktop bind mount (the
+	 * host's files reach the container through a userspace filesystem), and
+	 * the same is true of NFS and other network mounts. Silently watching such
+	 * a tree would leave PHPStan Pro looking frozen, which is far worse than
+	 * being slow, so a monitor that cannot see a file it created itself is
+	 * refused and the caller falls back to hashing.
+	 *
+	 * @throws FileMonitorNotSupportedException
+	 */
+	private function verifyWatchesDeliver(): void
+	{
+		$directory = null;
+		$probe = null;
+		foreach (array_keys($this->watchedDirectories) as $candidate) {
+			$path = $candidate . DIRECTORY_SEPARATOR . '.phpstan-file-monitor-probe-' . uniqid();
+			// no .php extension, so the finder never sees it even mid-probe
+			if (@file_put_contents($path, '') === false) {
+				continue;
+			}
+
+			$directory = $candidate;
+			$probe = $path;
+			break;
+		}
+
+		if ($probe === null || $directory === null) {
+			// nothing writable to prove anything with
+			throw new FileMonitorNotSupportedException();
+		}
+
+		$delivered = false;
+		$deadline = microtime(true) + self::PROBE_TIMEOUT_SECONDS;
+		while (microtime(true) < $deadline) {
+			if ($this->drainEvents()) {
+				$delivered = true;
+				break;
+			}
+
+			usleep(self::PROBE_POLL_MICROSECONDS);
+		}
+
+		@unlink($probe);
+		$this->drainEvents();
+
+		if (!$delivered) {
+			throw new FileMonitorNotSupportedException();
+		}
+	}
+
+	public function getChanges(): FileMonitorResult
+	{
+		if ($this->unwatchedStats === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		if (!$this->drainEvents() && !$this->hasUnwatchedChange()) {
+			return new FileMonitorResult([], [], []);
+		}
+
+		$changes = $this->hashingFileMonitor->getChanges();
+
+		try {
+			// the change may have created directories that need watching too
+			$this->arm();
+		} catch (FileMonitorNotSupportedException) {
+			// the project outgrew the watch budget mid-session - the wrapped
+			// monitor keeps answering correctly, only without the gate
+		}
+
+		return $changes;
+	}
+
+	public function getPollInterval(): float
+	{
+		return self::POLL_INTERVAL_SECONDS;
+	}
+
+	/**
+	 * @throws FileMonitorNotSupportedException
+	 */
+	private function arm(): void
+	{
+		$roots = [];
+		foreach ([...$this->analysedPaths, ...$this->analysedPathsFromConfig, ...$this->scanDirectories] as $path) {
+			if (!is_dir($path)) {
+				continue;
+			}
+
+			$roots[$path] = true;
+		}
+
+		$unwatchedStats = [];
+		foreach ($this->hashingFileMonitor->getMonitoredFiles() as $file) {
+			$directory = $this->watchTargetDirectory($file);
+			if ($directory !== null && $this->isUnder($directory, $roots)) {
+				continue;
+			}
+
+			$unwatchedStats[$file] = $this->statOf($file);
+		}
+
+		$directories = $this->watchesRecursively() ? array_keys($roots) : $this->expand($roots);
+		if (count($directories) > static::WATCH_LIMIT) {
+			throw new FileMonitorNotSupportedException();
+		}
+
+		foreach ($directories as $directory) {
+			if (isset($this->watchedDirectories[$directory])) {
+				continue;
+			}
+
+			$this->addWatch($directory);
+			$this->watchedDirectories[$directory] = true;
+		}
+
+		$this->unwatchedStats = $unwatchedStats;
+	}
+
+	/**
+	 * @return array{int, int}
+	 */
+	private function statOf(string $file): array
+	{
+		$stat = @stat($file);
+
+		return $stat === false ? [0, 0] : [$stat['mtime'], $stat['size']];
+	}
+
+	/**
+	 * Every directory below the roots, empty ones included: a file created in
+	 * one of them is a change nobody else would report.
+	 *
+	 * @param array<string, true> $roots
+	 * @return array<string>
+	 * @throws FileMonitorNotSupportedException
+	 */
+	private function expand(array $roots): array
+	{
+		$directories = $roots;
+		foreach (array_keys($roots) as $root) {
+			$iterator = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::SELF_FIRST,
+			);
+			foreach ($iterator as $entry) {
+				if (!$entry->isDir()) {
+					continue;
+				}
+
+				$directories[$entry->getPathname()] = true;
+				if (count($directories) > static::WATCH_LIMIT) {
+					throw new FileMonitorNotSupportedException();
+				}
+			}
+		}
+
+		return array_keys($directories);
+	}
+
+	/**
+	 * The real directory whose modification would reveal a change to $file, or
+	 * null when there is none.
+	 *
+	 * A file inside a phar cannot change unless the archive does, so the
+	 * archive's own directory is what needs watching.
+	 */
+	private function watchTargetDirectory(string $file): ?string
+	{
+		if (str_starts_with($file, 'phar://')) {
+			$file = substr($file, strlen('phar://'));
+			$end = strpos($file, '.phar');
+			if ($end === false) {
+				return null;
+			}
+
+			$file = substr($file, 0, $end + strlen('.phar'));
+			if (!is_file($file)) {
+				return null;
+			}
+		}
+
+		$directory = dirname($file);
+
+		return is_dir($directory) ? $directory : null;
+	}
+
+	/**
+	 * Whether a watch already covers this directory - directly for a recursive
+	 * backend, through {@see self::expand()} having watched every directory
+	 * below the root for a non-recursive one.
+	 *
+	 * @param array<string, true> $roots
+	 */
+	private function isUnder(string $directory, array $roots): bool
+	{
+		foreach (array_keys($roots) as $root) {
+			if ($directory === $root) {
+				return true;
+			}
+
+			if (str_starts_with($directory, rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private function hasUnwatchedChange(): bool
+	{
+		if ($this->unwatchedStats === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		foreach ($this->unwatchedStats as $file => $stat) {
+			if ($this->statOf($file) !== $stat) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** Whether one watch covers a whole subtree, or every directory needs its own. */
+	abstract protected function watchesRecursively(): bool;
+
+	/**
+	 * @throws FileMonitorNotSupportedException
+	 */
+	abstract protected function open(): void;
+
+	/**
+	 * @throws FileMonitorNotSupportedException
+	 */
+	abstract protected function addWatch(string $directory): void;
+
+	/** Consumes every queued event without blocking. */
+	abstract protected function drainEvents(): bool;
+
+}

--- a/tests/PHPStan/File/FileMonitorTest.php
+++ b/tests/PHPStan/File/FileMonitorTest.php
@@ -1,0 +1,220 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use DirectoryIterator;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sprintf;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+use function usleep;
+use const PHP_OS_FAMILY;
+
+/**
+ * Every monitor must report the same changes; the native ones only differ in
+ * how long they are allowed to take to notice.
+ */
+class FileMonitorTest extends TestCase
+{
+
+	/** Enough for a native backend to deliver an event; hashing needs none. */
+	private const WAIT_ITERATIONS_LIMIT = 200;
+
+	private const WAIT_STEP_MICROSECONDS = 10000;
+
+	private string $directory;
+
+	#[Override]
+	protected function setUp(): void
+	{
+		$this->directory = sys_get_temp_dir() . '/phpstan-file-monitor-' . uniqid();
+		mkdir($this->directory . '/sub', 0777, true);
+		file_put_contents($this->directory . '/a.php', "<?php\n// a\n");
+		file_put_contents($this->directory . '/sub/b.php', "<?php\n// b\n");
+	}
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->removeDirectory($this->directory);
+	}
+
+	public static function dataMonitors(): iterable
+	{
+		yield 'hashing' => ['hashing'];
+
+		if (PHP_OS_FAMILY === 'Darwin') {
+			yield 'fsevents' => ['fsevents'];
+		} elseif (PHP_OS_FAMILY === 'Linux') {
+			yield 'inotify' => ['inotify'];
+		}
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testNothingChanged(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		$this->assertNoChanges($monitor);
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testRewritingAFileWithTheSameContentIsNotAChange(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		file_put_contents($this->directory . '/a.php', "<?php\n// a\n");
+		$this->assertNoChanges($monitor);
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testChangedFile(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		file_put_contents($this->directory . '/a.php', "<?php\n// a changed\n");
+		$changes = $this->waitForChanges($monitor);
+		$this->assertSame([$this->directory . '/a.php'], $changes->getChangedFiles());
+		$this->assertSame([], $changes->getNewFiles());
+		$this->assertSame([], $changes->getDeletedFiles());
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testFileChangedInSubdirectory(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		file_put_contents($this->directory . '/sub/b.php', "<?php\n// b changed\n");
+		$changes = $this->waitForChanges($monitor);
+		$this->assertSame([$this->directory . '/sub/b.php'], $changes->getChangedFiles());
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testNewFile(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		file_put_contents($this->directory . '/c.php', "<?php\n// c\n");
+		$changes = $this->waitForChanges($monitor);
+		$this->assertSame([$this->directory . '/c.php'], $changes->getNewFiles());
+		$this->assertSame([], $changes->getChangedFiles());
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testNewFileInNewDirectory(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		mkdir($this->directory . '/fresh');
+		file_put_contents($this->directory . '/fresh/d.php', "<?php\n// d\n");
+		$changes = $this->waitForChanges($monitor);
+		$this->assertSame([$this->directory . '/fresh/d.php'], $changes->getNewFiles());
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testDeletedFile(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		unlink($this->directory . '/sub/b.php');
+		$changes = $this->waitForChanges($monitor);
+		$this->assertSame([$this->directory . '/sub/b.php'], $changes->getDeletedFiles());
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testChangesAreReportedOnlyOnce(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		file_put_contents($this->directory . '/a.php', "<?php\n// a changed\n");
+		$this->waitForChanges($monitor);
+		$this->assertNoChanges($monitor);
+	}
+
+	#[DataProvider('dataMonitors')]
+	public function testSecondChangeAfterTheFirstOne(string $kind): void
+	{
+		$monitor = $this->createMonitor($kind);
+		file_put_contents($this->directory . '/a.php', "<?php\n// once\n");
+		$this->waitForChanges($monitor);
+		file_put_contents($this->directory . '/sub/b.php', "<?php\n// twice\n");
+		$changes = $this->waitForChanges($monitor);
+		$this->assertSame([$this->directory . '/sub/b.php'], $changes->getChangedFiles());
+	}
+
+	private function createMonitor(string $kind): FileMonitor
+	{
+		$fileHelper = new FileHelper($this->directory);
+		$finder = new FileFinder(new FileExcluder($fileHelper, []), $fileHelper, ['php']);
+		$hashing = new HashingFileMonitor($finder, $finder, [$this->directory], [$this->directory], [], []);
+
+		if ($kind === 'hashing') {
+			$monitor = $hashing;
+		} elseif ($kind === 'fsevents') {
+			$monitor = new FsEventsFileMonitor($hashing, [$this->directory], [$this->directory], []);
+		} elseif ($kind === 'inotify') {
+			$monitor = new InotifyFileMonitor($hashing, [$this->directory], [$this->directory], []);
+		} else {
+			self::fail('Unknown monitor ' . $kind);
+		}
+
+		try {
+			$monitor->initialize([]);
+		} catch (FileMonitorNotSupportedException $e) {
+			// FFI disabled, or the kernel refused a watch - the factory would
+			// fall back to hashing here, and so does the test
+			self::markTestSkipped(sprintf('%s monitor is not supported here: %s', $kind, $e->getMessage()));
+		}
+
+		return $monitor;
+	}
+
+	private function waitForChanges(FileMonitor $monitor): FileMonitorResult
+	{
+		for ($i = 0; $i < self::WAIT_ITERATIONS_LIMIT; $i++) {
+			$changes = $monitor->getChanges();
+			if ($changes->hasAnyChanges()) {
+				return $changes;
+			}
+
+			usleep(self::WAIT_STEP_MICROSECONDS);
+		}
+
+		$this->fail(sprintf('No changes reported within %d ms', self::WAIT_ITERATIONS_LIMIT * self::WAIT_STEP_MICROSECONDS / 1000));
+	}
+
+	private function assertNoChanges(FileMonitor $monitor): void
+	{
+		// a native monitor may still have a queued event; it must not turn into
+		// a reported change, so poll a few times rather than only once
+		for ($i = 0; $i < 10; $i++) {
+			$changes = $monitor->getChanges();
+			$this->assertSame([], $changes->getNewFiles());
+			$this->assertSame([], $changes->getChangedFiles());
+			$this->assertSame([], $changes->getDeletedFiles());
+			usleep(self::WAIT_STEP_MICROSECONDS);
+		}
+	}
+
+	private function removeDirectory(string $directory): void
+	{
+		if (!is_dir($directory)) {
+			return;
+		}
+
+		foreach (new DirectoryIterator($directory) as $entry) {
+			if ($entry->isDot()) {
+				continue;
+			}
+
+			if ($entry->isDir()) {
+				$this->removeDirectory($entry->getPathname());
+				continue;
+			}
+
+			unlink($entry->getPathname());
+		}
+
+		rmdir($directory);
+	}
+
+}


### PR DESCRIPTION
PHPStan Pro's `FileMonitor` re-hashes every analysed and scanned file on every poll — 2772 files and ~230 ms on a mid-sized project, once a second, for as long as the browser tab is open. That is also the floor on how fast an edit can be noticed.

## What changed

`FileMonitor` becomes an interface. The old implementation is `HashingFileMonitor` and stays the answer for Windows and for anything the native backends cannot do. `FsEventsFileMonitor` (macOS) and `InotifyFileMonitor` (Linux) reach the kernel through FFI.

**The native monitors are a gate in front of the hashing one, not a replacement.** The kernel is only asked "was anything touched"; the wrapped `HashingFileMonitor` still decides *which* files that means, so the reported `FileMonitorResult` is exactly what it always was — exclude rules and the touch-without-content-change case stay in one place. An idle poll costs one non-blocking syscall instead of reading the project, which is what lets the poll interval drop from 1 s to 50 ms.

## Measurements

2760-file tree, hashing vs native:

| | idle poll | detection (median) |
|---|---|---|
| macOS hashing | 81.9 ms | 1110 ms |
| **macOS FSEvents** | **0.002 ms** | **143 ms** |
| Linux hashing | 34.2 ms | 1065 ms |
| **Linux inotify** | **0.002 ms** | **104 ms** |

End to end in Pro on a real project (edit → analysis starts): **0.749 s → 0.250 s**, and full hash passes over a 40 s session went from **26 to 4** — one per edit, none while idle.

## Design notes

- **kqueue was tried on macOS and rejected.** `EVFILT_VNODE` on a directory reports directory-entry changes only; a file rewritten in place — which is what most editor saves are — produces no event at all. FSEvents reports it, watches subtrees recursively, and needs no extra extension.
- **A watch can register successfully and then never deliver.** A monitor that silently sees nothing would leave Pro looking frozen, so `initialize()` writes a probe file into a watched directory and refuses the backend unless the kernel reports it. Costs ~17 ms once, and turns that failure into a fallback.
- Scattered monitored files (composer.lock, config files) are polled with `stat()` rather than pulling their parent — otherwise the project root becomes a recursive watch and every result-cache write reopens the gate.

## Compatibility

PHP floor is unchanged (7.4); FFI has existed since 7.4. Verified in real images:

| environment | native path |
|---|---|
| Homebrew macOS, Debian/Ubuntu `php-cli` | yes |
| Alpine | needs `phpXX-ffi` |
| official `php:*` Docker images | no (no ext-ffi) |
| Windows | no |

`ffi.enable=preload` is not a blocker — the CLI SAPI is exempt. Every failure path (no FFI, watch limits, unwritable tree, a filesystem that never delivers) falls back to `HashingFileMonitor`, so no configuration is worse off than before. `PHPSTAN_DISABLE_NATIVE_FILE_MONITOR` forces the hashing monitor.

Docker Desktop bind mounts were tested and do work; the 1–3 s there is VirtioFS propagation, which the hashing monitor pays identically.

## Tests

`tests/PHPStan/File/FileMonitorTest.php` runs the same 9 scenarios against every backend available on the host, asserting identical results — 18 tests / 198 assertions green on macOS (FSEvents) and in Docker on Linux (inotify).

## Open question for review

PHPStan cannot model FFI's methods (they are the C functions from the cdef string), so `build/phpstan.neon` carries a path-scoped `method.notFound` ignore for the two monitor classes. The proper fix would be an FFI methods-reflection extension — flagged rather than built, since it changes analysis for every FFI user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)