### PR TITLE
Narrow comparisons on a variable through its recorded defining call

### DIFF
--- a/src/Analyser/DirectInternalScopeFactory.php
+++ b/src/Analyser/DirectInternalScopeFactory.php
@@ -68,6 +68,7 @@ final class DirectInternalScopeFactory implements InternalScopeFactory
 		bool $nativeTypesPromoted = false,
 		?TemplateArgumentFrame $templateArgumentFrame = null,
 		?TemplateArgumentConstraints $templateArgumentConstraints = null,
+		array $resultProvenance = [],
 	): MutatingScope
 	{
 		$className = MutatingScope::class;
@@ -109,6 +110,7 @@ final class DirectInternalScopeFactory implements InternalScopeFactory
 			$nativeTypesPromoted,
 			$templateArgumentFrame,
 			$templateArgumentConstraints,
+			$resultProvenance,
 		);
 	}
 

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -113,6 +113,15 @@ final class AssignHandler implements ExprHandler
 
 	private const DERIVED_CONDITIONAL_EXPRESSIONS_LIMIT = 16;
 
+	/**
+	 * Pure information-carrying functions whose call result keeps provenance
+	 * when assigned to a variable: comparing the variable later narrows
+	 * through the call's own comparison machinery, exactly like comparing the
+	 * call directly (`$type = gettype($x); if ($type === 'string')` narrows
+	 * $x the way `if (gettype($x) === 'string')` does).
+	 */
+	private const RESULT_PROVENANCE_FUNCTIONS = ['count', 'sizeof', 'gettype', 'get_class', 'get_debug_type'];
+
 	public function __construct(
 		private TemplateArgumentObserver $templateArgumentObserver,
 		private VarAnnotationProcessor $varAnnotationProcessor,
@@ -1280,6 +1289,11 @@ final class AssignHandler implements ExprHandler
 					$scope = $scope->addConditionalExpressions((string) $exprString, $holders);
 				}
 
+				$provenanceCall = $this->resolveResultProvenanceCall($assignedExpr, $var->name);
+				if ($provenanceCall !== null) {
+					$scope = $scope->recordResultProvenance('$' . $var->name, $provenanceCall);
+				}
+
 				if ($assignedExpr instanceof Expr\Array_) {
 					$scope = $this->processArrayByRefItems($nodeScopeResolver, $scope, $storage, $var->name, $assignedExpr, new Variable($var->name));
 				}
@@ -1899,6 +1913,46 @@ final class AssignHandler implements ExprHandler
 		}
 
 		return $expr;
+	}
+
+	/**
+	 * The assigned expression, when it is a whitelisted pure call over a plain
+	 * variable whose result the target variable now provably holds - the shape
+	 * whose provenance the scope records. The single-variable-argument
+	 * requirement keeps invalidation exact: a write to the argument (or the
+	 * target) drops the record by key containment alone.
+	 */
+	private function resolveResultProvenanceCall(Expr $assignedExpr, string $targetVariableName): ?FuncCall
+	{
+		if (
+			!$assignedExpr instanceof FuncCall
+			|| !$assignedExpr->name instanceof Name
+			|| $assignedExpr->isFirstClassCallable()
+			|| !in_array($assignedExpr->name->toLowerString(), self::RESULT_PROVENANCE_FUNCTIONS, true)
+		) {
+			return null;
+		}
+
+		$args = $assignedExpr->getArgs();
+		if (count($args) !== 1 || $args[0]->unpack || $args[0]->name !== null) {
+			return null;
+		}
+
+		$argValue = $args[0]->value;
+		if (
+			!$argValue instanceof Variable
+			|| !is_string($argValue->name)
+			// the call read the target's pre-assignment value - after the
+			// assignment the record would describe the variable through itself
+			|| $argValue->name === $targetVariableName
+			// closure binds rebind $this without touching provenance
+			|| $argValue->name === 'this'
+			|| in_array($argValue->name, Scope::SUPERGLOBAL_VARIABLES, true)
+		) {
+			return null;
+		}
+
+		return $assignedExpr;
 	}
 
 	/**

--- a/src/Analyser/ExprHandler/Helper/IdenticalNarrowingHelper.php
+++ b/src/Analyser/ExprHandler/Helper/IdenticalNarrowingHelper.php
@@ -46,6 +46,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use function count;
 use function in_array;
+use function is_string;
 
 /**
  * New-world narrowing for `===` (and, via a negated context, `!==`): composed
@@ -237,6 +238,20 @@ final class IdenticalNarrowingHelper
 		if (count($constantType->getFiniteTypes()) !== 1) {
 			// a class constant does not have to be single-valued
 			return null;
+		}
+
+		// a provenance-recorded subject variable narrows through its defining
+		// call's families, exactly like the direct call comparison - the
+		// variable itself still pins to the constant alongside
+		$provenanceTypes = $this->specifyThroughResultProvenance($subject, $constantExpr, $constantType, $context, $evaluationScope);
+		if ($provenanceTypes !== null) {
+			return $provenanceTypes->unionWith($this->defaultNarrowingHelper->createSubjectTypes(
+				$evaluationScope,
+				$subject,
+				$subjectResult,
+				$constantType,
+				$context,
+			));
 		}
 
 		// $a::class === Foo::class narrows $a to a final Foo when true;
@@ -817,6 +832,40 @@ final class IdenticalNarrowingHelper
 	}
 
 	/**
+	 * When the subject variable is provenance-recorded as holding the result
+	 * of a pure call (`$v = count($x)`), the comparison against the constant
+	 * also runs the call's own family narrowing - `$v == 3` narrows $x like
+	 * `count($x) == 3` would. The recorded call comes from an earlier
+	 * statement and has no stored results in this walk, so the families read
+	 * the argument's current type from the evaluation scope's tracked state.
+	 */
+	private function specifyThroughResultProvenance(
+		Expr $subject,
+		Expr $constantExpr,
+		Type $constantType,
+		TypeSpecifierContext $context,
+		MutatingScope $evaluationScope,
+	): ?SpecifiedTypes
+	{
+		$unwrappedSubject = $subject instanceof AlwaysRememberedExpr ? $subject->getExpr() : $subject;
+		if (!$unwrappedSubject instanceof Expr\Variable || !is_string($unwrappedSubject->name)) {
+			return null;
+		}
+
+		$call = $evaluationScope->getResultProvenanceCall('$' . $unwrappedSubject->name);
+		if ($call === null) {
+			return null;
+		}
+
+		$familyTypes = $this->specifyFuncCallFamilies($call, null, $call, $constantExpr, $constantType, $context, $evaluationScope, null, true);
+		if (!$familyTypes instanceof SpecifiedTypes) {
+			return null;
+		}
+
+		return $familyTypes;
+	}
+
+	/**
 	 * The function-family compositions, shared by the literal and the
 	 * TYPE-based constant sides: a family answer, null to fall back to the
 	 * old-world path, or false when no family matched and the caller narrows
@@ -826,13 +875,14 @@ final class IdenticalNarrowingHelper
 	 */
 	private function specifyFuncCallFamilies(
 		Expr $subject,
-		ExpressionResult $subjectResult,
+		?ExpressionResult $subjectResult,
 		Expr\FuncCall $call,
 		Expr $constantExpr,
 		Type $constantType,
 		TypeSpecifierContext $context,
 		MutatingScope $evaluationScope,
 		?ExpressionResult $argResult,
+		bool $argTypesFromScopeState = false,
 	): SpecifiedTypes|false|null
 	{
 		if (!($call->name instanceof Name) || $call->isFirstClassCallable() || !isset($call->getArgs()[0])) {
@@ -845,6 +895,10 @@ final class IdenticalNarrowingHelper
 			$call->name->toLowerString() === 'preg_match'
 		) {
 			if ($context->true() && (new ConstantIntegerType(1))->isSuperTypeOf($constantType)->yes()) {
+				if ($subjectResult === null) {
+					return null;
+				}
+
 				return $subjectResult->getSpecifiedTypesForScope($evaluationScope, $context);
 			}
 
@@ -859,10 +913,11 @@ final class IdenticalNarrowingHelper
 				$constantStrings = $constantType->getConstantStrings();
 				if (count($constantStrings) === 1 && $constantStrings[0]->getValue() === '') {
 					$argExpr = $call->getArgs()[0]->value;
-					if ($argResult === null) {
+					$argType = $this->resolveFamilyArgType($call, $argResult, $argTypesFromScopeState, $evaluationScope);
+					if ($argType === null) {
 						return null;
 					}
-					if ($argResult->getTypeOnScope($evaluationScope, $evaluationScope->nativeTypesPromoted)->isString()->yes()) {
+					if ($argType->isString()->yes()) {
 						return $this->defaultNarrowingHelper->createForSubject(
 							$argExpr,
 							new IntersectionType([new StringType(), new AccessoryNonEmptyStringType()]),
@@ -882,10 +937,10 @@ final class IdenticalNarrowingHelper
 				$constantStrings = $constantType->getConstantStrings();
 				if (count($constantStrings) === 1 && $constantStrings[0]->getValue() !== '') {
 					$argExpr = $call->getArgs()[0]->value;
-					if ($argResult === null) {
+					$argType = $this->resolveFamilyArgType($call, $argResult, $argTypesFromScopeState, $evaluationScope);
+					if ($argType === null) {
 						return null;
 					}
-					$argType = $argResult->getTypeOnScope($evaluationScope, $evaluationScope->nativeTypesPromoted);
 					$objectType = new ObjectType($constantStrings[0]->getValue());
 					$classStringType = new GenericClassStringType($objectType);
 
@@ -916,10 +971,10 @@ final class IdenticalNarrowingHelper
 		) {
 			if ($context->truthy() && $constantType->isNonEmptyString()->yes()) {
 				$argExpr = $call->getArgs()[0]->value;
-				if ($argResult === null) {
+				$argType = $this->resolveFamilyArgType($call, $argResult, $argTypesFromScopeState, $evaluationScope);
+				if ($argType === null) {
 					return null;
 				}
-				$argType = $argResult->getTypeOnScope($evaluationScope, $evaluationScope->nativeTypesPromoted);
 
 				if ($argType->isString()->yes()) {
 					$types = new SpecifiedTypes();
@@ -961,10 +1016,10 @@ final class IdenticalNarrowingHelper
 				return $this->defaultNarrowingHelper->createForSubject($argExpr, new NeverType(), $context, $evaluationScope);
 			}
 
-			if ($argResult === null) {
+			$argType = $this->resolveFamilyArgType($call, $argResult, $argTypesFromScopeState, $evaluationScope);
+			if ($argType === null) {
 				return null;
 			}
-			$argType = $argResult->getTypeOnScope($evaluationScope, $evaluationScope->nativeTypesPromoted);
 
 			if ((new ConstantIntegerType(0))->isSuperTypeOf($constantType)->yes()) {
 				$newArgType = $context->truthy() && !$argType->isArray()->yes()
@@ -1022,10 +1077,11 @@ final class IdenticalNarrowingHelper
 			}
 
 			if ($context->truthy() && IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($constantType)->yes()) {
-				if ($argResult === null) {
+				$argType = $this->resolveFamilyArgType($call, $argResult, $argTypesFromScopeState, $evaluationScope);
+				if ($argType === null) {
 					return null;
 				}
-				if ($argResult->getTypeOnScope($evaluationScope, $evaluationScope->nativeTypesPromoted)->isString()->yes()) {
+				if ($argType->isString()->yes()) {
 					$accessory = IntegerRangeType::fromInterval(2, null)->isSuperTypeOf($constantType)->yes()
 						? new AccessoryNonFalsyStringType()
 						: new AccessoryNonEmptyStringType();
@@ -1100,6 +1156,25 @@ final class IdenticalNarrowingHelper
 		}
 
 		return false;
+	}
+
+	/**
+	 * The first argument's current type for the family compositions: from the
+	 * captured operand result or - for a provenance-recorded call from an
+	 * earlier statement, which has no captured results in this comparison -
+	 * from the evaluation scope's tracked state. Null means unknown and the
+	 * family falls back to the old-world path.
+	 */
+	private function resolveFamilyArgType(Expr\FuncCall $call, ?ExpressionResult $argResult, bool $argTypesFromScopeState, MutatingScope $evaluationScope): ?Type
+	{
+		if ($argTypesFromScopeState) {
+			return $evaluationScope->getStateType($call->getArgs()[0]->value);
+		}
+		if ($argResult === null) {
+			return null;
+		}
+
+		return $argResult->getTypeOnScope($evaluationScope, $evaluationScope->nativeTypesPromoted);
 	}
 
 	/**

--- a/src/Analyser/InternalScopeFactory.php
+++ b/src/Analyser/InternalScopeFactory.php
@@ -21,6 +21,7 @@ interface InternalScopeFactory
 	 * @param array<string, bool> $currentlyAssignedExpressions
 	 * @param array<string, true> $currentlyAllowedUndefinedExpressions
 	 * @param list<array{FunctionReflection|MethodReflection|null, ParameterReflection|null}> $inFunctionCallsStack
+	 * @param array<string, ResultProvenance> $resultProvenance
 	 */
 	public function create(
 		ScopeContext $context,
@@ -41,6 +42,7 @@ interface InternalScopeFactory
 		bool $nativeTypesPromoted = false,
 		?TemplateArgumentFrame $templateArgumentFrame = null,
 		?TemplateArgumentConstraints $templateArgumentConstraints = null,
+		array $resultProvenance = [],
 	): MutatingScope;
 
 	public function toNodeCallbackScopeFactory(): self;

--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -89,6 +89,7 @@ final class LazyInternalScopeFactory implements InternalScopeFactory
 		bool $nativeTypesPromoted = false,
 		?TemplateArgumentFrame $templateArgumentFrame = null,
 		?TemplateArgumentConstraints $templateArgumentConstraints = null,
+		array $resultProvenance = [],
 	): MutatingScope
 	{
 		$className = MutatingScope::class;
@@ -142,6 +143,7 @@ final class LazyInternalScopeFactory implements InternalScopeFactory
 			$nativeTypesPromoted,
 			$templateArgumentFrame,
 			$templateArgumentConstraints,
+			$resultProvenance,
 		);
 	}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -137,6 +137,7 @@ use function md5;
 use function preg_match;
 use function spl_object_id;
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
@@ -180,6 +181,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	 * @param array<string, ExpressionTypeHolder> $nativeExpressionTypes
 	 * @param list<array{MethodReflection|FunctionReflection|null, ParameterReflection|null}> $inFunctionCallsStack
 	 * @param ExtensionsCollection<ExpressionTypeResolverExtension> $expressionTypeResolverExtensions
+	 * @param array<string, ResultProvenance> $resultProvenance
 	 */
 	public function __construct(
 		private Container $container,
@@ -215,6 +217,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		public bool $nativeTypesPromoted = false,
 		protected ?TemplateArgumentFrame $templateArgumentFrame = null,
 		protected ?TemplateArgumentConstraints $templateArgumentConstraints = null,
+		protected array $resultProvenance = [],
 	)
 	{
 		if ($namespace === '') {
@@ -249,6 +252,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 		if ($nodeCallbackScope instanceof NodeCallbackScope) {
 			$nodeCallbackScope->seedWalkScope($this);
@@ -405,6 +409,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -592,6 +597,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -692,6 +698,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -734,6 +741,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -771,6 +779,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -1045,6 +1054,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -1141,6 +1151,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -1739,6 +1750,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			true,
 			templateArgumentFrame: $this->templateArgumentFrame,
 			templateArgumentConstraints: $this->templateArgumentConstraints,
+			resultProvenance: $this->resultProvenance,
 		);
 	}
 
@@ -1854,6 +1866,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 
 		if ($rememberTypes) {
@@ -1887,6 +1900,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 
 		$parentScope->resolvedTypes = $this->resolvedTypes;
@@ -2412,6 +2426,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->anonymousFunctionReflection,
 			templateArgumentFrame: $this->templateArgumentFrame,
 			templateArgumentConstraints: $this->templateArgumentConstraints,
+			resultProvenance: $this->resultProvenance,
 		);
 	}
 
@@ -2443,6 +2458,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->anonymousFunctionReflection,
 			templateArgumentFrame: $this->templateArgumentFrame,
 			templateArgumentConstraints: $this->templateArgumentConstraints,
+			resultProvenance: $this->resultProvenance,
 		);
 	}
 
@@ -2491,6 +2507,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -2514,6 +2531,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->anonymousFunctionReflection,
 			templateArgumentFrame: $this->templateArgumentFrame,
 			templateArgumentConstraints: $this->templateArgumentConstraints,
+			resultProvenance: $this->resultProvenance,
 		);
 	}
 
@@ -2547,6 +2565,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -3120,6 +3139,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 		$scope->resolvedTypes = $this->resolvedTypes;
 
@@ -3151,6 +3171,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 		$scope->resolvedTypes = $this->resolvedTypes;
 
@@ -3212,6 +3233,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 		$scope->resolvedTypes = $this->resolvedTypes;
 
@@ -3243,6 +3265,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 		$scope->resolvedTypes = $this->resolvedTypes;
 
@@ -3654,6 +3677,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 
@@ -3812,6 +3836,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	{
 		$exprStringToInvalidate = $this->getNodeKey($expressionToInvalidate);
 
+		$filteredResultProvenance = self::filterResultProvenance($this->resultProvenance, $exprStringToInvalidate);
 		$result = ScopeOps::invalidateExpressionEntries(
 			$this,
 			$this->exprPrinter,
@@ -3825,11 +3850,18 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$keepPropertyFetches,
 		);
 		if ($result === null) {
-			return $this;
+			if (count($filteredResultProvenance) === count($this->resultProvenance)) {
+				return $this;
+			}
+
+			$scope = $this->openSpecificationScope();
+			$scope->resultProvenance = $filteredResultProvenance;
+
+			return $scope;
 		}
 
-		/** @var static */
-		return ScopeOps::scopeWith(
+		/** @var static $scope */
+		$scope = ScopeOps::scopeWith(
 			$this,
 			$result[0],
 			$result[1],
@@ -3840,6 +3872,9 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->inFirstLevelStatement,
 			$this->afterExtractCall,
 		);
+		$scope->resultProvenance = $filteredResultProvenance;
+
+		return $scope;
 	}
 
 	/** @internal called by ScopeOps */
@@ -4266,6 +4301,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$scope->nativeTypesPromoted,
 			$scope->templateArgumentFrame,
 			$scope->templateArgumentConstraints,
+			$scope->resultProvenance,
 		);
 	}
 
@@ -4347,6 +4383,101 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->inFirstLevelStatement,
 			$this->afterExtractCall,
 		);
+	}
+
+	/**
+	 * The recorded pure defining call of the given expression key ("$v" holds
+	 * the result of this very call), or null when nothing is recorded.
+	 *
+	 * @internal
+	 */
+	public function getResultProvenanceCall(string $exprString): ?FuncCall
+	{
+		if (!isset($this->resultProvenance[$exprString])) {
+			return null;
+		}
+
+		return $this->resultProvenance[$exprString]->getCall();
+	}
+
+	/**
+	 * Records that the given expression key currently holds the result of the
+	 * given pure call - the caller (AssignHandler) has just performed the
+	 * assignment and vouches for the call's purity and its arguments being
+	 * invalidation-trackable.
+	 *
+	 * @internal
+	 */
+	public function recordResultProvenance(string $exprString, FuncCall $call): self
+	{
+		$scope = $this->openSpecificationScope();
+		$resultProvenance = $this->resultProvenance;
+		$resultProvenance[$exprString] = new ResultProvenance($call, $this->getNodeKey($call));
+		$scope->resultProvenance = $resultProvenance;
+
+		return $scope;
+	}
+
+	/**
+	 * Merge counterpart for result provenance: only entries recording the very
+	 * same defining call on both sides survive.
+	 *
+	 * @param array<string, ResultProvenance> $ours
+	 * @param array<string, ResultProvenance> $theirs
+	 * @return array<string, ResultProvenance>
+	 */
+	private static function intersectResultProvenance(array $ours, array $theirs): array
+	{
+		if ($ours === [] || $theirs === []) {
+			return [];
+		}
+
+		$intersected = [];
+		foreach ($ours as $exprString => $provenance) {
+			if (!isset($theirs[$exprString])) {
+				continue;
+			}
+			if ($theirs[$exprString]->getCallExprString() !== $provenance->getCallExprString()) {
+				continue;
+			}
+
+			$intersected[$exprString] = $provenance;
+		}
+
+		return $intersected;
+	}
+
+	/**
+	 * Drops provenance entries whose target or defining call mentions the
+	 * invalidated expression - conservatively by printed-key containment, a
+	 * cheap over-approximation of ScopeOps::shouldInvalidateExpression()
+	 * (sound because dropping an entry only loses narrowing). Containment is
+	 * exhaustive here: entries only ever target plain variables and record
+	 * calls over plain variable arguments, whose printed keys spell out every
+	 * subexpression.
+	 *
+	 * @param array<string, ResultProvenance> $resultProvenance
+	 * @return array<string, ResultProvenance>
+	 */
+	private static function filterResultProvenance(array $resultProvenance, string $exprStringToInvalidate): array
+	{
+		if ($resultProvenance === []) {
+			return $resultProvenance;
+		}
+
+		$filtered = [];
+		foreach ($resultProvenance as $exprString => $provenance) {
+			if (
+				str_contains($exprString, $exprStringToInvalidate)
+				|| str_contains($provenance->getCallExprString(), $exprStringToInvalidate)
+			) {
+				continue;
+			}
+
+			$filtered[$exprString] = $provenance;
+		}
+
+		return $filtered;
 	}
 
 	public function exitFirstLevelStatements(): self
@@ -4440,8 +4571,8 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$otherScope->nativeExpressionTypes,
 		);
 
-		/** @var static */
-		return ScopeOps::scopeWith(
+		/** @var static $mergedScope */
+		$mergedScope = ScopeOps::scopeWith(
 			$this,
 			$mergedExpressionTypes,
 			$mergedNativeTypes,
@@ -4452,6 +4583,11 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->inFirstLevelStatement,
 			$this->afterExtractCall && $otherScope->afterExtractCall,
 		);
+		// scopeWith() copied our side's provenance - a merge keeps only entries
+		// identical in both branches
+		$mergedScope->resultProvenance = self::intersectResultProvenance($this->resultProvenance, $otherScope->resultProvenance);
+
+		return $mergedScope;
 	}
 
 	/**
@@ -4733,6 +4869,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			self::intersectResultProvenance($this->resultProvenance, $finallyScope->resultProvenance),
 		);
 	}
 
@@ -4782,6 +4919,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			return $this;
 		}
 
+		$resultProvenance = $this->resultProvenance;
 		foreach ($byRefUses as $use) {
 			if (!is_string($use->var->name)) {
 				throw new ShouldNotHappenException();
@@ -4789,6 +4927,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 
 			$variableName = $use->var->name;
 			$variableExprString = '$' . $variableName;
+			$resultProvenance = self::filterResultProvenance($resultProvenance, $variableExprString);
 
 			if (!$closureScope->hasVariableType($variableName)->yes()) {
 				$holder = ExpressionTypeHolder::createYes($use->var, new NullType());
@@ -4831,6 +4970,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$resultProvenance,
 		);
 	}
 
@@ -4882,6 +5022,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			self::intersectResultProvenance($this->resultProvenance, $finalScope->resultProvenance),
 		);
 	}
 
@@ -4947,6 +5088,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			self::intersectResultProvenance($this->resultProvenance, $otherScope->resultProvenance),
 		);
 	}
 
@@ -5645,6 +5787,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 					$holder->getTypeHolder()->getCertainty()->describe(),
 				);
 			}
+		}
+
+		foreach ($this->resultProvenance as $exprString => $provenance) {
+			$descriptions[sprintf('result provenance of %s', $exprString)] = $provenance->getCallExprString();
 		}
 
 		return $descriptions;

--- a/src/Analyser/NodeCallbackScope.php
+++ b/src/Analyser/NodeCallbackScope.php
@@ -77,6 +77,7 @@ final class NodeCallbackScope extends MutatingScope
 			$this->nativeTypesPromoted,
 			$this->templateArgumentFrame,
 			$this->templateArgumentConstraints,
+			$this->resultProvenance,
 		);
 	}
 

--- a/src/Analyser/ResultProvenance.php
+++ b/src/Analyser/ResultProvenance.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node\Expr\FuncCall;
+
+/**
+ * Records that a tracked expression (a variable) currently holds the result of
+ * the given pure information-carrying call (count(), gettype(), get_class(), ...),
+ * so a comparison on the variable can narrow through the call's own comparison
+ * machinery as if the call had been compared directly.
+ *
+ * Entries live in MutatingScope::$resultProvenance keyed by the target
+ * expression's key; they are dropped when the target or anything the call
+ * reads is invalidated, and merges keep only entries identical on both sides.
+ */
+final class ResultProvenance
+{
+
+	public function __construct(
+		private FuncCall $call,
+		private string $callExprString,
+	)
+	{
+	}
+
+	public function getCall(): FuncCall
+	{
+		return $this->call;
+	}
+
+	public function getCallExprString(): string
+	{
+		return $this->callExprString;
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13972.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13972.php
@@ -1,0 +1,61 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug13972;
+
+use function gettype;
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+
+	public function getAssignment(string $flagKey, string|bool $defaultValue): string|bool
+	{
+			$type = gettype($defaultValue);
+
+			return match ($type) {
+				'string' => $this->getString($defaultValue),
+				'boolean' => $this->getBool($defaultValue),
+			};
+	}
+
+	public function getAssignmentMatchAsserts(string $flagKey, string|bool $defaultValue): void
+	{
+		$type = gettype($defaultValue);
+
+		match ($type) {
+			'string' => assertType('string', $defaultValue),
+			'boolean' => assertType('bool', $defaultValue),
+		};
+	}
+
+	public function getAssignmentIf(string $flagKey, string|bool $defaultValue): string|bool
+	{
+		$type = gettype($defaultValue);
+
+		if ($type === 'string') {
+			assertType('string', $defaultValue);
+			assertNativeType('string', $defaultValue);
+
+			return $this->getString($defaultValue);
+		}
+
+		assertType('bool', $defaultValue);
+		assertNativeType('bool', $defaultValue);
+
+		return $this->getBool($defaultValue);
+	}
+
+	public function getBool(bool $default): bool
+	{
+		return true;
+	}
+
+	public function getString(string $default): string
+	{
+		return 'toto';
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-14464.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14464.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14464;
+
+use LogicException;
+use RuntimeException;
+use function count;
+use function preg_last_error_msg;
+use function preg_split;
+use function sprintf;
+use function strtolower;
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+
+	protected function columnOrAlias(string $columnName): void
+	{
+		$colParts = preg_split('/\s+/', $columnName, -1, \PREG_SPLIT_NO_EMPTY);
+		if ($colParts === false) {
+			throw new RuntimeException(preg_last_error_msg());
+		}
+		$numParts = count($colParts);
+
+		if ($numParts == 3) {
+			assertType('array{non-empty-string, non-empty-string, non-empty-string}', $colParts);
+			// columnAbc as aliasName
+			$this->columnName($colParts[0]);
+			if (strtolower($colParts[1]) !== 'as') {
+				throw new LogicException(sprintf('"%s" is not a valid column name or alias', $columnName));
+			}
+			$this->columnName($colParts[2]);
+		} elseif ($numParts == 2) {
+			assertType('array{non-empty-string, non-empty-string}', $colParts);
+			// columnAbc aliasName
+			$this->columnName($colParts[0]);
+			$this->columnName($colParts[1]);
+		} elseif ($numParts == 1) {
+			assertType('array{non-empty-string}', $colParts);
+			if ($colParts[0] !== '*') {
+				// columnAbc
+				$this->columnName($colParts[0]);
+			}
+		} else {
+			throw new LogicException(sprintf('"%s" is not a valid column or alias', $columnName));
+		}
+		assertType('list{0: non-empty-string, 1?: non-empty-string, 2?: non-empty-string}', $colParts);
+	}
+
+	public function columnName(string $columnName): string
+	{
+		return 'abc';
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-523.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-523.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Bug523;
+
+use function get_class;
+use function PHPStan\Testing\assertType;
+
+class Base {}
+class Child1 extends Base {}
+
+function typeHintedFunction(Child1 $object)
+{
+}
+
+function testPasses(Base $object)
+{
+	switch (get_class($object)) {
+		case Child1::class:
+			assertType('Bug523\Child1', $object);
+			typeHintedFunction($object);
+	}
+
+	$type = get_class($object);
+	switch ($type) {
+		case Child1::class:
+			assertType('Bug523\Child1', $object);
+			typeHintedFunction($object);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/result-provenance.php
+++ b/tests/PHPStan/Analyser/nsrt/result-provenance.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types = 1);
+
+namespace ResultProvenance;
+
+use PHPStan\TrinaryLogic;
+use function array_pop;
+use function count;
+use function get_class;
+use function gettype;
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+
+class ProvBase {}
+class ProvChild extends ProvBase {}
+
+class Foo
+{
+
+	/** @param list<string> $parts */
+	public function narrowsThroughVariable(array $parts): void
+	{
+		$n = count($parts);
+		if ($n === 2) {
+			assertType('array{string, string}', $parts);
+		} else {
+			assertType('list<string>', $parts);
+		}
+	}
+
+	/** @param list<string> $parts */
+	public function argWrittenAfterAssign(array $parts): void
+	{
+		$n = count($parts);
+		$parts[] = 'x';
+		if ($n === 2) {
+			// $parts changed since the count() - no shape reconstruction
+			assertType('non-empty-list<string>', $parts);
+		}
+	}
+
+	/** @param list<string> $parts */
+	public function targetReassignedAfterAssign(array $parts): void
+	{
+		$n = count($parts);
+		$n = $this->someInt();
+		if ($n === 2) {
+			// $n no longer holds the count() result
+			assertType('list<string>', $parts);
+		}
+	}
+
+	public function argReassignedGettype(string|bool $v): void
+	{
+		$type = gettype($v);
+		$v = 'hello';
+		if ($type === 'boolean') {
+			// $v was overwritten - must not intersect with bool
+			assertType("'hello'", $v);
+		}
+	}
+
+	/** @param list<string> $parts */
+	public function unsetArgAfterAssign(array $parts): void
+	{
+		$n = count($parts);
+		unset($parts);
+		if ($n === 2) {
+			assertVariableCertainty(TrinaryLogic::createNo(), $parts);
+		}
+	}
+
+	/** @param list<string> $parts */
+	public function poppedArgAfterAssign(array $parts): void
+	{
+		$n = count($parts);
+		array_pop($parts);
+		if ($n === 2) {
+			// one element was removed since the count() - no 2-tuple
+			assertType('list<string>', $parts);
+		}
+	}
+
+	/**
+	 * @param list<string> $a
+	 * @param list<string> $b
+	 */
+	public function mergeOfDifferentCalls(array $a, array $b, bool $flag): void
+	{
+		if ($flag) {
+			$n = count($a);
+		} else {
+			$n = count($b);
+		}
+		if ($n === 2) {
+			// neither call survives the merge - which one $n came from is unknown
+			assertType('list<string>', $a);
+			assertType('list<string>', $b);
+		}
+	}
+
+	/** @param list<string> $a */
+	public function mergeOfSameCall(array $a, bool $flag): void
+	{
+		if ($flag) {
+			$n = count($a);
+		} else {
+			$n = count($a);
+		}
+		if ($n === 2) {
+			// the same defining call on both sides survives the merge
+			assertType('array{string, string}', $a);
+		}
+	}
+
+	/** @param list<string> $parts */
+	public function byRefClosureAfterAssign(array $parts): void
+	{
+		$n = count($parts);
+		$fn = function () use (&$parts): void {
+			$parts = ['a', 'b', 'c'];
+		};
+		$fn();
+		if ($n === 2) {
+			// the by-ref closure may have replaced $parts
+			assertType('non-empty-list<string>', $parts);
+		}
+	}
+
+	public function switchThroughVariable(ProvBase $object): void
+	{
+		$class = get_class($object);
+		switch ($class) {
+			case ProvChild::class:
+				assertType('ResultProvenance\ProvChild', $object);
+				break;
+			default:
+				assertType('ResultProvenance\ProvBase', $object);
+		}
+	}
+
+	/** @param list<list<string>> $matrix */
+	public function loopReassignsEachIteration(array $matrix): void
+	{
+		foreach ($matrix as $row) {
+			$n = count($row);
+			if ($n === 2) {
+				assertType('array{string, string}', $row);
+			}
+			$row = ['x'];
+		}
+	}
+
+	public function someInt(): int
+	{
+		return 5;
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/result-provenance.php
+++ b/tests/PHPStan/Analyser/nsrt/result-provenance.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace ResultProvenance;
 

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -4495,4 +4495,13 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/unconstrained-query-result.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.0.0')]
+	public function testBug13972(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-13972.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-13972.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-13972.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace Bug13972Methods;
+
+class HelloWorld
+{
+	public function getAssignment(string $flagKey, string|bool $defaultValue): string|bool
+    {
+            $type = gettype($defaultValue);
+
+            return match ($type) {
+                'string' => $this->getString($defaultValue),
+                'boolean' => $this->getBool($defaultValue),
+            };
+    }
+
+	public function getBool(bool $default): bool {
+		return true;
+	}
+
+	public function getString(string $default): string {
+		return "toto";
+	}
+}


### PR DESCRIPTION
Adds a scope-threaded result-provenance map so that a comparison on a variable narrows like the same comparison on the call that produced it.

When `$v = f(arg)` is assigned, where `f` is one of `count` / `sizeof` / `gettype` / `get_class` / `get_debug_type` and `arg` is a plain variable, the scope records that `$v` holds that call's result. When a later `===` / `==` / `match` arm / `switch` case pins `$v` to a single-valued constant, PHPStan additionally runs the recorded call through the existing narrowing machinery (count-shape reconstruction, `gettype` string-to-type map, `get_class` object pin). This covers `if`, `match` and `switch` uniformly, both type flavours and both branch directions.

The entry is dropped on any write or impure invalidation of the target or the call's argument, kept across merges only when identical, and dropped at closure boundaries — so it is never less sound than the direct-call form.

Regression tests added; the full `NodeScopeResolverTest` stays green. A local issue-bot run confirms the three fixes and no regressions.

Closes https://github.com/phpstan/phpstan/issues/14464
Closes https://github.com/phpstan/phpstan/issues/13972
Closes https://github.com/phpstan/phpstan/issues/523

🤖 Generated with [Claude Code](https://claude.com/claude-code)
