### PR TITLE
Narrow optional array offsets through isset() conditions

### DIFF
--- a/src/Analyser/ExprHandler/CoalesceHandler.php
+++ b/src/Analyser/ExprHandler/CoalesceHandler.php
@@ -56,15 +56,34 @@ final class CoalesceHandler implements ExprHandler
 		$scope = $this->nonNullabilityHelper->revertNonNullability($condResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 		$scope = $nodeScopeResolver->lookForUnsetAllowedUndefinedExpressions($scope, $expr->left);
 
+		$chainResults = [];
+		$this->defaultNarrowingHelper->captureChainResults($expr->left, $storage, $chainResults);
+
 		// the falsey narrowing of this very node - asking the scope about it
 		// mid-processing would take the on-demand path and recurse
-		$rightScope = $scope->applySpecifiedTypes($this->coalesceCompositionHelper->getFalseySpecifiedTypes($scope, $scope, $expr->left, $condResult, $expr, TypeSpecifierContext::createFalsey()));
+		$rightSideSpecifiedTypes = $this->coalesceCompositionHelper->getFalseySpecifiedTypes($scope, $scope, $expr->left, $condResult, $expr, TypeSpecifierContext::createFalsey());
+		$leftSurelySetNonNull = $condResult->getIssetabilityResolution($scope, false)->isSet(static function (Type $type): ?bool {
+			$isNull = $type->isNull();
+			if ($isNull->maybe()) {
+				return null;
+			}
+
+			return !$isNull->yes();
+		}) === true;
+		if (!$leftSurelySetNonNull) {
+			// the right side only evaluates when the left side is null or unset -
+			// the falsey isset() narrowing of the left side, like `??=`; skipped
+			// when the right side cannot evaluate at all, so its counterfactual
+			// certainty reductions do not survive the merge below
+			$rightSideSpecifiedTypes = $rightSideSpecifiedTypes->unionWith(
+				$this->coalesceCompositionHelper->getRightSideScopeSpecifiedTypes($scope, $expr->left, $condResult, $chainResults, $expr),
+			);
+		}
+		$rightScope = $scope->applySpecifiedTypes($rightSideSpecifiedTypes);
 		$rightResult = $nodeScopeResolver->processExprNode($stmt, $expr->right, $rightScope, $storage, $nodeCallback, $context->enterDeepKeepingValueFlow());
 		// the left-is-set narrowing, composed from the already-processed chain
 		// results - the inside-out equivalent of narrowing by isset($expr->left)
 		// without synthesizing an Isset_ node and re-walking the chain on demand
-		$chainResults = [];
-		$this->defaultNarrowingHelper->captureChainResults($expr->left, $storage, $chainResults);
 		$leftIssetTypes = $this->defaultNarrowingHelper->createIssetTruthyChainTypes(
 			$scope,
 			$expr->left,

--- a/src/Analyser/ExprHandler/Helper/DefaultNarrowingHelper.php
+++ b/src/Analyser/ExprHandler/Helper/DefaultNarrowingHelper.php
@@ -687,13 +687,31 @@ final class DefaultNarrowingHelper
 				if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {
 					$constantArrays = $varType->getConstantArrays();
 					$typesToRemove = [];
+					$hasOptionalNonNullableOffset = false;
+					$hasPossiblyNullOffsetValue = false;
 					foreach ($constantArrays as $constantArray) {
 						$hasOffset = $constantArray->hasOffsetValueType($dimType);
-						if (!$hasOffset->yes() || !$constantArray->getOffsetValueType($dimType)->isNull()->no()) {
+						if ($hasOffset->no()) {
+							continue;
+						}
+						if (!$constantArray->getOffsetValueType($dimType)->isNull()->no()) {
+							$hasPossiblyNullOffsetValue = true;
 							continue;
 						}
 
-						$typesToRemove[] = $constantArray;
+						if ($hasOffset->yes()) {
+							$typesToRemove[] = $constantArray;
+							continue;
+						}
+
+						$hasOptionalNonNullableOffset = true;
+					}
+
+					// !isset() on an optional key with a non-nullable value means the
+					// key is absent - but only when no member can hold null at that
+					// offset (the removal distributes over every union member).
+					if ($hasOptionalNonNullableOffset && !$hasPossiblyNullOffsetValue) {
+						$typesToRemove[] = new HasOffsetType($dimType);
 					}
 
 					if ($typesToRemove !== []) {

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -43,7 +43,6 @@ use function count;
 use function get_class;
 use function implode;
 use function in_array;
-use function is_int;
 use function sprintf;
 use function usort;
 use const PHP_INT_MAX;
@@ -990,19 +989,11 @@ final class TypeCombinator
 		$keyTypesForGeneralArray = [];
 		$valueTypesForGeneralArray = [];
 		$generalArrayOccurred = false;
-		$constantKeyTypesNumbered = [];
-		$filledArrays = 0;
-		$overflowed = false;
-
-		/** @var int|float $nextConstantKeyTypeIndex */
-		$nextConstantKeyTypeIndex = 1;
+		$seenConstantKeyTypes = [];
 
 		foreach ($arrayTypes as $arrayType) {
 			$constantArrays = $arrayType->getConstantArrays();
 			$isConstantArray = $constantArrays !== [];
-			if (!$isConstantArray || !$arrayType->isIterableAtLeastOnce()->no()) {
-				$filledArrays++;
-			}
 
 			if (!$isConstantArray) {
 				foreach ($arrayType->getArrays() as $type) {
@@ -1019,23 +1010,16 @@ final class TypeCombinator
 					$valueTypesForGeneralArray[] = $valueTypes[$i];
 
 					$keyTypeValue = $keyType->getValue();
-					if (array_key_exists($keyTypeValue, $constantKeyTypesNumbered)) {
+					if (array_key_exists($keyTypeValue, $seenConstantKeyTypes)) {
 						continue;
 					}
+					$seenConstantKeyTypes[$keyTypeValue] = true;
 					$keyTypesForGeneralArray[] = $keyType;
-
-					$constantKeyTypesNumbered[$keyTypeValue] = $nextConstantKeyTypeIndex;
-					$nextConstantKeyTypeIndex *= 2;
-					if (!is_int($nextConstantKeyTypeIndex)) {
-						$generalArrayOccurred = true;
-						$overflowed = true;
-						continue 2;
-					}
 				}
 			}
 		}
 
-		if ($generalArrayOccurred && (!$overflowed || $filledArrays > 1)) {
+		if ($generalArrayOccurred) {
 			$reducedArrayTypes = self::reduceArrays($arrayTypes, false);
 			if (count($reducedArrayTypes) === 1) {
 				return [self::intersect($reducedArrayTypes[0], ...$accessoryTypes)];

--- a/tests/PHPStan/Analyser/nsrt/bug-12786.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12786.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug12786;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12786.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12786.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12786;
+
+use function PHPStan\Testing\assertType;
+
+class A
+{
+	/** @param ?string[] $should_be_array */
+	public function __construct(
+		public ?array $should_be_array,
+	)
+	{
+	}
+
+	/** @param array{y?: string|string[]} $x */
+	public static function fromRequest(array $x): self
+	{
+		if (isset($x['y']) && is_string($x['y'])) {
+			$x['y'] = explode(',', $x['y']);
+		} // $x['y'] can't be string anymore
+
+		assertType('array<string>|null', $x['y'] ?? null);
+
+		return new self(
+			should_be_array: $x['y'] ?? null,
+		);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-15021.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-15021.php
@@ -7,7 +7,7 @@ use function PHPStan\Testing\assertType;
 /** @param array{foo?: string, bar?: string} $data */
 function optionalOffset(array $data): void
 {
-	$data['foo'] ??= assertType('array{foo?: string, bar?: string}', $data);
+	$data['foo'] ??= assertType('array{bar?: string}', $data);
 }
 
 /** @param array{foo?: string, bar?: string} $data */
@@ -65,7 +65,7 @@ function nonNullableStaticProperty(): void
 
 function propertyOffset(Foo $foo): void
 {
-	$foo->data['foo'] ??= assertType('array{foo?: string, bar?: string}', $foo->data);
+	$foo->data['foo'] ??= assertType('array{bar?: string}', $foo->data);
 }
 
 /** @param \ArrayAccess<string, string> $a */
@@ -133,14 +133,14 @@ function unsetTargetBeforeAssignOp(array $data): void
 function emptyTargetBeforeAssignOp(array $data): void
 {
 	if (empty($data['foo'])) {
-		$data['foo'] ??= assertType('array{foo?: string, bar?: string}', $data);
+		$data['foo'] ??= assertType('array{bar?: string}', $data);
 	}
 }
 
 /** @param array{foo?: string, bar?: string} $data */
 function assignOpInsideEmpty(array $data): void
 {
-	if (empty($data['foo'] ??= assertType('array{foo?: string, bar?: string}', $data))) {
+	if (empty($data['foo'] ??= assertType('array{bar?: string}', $data))) {
 		echo 'empty';
 	}
 }
@@ -148,7 +148,7 @@ function assignOpInsideEmpty(array $data): void
 /** @param array{foo?: string, bar?: string} $data */
 function assignOpInsideIsset(array $data): void
 {
-	if (isset($data['foo'] ??= assertType('array{foo?: string, bar?: string}', $data))) {
+	if (isset($data['foo'] ??= assertType('array{bar?: string}', $data))) {
 		echo 'isset';
 	}
 }
@@ -157,7 +157,7 @@ function assignOpInsideIsset(array $data): void
 function assignOpInsideUnsetOffset(array $data): void
 {
 	$other = ['x' => 1, 'fallback' => 2];
-	unset($other[$data['foo'] ??= assertType('array{foo?: string, bar?: string}', $data)]);
+	unset($other[$data['foo'] ??= assertType('array{bar?: string}', $data)]);
 }
 
 /** @param array{foo?: string, bar?: string} $data */

--- a/tests/PHPStan/Analyser/nsrt/bug-6379.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-6379.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6379Types;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+
+	/**
+	 * @param array{
+	 *    cr?: string,
+	 *    c?: string
+	 * } $params
+	 */
+	public static function paramsToString(array $params): string
+	{
+		if (isset($params['cr']) === true || isset($params['c']) === true) {
+			assertType('non-empty-array{cr?: string, c?: string}', $params);
+			if (!isset($params['cr'])) {
+				assertType('array{c: string}', $params);
+			}
+
+			return sprintf('-c%s', $params['cr'] ?? $params['c']);
+		}
+
+		return '';
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-9426.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9426.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Bug9426;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+
+final class A
+{
+
+	/**
+	 * @param array{something?: string} $a
+	 */
+	public function something(array $a): void
+	{
+		if (isset($a['something'])) {
+			$b = new \DateTimeImmutable();
+		}
+
+		if (!isset($a['something'])) {
+			assertType('array{}', $a);
+			assertVariableCertainty(TrinaryLogic::createNo(), $b);
+		} else {
+			assertType('array{something: string}', $a);
+			assertVariableCertainty(TrinaryLogic::createYes(), $b);
+		}
+	}
+
+	/**
+	 * @param array{something?: string|null} $a
+	 */
+	public function nullableValueStaysUntouched(array $a): void
+	{
+		if (!isset($a['something'])) {
+			assertType('array{something?: string|null}', $a);
+		} else {
+			assertType('array{something: string}', $a);
+		}
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/isset-property-default-value.php
+++ b/tests/PHPStan/Analyser/nsrt/isset-property-default-value.php
@@ -28,5 +28,5 @@ function coalesceWithoutDefault(Holder $a, Holder $b): void
 		throw new \LogicException();
 	}
 
-	assertType('int|null', $a->noDefault ?? $b->noDefault);
+	assertType('int', $a->noDefault ?? $b->noDefault);
 }

--- a/tests/PHPStan/Analyser/nsrt/preserve-large-constant-array.php
+++ b/tests/PHPStan/Analyser/nsrt/preserve-large-constant-array.php
@@ -17,7 +17,7 @@ function multiKeys(array $arr): void
 		return;
 	}
 
-	assertType('array{1: string|null, 2: int|null, 3: bool, 4: string, 5: int, 6: bool, 7: string, 8: int, 9: bool, 10: string, 11: int, 12: bool, 13: string, 14: int, 15: bool, 16: string, 17: int, 18: bool, 19: string, 20: int, 21: bool, 22: string, 23: int, 24: bool, 25: string, 26: int, 27: bool, 28: string, 29: int, 30: bool, 31: string, 32: int, 33: bool, 34: string, 35: int, 36: bool, 37: string, 38: int, 39: bool, 40: string, 41: int, 42: bool, 43: string, 44: int, 45: bool, 46: string, 47: int, 48: bool, 49: string, 50: int, 51: bool, 52: string, 53: int, 54: bool, 55: string, 56: int, 57: bool, 58: string, 59: int, 60: bool, 61: string, 62: int, 63: bool, 64: float}', $arr);
+	assertType('array{1: null, 2: null, 3: bool, 4: string, 5: int, 6: bool, 7: string, 8: int, 9: bool, 10: string, 11: int, 12: bool, 13: string, 14: int, 15: bool, 16: string, 17: int, 18: bool, 19: string, 20: int, 21: bool, 22: string, 23: int, 24: bool, 25: string, 26: int, 27: bool, 28: string, 29: int, 30: bool, 31: string, 32: int, 33: bool, 34: string, 35: int, 36: bool, 37: string, 38: int, 39: bool, 40: string, 41: int, 42: bool, 43: string, 44: int, 45: bool, 46: string, 47: int, 48: bool, 49: string, 50: int, 51: bool, 52: string, 53: int, 54: bool, 55: string, 56: int, 57: bool, 58: string, 59: int, 60: bool, 61: string, 62: int, 63: bool, 64: float}|array{1: string, 2: int, 3: bool, 4: string, 5: int, 6: bool, 7: string, 8: int, 9: bool, 10: string, 11: int, 12: bool, 13: string, 14: int, 15: bool, 16: string, 17: int, 18: bool, 19: string, 20: int, 21: bool, 22: string, 23: int, 24: bool, 25: string, 26: int, 27: bool, 28: string, 29: int, 30: bool, 31: string, 32: int, 33: bool, 34: string, 35: int, 36: bool, 37: string, 38: int, 39: bool, 40: string, 41: int, 42: bool, 43: string, 44: int, 45: bool, 46: string, 47: int, 48: bool, 49: string, 50: int, 51: bool, 52: string, 53: int, 54: bool, 55: string, 56: int, 57: bool, 58: string, 59: int, 60: bool, 61: string, 62: int, 63: bool, 64: float}', $arr);
 	echo 1;
 }
 
@@ -63,5 +63,16 @@ function multipleOptions(array $arr): void
 		$brr = $arr;
 	}
 	assertType('array{1: string, 2: int, 3: bool, 4: string, 5: int, 6: bool, 7: string, 8: int, 9: bool, 10: string, 11: int, 12: bool, 13: string, 14: int, 15: bool, 16: string, 17: int, 18: bool, 19: string, 20: int, 21: bool, 22: string, 23: int, 24: bool, 25: string, 26: int, 27: bool, 28: string, 29: int, 30: bool, 31: string, 32: int, 33: bool, 34: string, 35: int, 36: bool, 37: string, 38: int, 39: bool, 40: string, 41: int, 42: bool, 43: string, 44: int, 45: bool, 46: string, 47: int, 48: bool, 49: string, 50: int, 51: bool, 52: string, 53: int, 54: bool, 55: string, 56: int, 57: bool, 58: string, 59: int, 60: bool, 61: string, 62: int, 63: bool, 64: float}', $brr);
+	echo 1;
+}
+
+/**
+ * @param array{1: string, 2: int, 3: bool, 4: string, 5: int, 6: bool, 7: string, 8: int, 9: bool, 10: string, 11: int, 12: bool, 13: string, 14: int, 15: bool, 16: string, 17: int, 18: bool, 19: string, 20: int, 21: bool, 22: string, 23: int, 24: bool, 25: string, 26: int, 27: bool, 28: string, 29: int, 30: bool, 31: string, 32: int, 33: bool, 34: string, 35: int, 36: bool, 37: string, 38: int, 39: bool, 40: string, 41: int, 42: bool, 43: string, 44: int, 45: bool, 46: string, 47: int, 48: bool, 49: string, 50: int, 51: bool, 52: string, 53: int, 54: bool, 55: string, 56: int, 57: bool, 58: string, 59: int, 60: bool, 61: string, 62: int, 63: bool, 64: float} $full
+ * @param array{2: int, 3: bool, 4: string, 5: int, 6: bool, 7: string, 8: int, 9: bool, 10: string, 11: int, 12: bool, 13: string, 14: int, 15: bool, 16: string, 17: int, 18: bool, 19: string, 20: int, 21: bool, 22: string, 23: int, 24: bool, 25: string, 26: int, 27: bool, 28: string, 29: int, 30: bool, 31: string, 32: int, 33: bool, 34: string, 35: int, 36: bool, 37: string, 38: int, 39: bool, 40: string, 41: int, 42: bool, 43: string, 44: int, 45: bool, 46: string, 47: int, 48: bool, 49: string, 50: int, 51: bool, 52: string, 53: int, 54: bool, 55: string, 56: int, 57: bool, 58: string, 59: int, 60: bool, 61: string, 62: int, 63: bool, 64: float} $withoutFirst
+ */
+function unionOfManyKeys(array $full, array $withoutFirst): void
+{
+	$union = rand(0, 1) === 0 ? $full : $withoutFirst;
+	assertType('array{1?: string, 2: int, 3: bool, 4: string, 5: int, 6: bool, 7: string, 8: int, 9: bool, 10: string, 11: int, 12: bool, 13: string, 14: int, 15: bool, 16: string, 17: int, 18: bool, 19: string, 20: int, 21: bool, 22: string, 23: int, 24: bool, 25: string, 26: int, 27: bool, 28: string, 29: int, 30: bool, 31: string, 32: int, 33: bool, 34: string, 35: int, 36: bool, 37: string, 38: int, 39: bool, 40: string, 41: int, 42: bool, 43: string, 44: int, 45: bool, 46: string, 47: int, 48: bool, 49: string, 50: int, 51: bool, 52: string, 53: int, 54: bool, 55: string, 56: int, 57: bool, 58: string, 59: int, 60: bool, 61: string, 62: int, 63: bool, 64: float}', $union);
 	echo 1;
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -1358,6 +1358,11 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13688.php'], []);
 	}
 
+	public function testBug6379(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6379.php'], []);
+	}
+
 	public static function dataUnsealedArrayShapes(): iterable
 	{
 		foreach ([false, true] as $reportPossiblyNonexistentGeneralArrayOffset) {

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -1363,6 +1363,17 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6379.php'], []);
 	}
 
+	public function testBug13075(): void
+	{
+		$this->reportPossiblyNonexistentConstantArrayOffset = true;
+		$this->analyse([__DIR__ . '/data/bug-13075.php'], [
+			[
+				'Offset \'c\' might not exist on array{c?: string}.',
+				40,
+			],
+		]);
+	}
+
 	public static function dataUnsealedArrayShapes(): iterable
 	{
 		foreach ([false, true] as $reportPossiblyNonexistentGeneralArrayOffset) {

--- a/tests/PHPStan/Rules/Arrays/data/bug-13075.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-13075.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13075;
+
+// In all the examples the caller ensures there's at least one key present in
+// the $data parameter and we want to give that information to phpstan.
+
+/**
+ * @param array{a?: string, b?: string} $data
+ */
+function works(array $data): string {
+	if (isset($data['a'])) {
+		return $data['a'];
+	}
+	assert(isset($data['b']));
+	return $data['b'];
+}
+
+/**
+ * @param array{a?: string, b?: string} $data
+ */
+function fail1(array $data): string {
+	assert(isset($data['a']) || isset($data['b']));
+	return $data['a'] ?? $data['b'];
+}
+
+/**
+ * @param array{a?: string, b?: string} $data
+ */
+function fail2(array $data): string {
+	assert(array_key_exists('a', $data) || array_key_exists('b', $data));
+	return $data['a'] ?? $data['b'];
+}
+
+/**
+ * @param array{a?: string, b?: string, c?: string} $data
+ */
+function fail3(array $data): string {
+	assert((bool) array_intersect_key($data, array_flip(['a', 'b', 'c'])));
+	return $data['a'] ?? $data['b'] ?? $data['c'];
+}

--- a/tests/PHPStan/Rules/Arrays/data/bug-6379.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-6379.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6379;
+
+class HelloWorld
+{
+	/**
+	 * @param array{
+	 *    cr?: string,
+	 *    c?: string
+	 * } $params
+	 */
+	public static function paramsToString(array $params): string
+	{
+		if (isset($params['cr']) === true || isset($params['c']) === true) {
+			return sprintf('-c%s', $params['cr'] ?? $params['c']);
+		}
+
+		return '';
+	}
+}

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -1094,6 +1094,15 @@ class DefinedVariableRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10228.php'], []);
 	}
 
+	public function testBug9426(): void
+	{
+		$this->cliArgumentsVariablesRegistered = true;
+		$this->polluteScopeWithLoopInitialAssignments = true;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithAlwaysIterableForeach = true;
+		$this->analyse([__DIR__ . '/data/bug-9426.php'], []);
+	}
+
 	#[RequiresPhp('>= 8.4.0')]
 	public function testPropertyHooks(): void
 	{

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -567,8 +567,12 @@ class IssetRuleTest extends RuleTestCase
 				13,
 			],
 			[
-				'Offset 3 on array{string, string, string, string, string} in isset() always exists and is not nullable.',
+				'Offset 3 on array{0: string, 1: string, 2: string, 4: string} in isset() does not exist.',
 				17,
+			],
+			[
+				'Offset 3 on array{string, string, string, string, string} in isset() always exists and is not nullable.',
+				29,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Variables/data/bug-9426.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-9426.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug9426Rule;
+
+final class A
+{
+    /**
+     * @param array{something?: string} $a
+     */
+    public function something(array $a): void
+    {
+        if (isset($a['something'])) {
+            $b = new \DateTimeImmutable();
+        }
+
+        $c = [
+            !isset($a['something']) ? 'something' : $b,
+        ];
+    }
+}

--- a/tests/PHPStan/Rules/Variables/data/isset-constant-array.php
+++ b/tests/PHPStan/Rules/Variables/data/isset-constant-array.php
@@ -14,6 +14,18 @@ class HelloWorld
 		}
 
 		if (isset($list[4])) {
+			return isset($list[3]); // offset 4 cannot be set - offset 3 is not (see above), and the list is contiguous
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string, 4?: string} $list
+	 */
+	public function sayGoodbye(array $list): bool
+	{
+		if (isset($list[4])) {
 			return isset($list[3]); // offset 4 implies offset 3;
 		}
 


### PR DESCRIPTION
Improves narrowing of optional array offsets through `isset()`:

- A falsey `isset($a['k'])` on a constant-array shape with an optional, non-nullable value now removes the offset (narrows `$a` to the shape without `'k'`). Both branches then differ, so the existing merge machinery records the guards and the dependent variable's certainty resolves. Nullable optional values are left untouched.
- The right side of `??` now applies the falsey-isset narrowing of the left side (as `??=` already did), so a coalesce fallback sees the correlated offset as present.

Also removes a dead power-of-two key-numbering path in `TypeCombinator::processArrayTypes` whose only remaining effect was an integer overflow that degraded large constant-array unions.

Regression tests added; `NodeScopeResolverTest` stays green. A local issue-bot run shows the two fixes plus one collateral fix (#12786) and no regressions. The listed existing-expectation changes are precision improvements (documented in the commits).

Closes https://github.com/phpstan/phpstan/issues/9426
Closes https://github.com/phpstan/phpstan/issues/6379
Closes https://github.com/phpstan/phpstan/issues/12786

🤖 Generated with [Claude Code](https://claude.com/claude-code)
