### PR TITLE
Fix false positive comparing identical generic types below level 8

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -709,6 +709,12 @@ parameters:
 			path: src/Rules/RuleErrorBuilder.php
 
 		-
+			rawMessage: Doing instanceof PHPStan\Type\Generic\GenericObjectType is error-prone and deprecated.
+			identifier: phpstanApi.instanceofType
+			count: 1
+			path: src/Rules/RuleLevelHelper.php
+
+		-
 			rawMessage: Doing instanceof PHPStan\Type\IntersectionType is error-prone and deprecated.
 			identifier: phpstanApi.instanceofType
 			count: 1

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -6,11 +6,13 @@ use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
@@ -47,6 +49,29 @@ final class RuleLevelHelper
 		private bool $discoveringSymbolsTip,
 	)
 	{
+	}
+
+	/**
+	 * @param callable(Type): Type $traverse
+	 */
+	private function traverseWithoutMapping(Type $type, ?Type $acceptingType, callable $traverse): Type
+	{
+		if ($type instanceof GenericObjectType && $acceptingType !== null) {
+			return $type->traverseSimultaneously($acceptingType, function (Type $type, Type $acceptingType) use ($traverse): Type {
+				if (
+					!$this->checkNullables
+					&& !$type instanceof BenevolentUnionType
+					&& TypeCombinator::containsNull($type)
+					&& !TypeCombinator::containsNull($acceptingType)
+				) {
+					return $traverse(TypeCombinator::removeNull($type));
+				}
+
+				return $type;
+			});
+		}
+
+		return $traverse($type);
 	}
 
 	/** @api */
@@ -93,9 +118,10 @@ final class RuleLevelHelper
 					return $acceptedType;
 				}
 
+				$acceptingReturnType = $acceptingType instanceof ParametersAcceptor ? $acceptingType->getReturnType() : null;
 				return new CallableType(
 					$acceptedType->getParameters(),
-					$traverse($acceptedType->getReturnType()),
+					$this->traverseWithoutMapping($acceptedType->getReturnType(), $acceptingReturnType, $traverse),
 					$acceptedType->isVariadic(),
 					$acceptedType->getTemplateTypeMap(),
 					$acceptedType->getResolvedTemplateTypeMap(),
@@ -109,9 +135,10 @@ final class RuleLevelHelper
 					return $acceptedType;
 				}
 
+				$acceptingReturnType = $acceptingType instanceof ParametersAcceptor ? $acceptingType->getReturnType() : null;
 				return new ClosureType(
 					$acceptedType->getParameters(),
-					$traverse($acceptedType->getReturnType()),
+					$this->traverseWithoutMapping($acceptedType->getReturnType(), $acceptingReturnType, $traverse),
 					$acceptedType->isVariadic(),
 					$acceptedType->getTemplateTypeMap(),
 					$acceptedType->getResolvedTemplateTypeMap(),
@@ -125,6 +152,10 @@ final class RuleLevelHelper
 					$acceptedType->mustUseReturnValue(),
 					isStatic: $acceptedType->isStaticClosure(),
 				);
+			}
+
+			if ($acceptedType instanceof GenericObjectType) {
+				return $this->traverseWithoutMapping($acceptedType, $acceptingType, $traverse);
 			}
 
 			if (

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -20,6 +20,8 @@ use const PHP_VERSION_ID;
 class CallToFunctionParametersRuleTest extends RuleTestCase
 {
 
+	private bool $checkNullables = true;
+
 	private bool $checkExplicitMixed = false;
 
 	private bool $checkImplicitMixed = false;
@@ -32,7 +34,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			new FunctionCallParametersCheck(
 				new RuleLevelHelper(
 					$broker,
-					checkNullables: true,
+					checkNullables: $this->checkNullables,
 					checkThisOnly: false,
 					checkUnionTypes: true,
 					checkExplicitMixed: $this->checkExplicitMixed,
@@ -3107,6 +3109,18 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	public function testBug15168(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-15168.php'], []);
+	}
+
+	public function testBug9377(): void
+	{
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/bug-9377.php'], []);
+	}
+
+	public function testBug11041(): void
+	{
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/bug-11041.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/ClosureReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ClosureReturnTypeRuleTest.php
@@ -13,12 +13,14 @@ use PHPStan\Testing\RuleTestCase;
 class ClosureReturnTypeRuleTest extends RuleTestCase
 {
 
+	private bool $checkNullables = true;
+
 	protected function getRule(): Rule
 	{
 		return new ClosureReturnTypeRule(new FunctionReturnTypeCheck(
 			new RuleLevelHelper(
 				self::createReflectionProvider(),
-				checkNullables: true,
+				checkNullables: $this->checkNullables,
 				checkThisOnly: false,
 				checkUnionTypes: true,
 				checkExplicitMixed: false,
@@ -152,6 +154,12 @@ class ClosureReturnTypeRuleTest extends RuleTestCase
 	public function testBug14914(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-14914.php'], []);
+	}
+
+	public function testBug12008(): void
+	{
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/bug-12008.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-11041.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-11041.php
@@ -1,0 +1,41 @@
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
+
+namespace Bug11041;
+
+/**
+ * @template TKey
+ * @template TValue
+ */
+class Collection
+{
+
+	/** @var array<TKey, TValue> */
+	private array $items;
+
+	/** @param array<TKey, TValue> $items */
+	public function __construct(array $items)
+	{
+		$this->items = $items;
+	}
+
+	/**
+	 * @param TKey $key
+	 * @return TValue
+	 */
+	public function get($key)
+	{
+		return $this->items[$key];
+	}
+
+}
+
+/** @param Collection<int, string|null> $collection */
+function testFunc(Collection $collection): void
+{
+}
+
+$collection = new Collection([0 => 'foo', 1 => 'bar', 2 => null, 3 => 'baz']);
+
+testFunc($collection);

--- a/tests/PHPStan/Rules/Functions/data/bug-12008.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-12008.php
@@ -1,0 +1,54 @@
+<?php // lint >= 8.2
+
+declare(strict_types = 1);
+
+namespace Bug12008;
+
+use Closure;
+
+interface ProductOverview
+{
+
+	public function getId(): ?int;
+
+}
+
+/**
+ * @template T
+ */
+readonly class Pagination
+{
+
+	/**
+	 * @param iterable<T> $records
+	 */
+	public function __construct(
+		public iterable $records,
+	)
+	{
+	}
+
+}
+
+class HelloWorld
+{
+
+	private function respondToApiRequest(Closure|null $data): never
+	{
+		exit;
+	}
+
+	/** @param list<ProductOverview> $products */
+	public function run(array $products): never
+	{
+		$this->respondToApiRequest(function () use ($products) {
+			return new Pagination(array_map(
+				fn (ProductOverview $product) => [
+					'id' => $product->getId(),
+				],
+				$products,
+			));
+		});
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-9377.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9377.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9377;
+
+/**
+ * @template T
+ */
+class HelloWorld
+{
+
+}
+
+/** @param HelloWorld<array{id: int|null}> $foo */
+function foo($foo): void
+{
+}
+
+/** @return HelloWorld<array{id: int|null}> */
+function bar(): HelloWorld
+{
+	return new HelloWorld();
+}
+
+$a = bar();
+
+foo($a);

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3023,6 +3023,42 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/callables-without-check-nullables.php'], $expectedErrors);
 	}
 
+	public static function dataGenericArgumentNullability(): iterable
+	{
+		yield [false, [
+			[
+				'Parameter #1 $collection of method GenericArgumentNullability\\Foo::acceptNullable() expects GenericArgumentNullability\\Collection<string, int|null>, GenericArgumentNullability\\Collection<string, int> given.',
+				75,
+				'Template type TValue on class GenericArgumentNullability\\Collection is not covariant. Learn more: <fg=cyan>https://phpstan.org/blog/whats-up-with-template-covariant</>',
+			],
+		]];
+		yield [true, [
+			[
+				'Parameter #1 $collection of method GenericArgumentNullability\\Foo::acceptPlain() expects GenericArgumentNullability\\Collection<string, int>, GenericArgumentNullability\\Collection<string, int|null> given.',
+				74,
+			],
+			[
+				'Parameter #1 $collection of method GenericArgumentNullability\\Foo::acceptNullable() expects GenericArgumentNullability\\Collection<string, int|null>, GenericArgumentNullability\\Collection<string, int> given.',
+				75,
+				'Template type TValue on class GenericArgumentNullability\\Collection is not covariant. Learn more: <fg=cyan>https://phpstan.org/blog/whats-up-with-template-covariant</>',
+			],
+			[
+				'Parameter #1 $collection of method GenericArgumentNullability\\Foo::acceptCovariantPlain() expects GenericArgumentNullability\\CovariantCollection<int>, GenericArgumentNullability\\CovariantCollection<int|null> given.',
+				76,
+			],
+		]];
+	}
+
+	/** @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrors */
+	#[DataProvider('dataGenericArgumentNullability')]
+	public function testGenericArgumentNullability(bool $checkNullables, array $expectedErrors): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = $checkNullables;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/generic-argument-nullability.php'], $expectedErrors);
+	}
+
 	#[RequiresPhp('>= 8.0.0')]
 	public function testBug8713(): void
 	{

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -25,6 +25,8 @@ use function usort;
 class CallStaticMethodsRuleTest extends RuleTestCase
 {
 
+	private bool $checkNullables = true;
+
 	private bool $checkThisOnly;
 
 	private bool $checkExplicitMixed = false;
@@ -36,7 +38,7 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$ruleLevelHelper = new RuleLevelHelper(
 			$reflectionProvider,
-			checkNullables: true,
+			checkNullables: $this->checkNullables,
 			checkThisOnly: $this->checkThisOnly,
 			checkUnionTypes: true,
 			checkExplicitMixed: $this->checkExplicitMixed,
@@ -1082,6 +1084,13 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 				22,
 			],
 		]);
+	}
+
+	public function testBug10698(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/bug-10698.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -16,6 +16,8 @@ use const PHP_VERSION_ID;
 class ReturnTypeRuleTest extends RuleTestCase
 {
 
+	private bool $checkNullables = true;
+
 	private bool $checkExplicitMixed = false;
 
 	private bool $checkUnionTypes = true;
@@ -27,7 +29,7 @@ class ReturnTypeRuleTest extends RuleTestCase
 		return new ReturnTypeRule(new FunctionReturnTypeCheck(
 			new RuleLevelHelper(
 				self::createReflectionProvider(),
-				checkNullables: true,
+				checkNullables: $this->checkNullables,
 				checkThisOnly: false,
 				checkUnionTypes: $this->checkUnionTypes,
 				checkExplicitMixed: $this->checkExplicitMixed,
@@ -1362,6 +1364,12 @@ class ReturnTypeRuleTest extends RuleTestCase
 	public function testBug14893(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-14893.php'], []);
+	}
+
+	public function testBug12984(): void
+	{
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/bug-12984.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-10698.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-10698.php
@@ -1,0 +1,42 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug10698;
+
+/** @template T */
+class Foo
+{
+
+	/** @param T $subject */
+	public function __construct(private $subject)
+	{
+	}
+
+	/** @return T */
+	public function getSubject()
+	{
+		return $this->subject;
+	}
+
+}
+
+abstract class Bar
+{
+
+	/**
+	 * @template T
+	 * @param Foo<T> $foo
+	 * @return T
+	 */
+	public static function qux(Foo $foo)
+	{
+		return $foo->getSubject();
+	}
+
+}
+
+function test(?string $str): void
+{
+	Bar::qux(new Foo($str));
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-12984.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12984.php
@@ -1,0 +1,54 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug12984;
+
+use ArrayAccess;
+use ArrayIterator;
+use IteratorAggregate;
+use ReturnTypeWillChange;
+
+/**
+ * @implements ArrayAccess<string, array<string>|bool|int|null>
+ * @implements IteratorAggregate<string, array<string>|bool|int|null>
+ */
+class DocoptResultTest implements ArrayAccess, IteratorAggregate
+{
+
+	/** @var array<string, array<string>|bool|int|null> */
+	protected array $args;
+
+	/** @param array<string, array<string>|bool|int|null> $args */
+	public function __construct(array $args)
+	{
+		$this->args = $args;
+	}
+
+	public function offsetExists($offset): bool
+	{
+		return key_exists($offset, $this->args);
+	}
+
+	/** @return array<string>|bool|int|null */
+	#[ReturnTypeWillChange]
+	public function offsetGet($offset)
+	{
+		return $this->args[$offset] ?? null;
+	}
+
+	public function offsetSet($offset, $value): void
+	{
+	}
+
+	public function offsetUnset($offset): void
+	{
+	}
+
+	/** @return ArrayIterator<string, array<string>|bool|int|null> */
+	public function getIterator(): ArrayIterator
+	{
+		return new ArrayIterator($this->args);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/generic-argument-nullability.php
+++ b/tests/PHPStan/Rules/Methods/data/generic-argument-nullability.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace GenericArgumentNullability;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class Collection
+{
+
+}
+
+/** @template-covariant TValue */
+class CovariantCollection
+{
+
+}
+
+class Foo
+{
+
+	/**
+	 * @template T
+	 * @param callable(): T $cb
+	 * @return T
+	 */
+	public function grab(callable $cb)
+	{
+		return $cb();
+	}
+
+	/**
+	 * @template T
+	 * @param callable(mixed, array<string, mixed>): T $cb
+	 * @return T
+	 */
+	public function grabTwoArgs(callable $cb)
+	{
+		return $cb(null, []);
+	}
+
+	/** @param Collection<string, int|null> $collection */
+	public function acceptNullable(Collection $collection): void
+	{
+	}
+
+	/** @param Collection<string, int> $collection */
+	public function acceptPlain(Collection $collection): void
+	{
+	}
+
+	/** @param CovariantCollection<int> $collection */
+	public function acceptCovariantPlain(CovariantCollection $collection): void
+	{
+	}
+
+}
+
+/**
+ * @param Collection<string, int> $plain
+ * @param Collection<string, int|null> $nullable
+ * @param CovariantCollection<int|null> $covariantNullable
+ * @param array<string, int|null> $array
+ */
+function test(Foo $foo, Collection $plain, Collection $nullable, CovariantCollection $covariantNullable, array $array, ?int $scalar): void
+{
+	$foo->grab(fn () => $plain);
+	$foo->grab(fn () => $nullable);
+	$foo->grab(fn () => $array);
+	$foo->grab(fn () => $scalar);
+	$foo->grabTwoArgs(fn () => $nullable);
+	$foo->acceptNullable($nullable);
+	$foo->acceptPlain($nullable);
+	$foo->acceptNullable($plain);
+	$foo->acceptCovariantPlain($covariantNullable);
+}

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -13,6 +13,8 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 {
 
+	private bool $checkNullables = true;
+
 	private bool $checkExplicitMixed = false;
 
 	private bool $checkImplicitMixed = false;
@@ -22,7 +24,7 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		return new TypesAssignedToPropertiesRule(
 			new RuleLevelHelper(
 				self::createReflectionProvider(),
-				checkNullables: true,
+				checkNullables: $this->checkNullables,
 				checkThisOnly: false,
 				checkUnionTypes: true,
 				checkExplicitMixed: $this->checkExplicitMixed,
@@ -1101,6 +1103,18 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 	public function testBug15166(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-15166.php'], []);
+	}
+
+	public function testBug13876(): void
+	{
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/bug-13876.php'], []);
+	}
+
+	public function testBug9096(): void
+	{
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/bug-9096.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-13876.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13876.php
@@ -1,0 +1,61 @@
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
+
+namespace Bug13876;
+
+use Closure;
+
+/**
+ * @template TBait
+ * @template TPromised
+ */
+class Trap
+{
+
+	/** @var TBait */
+	private $bait;
+
+	/** @var Closure(TBait): TPromised */
+	private $switch;
+
+	/**
+	 * @param TBait $bait
+	 * @param Closure(TBait): TPromised $switch
+	 */
+	public function __construct($bait, Closure $switch)
+	{
+		$this->bait = $bait;
+		$this->switch = $switch;
+	}
+
+	/** @return TPromised */
+	public function fall()
+	{
+		return ($this->switch)($this->bait);
+	}
+
+}
+
+class A
+{
+
+}
+
+class B
+{
+
+	/** @var Trap<int|null, A|null> */
+	private Trap $b;
+
+	public function __construct()
+	{
+		/** @var Trap<int|null, A|null> $nullPerson */
+		$nullPerson = new Trap(null, function (): ?A {
+			return null;
+		});
+
+		$this->b = $nullPerson;
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-9096.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-9096.php
@@ -1,0 +1,93 @@
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
+
+namespace Bug9096;
+
+use ArrayIterator;
+use EmptyIterator;
+use IteratorAggregate;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ * @implements IteratorAggregate<T>
+ */
+abstract class Option implements IteratorAggregate
+{
+
+	/**
+	 * @template S
+	 * @param S $value
+	 * @param S $noneValue
+	 * @return Option<S>
+	 */
+	public static function fromValue($value, $noneValue = null)
+	{
+		if ($value === $noneValue) {
+			return None::create();
+		}
+
+		return new Some($value);
+	}
+
+}
+
+/** @extends Option<mixed> */
+final class None extends Option
+{
+
+	/** @var None|null */
+	private static $instance;
+
+	public static function create(): self
+	{
+		if (self::$instance === null) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function getIterator(): EmptyIterator
+	{
+		return new EmptyIterator();
+	}
+
+}
+
+/**
+ * @template T
+ * @extends Option<T>
+ */
+final class Some extends Option
+{
+
+	/** @var T */
+	private $value;
+
+	/** @param T $value */
+	public function __construct($value)
+	{
+		$this->value = $value;
+	}
+
+	/** @return ArrayIterator<int, T> */
+	public function getIterator(): ArrayIterator
+	{
+		return new ArrayIterator([$this->value]);
+	}
+
+}
+
+class Test
+{
+
+	/** @var Option<string|null> */
+	public Option $name;
+
+}
+
+$test = new Test();
+$test->name = Option::fromValue('test');
+assertType('Option<string|null>', $test->name);


### PR DESCRIPTION
Hello!

Closes phpstan/phpstan#13876
Closes phpstan/phpstan#12984
Closes phpstan/phpstan#12008
Closes phpstan/phpstan#11041
Closes phpstan/phpstan#10698
Closes phpstan/phpstan#9377
Closes phpstan/phpstan#9096


RuleLevelHelper relaxes the nullability of the accepted type but not of the accepting one, which is what lets a nullable value be passed where a non-nullable one is expected below level 8. TypeTraverser applied that relaxation to generic type arguments as well, so the argument of an accepted Collection<string, int|null> became int while the accepting side kept int|null. Compared invariantly, two identical types then stopped matching and the reported message printed the same type on both sides.

Map the arguments of a concrete generic type instead of feeding them through the relaxation. A template type keeps going through the regular traversal, as rebuilding it as a plain generic would lose its bound.

Thanks!