### PR TITLE
Do not resolve include paths through a stream wrapper that is not registered

### DIFF
--- a/src/File/IncludedFilePathResolver.php
+++ b/src/File/IncludedFilePathResolver.php
@@ -10,6 +10,10 @@ use function array_values;
 use function dirname;
 use function explode;
 use function get_include_path;
+use function in_array;
+use function preg_match;
+use function stream_get_wrappers;
+use function strtolower;
 use const PATH_SEPARATOR;
 
 /**
@@ -34,6 +38,10 @@ final class IncludedFilePathResolver
 	 */
 	public function resolve(string $path, Scope $scope): array
 	{
+		if ($this->hasUnavailableStreamWrapper($path)) {
+			return [];
+		}
+
 		$directories = array_merge(
 			[$this->currentWorkingDirectory],
 			explode(PATH_SEPARATOR, get_include_path()),
@@ -51,6 +59,23 @@ final class IncludedFilePathResolver
 		}
 
 		return array_values($candidatePaths);
+	}
+
+	/**
+	 * A path like `vfs://sites/default/x.php` names a stream wrapper rather than a place on the
+	 * filesystem. When that wrapper is not registered in the PHPStan process - vfsStream registers
+	 * its own from a test's setUp(), which never runs here - PHP cannot stat the path at all: every
+	 * is_file() on it raises "Unable to find the wrapper". Such a path has no candidates, and it
+	 * cannot come to have any, so nothing downstream should keep stat'ing it - the result cache
+	 * would otherwise record it as a missing file dependency and warn on every run.
+	 */
+	private function hasUnavailableStreamWrapper(string $path): bool
+	{
+		if (preg_match('~^([a-z0-9+\-.]+)://~i', $path, $matches) !== 1) {
+			return false;
+		}
+
+		return !in_array(strtolower($matches[1]), stream_get_wrappers(), true);
 	}
 
 	/**

--- a/tests/PHPStan/File/IncludedFilePathResolverTest.php
+++ b/tests/PHPStan/File/IncludedFilePathResolverTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Testing\PHPStanTestCase;
+
+final class IncludedFilePathResolverTest extends PHPStanTestCase
+{
+
+	private function createResolver(): IncludedFilePathResolver
+	{
+		return new IncludedFilePathResolver(__DIR__, self::getContainer()->getByType(FileHelper::class));
+	}
+
+	private function createScope(): Scope
+	{
+		$scope = $this->createMock(Scope::class);
+		$scope->method('isInTrait')->willReturn(false);
+		$scope->method('getFile')->willReturn(__DIR__ . '/test/lorem.php');
+
+		return $scope;
+	}
+
+	public function testPathWithAnUnregisteredStreamWrapperHasNoCandidates(): void
+	{
+		// is_file() on it raises "Unable to find the wrapper" instead of answering, and the path
+		// cannot become readable later either - vfsStream registers its wrapper from a test's
+		// setUp(), which never runs inside PHPStan.
+		$this->assertSame([], $this->createResolver()->resolve('vfs://drupal/sites/default/x.php', $this->createScope()));
+	}
+
+	public function testPathWithARegisteredStreamWrapperIsKept(): void
+	{
+		$this->assertSame(['php://memory'], $this->createResolver()->resolve('php://memory', $this->createScope()));
+	}
+
+	public function testRelativePathIsResolvedAgainstEveryDirectory(): void
+	{
+		$paths = $this->createResolver()->resolve('lorem.php', $this->createScope());
+
+		$this->assertContains(__DIR__ . '/lorem.php', $paths);
+		$this->assertContains(__DIR__ . '/test/lorem.php', $paths);
+	}
+
+}

--- a/tests/PHPStan/File/IncludedFilePathResolverTest.php
+++ b/tests/PHPStan/File/IncludedFilePathResolverTest.php
@@ -4,6 +4,8 @@ namespace PHPStan\File;
 
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
+use function array_map;
+use function str_replace;
 
 final class IncludedFilePathResolverTest extends PHPStanTestCase
 {
@@ -37,10 +39,16 @@ final class IncludedFilePathResolverTest extends PHPStanTestCase
 
 	public function testRelativePathIsResolvedAgainstEveryDirectory(): void
 	{
-		$paths = $this->createResolver()->resolve('lorem.php', $this->createScope());
+		// Compared with forward slashes so the expectations hold on Windows too, where
+		// absolutizePath() joins with a backslash.
+		$paths = array_map(
+			static fn (string $path): string => str_replace('\\', '/', $path),
+			$this->createResolver()->resolve('lorem.php', $this->createScope()),
+		);
+		$directory = str_replace('\\', '/', __DIR__);
 
-		$this->assertContains(__DIR__ . '/lorem.php', $paths);
-		$this->assertContains(__DIR__ . '/test/lorem.php', $paths);
+		$this->assertContains($directory . '/lorem.php', $paths);
+		$this->assertContains($directory . '/test/lorem.php', $paths);
 	}
 
 }

--- a/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
+++ b/tests/PHPStan/Rules/Keywords/RequireFileExistsRuleTest.php
@@ -41,6 +41,22 @@ class RequireFileExistsRuleTest extends RuleTestCase
 		];
 	}
 
+	public function testPathWithAnUnregisteredStreamWrapper(): void
+	{
+		// PHPStan cannot see through a wrapper that is not registered, so the path is still
+		// reported - it just must not be stat'd to get there, see IncludedFilePathResolverTest.
+		$this->analyse([__DIR__ . '/data/require-file-stream-wrapper.php'], [
+			[
+				'Path in include_once() "vfs://drupal/sites/default/modules/module_a/module_a.post_update.php" is not a file or it does not exist.',
+				7,
+			],
+			[
+				'Path in require() "not-a-registered-wrapper://somewhere/else.php" is not a file or it does not exist.',
+				8,
+			],
+		]);
+	}
+
 	public function testBasicCase(): void
 	{
 		$this->analyse([__DIR__ . '/data/require-file-simple-case.php'], [

--- a/tests/PHPStan/Rules/Keywords/data/require-file-stream-wrapper.php
+++ b/tests/PHPStan/Rules/Keywords/data/require-file-stream-wrapper.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace RequireFileStreamWrapper;
+
+// vfsStream registers the "vfs" wrapper from a test's setUp(), so it is not registered while
+// PHPStan runs and is_file() on the path cannot answer - it raises a warning instead.
+include_once 'vfs://drupal/sites/default/modules/module_a/module_a.post_update.php';
+require 'not-a-registered-wrapper://somewhere/else.php';


### PR DESCRIPTION
Analysing Drupal core prints this before the analysis starts, on **every** run:

```
PHP Warning:  is_file(): Unable to find the wrapper "vfs" - did you forget to enable it when you configured PHP? in .../ResultCacheManager.php on line 739
```

### How it happens

Drupal core has a literal `include_once 'vfs://drupal/sites/default/modules/module_a/module_a.post_update.php'` in `core/tests/Drupal/Tests/Core/Update/UpdateRegistryTest.php`. vfsStream registers that wrapper from a test's `setUp()`, which never runs inside PHPStan, so `is_file()` on the path cannot answer - it raises the warning and returns false.

`FileHelper::absolutizePath()` recognises `scheme://` and returns such a path unchanged, so `IncludedFilePathResolver::resolve()` handed it back as a filesystem candidate. Three callers then stat it:

1. `RequireFileExistsRule::doesFileExist()` - quiet, `FileAnalyser` installs an error handler that swallows warnings during the analysis.
2. `DependencyResolver`'s `Include_` branch - also quiet, and its own `is_file()` guard means the path is not recorded there.
3. The one that shows: the rule attaches its candidate paths to the error as a `FileDependenciesRuleError`, so the verdict is rechecked if the file ever appears. That lands in the dependency graph, the result cache stores it with `MISSING_FILE_HASH`, and every restore stats it again - outside any error handler.

### The fix

A path whose stream wrapper is not registered has no filesystem candidates, and cannot come to have any, so `resolve()` returns none for it.

The include is still reported as not found - PHPStan cannot see through the wrapper either way - it just no longer gets there by stat'ing, and no longer leaves behind a dependency that every restore stats again.

### Verification

On Drupal core: 8 warnings -> 0 on both a cold and a warm run, analysis output byte-identical (the same 22 pre-existing `ignore.unmatched` errors).

Note for reviewers: a `RuleTestCase` cannot catch this - `FileAnalyser`'s error handler eats the warning, so a rule test passes with and without the fix. The regression test is a unit test on the resolver; it fails before the fix with the path still in the candidate list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDcVRMjAXM7WQGSzysw7WH

Closes https://github.com/phpstan/phpstan/issues/15192