### PR TITLE
Compare conditional expressions in Scope::equals()

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4647,7 +4647,54 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		if (!$this->compareVariableTypeHolders($this->expressionTypes, $otherScope->expressionTypes)) {
 			return false;
 		}
-		return $this->compareVariableTypeHolders($this->nativeExpressionTypes, $otherScope->nativeExpressionTypes);
+		if (!$this->compareVariableTypeHolders($this->nativeExpressionTypes, $otherScope->nativeExpressionTypes)) {
+			return false;
+		}
+		return $this->compareConditionalExpressions($this->conditionalExpressions, $otherScope->conditionalExpressions);
+	}
+
+	/**
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 * @param array<string, ConditionalExpressionHolder[]> $otherConditionalExpressions
+	 */
+	private function compareConditionalExpressions(array $conditionalExpressions, array $otherConditionalExpressions): bool
+	{
+		if (count($conditionalExpressions) !== count($otherConditionalExpressions)) {
+			return false;
+		}
+		foreach ($conditionalExpressions as $exprString => $holders) {
+			if (!array_key_exists($exprString, $otherConditionalExpressions)) {
+				return false;
+			}
+			$otherHolders = $otherConditionalExpressions[$exprString];
+			if (count($holders) !== count($otherHolders)) {
+				return false;
+			}
+			foreach ($holders as $key => $holder) {
+				if (!array_key_exists($key, $otherHolders)) {
+					return false;
+				}
+				$otherHolder = $otherHolders[$key];
+				if (!$holder->getTypeHolder()->equals($otherHolder->getTypeHolder())) {
+					return false;
+				}
+				$conditionHolders = $holder->getConditionExpressionTypeHolders();
+				$otherConditionHolders = $otherHolder->getConditionExpressionTypeHolders();
+				if (count($conditionHolders) !== count($otherConditionHolders)) {
+					return false;
+				}
+				foreach ($conditionHolders as $conditionExprString => $conditionHolder) {
+					if (!array_key_exists($conditionExprString, $otherConditionHolders)) {
+						return false;
+					}
+					if (!$conditionHolder->equals($otherConditionHolders[$conditionExprString])) {
+						return false;
+					}
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/array-shift-while-count-loop.php
+++ b/tests/PHPStan/Analyser/nsrt/array-shift-while-count-loop.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace ArrayShiftWhileCountLoop;
+
+use function PHPStan\Testing\assertType;
+
+final class Item
+{
+}
+
+class Foo
+{
+
+	/** @param list<Item> $items */
+	public function run(array $items): void
+	{
+		foreach ([1, 2] as $_) {
+			$toCurrent = 0;
+			if ($items !== []) {
+				$toCurrent = count($items);
+			}
+
+			while ($toCurrent > 0) {
+				// array_shift() empties $items across iterations: the loop must not
+				// keep the guard's "$toCurrent positive means $items non-empty"
+				// conditional, so the shifted item is nullable
+				assertType('list<ArrayShiftWhileCountLoop\Item>', $items);
+				$item = array_shift($items);
+				assertType('ArrayShiftWhileCountLoop\Item|null', $item);
+				$toCurrent--;
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Loop convergence accepted a pass as the fixpoint even when the candidate entry scope still carried conditional expressions that a further iteration would have dropped — the walked pass then applied stale conditionals and its results were adopted.

Reproducer (https://phpstan.org/r/a1b77c66-8dec-4242-b316-0d1bfcb0dea8):

```php
$toCurrent = 0;
if ($items !== []) {
	$toCurrent = count($items);
}

while ($toCurrent > 0) {
	\PHPStan\dumpType($items);            // non-empty-list<Item>, should be list<Item>
	$item = array_shift($items);
	\PHPStan\dumpType($item);             // Item, should be Item|null
	$toCurrent--;
}
```

The `if` records the conditional "when `$toCurrent` is `int<1, max>`, `$items` is `non-empty-list<Item>`" (and its three mirror conditionals). `array_shift($items)` in the body breaks that correlation, and the entry scope of the next pass drops the conditionals accordingly — but `Scope::equals()` compared only the context and the (native) expression types, never `conditionalExpressions`, so the pass-0 entry (with the stale conditionals) was considered equal to the settled entry (without them), the loop stopped after a single pass and the recorded pass — which had applied the stale conditional through the `while` condition's truthy narrowing — was adopted. The shifted item stayed non-nullable across iterations.

`equals()` now compares the conditional-expression sets too: holders are aligned by their keys and then deep-compared with `ExpressionTypeHolder::equals()` (result type + certainty, and each condition's type). Scopes differing only in conditionals converge further and the stale conditionals are dropped; the NSRT test pins `list<Item>` / `Item|null` inside the loop.

The full test suite passes with zero expectation changes.

Closes https://github.com/phpstan/phpstan/issues/15157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbZPnVnRJDLbnqmtD3sYSy
