### PR TITLE
Cut the work a result cache restore does in the main process

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -2145,7 +2145,7 @@ final class ResultCacheManager
 		}
 
 		$directories = array_unique(array_merge($analysedDirectories, $this->scanDirectories));
-		foreach ($this->scanFileFinder->findFiles($directories)->getFiles() as $file) {
+		foreach ($this->scanFileFinder->findFilesCached($directories)->getFiles() as $file) {
 			$scannedFiles[] = $file;
 		}
 

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -612,7 +612,7 @@ final class CommandHelper
 				$errorOutput->writeLineFormatted('At least one path must be specified to analyse.');
 				throw new InceptionNotSuccessfulException();
 			}
-			$fileFinderResult = $fileFinder->findFiles($paths);
+			$fileFinderResult = $fileFinder->findFilesCached($paths);
 			$files = $fileFinderResult->getFiles();
 
 			$pathRoutingParser->setAnalysedFiles($files);

--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -47,6 +47,10 @@ final class DependencyResolver
 	/** @var array<string, list<ClassReflection|FunctionReflection|ConstantReflection>> */
 	private array $classDependencies = [];
 
+	private ExportedNameScopeTracker $nameScopeTracker;
+
+	private ?string $nameScopeFile = null;
+
 	public function __construct(
 		private FileHelper $fileHelper,
 		private IncludedFilePathResolver $includedFilePathResolver,
@@ -55,10 +59,21 @@ final class DependencyResolver
 		private FileTypeMapper $fileTypeMapper,
 	)
 	{
+		$this->nameScopeTracker = new ExportedNameScopeTracker();
 	}
 
 	public function resolveDependencies(Node $node, Scope $scope): NodeDependencies
 	{
+		// The exported nodes written to the result cache have to record the same PHPDoc scope the
+		// restore computes when it re-reads the file, so both go through the tracker. The nodes
+		// arrive here in document order, one file at a time.
+		$file = $scope->getFile();
+		if ($file !== $this->nameScopeFile) {
+			$this->nameScopeFile = $file;
+			$this->nameScopeTracker->reset();
+		}
+		$this->nameScopeTracker->enterNode($node);
+
 		$dependenciesReflections = [];
 		$dependenciesFilePaths = [];
 
@@ -552,7 +567,7 @@ final class DependencyResolver
 			}
 		}
 
-		return new NodeDependencies($this->fileHelper, $dependenciesReflections, $this->exportedNodeResolver->resolve($scope->getFile(), $node), $dependenciesFilePaths);
+		return new NodeDependencies($this->fileHelper, $dependenciesReflections, $this->exportedNodeResolver->resolve($node, $this->nameScopeTracker->getNameScope()), $dependenciesFilePaths);
 	}
 
 	public function resolveUsedTraitDependencies(InClassNode $inClassNode): NodeDependencies

--- a/src/Dependency/ExportedNameScope.php
+++ b/src/Dependency/ExportedNameScope.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Dependency;
+
+/**
+ * The namespace and the use statements in effect at a point in a file.
+ *
+ * This is everything an ExportedPhpDocNode records about the scope a PHPDoc was written in, and
+ * all of it is read straight off the AST by ExportedNodeVisitor. Asking FileTypeMapper for a
+ * NameScope instead would build the name scope map of the whole file, which resolves every PHPDoc
+ * in it - far more than the exported nodes need, and it happens in the main process during a
+ * result cache restore, in front of the analysis.
+ */
+final class ExportedNameScope
+{
+
+	/**
+	 * @param non-empty-string|null $namespace
+	 * @param array<string, string> $uses alias(string) => fullName(string)
+	 * @param array<string, string> $constUses alias(string) => fullName(string)
+	 */
+	public function __construct(
+		private ?string $namespace,
+		private array $uses,
+		private array $constUses,
+	)
+	{
+	}
+
+	/**
+	 * @return non-empty-string|null
+	 */
+	public function getNamespace(): ?string
+	{
+		return $this->namespace;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getUses(): array
+	{
+		return $this->uses;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getConstUses(): array
+	{
+		return $this->constUses;
+	}
+
+}

--- a/src/Dependency/ExportedNameScopeTracker.php
+++ b/src/Dependency/ExportedNameScopeTracker.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Dependency;
+
+use PhpParser\Node;
+use function sprintf;
+use function strtolower;
+
+/**
+ * Keeps the namespace and the use statements seen so far while walking a file's statements.
+ *
+ * Both places that build exported nodes drive one of these - ExportedNodeVisitor for a result
+ * cache restore, DependencyResolver during the analysis - so that the PHPDoc scope recorded in
+ * the cache and the one computed when checking the cache are produced by the same code.
+ *
+ * It mirrors what FileTypeMapper does while building a name scope map, except that the uses are
+ * cleared when a namespace is entered rather than when it is left. Namespace blocks cover every
+ * statement of a file, so nothing can observe the difference.
+ */
+final class ExportedNameScopeTracker
+{
+
+	/** @var non-empty-string|null */
+	private ?string $namespace = null;
+
+	/** @var array<string, string> */
+	private array $uses = [];
+
+	/** @var array<string, string> */
+	private array $constUses = [];
+
+	private ?ExportedNameScope $nameScope = null;
+
+	public function reset(): void
+	{
+		$this->namespace = null;
+		$this->uses = [];
+		$this->constUses = [];
+		$this->nameScope = null;
+	}
+
+	public function enterNode(Node $node): void
+	{
+		if ($node instanceof Node\Stmt\Namespace_) {
+			$this->namespace = $node->name !== null ? $node->name->toString() : null;
+			$this->uses = [];
+			$this->constUses = [];
+		} elseif ($node instanceof Node\Stmt\Use_) {
+			if ($node->type === Node\Stmt\Use_::TYPE_NORMAL) {
+				foreach ($node->uses as $use) {
+					$this->uses[strtolower($use->getAlias()->name)] = $use->name->toString();
+				}
+			} elseif ($node->type === Node\Stmt\Use_::TYPE_CONSTANT) {
+				foreach ($node->uses as $use) {
+					$this->constUses[strtolower($use->getAlias()->name)] = $use->name->toString();
+				}
+			} else {
+				return;
+			}
+		} elseif ($node instanceof Node\Stmt\GroupUse) {
+			$prefix = $node->prefix->toString();
+			foreach ($node->uses as $use) {
+				if ($node->type === Node\Stmt\Use_::TYPE_NORMAL || $use->type === Node\Stmt\Use_::TYPE_NORMAL) {
+					$this->uses[strtolower($use->getAlias()->name)] = sprintf('%s\\%s', $prefix, $use->name->toString());
+				} elseif ($node->type === Node\Stmt\Use_::TYPE_CONSTANT || $use->type === Node\Stmt\Use_::TYPE_CONSTANT) {
+					$this->constUses[strtolower($use->getAlias()->name)] = sprintf('%s\\%s', $prefix, $use->name->toString());
+				}
+			}
+		} else {
+			return;
+		}
+
+		$this->nameScope = null;
+	}
+
+	public function getNameScope(): ExportedNameScope
+	{
+		return $this->nameScope ??= new ExportedNameScope($this->namespace, $this->uses, $this->constUses);
+	}
+
+}

--- a/src/Dependency/ExportedNodeResolver.php
+++ b/src/Dependency/ExportedNodeResolver.php
@@ -30,10 +30,8 @@ use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Node\Printer\NodeTypePrinter;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\FileTypeMapper;
 use function array_map;
 use function is_string;
-use function sprintf;
 
 #[AutowiredService]
 final class ExportedNodeResolver
@@ -41,13 +39,12 @@ final class ExportedNodeResolver
 
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
-		private FileTypeMapper $fileTypeMapper,
 		private ExprPrinter $exprPrinter,
 	)
 	{
 	}
 
-	public function resolve(string $fileName, Node $node): ?RootExportedNode
+	public function resolve(Node $node, ExportedNameScope $nameScope): ?RootExportedNode
 	{
 		if ($node instanceof Class_ && isset($node->namespacedName)) {
 			$docComment = $node->getDocComment();
@@ -76,12 +73,7 @@ final class ExportedNodeResolver
 
 			return new ExportedClassNode(
 				$className,
-				$this->exportPhpDocNode(
-					$fileName,
-					$className,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				$node->isAbstract(),
 				$node->isFinal(),
 				$extendsName,
@@ -107,7 +99,7 @@ final class ExportedNodeResolver
 
 					throw new ShouldNotHappenException();
 				}, $adaptations),
-				$this->exportClassStatements($node->stmts, $fileName, $className),
+				$this->exportClassStatements($node->stmts, $className, $nameScope),
 				$this->exportAttributeNodes($node->attrGroups),
 			);
 		}
@@ -120,14 +112,9 @@ final class ExportedNodeResolver
 
 			return new ExportedInterfaceNode(
 				$interfaceName,
-				$this->exportPhpDocNode(
-					$fileName,
-					$interfaceName,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				$extendsNames,
-				$this->exportClassStatements($node->stmts, $fileName, $interfaceName),
+				$this->exportClassStatements($node->stmts, $interfaceName, $nameScope),
 			);
 		}
 
@@ -144,14 +131,9 @@ final class ExportedNodeResolver
 			return new ExportedEnumNode(
 				$enumName,
 				$scalarType,
-				$this->exportPhpDocNode(
-					$fileName,
-					$enumName,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				$implementsNames,
-				$this->exportClassStatements($node->stmts, $fileName, $enumName),
+				$this->exportClassStatements($node->stmts, $enumName, $nameScope),
 				$this->exportAttributeNodes($node->attrGroups),
 			);
 		}
@@ -173,12 +155,7 @@ final class ExportedNodeResolver
 
 			return new ExportedTraitNode(
 				$className,
-				$this->exportPhpDocNode(
-					$fileName,
-					$className,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				$usedTraits,
 				array_map(static function (Node\Stmt\TraitUseAdaptation $adaptation): ExportedTraitUseAdaptation {
 					if ($adaptation instanceof Node\Stmt\TraitUseAdaptation\Alias) {
@@ -200,7 +177,7 @@ final class ExportedNodeResolver
 
 					throw new ShouldNotHappenException();
 				}, $adaptations),
-				$this->exportClassStatements($node->stmts, $fileName, $className),
+				$this->exportClassStatements($node->stmts, $className, $nameScope),
 				$this->exportAttributeNodes($node->attrGroups),
 			);
 		}
@@ -215,15 +192,10 @@ final class ExportedNodeResolver
 
 			return new ExportedFunctionNode(
 				$functionName,
-				$this->exportPhpDocNode(
-					$fileName,
-					null,
-					$functionName,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				$node->byRef,
 				NodeTypePrinter::printType($node->returnType),
-				$this->exportParameterNodes($node->params, $fileName, null),
+				$this->exportParameterNodes($node->params, $nameScope),
 				$this->exportAttributeNodes($node->attrGroups),
 			);
 		}
@@ -266,7 +238,7 @@ final class ExportedNodeResolver
 	 * @param Node\Param[] $params
 	 * @return ExportedParameterNode[]
 	 */
-	private function exportParameterNodes(array $params, string $fileName, ?string $className): array
+	private function exportParameterNodes(array $params, ExportedNameScope $nameScope): array
 	{
 		$nodes = [];
 		foreach ($params as $param) {
@@ -295,12 +267,7 @@ final class ExportedNodeResolver
 				$param->variadic,
 				$param->default !== null,
 				$this->exportAttributeNodes($param->attrGroups),
-				$this->exportPhpDocNode(
-					$fileName,
-					$className,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				$param->flags,
 			);
 		}
@@ -308,23 +275,9 @@ final class ExportedNodeResolver
 		return $nodes;
 	}
 
-	private function exportPhpDocNode(
-		string $file,
-		?string $className,
-		?string $functionName,
-		?string $text,
-	): ?ExportedPhpDocNode
+	private function exportPhpDocNode(?string $text, ExportedNameScope $nameScope): ?ExportedPhpDocNode
 	{
 		if ($text === null) {
-			return null;
-		}
-
-		// Only the namespace and the uses are exported, so the fully resolved PHPDoc block is not
-		// needed - and building it would resolve the surrounding @template bounds through the
-		// ReflectionProvider. The result cache restore fetches exported nodes in the main process
-		// before the deferred bootstrapFiles have run, where reading PHPDocs is not allowed.
-		$nameScope = $this->fileTypeMapper->getIntermediaryNameScope($file, $className, null, $functionName);
-		if ($nameScope === null) {
 			return null;
 		}
 
@@ -335,11 +288,11 @@ final class ExportedNodeResolver
 	 * @param Node\Stmt[] $statements
 	 * @return ExportedNode[]
 	 */
-	private function exportClassStatements(array $statements, string $fileName, string $namespacedName): array
+	private function exportClassStatements(array $statements, string $namespacedName, ExportedNameScope $nameScope): array
 	{
 		$exportedNodes = [];
 		foreach ($statements as $statement) {
-			$exportedNode = $this->exportClassStatement($statement, $fileName, $namespacedName);
+			$exportedNode = $this->exportClassStatement($statement, $namespacedName, $nameScope);
 			if ($exportedNode === null) {
 				continue;
 			}
@@ -350,7 +303,7 @@ final class ExportedNodeResolver
 		return $exportedNodes;
 	}
 
-	private function exportClassStatement(Node\Stmt $node, string $fileName, string $namespacedName): ?ExportedNode
+	private function exportClassStatement(Node\Stmt $node, string $namespacedName, ExportedNameScope $nameScope): ?ExportedNode
 	{
 		if ($node instanceof ClassMethod) {
 			if ($node->isAbstract() || $node->isFinal() || !$node->isPrivate()) {
@@ -359,12 +312,7 @@ final class ExportedNodeResolver
 
 				return new ExportedMethodNode(
 					$methodName,
-					$this->exportPhpDocNode(
-						$fileName,
-						$namespacedName,
-						$methodName,
-						$docComment !== null ? $docComment->getText() : null,
-					),
+					$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 					$node->byRef,
 					$node->isPublic(),
 					$node->isPrivate(),
@@ -372,7 +320,7 @@ final class ExportedNodeResolver
 					$node->isFinal(),
 					$node->isStatic(),
 					NodeTypePrinter::printType($node->returnType),
-					$this->exportParameterNodes($node->params, $fileName, $namespacedName),
+					$this->exportParameterNodes($node->params, $nameScope),
 					$this->exportAttributeNodes($node->attrGroups),
 				);
 			}
@@ -405,12 +353,7 @@ final class ExportedNodeResolver
 
 			return new ExportedPropertiesNode(
 				$names,
-				$this->exportPhpDocNode(
-					$fileName,
-					$namespacedName,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				NodeTypePrinter::printType($node->type),
 				$node->isPublic(),
 				$node->isPrivate(),
@@ -423,7 +366,7 @@ final class ExportedNodeResolver
 				$node->isPrivateSet(),
 				$virtual,
 				$this->exportAttributeNodes($node->attrGroups),
-				$this->exportPropertyHooks($node->hooks, $fileName, $namespacedName),
+				$this->exportPropertyHooks($node->hooks, $namespacedName, $nameScope),
 			);
 		}
 
@@ -448,12 +391,7 @@ final class ExportedNodeResolver
 				$node->isPublic(),
 				$node->isPrivate(),
 				$node->isFinal(),
-				$this->exportPhpDocNode(
-					$fileName,
-					$namespacedName,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 			);
 		}
 
@@ -463,12 +401,7 @@ final class ExportedNodeResolver
 			return new ExportedEnumCaseNode(
 				$node->name->toString(),
 				$node->expr !== null ? $this->exprPrinter->printExpr($node->expr) : null,
-				$this->exportPhpDocNode(
-					$fileName,
-					$namespacedName,
-					null,
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 			);
 		}
 
@@ -505,8 +438,8 @@ final class ExportedNodeResolver
 	 */
 	private function exportPropertyHooks(
 		array $hooks,
-		string $fileName,
 		string $namespacedName,
+		ExportedNameScope $nameScope,
 	): array
 	{
 		$nodes = [];
@@ -518,17 +451,12 @@ final class ExportedNodeResolver
 			}
 			$nodes[] = new ExportedPropertyHookNode(
 				$hook->name->toString(),
-				$this->exportPhpDocNode(
-					$fileName,
-					$namespacedName,
-					sprintf('$%s::%s', $propertyName, $hook->name->toString()),
-					$docComment !== null ? $docComment->getText() : null,
-				),
+				$this->exportPhpDocNode($docComment !== null ? $docComment->getText() : null, $nameScope),
 				$hook->byRef,
 				$hook->body === null,
 				$hook->isFinal(),
 				$hook->body instanceof Expr,
-				$this->exportParameterNodes($hook->params, $fileName, $namespacedName),
+				$this->exportParameterNodes($hook->params, $nameScope),
 				$this->exportAttributeNodes($hook->attrGroups),
 			);
 		}

--- a/src/Dependency/ExportedNodeResolver.php
+++ b/src/Dependency/ExportedNodeResolver.php
@@ -389,8 +389,14 @@ final class ExportedNodeResolver
 			// Virtuality is decided by the native reflection, so it is read straight off it.
 			// PhpPropertyReflection would give the same answer, but building it resolves the
 			// class PHPDoc - see exportPhpDocNode() for why that is not allowed here.
+			//
+			// Only a hooked property can be virtual, so the hook-less ones are answered from the
+			// node alone. Reaching the ReflectionProvider boots BetterReflection and the stub
+			// files, and this runs in the main process during a result cache restore - where that
+			// boot is pure latency in front of the analysis, paid as soon as a single file with a
+			// non-private property changed.
 			$virtual = false;
-			if ($this->reflectionProvider->hasClass($namespacedName)) {
+			if ($node->hooks !== [] && $this->reflectionProvider->hasClass($namespacedName)) {
 				$nativeReflection = $this->reflectionProvider->getClass($namespacedName)->getNativeReflection();
 				if ($nativeReflection->hasProperty($names[0])) {
 					$virtual = $nativeReflection->getProperty($names[0])->isVirtual();

--- a/src/Dependency/ExportedNodeVisitor.php
+++ b/src/Dependency/ExportedNodeVisitor.php
@@ -19,18 +19,22 @@ final class ExportedNodeVisitor extends NodeVisitorAbstract
 	/** @var RootExportedNode[] */
 	private array $currentNodes = [];
 
+	private ExportedNameScopeTracker $nameScopeTracker;
+
 	/**
 	 * ExportedNodeVisitor constructor.
 	 *
 	 */
 	public function __construct(private ExportedNodeResolver $exportedNodeResolver)
 	{
+		$this->nameScopeTracker = new ExportedNameScopeTracker();
 	}
 
 	public function reset(string $fileName): void
 	{
 		$this->fileName = $fileName;
 		$this->currentNodes = [];
+		$this->nameScopeTracker->reset();
 	}
 
 	/**
@@ -47,7 +51,8 @@ final class ExportedNodeVisitor extends NodeVisitorAbstract
 		if ($this->fileName === null) {
 			throw new ShouldNotHappenException();
 		}
-		$exportedNode = $this->exportedNodeResolver->resolve($this->fileName, $node);
+		$this->nameScopeTracker->enterNode($node);
+		$exportedNode = $this->exportedNodeResolver->resolve($node, $this->nameScopeTracker->getNameScope());
 		if ($exportedNode !== null) {
 			$this->currentNodes[] = $exportedNode;
 		}

--- a/src/File/DirectoryWalker.php
+++ b/src/File/DirectoryWalker.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use Symfony\Component\Finder\Finder;
+use function array_key_exists;
+use function implode;
+
+/**
+ * The raw filesystem walk behind FileFinder.
+ *
+ * The analyse and the scan FileFinder differ only in their FileExcluder, so an analysis walks the
+ * same directories twice: once to build the list of analysed files, and once for the result cache
+ * metadata, which records the files that are scanned but not analysed. walkCached() shares that
+ * walk between the two - both happen before the analysis starts, on a file set that is snapshotted
+ * for the whole run anyway.
+ *
+ * FileMonitor detects changes by re-running the finder and must see the filesystem as it is now,
+ * so it walks uncached and clears the shared walks before each check.
+ */
+#[AutowiredService]
+final class DirectoryWalker
+{
+
+	/** @var array<string, list<string>> */
+	private array $cachedWalks = [];
+
+	/**
+	 * @param string[] $fileExtensions
+	 * @return list<string>
+	 */
+	public function walk(string $directory, array $fileExtensions): array
+	{
+		$finder = new Finder();
+		$finder->followLinks();
+
+		$files = [];
+		foreach ($finder->files()->name('*.{' . implode(',', $fileExtensions) . '}')->in($directory) as $fileInfo) {
+			$files[] = $fileInfo->getPathname();
+		}
+
+		return $files;
+	}
+
+	/**
+	 * @param string[] $fileExtensions
+	 * @return list<string>
+	 */
+	public function walkCached(string $directory, array $fileExtensions): array
+	{
+		$key = $directory . "\n" . implode(',', $fileExtensions);
+		if (array_key_exists($key, $this->cachedWalks)) {
+			return $this->cachedWalks[$key];
+		}
+
+		return $this->cachedWalks[$key] = $this->walk($directory, $fileExtensions);
+	}
+
+	public function clearCachedWalks(): void
+	{
+		$this->cachedWalks = [];
+	}
+
+}

--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -2,13 +2,11 @@
 
 namespace PHPStan\File;
 
-use Symfony\Component\Finder\Finder;
 use function array_filter;
 use function array_map;
 use function array_unique;
 use function array_values;
 use function file_exists;
-use function implode;
 use function is_file;
 use function sort;
 
@@ -22,6 +20,7 @@ final class FileFinder
 		private FileExcluder $fileExcluder,
 		private FileHelper $fileHelper,
 		private array $fileExtensions,
+		private DirectoryWalker $directoryWalker,
 	)
 	{
 	}
@@ -31,6 +30,25 @@ final class FileFinder
 	 */
 	public function findFiles(array $paths): FileFinderResult
 	{
+		return $this->doFindFiles($paths, false);
+	}
+
+	/**
+	 * Like findFiles(), but the directory walk is shared with the other FileFinder - see
+	 * DirectoryWalker. Only for the callers that run once per analysis, before it starts.
+	 *
+	 * @param string[] $paths
+	 */
+	public function findFilesCached(array $paths): FileFinderResult
+	{
+		return $this->doFindFiles($paths, true);
+	}
+
+	/**
+	 * @param string[] $paths
+	 */
+	private function doFindFiles(array $paths, bool $cached): FileFinderResult
+	{
 		$onlyFiles = true;
 		$files = [];
 		foreach ($paths as $path) {
@@ -39,10 +57,11 @@ final class FileFinder
 			} elseif (!file_exists($path)) {
 				throw new PathNotFoundException($path);
 			} else {
-				$finder = new Finder();
-				$finder->followLinks();
-				foreach ($finder->files()->name('*.{' . implode(',', $this->fileExtensions) . '}')->in($path) as $fileInfo) {
-					$files[] = $fileInfo->getPathname();
+				$walkedFiles = $cached
+					? $this->directoryWalker->walkCached($path, $this->fileExtensions)
+					: $this->directoryWalker->walk($path, $this->fileExtensions);
+				foreach ($walkedFiles as $walkedFile) {
+					$files[] = $walkedFile;
 					$onlyFiles = false;
 				}
 			}

--- a/src/File/FileMonitor.php
+++ b/src/File/FileMonitor.php
@@ -43,6 +43,7 @@ final class FileMonitor
 		private array $scanFiles,
 		#[AutowiredParameter]
 		private array $scanDirectories,
+		private DirectoryWalker $directoryWalker,
 	)
 	{
 	}
@@ -67,6 +68,10 @@ final class FileMonitor
 		if ($this->fileHashes === null || $this->filePaths === null) {
 			throw new ShouldNotHappenException();
 		}
+
+		// Detecting a change means looking at the filesystem as it is now, so the walks shared
+		// with the analysis file discovery must not be reused here.
+		$this->directoryWalker->clearCachedWalks();
 		$finderResult = $this->analyseFileFinder->findFiles($this->analysedPaths);
 		$oldFileHashes = $this->fileHashes;
 		$fileHashes = [];

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -888,7 +888,7 @@ class AnalyserTest extends PHPStanTestCase
 				$container->getExtensionsCollection(NodeVisitor::class),
 				new IgnoreLexer(),
 			),
-			new DependencyResolver($fileHelper, new IncludedFilePathResolver(__DIR__, $fileHelper), $reflectionProvider, new ExportedNodeResolver($reflectionProvider, $fileTypeMapper, new ExprPrinter(new Printer())), $fileTypeMapper),
+			new DependencyResolver($fileHelper, new IncludedFilePathResolver(__DIR__, $fileHelper), $reflectionProvider, new ExportedNodeResolver($reflectionProvider, new ExprPrinter(new Printer())), $fileTypeMapper),
 			new PackageDependencyResolver([], $fileHelper),
 			new DirectExtensionsCollection([]),
 			$container->getByType(RuleErrorTransformer::class),

--- a/tests/PHPStan/Dependency/CountingReflectionProvider.php
+++ b/tests/PHPStan/Dependency/CountingReflectionProvider.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Dependency;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ConstantReflection;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\NamespaceAnswerer;
+use PHPStan\Reflection\ReflectionProvider;
+
+/**
+ * Records how many times a class is looked up, so a test can assert that resolving exported
+ * nodes does not reach for reflection when it does not have to.
+ */
+final class CountingReflectionProvider implements ReflectionProvider
+{
+
+	public int $hasClassCallCount = 0;
+
+	public function __construct(private ReflectionProvider $inner)
+	{
+	}
+
+	public function hasClass(string $className): bool
+	{
+		$this->hasClassCallCount++;
+
+		return $this->inner->hasClass($className);
+	}
+
+	public function getClass(string $className): ClassReflection
+	{
+		return $this->inner->getClass($className);
+	}
+
+	public function getClassName(string $className): string
+	{
+		return $this->inner->getClassName($className);
+	}
+
+	public function getAnonymousClassReflection(Node\Stmt\Class_ $classNode, Scope $scope): ClassReflection
+	{
+		return $this->inner->getAnonymousClassReflection($classNode, $scope);
+	}
+
+	public function getUniversalObjectCratesClasses(): array
+	{
+		return $this->inner->getUniversalObjectCratesClasses();
+	}
+
+	public function hasFunction(Node\Name $nameNode, ?NamespaceAnswerer $namespaceAnswerer): bool
+	{
+		return $this->inner->hasFunction($nameNode, $namespaceAnswerer);
+	}
+
+	public function getFunction(Node\Name $nameNode, ?NamespaceAnswerer $namespaceAnswerer): FunctionReflection
+	{
+		return $this->inner->getFunction($nameNode, $namespaceAnswerer);
+	}
+
+	public function resolveFunctionName(Node\Name $nameNode, ?NamespaceAnswerer $namespaceAnswerer): ?string
+	{
+		return $this->inner->resolveFunctionName($nameNode, $namespaceAnswerer);
+	}
+
+	public function hasConstant(Node\Name $nameNode, ?NamespaceAnswerer $namespaceAnswerer): bool
+	{
+		return $this->inner->hasConstant($nameNode, $namespaceAnswerer);
+	}
+
+	public function getConstant(Node\Name $nameNode, ?NamespaceAnswerer $namespaceAnswerer): ConstantReflection
+	{
+		return $this->inner->getConstant($nameNode, $namespaceAnswerer);
+	}
+
+	public function resolveConstantName(Node\Name $nameNode, ?NamespaceAnswerer $namespaceAnswerer): ?string
+	{
+		return $this->inner->resolveConstantName($nameNode, $namespaceAnswerer);
+	}
+
+}

--- a/tests/PHPStan/Dependency/ExportedNameScopeCollectingVisitor.php
+++ b/tests/PHPStan/Dependency/ExportedNameScopeCollectingVisitor.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Dependency;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Records the name scope in effect at every class declaration of a file.
+ */
+final class ExportedNameScopeCollectingVisitor extends NodeVisitorAbstract
+{
+
+	/** @var array<string, ExportedNameScope> */
+	private array $scopes = [];
+
+	public function __construct(private ExportedNameScopeTracker $tracker)
+	{
+	}
+
+	/**
+	 * @return array<string, ExportedNameScope>
+	 */
+	public function getScopes(): array
+	{
+		return $this->scopes;
+	}
+
+	#[Override]
+	public function enterNode(Node $node): ?int
+	{
+		$this->tracker->enterNode($node);
+		if ($node instanceof Node\Stmt\Class_ && isset($node->namespacedName)) {
+			$this->scopes[$node->namespacedName->toString()] = $this->tracker->getNameScope();
+		}
+
+		return null;
+	}
+
+}

--- a/tests/PHPStan/Dependency/ExportedNameScopeTrackerTest.php
+++ b/tests/PHPStan/Dependency/ExportedNameScopeTrackerTest.php
@@ -2,10 +2,7 @@
 
 namespace PHPStan\Dependency;
 
-use Override;
-use PhpParser\Node;
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
 use PHPStan\Parser\Parser;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -20,36 +17,13 @@ final class ExportedNameScopeTrackerTest extends PHPStanTestCase
 	{
 		/** @var Parser $parser */
 		$parser = self::getContainer()->getService('defaultAnalysisParser');
-		$tracker = new ExportedNameScopeTracker();
-		$scopes = [];
 
-		$visitor = new class ($tracker, $scopes) extends NodeVisitorAbstract {
-
-			/**
-			 * @param array<string, ExportedNameScope> $scopes
-			 */
-			public function __construct(private ExportedNameScopeTracker $tracker, public array &$scopes)
-			{
-			}
-
-			#[Override]
-			public function enterNode(Node $node): ?int
-			{
-				$this->tracker->enterNode($node);
-				if ($node instanceof Node\Stmt\Class_ && isset($node->namespacedName)) {
-					$this->scopes[$node->namespacedName->toString()] = $this->tracker->getNameScope();
-				}
-
-				return null;
-			}
-
-		};
-
+		$visitor = new ExportedNameScopeCollectingVisitor(new ExportedNameScopeTracker());
 		$traverser = new NodeTraverser();
 		$traverser->addVisitor($visitor);
 		$traverser->traverse($parser->parseFile($file));
 
-		return $scopes;
+		return $visitor->getScopes();
 	}
 
 	public function testTracksNamespacesAndUses(): void

--- a/tests/PHPStan/Dependency/ExportedNameScopeTrackerTest.php
+++ b/tests/PHPStan/Dependency/ExportedNameScopeTrackerTest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Dependency;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Parser\Parser;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\FileTypeMapper;
+
+final class ExportedNameScopeTrackerTest extends PHPStanTestCase
+{
+
+	/**
+	 * @return array<string, ExportedNameScope> class name => the scope in effect at its declaration
+	 */
+	private function collectScopes(string $file): array
+	{
+		/** @var Parser $parser */
+		$parser = self::getContainer()->getService('defaultAnalysisParser');
+		$tracker = new ExportedNameScopeTracker();
+		$scopes = [];
+
+		$visitor = new class ($tracker, $scopes) extends NodeVisitorAbstract {
+
+			/**
+			 * @param array<string, ExportedNameScope> $scopes
+			 */
+			public function __construct(private ExportedNameScopeTracker $tracker, public array &$scopes)
+			{
+			}
+
+			#[Override]
+			public function enterNode(Node $node): ?int
+			{
+				$this->tracker->enterNode($node);
+				if ($node instanceof Node\Stmt\Class_ && isset($node->namespacedName)) {
+					$this->scopes[$node->namespacedName->toString()] = $this->tracker->getNameScope();
+				}
+
+				return null;
+			}
+
+		};
+
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor($visitor);
+		$traverser->traverse($parser->parseFile($file));
+
+		return $scopes;
+	}
+
+	public function testTracksNamespacesAndUses(): void
+	{
+		$file = __DIR__ . '/data/name-scope.php';
+		$scopes = $this->collectScopes($file);
+
+		$first = $scopes['NameScopeA\First'];
+		$this->assertSame('NameScopeA', $first->getNamespace());
+		$this->assertSame([
+			'scope' => 'PHPStan\Analyser\Scope',
+			'mutating' => 'PHPStan\Analyser\MutatingScope',
+			'type' => 'PHPStan\Type\Type',
+			'verbositylevel' => 'PHPStan\Type\VerbosityLevel',
+			'classreflection' => 'PHPStan\Reflection\ClassReflection',
+		], $first->getUses());
+		$this->assertSame([
+			'php_eol' => 'PHP_EOL',
+			'const_a' => 'PHPStan\Type\CONST_A',
+			'const_b' => 'PHPStan\Type\CONST_B',
+			'some_const' => 'PHPStan\Reflection\SOME_CONST',
+		], $first->getConstUses());
+
+		// A second namespace block starts from nothing.
+		$second = $scopes['NameScopeB\Second'];
+		$this->assertSame('NameScopeB', $second->getNamespace());
+		$this->assertSame(['classreflection' => 'PHPStan\Reflection\ClassReflection'], $second->getUses());
+		$this->assertSame([], $second->getConstUses());
+	}
+
+	public function testMatchesFileTypeMapper(): void
+	{
+		$file = __DIR__ . '/data/name-scope.php';
+		$fileTypeMapper = self::getContainer()->getByType(FileTypeMapper::class);
+
+		foreach ($this->collectScopes($file) as $className => $trackedScope) {
+			$nameScope = $fileTypeMapper->getIntermediaryNameScope($file, $className, null, null);
+			$this->assertNotNull($nameScope, $className);
+			$this->assertSame($nameScope->getNamespace(), $trackedScope->getNamespace(), $className);
+			$this->assertSame($nameScope->getUses(), $trackedScope->getUses(), $className);
+			$this->assertSame($nameScope->getConstUses(), $trackedScope->getConstUses(), $className);
+		}
+	}
+
+}

--- a/tests/PHPStan/Dependency/ExportedNodeResolverTest.php
+++ b/tests/PHPStan/Dependency/ExportedNodeResolverTest.php
@@ -6,6 +6,7 @@ use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Parser\Parser;
 use PHPStan\Reflection\ReflectionProvider\DummyReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 final class ExportedNodeResolverTest extends PHPStanTestCase
 {
@@ -38,6 +39,9 @@ final class ExportedNodeResolverTest extends PHPStanTestCase
 		$this->assertSame(0, $reflectionProvider->hasClassCallCount);
 	}
 
+	// The parser follows the analysed PHP version, which defaults to the running one, so the hooks
+	// in the data file do not parse below 8.4 and no nodes come out at all.
+	#[RequiresPhp('>= 8.4.0')]
 	public function testHookedPropertyStillLooksUpTheClass(): void
 	{
 		$reflectionProvider = new CountingReflectionProvider(new DummyReflectionProvider());

--- a/tests/PHPStan/Dependency/ExportedNodeResolverTest.php
+++ b/tests/PHPStan/Dependency/ExportedNodeResolverTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Dependency;
+
+use PHPStan\Node\Printer\ExprPrinter;
+use PHPStan\Parser\Parser;
+use PHPStan\Reflection\ReflectionProvider\DummyReflectionProvider;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\FileTypeMapper;
+
+final class ExportedNodeResolverTest extends PHPStanTestCase
+{
+
+	/**
+	 * @return RootExportedNode[]
+	 */
+	private function fetchNodes(string $file, CountingReflectionProvider $reflectionProvider): array
+	{
+		$resolver = new ExportedNodeResolver(
+			$reflectionProvider,
+			self::getContainer()->getByType(FileTypeMapper::class),
+			self::getContainer()->getByType(ExprPrinter::class),
+		);
+
+		/** @var Parser $parser */
+		$parser = self::getContainer()->getService('defaultAnalysisParser');
+
+		return (new ExportedNodeFetcher($parser, new ExportedNodeVisitor($resolver)))->fetchNodes($file);
+	}
+
+	public function testPropertiesWithoutHooksDoNotLookUpTheClass(): void
+	{
+		// A property without hooks can never be virtual, so answering that must not reach for
+		// reflection: during a result cache restore this runs in the main process and the first
+		// lookup boots BetterReflection and the stub files in front of the analysis.
+		$reflectionProvider = new CountingReflectionProvider(new DummyReflectionProvider());
+		$nodes = $this->fetchNodes(__DIR__ . '/data/exported-properties-no-hooks.php', $reflectionProvider);
+
+		$this->assertNotSame([], $nodes);
+		$this->assertSame(0, $reflectionProvider->hasClassCallCount);
+	}
+
+	public function testHookedPropertyStillLooksUpTheClass(): void
+	{
+		$reflectionProvider = new CountingReflectionProvider(new DummyReflectionProvider());
+		$nodes = $this->fetchNodes(__DIR__ . '/data/exported-properties-hooks.php', $reflectionProvider);
+
+		$this->assertNotSame([], $nodes);
+		$this->assertGreaterThan(0, $reflectionProvider->hasClassCallCount);
+	}
+
+}

--- a/tests/PHPStan/Dependency/ExportedNodeResolverTest.php
+++ b/tests/PHPStan/Dependency/ExportedNodeResolverTest.php
@@ -6,7 +6,6 @@ use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Parser\Parser;
 use PHPStan\Reflection\ReflectionProvider\DummyReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
-use PHPStan\Type\FileTypeMapper;
 
 final class ExportedNodeResolverTest extends PHPStanTestCase
 {
@@ -18,7 +17,6 @@ final class ExportedNodeResolverTest extends PHPStanTestCase
 	{
 		$resolver = new ExportedNodeResolver(
 			$reflectionProvider,
-			self::getContainer()->getByType(FileTypeMapper::class),
 			self::getContainer()->getByType(ExprPrinter::class),
 		);
 

--- a/tests/PHPStan/Dependency/data/exported-properties-hooks.php
+++ b/tests/PHPStan/Dependency/data/exported-properties-hooks.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types = 1); // lint >= 8.4
 
 namespace ExportedPropertiesHooks;
 

--- a/tests/PHPStan/Dependency/data/exported-properties-hooks.php
+++ b/tests/PHPStan/Dependency/data/exported-properties-hooks.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace ExportedPropertiesHooks;
+
+class Foo
+{
+
+	public string $virtualProperty { get => 'computed'; }
+
+}

--- a/tests/PHPStan/Dependency/data/exported-properties-no-hooks.php
+++ b/tests/PHPStan/Dependency/data/exported-properties-no-hooks.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace ExportedPropertiesNoHooks;
+
+class Foo
+{
+
+	public string $publicProperty = 'x';
+
+	protected int $protectedProperty = 1;
+
+	private string $privateProperty = 'y';
+
+}

--- a/tests/PHPStan/Dependency/data/name-scope.php
+++ b/tests/PHPStan/Dependency/data/name-scope.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace NameScopeA {
+
+	use PHPStan\Analyser\Scope;
+	use PHPStan\Analyser\MutatingScope as Mutating;
+	use function strlen;
+	use const PHP_EOL;
+	use PHPStan\Type\{Type, VerbosityLevel};
+	use const PHPStan\Type\{CONST_A, CONST_B};
+	use PHPStan\Reflection\{ClassReflection, function someFunction, const SOME_CONST};
+
+	/** first */
+	class First
+	{
+
+		/** a property */
+		public ?Scope $scope = null;
+
+	}
+
+}
+
+namespace NameScopeB {
+
+	use PHPStan\Reflection\ClassReflection;
+
+	/** second */
+	class Second
+	{
+	}
+
+}

--- a/tests/PHPStan/File/DirectoryWalkerTest.php
+++ b/tests/PHPStan/File/DirectoryWalkerTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use PHPStan\Testing\PHPStanTestCase;
+use function file_put_contents;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+final class DirectoryWalkerTest extends PHPStanTestCase
+{
+
+	private string $directory;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->directory = sys_get_temp_dir() . '/' . uniqid('phpstan-walker-', true);
+		mkdir($this->directory);
+		file_put_contents($this->directory . '/first.php', '<?php');
+	}
+
+	public function testWalkAlwaysSeesTheCurrentState(): void
+	{
+		$walker = new DirectoryWalker();
+
+		$beforeAdding = $walker->walk($this->directory, ['php']);
+		file_put_contents($this->directory . '/second.php', '<?php');
+		$afterAdding = $walker->walk($this->directory, ['php']);
+
+		$this->assertCount(1, $beforeAdding);
+		$this->assertCount(2, $afterAdding);
+	}
+
+	public function testWalkCachedIsSharedBetweenCalls(): void
+	{
+		$walker = new DirectoryWalker();
+
+		$firstWalk = $walker->walkCached($this->directory, ['php']);
+		file_put_contents($this->directory . '/second.php', '<?php');
+		// The analyse and the scan FileFinder must see one and the same file set - the analysis
+		// works off a snapshot taken before it starts.
+		$secondWalk = $walker->walkCached($this->directory, ['php']);
+		$walker->clearCachedWalks();
+		$walkAfterClearing = $walker->walkCached($this->directory, ['php']);
+
+		$this->assertCount(1, $firstWalk);
+		$this->assertCount(1, $secondWalk);
+		$this->assertCount(2, $walkAfterClearing);
+	}
+
+	public function testCachedWalksAreKeyedByExtensions(): void
+	{
+		$walker = new DirectoryWalker();
+		file_put_contents($this->directory . '/notes.txt', 'x');
+
+		$phpFiles = $walker->walkCached($this->directory, ['php']);
+		$textFiles = $walker->walkCached($this->directory, ['txt']);
+
+		$this->assertCount(1, $phpFiles);
+		$this->assertCount(1, $textFiles);
+	}
+
+}


### PR DESCRIPTION
Three things a warm result cache restore did in the main process, in front of the analysis, that it did not have to do. Analysis output is unchanged - verified byte-for-byte on Drupal core (10289 analysed files).

Found while looking into a Drupal CI job reporting `Result cache restored in 25.2 seconds`.

### Do not look up class reflection for properties without hooks

`ExportedNodeResolver` asked the `ReflectionProvider` whether every non-private property is virtual. Only a hooked property can be, so the hook-less ones are now answered from the node alone. The first such lookup boots BetterReflection and the stub files.

### Share the directory walk between the analyse and the scan file finder

The two `FileFinder` services differ only in their `FileExcluder`, so a run walked the same directories twice: once in `CommandHelper` to build the list of analysed files, once in `ResultCacheManager::getScannedFiles()` to record the files that are scanned but not analysed. Both happen before the analysis starts, on a file set that is snapshotted for the whole run, so the raw walk is taken once and shared through the new `DirectoryWalker`.

On Drupal the second walk turned up 35475 paths, narrowed to 10288 by the scan excluder, of which exactly one was not already analysed.

`FileMonitor` is the one caller that has to see the filesystem as it is now rather than as the analysis snapshotted it, so it keeps walking uncached and clears the shared walks before each change check.

### Read the exported PHPDoc scope off the AST instead of through FileTypeMapper

An `ExportedPhpDocNode` records the namespace and the use statements a PHPDoc was written under. Both are in the AST, but the resolver asked `FileTypeMapper` for a name scope, which builds the name scope map of the whole file - it resolves every PHPDoc in it, far more than the exported nodes need.

Exported nodes are produced in two places that have to agree, or the cache reads its own nodes as changed: `ExportedNodeVisitor` when a restore re-reads a file, and `DependencyResolver` during the analysis, which is what writes them. Both now drive one `ExportedNameScopeTracker`, so they cannot drift apart. `ExportedNodeResolver` no longer needs the file name or `FileTypeMapper` at all.

## Measurements

Drupal core (10289 analysed files), warm cache, one edited file, MacBook. Restore phases, both PHARs instrumented identically:

```
before: total=4.90-5.10  metaAndStubHash=1.53-1.66  fetch=2.17-2.31
after : total=1.76-1.83  metaAndStubHash=0.56       fetch=0.00
```

Restore 4.9s -> 1.8s. Whole run, three reps each:

| worker mechanism | before | after |
| --- | --- | --- |
| spawn | 13.72-13.89s real / 8.12s user | 10.62-10.84s / 6.91s |
| fork + turbo | 9.58-9.72s real / 5.61s user | 8.64-8.72s / 5.47s |

Under fork about 2.1s of the saving is absorbed rather than lost: the old main-process boot was inadvertently pre-warming the forked workers, which now do that PHPDoc bootstrap themselves - in parallel, and work they needed anyway. Under spawn nothing comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDcVRMjAXM7WQGSzysw7WH