### PR TITLE
Record variable definedness as conditional expressions

### DIFF
--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -68,6 +68,7 @@ use PHPStan\Node\Variable\VariableWrite;
 use PHPStan\Node\VariableAssignNode;
 use PHPStan\Node\VirtualNode;
 use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
@@ -107,6 +108,7 @@ use function is_int;
 use function is_nan;
 use function is_string;
 use function spl_object_id;
+use function str_contains;
 
 /**
  * @implements ExprHandler<Assign|AssignRef>
@@ -138,6 +140,7 @@ final class AssignHandler implements ExprHandler
 		private StaticPropertyFetchHandler $staticPropertyFetchHandler,
 		private MethodThrowPointHelper $methodThrowPointHelper,
 		private PropertyHookThrowPointsResolver $propertyHookThrowPointsResolver,
+		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
 	}
@@ -1296,7 +1299,23 @@ final class AssignHandler implements ExprHandler
 				}
 
 				$nodeScopeResolver->callNodeCallback($nodeCallback, new VariableAssignNode($var, $assignedExpr), $scopeBeforeAssignEval, $storage);
-
+				$remappedConditionalExpressions = [];
+				if (
+					// only the concat-assign's own write remaps - an enclosing plain
+					// assignment of the same variable (`$s = $s .= 'x'`) sees the
+					// already-remapped holders and would remap them a second time
+					$isAssignOp
+					&& $assignedExpr instanceof AssignOp\Concat
+					&& $assignedExpr->var instanceof Variable
+					&& $assignedExpr->var->name === $var->name
+					&& $scope->getConditionalExpressions() !== []
+				) {
+					$remappedConditionalExpressions = $this->remapConditionalExpressionsThroughConcatAssign(
+						$scope->getConditionalExpressions(),
+						'$' . $var->name,
+						$valueResult->getType(),
+					);
+				}
 				$nativeType = $this->readAssignedValueType($nodeScopeResolver, $storedAssignedExprResult, $assignedExpr, $scope->doNotTreatPhpDocTypesAsCertain());
 				$scope = $scope->assignVariable(
 					$var->name,
@@ -1305,6 +1324,9 @@ final class AssignHandler implements ExprHandler
 					TrinaryLogic::createYes(),
 					[],
 				);
+				foreach ($remappedConditionalExpressions as $exprString => $holders) {
+					$scope = $scope->addConditionalExpressions((string) $exprString, $holders); // @phpstan-ignore cast.useless
+				}
 				foreach ($conditionalExpressions as $exprString => $holders) {
 					$scope = $scope->addConditionalExpressions((string) $exprString, $holders);
 				}
@@ -2012,6 +2034,100 @@ final class AssignHandler implements ExprHandler
 		}
 
 		return $conditionalExpressions;
+	}
+
+	/**
+	 * `$var .= <single constant string>` keeps the conditional-expression
+	 * holders about $var alive by remapping them through the append instead of
+	 * losing them to the write's invalidation. A consequence type about $var is
+	 * concatenated with the appended constant; a condition on $var is remapped
+	 * only when it is itself a single constant string - appending a fixed
+	 * suffix is injective, so the remapped condition selects exactly the states
+	 * the original condition did. Holders mentioning $var inside a composite
+	 * expression, with a non-Yes certainty about $var, or with a non-constant
+	 * condition on $var are left to the regular invalidation. This keeps e.g. a
+	 * format string built across `if (!empty($target))` correlated with
+	 * $target while further pieces are appended.
+	 *
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 * @return array<string, ConditionalExpressionHolder[]>
+	 */
+	private function remapConditionalExpressionsThroughConcatAssign(
+		array $conditionalExpressions,
+		string $varExprString,
+		Type $appendedType,
+	): array
+	{
+		$appendedConstantStrings = $appendedType->getConstantStrings();
+		if (count($appendedConstantStrings) !== 1 || !$appendedType->equals($appendedConstantStrings[0])) {
+			return [];
+		}
+		$appendedConstantString = $appendedConstantStrings[0];
+
+		$remapped = [];
+		foreach ($conditionalExpressions as $targetExprString => $holders) {
+			$targetExprString = (string) $targetExprString; // @phpstan-ignore cast.useless
+			$targetIsVar = $targetExprString === $varExprString;
+			if (!$targetIsVar && str_contains($targetExprString, $varExprString)) {
+				// a composite target containing the variable ($var[0], f($var), ...)
+				continue;
+			}
+
+			foreach ($holders as $holder) {
+				$holderTouchesVar = $targetIsVar;
+				$remappable = true;
+				$newConditions = [];
+				foreach ($holder->getConditionExpressionTypeHolders() as $conditionExprString => $conditionHolder) {
+					$conditionExprString = (string) $conditionExprString; // @phpstan-ignore cast.useless
+					if ($conditionExprString === $varExprString) {
+						$holderTouchesVar = true;
+						$conditionConstantStrings = $conditionHolder->getType()->getConstantStrings();
+						if (
+							!$conditionHolder->getCertainty()->yes()
+							|| count($conditionConstantStrings) !== 1
+							|| !$conditionHolder->getType()->equals($conditionConstantStrings[0])
+						) {
+							$remappable = false;
+							break;
+						}
+						$newConditions[$conditionExprString] = ExpressionTypeHolder::createYes(
+							$conditionHolder->getExpr(),
+							$conditionConstantStrings[0]->append($appendedConstantString),
+						);
+						continue;
+					}
+
+					if (str_contains($conditionExprString, $varExprString)) {
+						$remappable = false;
+						break;
+					}
+
+					$newConditions[$conditionExprString] = $conditionHolder;
+				}
+				if (!$remappable || !$holderTouchesVar) {
+					continue;
+				}
+
+				$typeHolder = $holder->getTypeHolder();
+				if ($targetIsVar) {
+					if (!$typeHolder->getCertainty()->yes()) {
+						// the append leaves the variable defined on every path -
+						// an undefined/maybe consequence cannot be carried over
+						continue;
+					}
+					$concatType = $this->initializerExprTypeResolver->resolveConcatType($typeHolder->getType(), $appendedType);
+					if ($concatType instanceof ErrorType) {
+						continue;
+					}
+					$typeHolder = ExpressionTypeHolder::createYes($typeHolder->getExpr(), $concatType);
+				}
+
+				$newHolder = new ConditionalExpressionHolder($newConditions, $typeHolder);
+				$remapped[$targetExprString][$newHolder->getKey()] = $newHolder;
+			}
+		}
+
+		return $remapped;
 	}
 
 	/**

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -2049,7 +2049,7 @@ final class AssignHandler implements ExprHandler
 			$conditionalHolder = new ConditionalExpressionHolder([
 				'$' . $variableName => ExpressionTypeHolder::createYes(new Variable($variableName), $variableType),
 			], $holder);
-			$conditionalExpressions[(string) $exprString][$conditionalHolder->getKey()] = $conditionalHolder;
+			$conditionalExpressions[(string) $exprString][$conditionalHolder->getKey()] = $conditionalHolder; // @phpstan-ignore cast.useless
 		}
 
 		return $conditionalExpressions;

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -8,7 +8,12 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
+use PhpParser\Node\Expr\BinaryOp\LogicalOr;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\List_;
@@ -96,6 +101,7 @@ use function array_reverse;
 use function array_slice;
 use function count;
 use function in_array;
+use function is_array;
 use function is_float;
 use function is_int;
 use function is_nan;
@@ -1218,6 +1224,29 @@ final class AssignHandler implements ExprHandler
 						: $this->defaultNarrowingHelper->specifyTypesForNode($scope, $assignedExpr, TypeSpecifierContext::createFalsey());
 					$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($nodeScopeResolver, $scope, $storage, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType, $impurePoints, $assignedExpr, $storedAssignedExprResult);
 					$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($nodeScopeResolver, $scope, $storage, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType, $impurePoints, $assignedExpr, $storedAssignedExprResult);
+
+					// An assignment inside a short-circuit operand may or may not have run
+					// (its variable is only maybe-defined after the RHS walk), but a truthy
+					// && (or falsey ||) guarantees the right operand was evaluated. The
+					// operand walk's truthy/falsey scope knows exactly which variables it
+					// defined - record their certainty as a consequence of the assigned
+					// boolean, e.g. "$bool = $x && ($var = 'foo'); if ($bool) { … $var … }".
+					if (
+						$storedAssignedExprResult !== null
+						&& (
+							$assignedExpr instanceof BooleanAnd
+							|| $assignedExpr instanceof BooleanOr
+							|| $assignedExpr instanceof LogicalAnd
+							|| $assignedExpr instanceof LogicalOr
+						)
+						&& self::containsVariableAssignment($assignedExpr)
+					) {
+						if ($assignedExpr instanceof BooleanAnd || $assignedExpr instanceof LogicalAnd) {
+							$conditionalExpressions = $this->processDefinednessForConditionalExpressionsAfterAssign($conditionalExpressions, $var->name, $truthyType, $storedAssignedExprResult->getTruthyScope(), $scope);
+						} else {
+							$conditionalExpressions = $this->processDefinednessForConditionalExpressionsAfterAssign($conditionalExpressions, $var->name, $falseyType, $storedAssignedExprResult->getFalseyScope(), $scope);
+						}
+					}
 				}
 
 				foreach ([null, false, 0, 0.0, '', '0', []] as $falseyScalar) {
@@ -1983,6 +2012,76 @@ final class AssignHandler implements ExprHandler
 		}
 
 		return $conditionalExpressions;
+	}
+
+	/**
+	 * Records "if the assigned variable has $variableType, the target variable is
+	 * certainly defined (with its branch-scope type)" holders for variables whose
+	 * certainty is Yes in the given branch continuation scope of the RHS (the
+	 * truthy scope of a `&&`, the falsey scope of a `||` - the scopes where every
+	 * short-circuit operand was guaranteed evaluated) but only Maybe in the
+	 * merged after-RHS scope.
+	 *
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 * @return array<string, ConditionalExpressionHolder[]>
+	 */
+	private function processDefinednessForConditionalExpressionsAfterAssign(
+		array $conditionalExpressions,
+		string $variableName,
+		Type $variableType,
+		MutatingScope $branchScope,
+		MutatingScope $mergedScope,
+	): array
+	{
+		foreach ($branchScope->expressionTypes as $exprString => $holder) {
+			if (!$holder->getCertainty()->yes()) {
+				continue;
+			}
+			$expr = $holder->getExpr();
+			if (!$expr instanceof Variable || !is_string($expr->name) || $expr->name === $variableName) {
+				continue;
+			}
+			$mergedHolder = $mergedScope->expressionTypes[$exprString] ?? null;
+			if ($mergedHolder === null || !$mergedHolder->getCertainty()->maybe()) {
+				continue;
+			}
+
+			$conditionalHolder = new ConditionalExpressionHolder([
+				'$' . $variableName => ExpressionTypeHolder::createYes(new Variable($variableName), $variableType),
+			], $holder);
+			$conditionalExpressions[(string) $exprString][$conditionalHolder->getKey()] = $conditionalHolder;
+		}
+
+		return $conditionalExpressions;
+	}
+
+	/**
+	 * Whether the expression contains an assignment whose execution short-circuit
+	 * evaluation may have skipped - a cheap AST gate so the truthy/falsey scope
+	 * is only derived for boolean RHS expressions that can define a variable.
+	 */
+	private static function containsVariableAssignment(Node $node): bool
+	{
+		if ($node instanceof Assign || $node instanceof AssignOp || $node instanceof AssignRef) {
+			return true;
+		}
+
+		foreach ($node->getSubNodeNames() as $subNodeName) {
+			$subNode = $node->$subNodeName;
+			if ($subNode instanceof Node) {
+				if (self::containsVariableAssignment($subNode)) {
+					return true;
+				}
+			} elseif (is_array($subNode)) {
+				foreach ($subNode as $subNodeItem) {
+					if ($subNodeItem instanceof Node && self::containsVariableAssignment($subNodeItem)) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4120,7 +4120,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 					}
 					$scope = $scope->unsetExpression($expr);
 					foreach ($rescuedHolders as $targetExprString => $targetHolders) {
-						$scope = $scope->addConditionalExpressions((string) $targetExprString, $targetHolders);
+						$scope = $scope->addConditionalExpressions((string) $targetExprString, $targetHolders); // @phpstan-ignore cast.useless
 					}
 					$specifiedExpressions[$innerExprString] = new ExpressionTypeHolder($expr, new ErrorType(), TrinaryLogic::createNo());
 				}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4092,12 +4092,37 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				$expr = $issetExpr->getExpr();
 
 				if ($typeSpecification['sure']) {
+					$innerExprString = $scope->getNodeKey($expr);
 					$scope = $scope->setExpressionCertaintyKeepingType(
 						$expr,
 						TrinaryLogic::createMaybe(),
 					);
+					$specifiedExpressions[$innerExprString] = ExpressionTypeHolder::createMaybe(
+						$expr,
+						$scope->expressionTypes[$innerExprString]->getType(),
+					);
 				} else {
+					$innerExprString = $scope->getNodeKey($expr);
+					// Holders conditioned on this expression being undefined (a
+					// certainty-No condition) wait for exactly the specification
+					// applied here, but unsetExpression()'s invalidation would drop
+					// them before the conditional-expressions matcher below could
+					// fire them - carve them out and re-add them afterwards.
+					$rescuedHolders = [];
+					foreach ($scope->conditionalExpressions as $targetExprString => $targetHolders) {
+						foreach ($targetHolders as $holderKey => $conditionalHolder) {
+							$conditionHolder = $conditionalHolder->getConditionExpressionTypeHolders()[$innerExprString] ?? null;
+							if ($conditionHolder === null || !$conditionHolder->getCertainty()->no()) {
+								continue;
+							}
+							$rescuedHolders[$targetExprString][$holderKey] = $conditionalHolder;
+						}
+					}
 					$scope = $scope->unsetExpression($expr);
+					foreach ($rescuedHolders as $targetExprString => $targetHolders) {
+						$scope = $scope->addConditionalExpressions((string) $targetExprString, $targetHolders);
+					}
+					$specifiedExpressions[$innerExprString] = new ExpressionTypeHolder($expr, new ErrorType(), TrinaryLogic::createNo());
 				}
 				$scopeIsWorkingCopy = false;
 

--- a/src/Analyser/StmtHandler/TryCatchHandler.php
+++ b/src/Analyser/StmtHandler/TryCatchHandler.php
@@ -8,7 +8,10 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\ConditionalExpressionHolder;
 use PHPStan\Analyser\ExpressionResultStorage;
+use PHPStan\Analyser\ExpressionTypeHolder;
 use PHPStan\Analyser\InternalStatementExitPoint;
 use PHPStan\Analyser\InternalStatementResult;
 use PHPStan\Analyser\InternalThrowPoint;
@@ -26,7 +29,10 @@ use PHPStan\Node\ReturnAfterFinallyNode;
 use PHPStan\Node\Variable\VariableWrite;
 use PHPStan\Node\VariableAssignNode;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use Throwable;
@@ -239,7 +245,13 @@ final class TryCatchHandler implements StmtHandler
 			$catchScopeForFinally = $catchScopeResult->getScope();
 			$catchFlows[] = [$originalCatchType, VariableFlow::sequence($catchNode->var !== null ? VariableFlowBuilder::targetWrite($catchNode->var, VariableWrite::KIND_CATCH, $catchScopeForFinally, $storage) : null, $catchScopeResult->getVariableFlow())];
 
-			$finalScope = $catchScopeResult->isAlwaysTerminating() ? $finalScope : $catchScopeResult->getScope()->mergeWith($finalScope);
+			if (!$catchScopeResult->isAlwaysTerminating()) {
+				$mergedScope = $catchScopeResult->getScope()->mergeWith($finalScope);
+				if ($variableName !== null && $finalScope !== null) {
+					$mergedScope = $this->addCatchVariableDefinednessConditionals($mergedScope, $finalScope, $catchScopeResult->getScope(), $variableName);
+				}
+				$finalScope = $mergedScope;
+			}
 			$alwaysTerminating = $alwaysTerminating && $catchScopeResult->isAlwaysTerminating();
 			$hasYield = $hasYield || $catchScopeResult->hasYield();
 			$catchThrowPoints = $catchScopeResult->getThrowPoints();
@@ -321,6 +333,72 @@ final class TryCatchHandler implements StmtHandler
 		}
 
 		return new InternalStatementResult($finalScope, hasYield: $hasYield, isAlwaysTerminating: $alwaysTerminating, exitPoints: $exitPoints, throwPoints: array_merge($throwPoints, $throwPointsForLater), impurePoints: $impurePoints, variableFlow: VariableFlow::tryCatch($branchScopeResult->getVariableFlow(), $catchFlows, $finallyFlow));
+	}
+
+	/**
+	 * The catch variable's definedness after the try/catch tells the two joined
+	 * paths apart: when it is untracked on the non-catch path and certainly
+	 * defined at the end of the catch body, "the catch variable is undefined"
+	 * later implies the non-catch path ran. Record that as conditional
+	 * expression holders with a certainty-No condition on the catch variable,
+	 * restoring the non-catch certainty (and type) of variables the join
+	 * demoted to maybe-defined - e.g. `isset($e) || $var instanceof \DateTime`
+	 * evaluates `$var` only where `$e` is narrowed away.
+	 */
+	private function addCatchVariableDefinednessConditionals(
+		MutatingScope $mergedScope,
+		MutatingScope $nonCatchScope,
+		MutatingScope $catchEndScope,
+		string $variableName,
+	): MutatingScope
+	{
+		$variableExprString = '$' . $variableName;
+		if (isset($nonCatchScope->expressionTypes[$variableExprString])) {
+			return $mergedScope;
+		}
+
+		$catchVariableHolder = $catchEndScope->expressionTypes[$variableExprString] ?? null;
+		if ($catchVariableHolder === null || !$catchVariableHolder->getCertainty()->yes()) {
+			return $mergedScope;
+		}
+
+		$conditions = [
+			[
+				$variableExprString => new ExpressionTypeHolder(new Variable($variableName), new ErrorType(), TrinaryLogic::createNo()),
+			],
+		];
+		if ($catchVariableHolder->getType()->isNull()->no()) {
+			// In a scope where any variable can exist (e.g. the top level), the
+			// isset() machinery models "!isset($e)" on a maybe-defined variable as
+			// "maybe defined, null when defined" instead of unsetting it. That
+			// state excludes the catch path just the same - it guarantees a
+			// defined, non-null catch variable.
+			$conditions[] = [
+				$variableExprString => ExpressionTypeHolder::createMaybe(new Variable($variableName), new NullType()),
+			];
+		}
+		foreach ($nonCatchScope->expressionTypes as $exprString => $holder) {
+			if (!$holder->getCertainty()->yes()) {
+				continue;
+			}
+			$expr = $holder->getExpr();
+			if (!$expr instanceof Variable || !is_string($expr->name)) {
+				continue;
+			}
+			$mergedHolder = $mergedScope->expressionTypes[$exprString] ?? null;
+			if ($mergedHolder === null || !$mergedHolder->getCertainty()->maybe()) {
+				continue;
+			}
+
+			$conditionalHolders = [];
+			foreach ($conditions as $condition) {
+				$conditionalHolder = new ConditionalExpressionHolder($condition, $holder);
+				$conditionalHolders[$conditionalHolder->getKey()] = $conditionalHolder;
+			}
+			$mergedScope = $mergedScope->addConditionalExpressions((string) $exprString, $conditionalHolders);
+		}
+
+		return $mergedScope;
 	}
 
 }

--- a/src/Analyser/StmtHandler/TryCatchHandler.php
+++ b/src/Analyser/StmtHandler/TryCatchHandler.php
@@ -6,9 +6,9 @@ use Error;
 use Exception;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\TryCatch;
-use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\ConditionalExpressionHolder;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExpressionTypeHolder;
@@ -395,7 +395,7 @@ final class TryCatchHandler implements StmtHandler
 				$conditionalHolder = new ConditionalExpressionHolder($condition, $holder);
 				$conditionalHolders[$conditionalHolder->getKey()] = $conditionalHolder;
 			}
-			$mergedScope = $mergedScope->addConditionalExpressions((string) $exprString, $conditionalHolders);
+			$mergedScope = $mergedScope->addConditionalExpressions((string) $exprString, $conditionalHolders); // @phpstan-ignore cast.useless
 		}
 
 		return $mergedScope;

--- a/tests/PHPStan/Analyser/nsrt/bug-11109.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11109.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11109;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+
+function (): void {
+	$bool = 1 == random_int(1, 2)
+		&& 2 == random_int(1, 2)
+		&& in_array(
+			'foo',
+			[$var = 'foo', 'bar']
+		);
+
+	if ($bool) {
+		// here $bool is true
+		// so $var must be defined
+		// because the 3rd condition above must have been fulfilled for the $bool to be true
+		// so 2nd argument to in_array() must have been computed
+		assertVariableCertainty(TrinaryLogic::createYes(), $var);
+		assertType("'foo'", $var);
+		throw new \Exception($var);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $var);
+};
+
+function (): void {
+	$bool = 1 == random_int(1, 2)
+		|| in_array(random_int(1, 2), [$var = 1, 3], true);
+
+	if (!$bool) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $var);
+		assertType('1', $var);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $var);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/bug-6608.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-6608.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6608;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+
+function (string $s): void {
+	try {
+		$var = new \DateTime($s);
+	} catch (\Throwable $e) {}
+
+	if (isset($e) || $var instanceof \DateTime) {
+	}
+
+	if (!isset($e)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $var);
+		assertType('DateTime', $var);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $var);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/bug-9854.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9854.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9854;
+
+use function PHPStan\Testing\assertType;
+
+$url = 'testUrl';
+$linkText = 'testLinkText';
+
+$htmlLinkStructure = '<a href="%s"';
+if (!empty($target)) {
+	$htmlLinkStructure .= ' target="%s"';
+}
+$htmlLinkStructure .= ' class="link">%s</a>';
+
+if (empty($target)) {
+	assertType('\'<a href="%s" class="link">%s</a>\'', $htmlLinkStructure);
+	return sprintf($htmlLinkStructure, $url, $linkText);
+}
+
+assertType('\'<a href="%s" target="%s" class="link">%s</a>\'', $htmlLinkStructure);
+return sprintf($htmlLinkStructure, $url, $target, $linkText);

--- a/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
@@ -160,4 +160,9 @@ class PrintfParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14567.php'], []);
 	}
 
+	public function testBug9854(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9854.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-9854.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9854.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+$url = 'testUrl';
+$linkText = 'testLinkText';
+
+$htmlLinkStructure = '<a href="%s"';
+if (!empty($target)) {
+	$htmlLinkStructure .= ' target="%s"';
+}
+$htmlLinkStructure .= ' class="link">%s</a>';
+
+if (empty($target)) {
+	return sprintf($htmlLinkStructure, $url, $linkText);
+}
+
+return sprintf($htmlLinkStructure, $url, $target, $linkText);

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -1768,4 +1768,13 @@ class DefinedVariableRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14418.php'], []);
 	}
 
+	public function testBug11109(): void
+	{
+		$this->cliArgumentsVariablesRegistered = true;
+		$this->polluteScopeWithLoopInitialAssignments = false;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithAlwaysIterableForeach = true;
+		$this->analyse([__DIR__ . '/data/bug-11109.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -1777,4 +1777,13 @@ class DefinedVariableRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11109.php'], []);
 	}
 
+	public function testBug6608(): void
+	{
+		$this->cliArgumentsVariablesRegistered = true;
+		$this->polluteScopeWithLoopInitialAssignments = false;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithAlwaysIterableForeach = true;
+		$this->analyse([__DIR__ . '/data/bug-6608.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-11109.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-11109.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+$bool = 1 == random_int(1, 2)
+	&& 2 == random_int(1, 2)
+	&& in_array(
+		'foo',
+		[$var = 'foo', 'bar']
+	);
+
+if ($bool) {
+	// here $bool is true
+	// so $var must be defined
+	// because the 3rd condition above must have been fulfilled for the $bool to be true
+	// so 2nd argument to in_array() must have been computed
+	throw new \Exception($var);
+}

--- a/tests/PHPStan/Rules/Variables/data/bug-6608.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-6608.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+try {
+	$var = new \DateTime('nope');
+} catch (\Throwable $e) {}
+
+if (isset($e) || $var instanceof \DateTime) {
+}


### PR DESCRIPTION
Records variable definedness — not only type — as conditional expressions in three cases:

- **Short-circuit operand assignment** — when a boolean-typed value is assigned, an assignment that must have executed for the value to be truthy is recorded as "if the boolean is true then the variable is defined". So `if ($bool)` later restores the variable's certainty.
- **try / catch** — at the join, when a catch clause binds a catch variable, the try-assigned variables' definedness is recorded as conditional on the catch variable being undefined. So `!isset($e)` restores them.
- **Constant-string concat-assign** — `$s .= '<constant>'` now remaps the holders that target `$s` through the concatenation instead of invalidating them.

Regression tests added; the full `NodeScopeResolverTest` stays green and a local issue-bot run confirms the three fixes with no regressions.

Closes https://github.com/phpstan/phpstan/issues/11109
Closes https://github.com/phpstan/phpstan/issues/6608
Closes https://github.com/phpstan/phpstan/issues/9854

🤖 Generated with [Claude Code](https://claude.com/claude-code)
