### PR TITLE
Record conditional expressions for more assignment shapes

### DIFF
--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -21,6 +21,7 @@ use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
 use PHPStan\Analyser\AssignTargetWalkMode;
 use PHPStan\Analyser\ConditionalExpressionHolder;
 use PHPStan\Analyser\ExpressionContext;
@@ -79,6 +80,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use TypeError;
+use function array_key_exists;
 use function array_key_last;
 use function array_merge;
 use function array_pop;
@@ -99,6 +101,8 @@ final class AssignHandler implements ExprHandler
 {
 
 	private const TERNARY_ARM_EXCLUDED_VALUES_LIMIT = 3;
+
+	private const DERIVED_CONDITIONAL_EXPRESSIONS_LIMIT = 16;
 
 	public function __construct(
 		private VarAnnotationProcessor $varAnnotationProcessor,
@@ -950,6 +954,8 @@ final class AssignHandler implements ExprHandler
 					$conditionalExpressions = $this->processInArrayForConditionalExpressionsAfterAssign($scopeBeforeAssignEval, $var->name, $conditionalExpressions, $assignedExpr, $type, $impurePoints);
 				}
 
+				$conditionalExpressions = $this->processDerivedConditionalExpressionsAfterAssign($scopeBeforeAssignEval, $var->name, $conditionalExpressions, $assignedExpr, $type, $impurePoints);
+
 				$truthyType = TypeCombinator::removeFalsey($type);
 				// Value comparison, not identity: remove() happens to hand back the very same
 				// instance when it removes nothing, but that is not part of its contract — the
@@ -1661,6 +1667,87 @@ final class AssignHandler implements ExprHandler
 		}
 
 		return $newConditionalExpressions;
+	}
+
+	/**
+	 * Propagates conditional expressions through a derived assignment: when the
+	 * right-hand side reads a variable that existing conditional expressions describe
+	 * (e.g. `if $key = 'test1' then $functionName is 'Test'`), the assigned variable
+	 * gets its own conditional expressions under the same conditions, with the
+	 * right-hand side re-evaluated under each consequent
+	 * (`if $key = 'test1' then $functionToCall is 'fetchTest'`).
+	 *
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 * @param ImpurePoint[] $rhsImpurePoints
+	 * @return array<string, ConditionalExpressionHolder[]>
+	 */
+	private function processDerivedConditionalExpressionsAfterAssign(
+		MutatingScope $scope,
+		string $variableName,
+		array $conditionalExpressions,
+		Expr $assignedExpr,
+		Type $assignedType,
+		array $rhsImpurePoints,
+	): array
+	{
+		if (count($rhsImpurePoints) > 0) {
+			return $conditionalExpressions;
+		}
+		$scopeConditionalExpressions = $scope->getConditionalExpressions();
+		if (count($scopeConditionalExpressions) === 0) {
+			return $conditionalExpressions;
+		}
+
+		$targetExprString = '$' . $variableName;
+		$evaluations = 0;
+		$seenReadExprStrings = [];
+		/** @var Variable[] $readVariables */
+		$readVariables = (new NodeFinder())->findInstanceOf([$assignedExpr], Variable::class);
+		foreach ($readVariables as $readVariable) {
+			if (!is_string($readVariable->name) || $readVariable->name === $variableName) {
+				continue;
+			}
+			$readExprString = '$' . $readVariable->name;
+			if (array_key_exists($readExprString, $seenReadExprStrings)) {
+				continue;
+			}
+			$seenReadExprStrings[$readExprString] = true;
+
+			foreach ($scopeConditionalExpressions[$readExprString] ?? [] as $holder) {
+				$consequent = $holder->getTypeHolder();
+				if (!$consequent->getCertainty()->yes()) {
+					continue;
+				}
+
+				$conditionHolders = $holder->getConditionExpressionTypeHolders();
+				$evalScope = $scope;
+				foreach ($conditionHolders as $conditionExprString => $conditionHolder) {
+					if ($conditionExprString === $targetExprString || !$conditionHolder->getCertainty()->yes()) {
+						// a condition on the just-overwritten variable is stale
+						continue 2;
+					}
+					$evalScope = $evalScope->assignExpression($conditionHolder->getExpr(), $conditionHolder->getType(), $conditionHolder->getType());
+				}
+
+				if (++$evaluations > self::DERIVED_CONDITIONAL_EXPRESSIONS_LIMIT) {
+					return $conditionalExpressions;
+				}
+
+				$evalScope = $evalScope->assignExpression($consequent->getExpr(), $consequent->getType(), $consequent->getType());
+				$derivedType = $evalScope->getType($assignedExpr);
+				if ($derivedType->equals($assignedType)) {
+					continue;
+				}
+
+				$derivedHolder = new ConditionalExpressionHolder(
+					$conditionHolders,
+					ExpressionTypeHolder::createYes(new Variable($variableName), $derivedType),
+				);
+				$conditionalExpressions[$targetExprString][$derivedHolder->getKey()] = $derivedHolder;
+			}
+		}
+
+		return $conditionalExpressions;
 	}
 
 	/**

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -86,7 +86,9 @@ use function array_reverse;
 use function array_slice;
 use function count;
 use function in_array;
+use function is_float;
 use function is_int;
+use function is_nan;
 use function is_string;
 
 /**
@@ -944,6 +946,10 @@ final class AssignHandler implements ExprHandler
 					);
 				}
 
+				if ($assignedExpr instanceof FuncCall) {
+					$conditionalExpressions = $this->processInArrayForConditionalExpressionsAfterAssign($scopeBeforeAssignEval, $var->name, $conditionalExpressions, $assignedExpr, $type, $impurePoints);
+				}
+
 				$truthyType = TypeCombinator::removeFalsey($type);
 				// Value comparison, not identity: remove() happens to hand back the very same
 				// instance when it removes nothing, but that is not part of its contract — the
@@ -1655,6 +1661,89 @@ final class AssignHandler implements ExprHandler
 		}
 
 		return $newConditionalExpressions;
+	}
+
+	/**
+	 * Records the reverse implication of a `$var = in_array($needle, [...known values])`
+	 * assignment: a needle that is one of the haystack's always-present values makes the
+	 * call return true, whether the comparison is loose or strict (`==` cannot miss an
+	 * identical value). A later narrowing of the needle below the recorded value union
+	 * then forces `$var` to true — and cascades into conditional expressions guarded
+	 * by `$var`.
+	 *
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 * @param ImpurePoint[] $rhsImpurePoints
+	 * @return array<string, ConditionalExpressionHolder[]>
+	 */
+	private function processInArrayForConditionalExpressionsAfterAssign(
+		MutatingScope $scope,
+		string $variableName,
+		array $conditionalExpressions,
+		FuncCall $assignedExpr,
+		Type $assignedType,
+		array $rhsImpurePoints,
+	): array
+	{
+		if (
+			!$assignedExpr->name instanceof Name
+			|| $assignedExpr->name->toLowerString() !== 'in_array'
+			|| $assignedExpr->isFirstClassCallable()
+			|| !$assignedType->isTrue()->maybe()
+		) {
+			return $conditionalExpressions;
+		}
+
+		$args = $assignedExpr->getArgs();
+		if (count($args) < 2 || $args[0]->name !== null || $args[0]->unpack || $args[1]->name !== null || $args[1]->unpack) {
+			return $conditionalExpressions;
+		}
+
+		$needleExpr = $args[0]->value;
+		if (!$this->isExprSafeToProjectThroughVariable($needleExpr, $variableName, $rhsImpurePoints, $assignedExpr)) {
+			return $conditionalExpressions;
+		}
+
+		$haystackType = $scope->getType($args[1]->value);
+		if (!$haystackType->isConstantArray()->yes()) {
+			return $conditionalExpressions;
+		}
+		$constantArrays = $haystackType->getConstantArrays();
+		if (count($constantArrays) !== 1) {
+			return $conditionalExpressions;
+		}
+
+		$guaranteedValueTypes = [];
+		$constantArray = $constantArrays[0];
+		foreach ($constantArray->getValueTypes() as $i => $valueType) {
+			if ($constantArray->isOptionalKey($i)) {
+				continue;
+			}
+			if (!$valueType->isConstantScalarValue()->yes()) {
+				continue;
+			}
+			$scalarValues = $valueType->getConstantScalarValues();
+			if (count($scalarValues) !== 1) {
+				continue;
+			}
+			if (is_float($scalarValues[0]) && is_nan($scalarValues[0])) {
+				// NAN never compares equal, not even to itself
+				continue;
+			}
+
+			$guaranteedValueTypes[] = $valueType;
+		}
+
+		if (count($guaranteedValueTypes) === 0) {
+			return $conditionalExpressions;
+		}
+
+		$holder = new ConditionalExpressionHolder(
+			[$this->exprPrinter->printExpr($needleExpr) => ExpressionTypeHolder::createYes($needleExpr, TypeCombinator::union(...$guaranteedValueTypes))],
+			ExpressionTypeHolder::createYes(new Variable($variableName), new ConstantBooleanType(true)),
+		);
+		$conditionalExpressions['$' . $variableName][$holder->getKey()] = $holder;
+
+		return $conditionalExpressions;
 	}
 
 	/**

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -96,6 +96,8 @@ use function is_string;
 final class AssignHandler implements ExprHandler
 {
 
+	private const TERNARY_ARM_EXCLUDED_VALUES_LIMIT = 3;
+
 	public function __construct(
 		private VarAnnotationProcessor $varAnnotationProcessor,
 		private TypeSpecifier $typeSpecifier,
@@ -917,14 +919,21 @@ final class AssignHandler implements ExprHandler
 					$truthyType = $truthyScope->getType($if);
 					$falseyType = $falsyScope->getType($assignedExpr->else);
 
-					if (
-						$truthyType->isSuperTypeOf($falseyType)->no()
-						&& $falseyType->isSuperTypeOf($truthyType)->no()
-					) {
-						$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType, $impurePoints, $assignedExpr);
-						$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType, $impurePoints, $assignedExpr);
-						$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType, $impurePoints, $assignedExpr);
-						$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType, $impurePoints, $assignedExpr);
+					// The variable can prove an arm was taken even when the arm types overlap:
+					// the part of an arm's type not producible by the other arm implies that
+					// arm's condition outcome. With fully disjoint arms both remainders are
+					// the full arm types.
+					$truthyRemainder = TypeCombinator::remove($truthyType, $falseyType);
+					if ($falseyType->isSuperTypeOf($truthyRemainder)->no()) {
+						$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyRemainder, $impurePoints, $assignedExpr);
+						$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyRemainder, $impurePoints, $assignedExpr);
+						$conditionalExpressions = $this->processTernaryArmValueImpliedTypesAfterAssign($truthyScope, $var->name, $conditionalExpressions, $if, $truthyRemainder, $falseyType, $impurePoints, $assignedExpr);
+					}
+					$falseyRemainder = TypeCombinator::remove($falseyType, $truthyType);
+					if ($truthyType->isSuperTypeOf($falseyRemainder)->no()) {
+						$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyRemainder, $impurePoints, $assignedExpr);
+						$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyRemainder, $impurePoints, $assignedExpr);
+						$conditionalExpressions = $this->processTernaryArmValueImpliedTypesAfterAssign($falsyScope, $var->name, $conditionalExpressions, $assignedExpr->else, $falseyRemainder, $truthyType, $impurePoints, $assignedExpr);
 					}
 				}
 
@@ -1502,6 +1511,50 @@ final class AssignHandler implements ExprHandler
 				TypeCombinator::remove($scope->getType($expr), $exprType),
 				TrinaryLogic::createYes(),
 			);
+		}
+
+		return $conditionalExpressions;
+	}
+
+	/**
+	 * A ternary-assigned variable holding a value only one arm can produce proves that
+	 * arm's expression produced it — so the arm expression's value is also outside the
+	 * other arm's type. For each concrete value of the other arm's type this projects
+	 * the narrowings of `$armExpr !== $value` (e.g. `array_key_first($arr) !== null`
+	 * implying a non-empty `$arr`) into conditional expressions guarded by the variable.
+	 *
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 * @param ImpurePoint[] $rhsImpurePoints
+	 * @return array<string, ConditionalExpressionHolder[]>
+	 */
+	private function processTernaryArmValueImpliedTypesAfterAssign(
+		MutatingScope $armScope,
+		string $variableName,
+		array $conditionalExpressions,
+		Expr $armExpr,
+		Type $remainderType,
+		Type $otherArmType,
+		array $rhsImpurePoints,
+		Expr $assignedExpr,
+	): array
+	{
+		$otherArmFiniteTypes = $otherArmType->getFiniteTypes();
+		if (count($otherArmFiniteTypes) === 0 || count($otherArmFiniteTypes) > self::TERNARY_ARM_EXCLUDED_VALUES_LIMIT) {
+			return $conditionalExpressions;
+		}
+
+		foreach ($otherArmFiniteTypes as $finiteType) {
+			if (!$remainderType->isSuperTypeOf($finiteType)->no()) {
+				continue;
+			}
+
+			$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition(
+				$armScope,
+				new Expr\BinaryOp\NotIdentical($armExpr, new TypeExpr($finiteType)),
+				TypeSpecifierContext::createTrue(),
+			);
+			$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($armScope, $variableName, $conditionalExpressions, $specifiedTypes, $remainderType, $rhsImpurePoints, $assignedExpr);
+			$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($armScope, $variableName, $conditionalExpressions, $specifiedTypes, $remainderType, $rhsImpurePoints, $assignedExpr);
 		}
 
 		return $conditionalExpressions;

--- a/src/Analyser/RuleErrorTransformer.php
+++ b/src/Analyser/RuleErrorTransformer.php
@@ -188,7 +188,7 @@ final class RuleErrorTransformer
 			}
 		}
 
-		if (!$replacingVisitor->isFound() || $indent === null) {
+		if (!$replacingVisitor->isFound()) {
 			return null;
 		}
 

--- a/src/Analyser/StmtHandler/WhileHandler.php
+++ b/src/Analyser/StmtHandler/WhileHandler.php
@@ -91,7 +91,7 @@ final class WhileHandler implements StmtHandler
 				}
 				// the candidate to replace the final walk when this pass's
 				// entry turns out to be the fixpoint
-				if ($condRecording instanceof RecordingNodeCallback && $bodyRecording instanceof RecordingNodeCallback) {
+				if ($condRecording instanceof RecordingNodeCallback) {
 					$replayCondRecording = $condRecording;
 					$replayBodyRecording = $bodyRecording;
 					$replayPassStorage = $storage;

--- a/tests/PHPStan/Analyser/nsrt/bug-12620.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12620.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12620;
+
+use function PHPStan\Testing\assertType;
+
+function (): void {
+	$data = [];
+	if(isset($GLOBALS['data']) && is_string($GLOBALS['data'])){
+	$data  = (array)json_decode($GLOBALS['data']);
+	}
+
+	$isA = isset($data['a']) && $data['a'] !== '';
+	$isB = isset($data['b']) && $data['b'] !== '';
+
+
+
+	if($isA){
+		assertType("non-empty-array<mixed>&hasOffset('a')", $data);
+		assertType("mixed~(''|null)", $data['a']);
+		var_dump($data['a']);
+	}
+	if($isB){
+		assertType("non-empty-array<mixed>&hasOffset('b')", $data);
+		assertType("mixed~(''|null)", $data['b']);
+		var_dump($data['b']);
+	}
+};
+
+// order-swapped variant: the historical bug was order-dependent
+function (): void {
+	$data = [];
+	if(isset($GLOBALS['data']) && is_string($GLOBALS['data'])){
+	$data  = (array)json_decode($GLOBALS['data']);
+	}
+
+	$isB = isset($data['b']) && $data['b'] !== '';
+	$isA = isset($data['a']) && $data['a'] !== '';
+
+
+	if($isA){
+		assertType("non-empty-array<mixed>&hasOffset('a')", $data);
+		assertType("mixed~(''|null)", $data['a']);
+		var_dump($data['a']);
+	}
+	if($isB){
+		assertType("non-empty-array<mixed>&hasOffset('b')", $data);
+		assertType("mixed~(''|null)", $data['b']);
+		var_dump($data['b']);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/bug-13054.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13054.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13054;
+
+use function PHPStan\Testing\assertType;
+
+class Test {
+	public function fetchTest(int $i): void {
+		echo $i;
+	}
+
+	public function fetchTest2(): void {
+		echo 'test';
+	}
+
+	public function exec(): void {
+		$list = [
+			'test1' => 'Test',
+			'test2' => 'Test2',
+		];
+
+		foreach ($list as $key => $functionName) {
+			$functionToCall = 'fetch' . $functionName;
+
+			if ($key === 'test1') {
+				assertType("'fetchTest'", $functionToCall);
+				$this->$functionToCall(1);
+			} else {
+				assertType("'fetchTest2'", $functionToCall);
+				$this->$functionToCall();
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-7905.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7905.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7905;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+     * @param array<string, string> $data
+	 */
+	public function sayHello(array|null $data): void
+	{
+		$key = $data === null ? null : array_key_first($data);
+		if ($key !== null) {
+			assertType('non-empty-array<string, string>', $data);
+			assertType('string', $key);
+			echo $data[$key];
+		}
+		echo $key === null ? null : $data[$key];
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-7905.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7905.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug7905;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-9752.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9752.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bug9752;
+
+use function PHPStan\Testing\assertType;
+
+function isOkOrNot(string $type, ?object $car): void {
+	$supportedTypes = ['compact', '4x4'];
+	$hasType = \in_array($type, $supportedTypes);
+
+	if (null === $car && true === $hasType) {
+		echo 'Not OK';
+	} elseif ('compact' === $type) {
+		assertType('true', $hasType);
+		assertType('object', $car);
+		displayOk($car);
+	}
+}
+
+function displayOk(object $car): void
+{
+	echo 'OK';
+}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -354,6 +354,11 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14448.php'], []);
 	}
 
+	public function testBug7905(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7905.php'], []);
+	}
+
 	public function testBug3784(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-3784.php'], []);

--- a/tests/PHPStan/Rules/Arrays/data/bug-7905.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-7905.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7905Rule;
+
+class HelloWorld
+{
+	/**
+     * @param array<string, string> $data
+	 */
+	public function sayHello(array|null $data): void
+	{
+		$key = $data === null ? null : array_key_first($data);
+		echo $key === null ? null : $data[$key];
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/bug-7905.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-7905.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug7905Rule;
 

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3812,6 +3812,16 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13708.php'], []);
 	}
 
+	public function testBug13054(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = false;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = false;
+
+		$this->analyse([__DIR__ . '/data/bug-13054.php'], []);
+	}
+
 	public function testBug3396(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/bug-13054.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-13054.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13054Rule;
+
+class Test {
+	public function fetchTest(int $i): void {
+		echo $i;
+	}
+
+	public function fetchTest2(): void {
+		echo 'test';
+	}
+
+	public function exec(): void {
+		$list = [
+			'test1' => 'Test',
+			'test2' => 'Test2',
+		];
+
+		foreach ($list as $key => $functionName) {
+			$functionToCall = 'fetch' . $functionName;
+
+			if ($key === 'test1') {
+				$this->$functionToCall(1);
+			} else {
+				$this->$functionToCall();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Records conditional expressions for three more assignment shapes:

- **Overlapping ternary arms** — a `$v = $c ? A : B` assignment now records per-direction implications derived from the value that is unique to one arm, instead of only when the two arm types are mutually disjoint.
- **`in_array()` result** — `$flag = in_array($needle, [literals])` records the reverse holder "if `$needle` is one of the constant haystack values then `$flag` is `true`", so narrowing the needle later re-narrows the flag.
- **Derived assignments** — after `$b = expr($a)` where the right side reads a variable that carries conditional holders, the holders are re-evaluated and re-recorded for the assigned variable, so the dependency chain is not severed.

Also adds a regression test for #12620 (already fixed) and removes two conditions in PHPStan's own source that the new precision proves dead.

Based on 2.2.x. Regression tests added for each issue; a local issue-bot run shows the three fixes plus one collateral fix (#11824) and no regressions.

Closes https://github.com/phpstan/phpstan/issues/7905
Closes https://github.com/phpstan/phpstan/issues/9752
Closes https://github.com/phpstan/phpstan/issues/13054

🤖 Generated with [Claude Code](https://claude.com/claude-code)
