### PR TITLE
Fix containsNull() for union with (null&T of mixed)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1653,7 +1653,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\NullType is error-prone and deprecated. Use Type::isNull() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 2
+			count: 1
 			path: src/Type/TypeCombinator.php
 
 		-

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -175,7 +175,7 @@ final class TypeCombinator
 	{
 		if ($type instanceof UnionType) {
 			foreach ($type->getTypes() as $innerType) {
-				if ($innerType instanceof NullType) {
+				if ($innerType->isNull()->yes()) {
 					return true;
 				}
 			}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -1873,6 +1873,15 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testNullSafeOnTemplateTypeNarrowedAgainstNull(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+
+		$this->analyse([__DIR__ . '/data/nullsafe-method-call-template-type.php'], []);
+	}
+
 	#[RequiresPhp('< 8.0.0')]
 	public function testDisallowNamedArguments(): void
 	{

--- a/tests/PHPStan/Rules/Methods/data/nullsafe-method-call-template-type.php
+++ b/tests/PHPStan/Rules/Methods/data/nullsafe-method-call-template-type.php
@@ -1,0 +1,26 @@
+<?php // lint >= 8.0
+
+namespace NullsafeMethodCallTemplateType;
+
+class Foo
+{
+
+	public function getValue(): ?string
+	{
+		return null;
+	}
+
+}
+
+/**
+ * @template T
+ * @param T $foo
+ */
+function foo($foo)
+{
+	if ($foo !== null && !$foo instanceof Foo) {
+		throw new \Exception();
+	}
+
+	return $foo?->getValue();
+}


### PR DESCRIPTION
When `$var` is union with `null`, but that `null` is part of intersection, `TypeCombinator::containsNull` currently doesn't detect this null, leading to false negative.

Fixes for example https://phpstan.org/r/1e3fa9bb-efec-4ba4-aec5-8d189e82c990.