### PR TITLE
Preserve conditional expression holders across more scope merges

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4232,6 +4232,14 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	}
 
 	/**
+	 * Rescues one-sided conditional holders across an if-merge.
+	 *
+	 * A holder missing from the intersection survives when either some guard's
+	 * recorded type is impossible in the other branch (the holder is vacuously
+	 * true there), or the other branch's flat state for the holder's target
+	 * already satisfies the holder's consequent (subtype with at-least-as-strong
+	 * certainty) - the consequent then holds on both paths under the guard.
+	 *
 	 * @param array<string, ConditionalExpressionHolder[]> $currentConditionalExpressions
 	 * @param array<string, ConditionalExpressionHolder[]> $sourceConditionalExpressions
 	 * @param array<string, ExpressionTypeHolder> $otherExpressionTypes
@@ -4264,8 +4272,21 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 
 					if ($otherType->isSuperTypeOf($guardType)->no()) {
 						$currentConditionalExpressions[$exprString][$key] = $holder;
-						break;
+						continue 2;
 					}
+				}
+
+				if ($typeHolder->getCertainty()->no() || !array_key_exists($exprString, $otherExpressionTypes)) {
+					continue;
+				}
+
+				$otherTargetHolder = $otherExpressionTypes[$exprString];
+				$otherTargetCertainty = $otherTargetHolder->getCertainty();
+				if (
+					($otherTargetCertainty->yes() || $otherTargetCertainty->equals($typeHolder->getCertainty()))
+					&& $typeHolder->getType()->isSuperTypeOf($otherTargetHolder->getType())->yes()
+				) {
+					$currentConditionalExpressions[$exprString][$key] = $holder;
 				}
 			}
 		}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4140,6 +4140,11 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				$ourExpressionTypes,
 			);
 		}
+		$conditionalExpressions = $this->mergeSameGuardConditionalExpressions(
+			$conditionalExpressions,
+			$this->conditionalExpressions,
+			$otherScope->conditionalExpressions,
+		);
 		$conditionalExpressions = ScopeOps::createConditionalExpressions(
 			$conditionalExpressions,
 			$ourExpressionTypes,
@@ -4287,6 +4292,80 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 					&& $typeHolder->getType()->isSuperTypeOf($otherTargetHolder->getType())->yes()
 				) {
 					$currentConditionalExpressions[$exprString][$key] = $holder;
+				}
+			}
+		}
+
+		return $currentConditionalExpressions;
+	}
+
+	/**
+	 * Merges one-sided holders that share a target and an identical guard set:
+	 * whichever branch a merged path came from, the guard matching later implies
+	 * one of the recorded consequents, so the union of the consequent types
+	 * (under their shared certainty) holds on every merged path.
+	 *
+	 * @param array<string, ConditionalExpressionHolder[]> $currentConditionalExpressions
+	 * @param array<string, ConditionalExpressionHolder[]> $ourConditionalExpressions
+	 * @param array<string, ConditionalExpressionHolder[]> $theirConditionalExpressions
+	 * @return array<string, ConditionalExpressionHolder[]>
+	 */
+	private function mergeSameGuardConditionalExpressions(
+		array $currentConditionalExpressions,
+		array $ourConditionalExpressions,
+		array $theirConditionalExpressions,
+	): array
+	{
+		foreach ($ourConditionalExpressions as $exprString => $ourHolders) {
+			if (!array_key_exists($exprString, $theirConditionalExpressions)) {
+				continue;
+			}
+
+			$theirHolders = $theirConditionalExpressions[$exprString];
+			foreach ($ourHolders as $ourKey => $ourHolder) {
+				if (isset($currentConditionalExpressions[$exprString][$ourKey])) {
+					continue;
+				}
+
+				$ourTypeHolder = $ourHolder->getTypeHolder();
+				if ($ourTypeHolder->getCertainty()->no()) {
+					continue;
+				}
+
+				foreach ($theirHolders as $theirKey => $theirHolder) {
+					if (isset($currentConditionalExpressions[$exprString][$theirKey])) {
+						continue;
+					}
+
+					$theirTypeHolder = $theirHolder->getTypeHolder();
+					if (!$theirTypeHolder->getCertainty()->equals($ourTypeHolder->getCertainty())) {
+						continue;
+					}
+
+					$ourGuards = $ourHolder->getConditionExpressionTypeHolders();
+					$theirGuards = $theirHolder->getConditionExpressionTypeHolders();
+					if (count($ourGuards) !== count($theirGuards)) {
+						continue;
+					}
+
+					foreach ($ourGuards as $guardExprString => $ourGuardHolder) {
+						if (
+							!array_key_exists($guardExprString, $theirGuards)
+							|| !$ourGuardHolder->equals($theirGuards[$guardExprString])
+						) {
+							continue 2;
+						}
+					}
+
+					$unionHolder = new ConditionalExpressionHolder(
+						$ourGuards,
+						new ExpressionTypeHolder(
+							$ourTypeHolder->getExpr(),
+							TypeCombinator::union($ourTypeHolder->getType(), $theirTypeHolder->getType()),
+							$ourTypeHolder->getCertainty(),
+						),
+					);
+					$currentConditionalExpressions[$exprString][$unionHolder->getKey()] = $unionHolder;
 				}
 			}
 		}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4287,12 +4287,24 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 
 				$otherTargetHolder = $otherExpressionTypes[$exprString];
 				$otherTargetCertainty = $otherTargetHolder->getCertainty();
-				if (
-					($otherTargetCertainty->yes() || $otherTargetCertainty->equals($typeHolder->getCertainty()))
-					&& $typeHolder->getType()->isSuperTypeOf($otherTargetHolder->getType())->yes()
-				) {
-					$currentConditionalExpressions[$exprString][$key] = $holder;
+				if (!$otherTargetCertainty->yes() && !$otherTargetCertainty->equals($typeHolder->getCertainty())) {
+					continue;
 				}
+
+				// An unresolved expression (e.g. an access to an undefined property) is held
+				// as ErrorType. ErrorType is a subtype of everything, so a consequent or an
+				// other-branch state of ErrorType would look "already satisfied" and preserve
+				// a holder that tracks the expression and hides the underlying error. Such a
+				// holder carries no real type relationship, so skip it.
+				if ($typeHolder->getType() instanceof ErrorType || $otherTargetHolder->getType() instanceof ErrorType) {
+					continue;
+				}
+
+				if (!$typeHolder->getType()->isSuperTypeOf($otherTargetHolder->getType())->yes()) {
+					continue;
+				}
+
+				$currentConditionalExpressions[$exprString][$key] = $holder;
 			}
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-6830.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-6830.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Bug6830Nsrt;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+
+function test(bool $do): void {
+
+	if ($do) {
+
+		$x = 9999;
+	}
+
+	foreach([1, 2, 3] as $whatever) {
+
+		if ($do) {
+
+			assertVariableCertainty(TrinaryLogic::createYes(), $x);
+			assertType('123|9999', $x);
+
+			if ($x) {
+
+				$x = 123;
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-9628.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9628.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9628;
+
+use function PHPStan\Testing\assertType;
+use function is_null;
+use function rand;
+
+function findFoo(int $fooId): \stdClass
+{
+	return new \stdClass();
+}
+
+function processFoo(?\stdClass $foo): void
+{
+	$fooId = rand(0, 1);
+
+	if (is_null($foo) && 0 !== $fooId) {
+		$foo = findFoo($fooId);
+	}
+
+	if (0 !== $fooId) {
+		assertType('stdClass', $foo); // it's always non-nullable stdClass inside this condition
+	}
+}

--- a/tests/PHPStan/Rules/Variables/data/bug-6830.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-6830.php
@@ -16,3 +16,22 @@ function test(array $bools): void
 		}
 	}
 }
+
+function test2(bool $do): void {
+
+	if ($do) {
+
+		$x = 9999;
+	}
+
+	foreach([1, 2, 3] as $whatever) {
+
+		if ($do) {
+
+			if ($x) {
+
+				$x = 123;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Keeps conditional-expression holders alive across two more merge situations:

- **Satisfied consequent** — a one-sided holder is preserved when the other branch's flat type for the holder's target already satisfies the holder's consequent. The consequent then holds on both paths under the guard, so applying it later is sound.
- **Loop-body reassignment** — a certainty-bearing holder for a variable that is reassigned inside a loop body is re-created at the loop-convergence merge, so a repeated flag check inside the loop restores the variable's definedness.

Regression tests added; the full `NodeScopeResolverTest` stays green and a local issue-bot run confirms the two fixes with no regressions.

Closes https://github.com/phpstan/phpstan/issues/9628
Closes https://github.com/phpstan/phpstan/issues/6830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
