### PR TITLE
feat: add @phpstan-closure-scope tag

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1656,6 +1656,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	 * @param array<string, bool> $immediatelyInvokedCallableParameters
 	 * @param array<string, Type> $phpDocClosureThisTypeParameters
 	 * @param array<string, bool> $phpDocPureUnlessCallableIsImpureParameters
+	 * @param array<string, Type> $phpDocClosureScopeTypeParameters
 	 */
 	public function enterClassMethod(
 		Node\Stmt\ClassMethod $classMethod,
@@ -1678,6 +1679,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		bool $isConstructor = false,
 		?ResolvedPhpDocBlock $resolvedPhpDocBlock = null,
 		array $phpDocPureUnlessCallableIsImpureParameters = [],
+		array $phpDocClosureScopeTypeParameters = [],
 	): self
 	{
 		if (!$this->isInClass()) {
@@ -1714,6 +1716,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				$isConstructor,
 				$this->attributeReflectionFactory->fromAttrGroups($classMethod->attrGroups, InitializerExprContext::fromStubParameter($this->getClassReflection()->getName(), $this->getFile(), $classMethod)),
 				$phpDocPureUnlessCallableIsImpureParameters,
+				array_map(fn (Type $type): Type => $this->transformStaticType(TemplateTypeHelper::toArgument($type)), $phpDocClosureScopeTypeParameters),
 			),
 			!$classMethod->isStatic(),
 		);
@@ -1881,6 +1884,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	 * @param array<string, bool> $immediatelyInvokedCallableParameters
 	 * @param array<string, Type> $phpDocClosureThisTypeParameters
 	 * @param array<string, bool> $pureUnlessCallableIsImpureParameters
+	 * @param array<string, Type> $phpDocClosureScopeTypeParameters
 	 */
 	public function enterFunction(
 		Node\Stmt\Function_ $function,
@@ -1899,6 +1903,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		array $immediatelyInvokedCallableParameters = [],
 		array $phpDocClosureThisTypeParameters = [],
 		array $pureUnlessCallableIsImpureParameters = [],
+		array $phpDocClosureScopeTypeParameters = [],
 	): self
 	{
 		return $this->enterFunctionLike(
@@ -1925,6 +1930,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 				$phpDocClosureThisTypeParameters,
 				$this->attributeReflectionFactory->fromAttrGroups($function->attrGroups, InitializerExprContext::fromStubParameter(null, $this->getFile(), $function)),
 				$pureUnlessCallableIsImpureParameters,
+				$phpDocClosureScopeTypeParameters,
 			),
 			false,
 		);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1798,6 +1798,43 @@ class NodeScopeResolver
 	}
 
 	/**
+	 * @param FunctionReflection|MethodReflection|null $calleeReflection
+	 * @return array{MutatingScope, MutatingScope|null}
+	 */
+	private function applyClosureThisAndScope(
+		MutatingScope $scopeToPass,
+		?CallLike $call,
+		$calleeReflection,
+		ParameterReflection $parameter,
+		bool $isStatic,
+	): array
+	{
+		if (!$parameter instanceof ExtendedParameterReflection) {
+			return [$scopeToPass, null];
+		}
+
+		$closureThisType = null;
+		if (!$isStatic) {
+			$closureThisType = $this->resolveClosureThisType($call, $calleeReflection, $parameter, $scopeToPass);
+		}
+		$closureScopeType = $parameter->getClosureScopeType();
+
+		if ($closureThisType === null && $closureScopeType === null) {
+			return [$scopeToPass, null];
+		}
+
+		$restoreThisScope = $scopeToPass;
+		if ($closureThisType !== null) {
+			$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes());
+		}
+		if ($closureScopeType !== null) {
+			$scopeToPass = $scopeToPass->withClosureBindScopeClasses($closureScopeType->getObjectClassNames());
+		}
+
+		return [$scopeToPass, $restoreThisScope];
+	}
+
+	/**
 	 * @param MethodReflection|FunctionReflection|null $calleeReflection
 	 * @param ParametersAcceptor[] $parametersAcceptors
 	 * @param ParametersAcceptor[]|null $namedArgumentsVariants
@@ -2039,14 +2076,8 @@ class NodeScopeResolver
 				if (
 					$closureBindScopeFactory === null
 					&& $parameter instanceof ExtendedParameterReflection
-					&& !$arg->value->static
 				) {
-					$closureThisType = $this->resolveClosureThisType($callLike, $calleeReflection, $parameter, $scopeToPass);
-					if ($closureThisType !== null) {
-						$restoreThisScope = $scopeToPass;
-						$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes())
-							->withClosureBindScopeClasses($closureThisType->getObjectClassNames());
-					}
+					[$scopeToPass, $restoreThisScope] = $this->applyClosureThisAndScope($scopeToPass, $callLike, $calleeReflection, $parameter, $arg->value->static);
 				}
 
 				if ($parameter !== null) {
@@ -2131,13 +2162,8 @@ class NodeScopeResolver
 				if (
 					$closureBindScopeFactory === null
 					&& $parameter instanceof ExtendedParameterReflection
-					&& !$arg->value->static
 				) {
-					$closureThisType = $this->resolveClosureThisType($callLike, $calleeReflection, $parameter, $scopeToPass);
-					if ($closureThisType !== null) {
-						$scopeToPass = $scopeToPass->assignVariable('this', $closureThisType, new ObjectWithoutClassType(), TrinaryLogic::createYes())
-							->withClosureBindScopeClasses($closureThisType->getObjectClassNames());
-					}
+					[$scopeToPass] = $this->applyClosureThisAndScope($scopeToPass, $callLike, $calleeReflection, $parameter, $arg->value->static);
 				}
 
 				if ($parameter !== null) {

--- a/src/Analyser/PhpDocsResolver.php
+++ b/src/Analyser/PhpDocsResolver.php
@@ -40,7 +40,7 @@ final class PhpDocsResolver
 	}
 
 	/**
-	 * @return array{TemplateTypeMap, array<string, Type>, array<string, bool>, array<string, Type>, ?Type, ?Type, ?string, bool, bool, bool, bool|null, bool, bool, string|null, Assertions, ?Type, array<string, Type>, array<(string|int), VarTag>, bool, ?ResolvedPhpDocBlock, array<string, bool>}
+	 * @return array{TemplateTypeMap, array<string, Type>, array<string, bool>, array<string, Type>, ?Type, ?Type, ?string, bool, bool, bool, bool|null, bool, bool, string|null, Assertions, ?Type, array<string, Type>, array<(string|int), VarTag>, bool, ?ResolvedPhpDocBlock, array<string, bool>, array<string, Type>}
 	 */
 	public function getPhpDocs(Scope $scope, Node\FunctionLike|Node\Stmt\Property $node): array
 	{
@@ -48,6 +48,7 @@ final class PhpDocsResolver
 		$phpDocParameterTypes = [];
 		$phpDocImmediatelyInvokedCallableParameters = [];
 		$phpDocClosureThisTypeParameters = [];
+		$phpDocClosureScopeTypeParameters = [];
 		$phpDocReturnType = null;
 		$phpDocThrowType = null;
 		$deprecatedDescription = null;
@@ -181,6 +182,16 @@ final class PhpDocsResolver
 				}
 				$phpDocClosureThisTypeParameters[$paramName] = $paramClosureThisType;
 			}
+			foreach ($resolvedPhpDoc->getParamClosureScopeTags() as $paramName => $paramClosureScopeTag) {
+				if (array_key_exists($paramName, $phpDocClosureScopeTypeParameters)) {
+					continue;
+				}
+				$paramClosureScopeType = $paramClosureScopeTag->getType();
+				if ($scope->isInClass()) {
+					$paramClosureScopeType = $this->transformStaticType($scope->getClassReflection(), $paramClosureScopeType);
+				}
+				$phpDocClosureScopeTypeParameters[$paramName] = $paramClosureScopeType;
+			}
 
 			foreach ($resolvedPhpDoc->getParamOutTags() as $paramName => $paramOutTag) {
 				$phpDocParameterOutTypes[$paramName] = $paramOutTag->getType();
@@ -228,7 +239,7 @@ final class PhpDocsResolver
 			}
 		}
 
-		return [$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, $isReadOnly, $docComment, $asserts, $selfOutType, $phpDocParameterOutTypes, $varTags, $isAllowedPrivateMutation, $resolvedPhpDoc, $phpDocPureUnlessCallableIsImpureParameters];
+		return [$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, $isReadOnly, $docComment, $asserts, $selfOutType, $phpDocParameterOutTypes, $varTags, $isAllowedPrivateMutation, $resolvedPhpDoc, $phpDocPureUnlessCallableIsImpureParameters, $phpDocClosureScopeTypeParameters];
 	}
 
 	private function getPhpDocReturnType(ResolvedPhpDocBlock $resolvedPhpDoc, Type $nativeReturnType): ?Type

--- a/src/Analyser/StmtHandler/ClassMethodHandler.php
+++ b/src/Analyser/StmtHandler/ClassMethodHandler.php
@@ -66,7 +66,7 @@ final class ClassMethodHandler implements StmtHandler
 	): InternalStatementResult
 	{
 		$nodeScopeResolver->processAttributeGroups($stmt, $stmt->attrGroups, $scope, $storage, $nodeCallback);
-		[$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, $isReadOnly, $phpDocComment, $asserts, $selfOutType, $phpDocParameterOutTypes, , , , $pureUnlessCallableIsImpureParameters] = $this->phpDocsResolver->getPhpDocs($scope, $stmt);
+		[$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, $isReadOnly, $phpDocComment, $asserts, $selfOutType, $phpDocParameterOutTypes, , , , $pureUnlessCallableIsImpureParameters, $phpDocClosureScopeTypeParameters] = $this->phpDocsResolver->getPhpDocs($scope, $stmt);
 
 		foreach ($stmt->params as $param) {
 			$nodeScopeResolver->processParamNode($stmt, $param, $scope, $storage, $nodeCallback);
@@ -104,6 +104,7 @@ final class ClassMethodHandler implements StmtHandler
 			$isConstructor,
 			null,
 			$pureUnlessCallableIsImpureParameters,
+			$phpDocClosureScopeTypeParameters,
 		);
 
 		if (!$scope->isInClass()) {

--- a/src/Analyser/StmtHandler/FunctionHandler.php
+++ b/src/Analyser/StmtHandler/FunctionHandler.php
@@ -57,7 +57,7 @@ final class FunctionHandler implements StmtHandler
 	): InternalStatementResult
 	{
 		$nodeScopeResolver->processAttributeGroups($stmt, $stmt->attrGroups, $scope, $storage, $nodeCallback);
-		[$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, , $isPure, $acceptsNamedArguments, , $phpDocComment, $asserts,, $phpDocParameterOutTypes, , , , $pureUnlessCallableIsImpureParameters] = $this->phpDocsResolver->getPhpDocs($scope, $stmt);
+		[$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, , $isPure, $acceptsNamedArguments, , $phpDocComment, $asserts,, $phpDocParameterOutTypes, , , , $pureUnlessCallableIsImpureParameters, $phpDocClosureScopeTypeParameters] = $this->phpDocsResolver->getPhpDocs($scope, $stmt);
 
 		foreach ($stmt->params as $param) {
 			$nodeScopeResolver->processParamNode($stmt, $param, $scope, $storage, $nodeCallback);
@@ -88,6 +88,7 @@ final class FunctionHandler implements StmtHandler
 			$phpDocImmediatelyInvokedCallableParameters,
 			$phpDocClosureThisTypeParameters,
 			$pureUnlessCallableIsImpureParameters,
+			$phpDocClosureScopeTypeParameters,
 		);
 		$functionReflection = $functionScope->getFunction();
 		if (!$functionReflection instanceof PhpFunctionFromParserNodeReflection) {

--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -190,11 +190,15 @@ final class DependencyResolver
 									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
 								}
 							}
-							if ($parameter->getClosureThisType() === null) {
-								continue;
+							if ($parameter->getClosureThisType() !== null) {
+								foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
+									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+								}
 							}
-							foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
-								$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+							if ($parameter->getClosureScopeType() !== null) {
+								foreach ($parameter->getClosureScopeType()->getReferencedClasses() as $referencedClass) {
+									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+								}
 							}
 						}
 					}
@@ -229,11 +233,15 @@ final class DependencyResolver
 									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
 								}
 							}
-							if ($parameter->getClosureThisType() === null) {
-								continue;
+							if ($parameter->getClosureThisType() !== null) {
+								foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
+									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+								}
 							}
-							foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
-								$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+							if ($parameter->getClosureScopeType() !== null) {
+								foreach ($parameter->getClosureScopeType()->getReferencedClasses() as $referencedClass) {
+									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+								}
 							}
 						}
 					}
@@ -267,11 +275,15 @@ final class DependencyResolver
 									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
 								}
 							}
-							if ($parameter->getClosureThisType() === null) {
-								continue;
+							if ($parameter->getClosureThisType() !== null) {
+								foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
+									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+								}
 							}
-							foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
-								$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+							if ($parameter->getClosureScopeType() !== null) {
+								foreach ($parameter->getClosureScopeType()->getReferencedClasses() as $referencedClass) {
+									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+								}
 							}
 						}
 					}
@@ -334,17 +346,21 @@ final class DependencyResolver
 							$this->addClassToDependencies($methodReflection->getDeclaringClass()->getName(), $dependenciesReflections);
 							foreach ($methodReflection->getVariants() as $methodVariant) {
 								foreach ($methodVariant->getParameters() as $parameter) {
-									if ($parameter->getOutType() !== null) {
-										foreach ($parameter->getOutType()->getReferencedClasses() as $referencedClass) {
-											$this->addClassToDependencies($referencedClass, $dependenciesReflections);
-										}
+								if ($parameter->getOutType() !== null) {
+									foreach ($parameter->getOutType()->getReferencedClasses() as $referencedClass) {
+										$this->addClassToDependencies($referencedClass, $dependenciesReflections);
 									}
-									if ($parameter->getClosureThisType() === null) {
-										continue;
-									}
+								}
+								if ($parameter->getClosureThisType() !== null) {
 									foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
 										$this->addClassToDependencies($referencedClass, $dependenciesReflections);
 									}
+								}
+								if ($parameter->getClosureScopeType() !== null) {
+									foreach ($parameter->getClosureScopeType()->getReferencedClasses() as $referencedClass) {
+										$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+									}
+								}
 								}
 							}
 						}
@@ -360,11 +376,15 @@ final class DependencyResolver
 										$this->addClassToDependencies($referencedClass, $dependenciesReflections);
 									}
 								}
-								if ($parameter->getClosureThisType() === null) {
-									continue;
+								if ($parameter->getClosureThisType() !== null) {
+									foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
+										$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+									}
 								}
-								foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
-									$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+								if ($parameter->getClosureScopeType() !== null) {
+									foreach ($parameter->getClosureScopeType()->getReferencedClasses() as $referencedClass) {
+										$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+									}
 								}
 							}
 						}
@@ -838,11 +858,15 @@ final class DependencyResolver
 					$this->addClassToDependencies($referencedClass, $dependenciesReflections);
 				}
 			}
-			if ($parameter->getClosureThisType() === null) {
-				continue;
+			if ($parameter->getClosureThisType() !== null) {
+				foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
+					$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+				}
 			}
-			foreach ($parameter->getClosureThisType()->getReferencedClasses() as $referencedClass) {
-				$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+			if ($parameter->getClosureScopeType() !== null) {
+				foreach ($parameter->getClosureScopeType()->getReferencedClasses() as $referencedClass) {
+					$this->addClassToDependencies($referencedClass, $dependenciesReflections);
+				}
 			}
 		}
 

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDoc\Tag\ImplementsTag;
 use PHPStan\PhpDoc\Tag\MethodTag;
 use PHPStan\PhpDoc\Tag\MethodTagParameter;
 use PHPStan\PhpDoc\Tag\MixinTag;
+use PHPStan\PhpDoc\Tag\ParamClosureScopeTag;
 use PHPStan\PhpDoc\Tag\ParamClosureThisTag;
 use PHPStan\PhpDoc\Tag\ParamOutTag;
 use PHPStan\PhpDoc\Tag\ParamTag;
@@ -47,7 +48,6 @@ use function array_merge;
 use function array_reverse;
 use function count;
 use function in_array;
-use function method_exists;
 use function str_starts_with;
 use function substr;
 
@@ -422,6 +422,27 @@ final class PhpDocNodeResolver
 		}
 
 		return $closureThisTypes;
+	}
+
+	/**
+	 * @return array<string, ParamClosureScopeTag>
+	 */
+	public function resolveParamClosureScopeTags(PhpDocNode $phpDocNode, NameScope $nameScope): array
+	{
+		$closureScopeTypes = [];
+		foreach (['@param-closure-scope', '@phpstan-param-closure-scope'] as $tagName) {
+			foreach ($phpDocNode->getParamClosureScopeTagValues($tagName) as $tagValue) {
+				$parameterName = substr($tagValue->parameterName, 1);
+				$closureScopeTypes[$parameterName] = new ParamClosureScopeTag(
+					TypeCombinator::intersect(
+						$this->typeNodeResolver->resolve($tagValue->type, $nameScope),
+						new ObjectWithoutClassType(),
+					),
+				);
+			}
+		}
+
+		return $closureScopeTypes;
 	}
 
 	public function resolveReturnTag(PhpDocNode $phpDocNode, NameScope $nameScope): ?ReturnTag

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -9,6 +9,7 @@ use PHPStan\PhpDoc\Tag\ExtendsTag;
 use PHPStan\PhpDoc\Tag\ImplementsTag;
 use PHPStan\PhpDoc\Tag\MethodTag;
 use PHPStan\PhpDoc\Tag\MixinTag;
+use PHPStan\PhpDoc\Tag\ParamClosureScopeTag;
 use PHPStan\PhpDoc\Tag\ParamClosureThisTag;
 use PHPStan\PhpDoc\Tag\ParamOutTag;
 use PHPStan\PhpDoc\Tag\ParamTag;
@@ -102,6 +103,9 @@ final class ResolvedPhpDocBlock
 
 	/** @var array<string, ParamClosureThisTag>|false */
 	private array|false $paramClosureThisTags = false;
+
+	/** @var array<string, ParamClosureScopeTag>|false */
+	private array|false $paramClosureScopeTags = false;
 
 	private ReturnTag|false|null $returnTag = false;
 
@@ -226,6 +230,7 @@ final class ResolvedPhpDocBlock
 		$self->paramsImmediatelyInvokedCallable = [];
 		$self->paramsPureUnlessCallableIsImpure = [];
 		$self->paramClosureThisTags = [];
+		$self->paramClosureScopeTags = [];
 		$self->returnTag = null;
 		$self->throwsTag = null;
 		$self->mixinTags = [];
@@ -283,6 +288,7 @@ final class ResolvedPhpDocBlock
 		$result->paramsImmediatelyInvokedCallable = self::mergeParamsImmediatelyInvokedCallable($this->getParamsImmediatelyInvokedCallable(), $parent, $parameterMapping);
 		$result->paramsPureUnlessCallableIsImpure = self::mergeParamsPureUnlessCallableIsImpure($this->getParamsPureUnlessCallableIsImpure(), $parent, $parameterMapping);
 		$result->paramClosureThisTags = self::mergeParamClosureThisTags($this->getParamClosureThisTags(), $parent, $parameterMapping, $parentClass);
+		$result->paramClosureScopeTags = self::mergeParamClosureScopeTags($this->getParamClosureScopeTags(), $parent, $parameterMapping, $parentClass);
 		$result->returnTag = self::mergeReturnTags($this->getReturnTag(), $declaringClass, $parent, $parameterMapping, $parentClass);
 		$result->throwsTag = self::mergeThrowsTags($this->getThrowsTag(), $parent);
 		$result->mixinTags = $this->getMixinTags();
@@ -369,6 +375,17 @@ final class ResolvedPhpDocBlock
 			$newParamClosureThisTags[$parameterNameMapping[$key]] = $paramClosureThisTag->withType($transformedType);
 		}
 
+		$paramClosureScopeTags = $this->getParamClosureScopeTags();
+		$newParamClosureScopeTags = [];
+		foreach ($paramClosureScopeTags as $key => $paramClosureScopeTag) {
+			if (!array_key_exists($key, $parameterNameMapping)) {
+				continue;
+			}
+
+			$transformedType = TypeTraverser::map($paramClosureScopeTag->getType(), $mapParameterCb);
+			$newParamClosureScopeTags[$parameterNameMapping[$key]] = $paramClosureScopeTag->withType($transformedType);
+		}
+
 		$returnTag = $this->getReturnTag();
 		if ($returnTag !== null) {
 			$transformedType = TypeTraverser::map($returnTag->getType(), $mapParameterCb);
@@ -406,6 +423,7 @@ final class ResolvedPhpDocBlock
 		$self->paramOutTags = $newParamOutTags;
 		$self->paramsImmediatelyInvokedCallable = $newParamsImmediatelyInvokedCallable;
 		$self->paramClosureThisTags = $newParamClosureThisTags;
+		$self->paramClosureScopeTags = $newParamClosureScopeTags;
 		$self->returnTag = $returnTag;
 		$self->throwsTag = $this->throwsTag;
 		$self->mixinTags = $this->mixinTags;
@@ -619,6 +637,21 @@ final class ResolvedPhpDocBlock
 		}
 
 		return $this->paramClosureThisTags;
+	}
+
+	/**
+	 * @return array<string, ParamClosureScopeTag>
+	 */
+	public function getParamClosureScopeTags(): array
+	{
+		if ($this->paramClosureScopeTags === false) {
+			$this->paramClosureScopeTags = $this->phpDocNodeResolver->resolveParamClosureScopeTags(
+				$this->phpDocNode,
+				$this->getNameScope(),
+			);
+		}
+
+		return $this->paramClosureScopeTags;
 	}
 
 	public function getReturnTag(): ?ReturnTag
@@ -1167,6 +1200,40 @@ final class ResolvedPhpDocBlock
 		}
 
 		return $paramsClosureThisTags;
+	}
+
+	/**
+	 * @param array<string, ParamClosureScopeTag> $paramsClosureScopeTags
+	 * @return array<string, ParamClosureScopeTag>
+	 */
+	private static function mergeParamClosureScopeTags(array $paramsClosureScopeTags, self $parent, InheritedPhpDocParameterMapping $parameterMapping, ClassReflection $parentClass): array
+	{
+		return self::mergeOneParentParamClosureScopeTag($paramsClosureScopeTags, $parent, $parameterMapping, $parentClass);
+	}
+
+	/**
+	 * @param array<string, ParamClosureScopeTag> $paramsClosureScopeTags
+	 * @return array<string, ParamClosureScopeTag>
+	 */
+	private static function mergeOneParentParamClosureScopeTag(array $paramsClosureScopeTags, self $parent, InheritedPhpDocParameterMapping $parameterMapping, ClassReflection $parentClass): array
+	{
+		$parentClosureScopeTags = $parameterMapping->transformArrayKeysWithParameterNameMapping($parent->getParamClosureScopeTags());
+
+		foreach ($parentClosureScopeTags as $name => $parentParamClosureScopeTag) {
+			if (array_key_exists($name, $paramsClosureScopeTags)) {
+				continue;
+			}
+
+			$paramsClosureScopeTags[$name] = self::resolveTemplateTypeInTag(
+				$parentParamClosureScopeTag->withType(
+					$parameterMapping->transformConditionalReturnTypeWithParameterNameMapping($parentParamClosureScopeTag->getType()),
+				),
+				$parentClass,
+				TemplateTypeVariance::createContravariant(),
+			);
+		}
+
+		return $paramsClosureScopeTags;
 	}
 
 	private static function mergePureTags(?bool $isPure, self $parent): ?bool

--- a/src/PhpDoc/Tag/ParamClosureScopeTag.php
+++ b/src/PhpDoc/Tag/ParamClosureScopeTag.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDoc\Tag;
+
+use PHPStan\Type\Type;
+
+/**
+ * @api
+ */
+final class ParamClosureScopeTag implements TypedTag
+{
+
+	public function __construct(
+		private Type $type,
+	)
+	{
+	}
+
+	public function getType(): Type
+	{
+		return $this->type;
+	}
+
+	public function withType(Type $type): self
+	{
+		return new self($type);
+	}
+
+}

--- a/src/Reflection/Annotations/AnnotationsMethodParameterReflection.php
+++ b/src/Reflection/Annotations/AnnotationsMethodParameterReflection.php
@@ -62,6 +62,11 @@ final class AnnotationsMethodParameterReflection implements ExtendedParameterRef
 		return null;
 	}
 
+	public function getClosureScopeType(): ?Type
+	{
+		return null;
+	}
+
 	public function passedByReference(): PassedByReference
 	{
 		return $this->passedByReference;

--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -31,6 +31,7 @@ use PHPStan\Parser\AnonymousClassVisitor;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDoc\StubPhpDocProvider;
+use PHPStan\PhpDoc\Tag\ParamClosureScopeTag;
 use PHPStan\PhpDoc\Tag\ParamClosureThisTag;
 use PHPStan\PhpDoc\Tag\ParamOutTag;
 use PHPStan\Reflection\Assertions;
@@ -295,6 +296,7 @@ final class BetterReflectionProvider implements ReflectionProvider
 		$phpDocParameterOutTags = [];
 		$phpDocParameterImmediatelyInvokedCallable = [];
 		$phpDocParameterClosureThisTypeTags = [];
+		$phpDocParameterClosureScopeTypeTags = [];
 		$phpDocParameterPureUnlessCallableIsImpure = [];
 
 		$resolvedPhpDoc = $this->stubPhpDocProvider->findFunctionPhpDoc($reflectionFunction->getName(), array_map(static fn (ReflectionParameter $parameter): string => $parameter->getName(), $reflectionFunction->getParameters()));
@@ -322,6 +324,7 @@ final class BetterReflectionProvider implements ReflectionProvider
 			$phpDocParameterOutTags = $resolvedPhpDoc->getParamOutTags();
 			$phpDocParameterImmediatelyInvokedCallable = $resolvedPhpDoc->getParamsImmediatelyInvokedCallable();
 			$phpDocParameterClosureThisTypeTags = $resolvedPhpDoc->getParamClosureThisTags();
+			$phpDocParameterClosureScopeTypeTags = $resolvedPhpDoc->getParamClosureScopeTags();
 			$phpDocParameterPureUnlessCallableIsImpure = $resolvedPhpDoc->getParamsPureUnlessCallableIsImpure();
 		}
 
@@ -356,6 +359,7 @@ final class BetterReflectionProvider implements ReflectionProvider
 			array_map(static fn (ParamClosureThisTag $tag): Type => $tag->getType(), $phpDocParameterClosureThisTypeTags),
 			$this->attributeReflectionFactory->fromNativeReflection($reflectionFunction->getAttributes(), InitializerExprContext::fromFunction($reflectionFunction->getName(), $reflectionFunction->getFileName() !== false ? $reflectionFunction->getFileName() : null)),
 			$phpDocParameterPureUnlessCallableIsImpure,
+			array_map(static fn (ParamClosureScopeTag $tag): Type => $tag->getType(), $phpDocParameterClosureScopeTypeTags),
 		);
 	}
 

--- a/src/Reflection/ExtendedParameterReflection.php
+++ b/src/Reflection/ExtendedParameterReflection.php
@@ -24,6 +24,8 @@ interface ExtendedParameterReflection extends ParameterReflection
 
 	public function getClosureThisType(): ?Type;
 
+	public function getClosureScopeType(): ?Type;
+
 	/**
 	 * @return list<AttributeReflection>
 	 */

--- a/src/Reflection/FunctionReflectionFactory.php
+++ b/src/Reflection/FunctionReflectionFactory.php
@@ -17,6 +17,7 @@ interface FunctionReflectionFactory
 	 * @param array<string, Type> $phpDocParameterClosureThisTypes
 	 * @param list<AttributeReflection> $attributes
 	 * @param array<string, bool> $phpDocParameterPureUnlessCallableIsImpure
+	 * @param array<string, Type> $phpDocParameterClosureScopeTypes
 	 */
 	public function create(
 		ReflectionFunction $reflection,
@@ -37,6 +38,7 @@ interface FunctionReflectionFactory
 		array $phpDocParameterClosureThisTypes,
 		array $attributes,
 		array $phpDocParameterPureUnlessCallableIsImpure,
+		array $phpDocParameterClosureScopeTypes = [],
 	): PhpFunctionReflection;
 
 }

--- a/src/Reflection/Native/ExtendedNativeParameterReflection.php
+++ b/src/Reflection/Native/ExtendedNativeParameterReflection.php
@@ -32,6 +32,7 @@ final class ExtendedNativeParameterReflection implements ExtendedParameterReflec
 		private array $attributes,
 		private ?ParameterAllowedConstants $allowedConstants,
 		private TrinaryLogic $pureUnlessCallableIsImpureParameter,
+		private ?Type $closureScopeType = null,
 	)
 	{
 	}
@@ -94,6 +95,11 @@ final class ExtendedNativeParameterReflection implements ExtendedParameterReflec
 	public function getClosureThisType(): ?Type
 	{
 		return $this->closureThisType;
+	}
+
+	public function getClosureScopeType(): ?Type
+	{
+		return $this->closureScopeType;
 	}
 
 	public function getAttributes(): array

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -611,6 +611,14 @@ final class ParametersAcceptorSelector
 				return true;
 			}
 
+			if (
+				$parameter instanceof ExtendedParameterReflection
+				&& $parameter->getClosureScopeType() !== null
+				&& $parameter->getClosureScopeType()->hasTemplateOrLateResolvableType()
+			) {
+				return true;
+			}
+
 			if (!$parameter->getType()->hasTemplateOrLateResolvableType()) {
 				continue;
 			}
@@ -842,6 +850,7 @@ final class ParametersAcceptorSelector
 						$parameter instanceof ExtendedParameterReflection ? $parameter->getAttributes() : [],
 						$parameter instanceof ExtendedParameterReflection ? $parameter->getAllowedConstants() : null,
 						$parameter instanceof ExtendedParameterReflection ? $parameter->isPureUnlessCallableIsImpureParameter() : TrinaryLogic::createNo(),
+						$parameter instanceof ExtendedParameterReflection ? $parameter->getClosureScopeType() : null,
 					);
 					continue;
 				}
@@ -861,6 +870,7 @@ final class ParametersAcceptorSelector
 				$outType = $parameters[$i]->getOutType();
 				$immediatelyInvokedCallable = $parameters[$i]->isImmediatelyInvokedCallable();
 				$closureThisType = $parameters[$i]->getClosureThisType();
+				$closureScopeType = $parameters[$i]->getClosureScopeType();
 				$attributes = $parameters[$i]->getAttributes();
 				if ($parameter instanceof ExtendedParameterReflection) {
 					$nativeType = TypeCombinator::union($nativeType, $parameter->getNativeType());
@@ -878,6 +888,12 @@ final class ParametersAcceptorSelector
 						$closureThisType = null;
 					}
 
+					if ($parameter->getClosureScopeType() !== null && $closureScopeType !== null) {
+						$closureScopeType = TypeCombinator::union($closureScopeType, $parameter->getClosureScopeType());
+					} else {
+						$closureScopeType = null;
+					}
+
 					$immediatelyInvokedCallable = $parameter->isImmediatelyInvokedCallable()->or($immediatelyInvokedCallable);
 					$attributes = array_merge($attributes, $parameter->getAttributes());
 				} else {
@@ -886,6 +902,7 @@ final class ParametersAcceptorSelector
 					$outType = null;
 					$immediatelyInvokedCallable = TrinaryLogic::createMaybe();
 					$closureThisType = null;
+					$closureScopeType = null;
 				}
 
 				$allowedConstants = $parameters[$i]->getAllowedConstants();
@@ -915,6 +932,7 @@ final class ParametersAcceptorSelector
 					$attributes,
 					$allowedConstants,
 					$pureUnlessCallableIsImpureParameter,
+					$closureScopeType,
 				);
 
 				if ($isVariadic) {
@@ -1375,6 +1393,7 @@ final class ParametersAcceptorSelector
 			$wrapped->getAttributes(),
 			$wrapped->getAllowedConstants(),
 			$wrapped->isPureUnlessCallableIsImpureParameter(),
+			$wrapped->getClosureScopeType(),
 		);
 	}
 

--- a/src/Reflection/Php/ExtendedDummyParameter.php
+++ b/src/Reflection/Php/ExtendedDummyParameter.php
@@ -32,6 +32,7 @@ final class ExtendedDummyParameter extends DummyParameter implements ExtendedPar
 		private array $attributes,
 		private ?ParameterAllowedConstants $allowedConstants,
 		private TrinaryLogic $pureUnlessCallableIsImpureParameter,
+		private ?Type $closureScopeType = null,
 	)
 	{
 		parent::__construct($name, $type, $optional, $passedByReference, $variadic, $defaultValue);
@@ -65,6 +66,11 @@ final class ExtendedDummyParameter extends DummyParameter implements ExtendedPar
 	public function getClosureThisType(): ?Type
 	{
 		return $this->closureThisType;
+	}
+
+	public function getClosureScopeType(): ?Type
+	{
+		return $this->closureScopeType;
 	}
 
 	public function getAttributes(): array

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -669,6 +669,7 @@ final class PhpClassReflectionExtension
 					$phpDocParameterOutTypes = [];
 					$immediatelyInvokedCallableParameters = [];
 					$closureThisParameters = [];
+					$closureScopeParameters = [];
 					$currentResolvedPhpDoc = null;
 					$phpDocDeclaringClass = $declaringClass;
 					$phpDocFromStubs = false;
@@ -712,6 +713,7 @@ final class PhpClassReflectionExtension
 						}
 
 						$closureThisParameters = array_map(static fn ($tag) => $tag->getType(), $currentResolvedPhpDoc->getParamClosureThisTags());
+						$closureScopeParameters = array_map(static fn ($tag) => $tag->getType(), $currentResolvedPhpDoc->getParamClosureScopeTags());
 						foreach ($currentResolvedPhpDoc->getParamTags() as $name => $paramTag) {
 							$phpDocParameterTypes[$name] = TemplateTypeHelper::resolveTemplateTypes(
 								$paramTag->getType(),
@@ -759,7 +761,7 @@ final class PhpClassReflectionExtension
 							}
 						}
 					}
-					$variantsByType[$signatureType][] = $this->createNativeMethodVariant($declaringClassName, $methodReflection->getName(), $methodSignature, $phpDocParameterTypes, $phpDocReturnType, $phpDocParameterNameMapping, $phpDocParameterOutTypes, $immediatelyInvokedCallableParameters, $closureThisParameters, $phpDocFromStubs, $signatureType !== 'named');
+					$variantsByType[$signatureType][] = $this->createNativeMethodVariant($declaringClassName, $methodReflection->getName(), $methodSignature, $phpDocParameterTypes, $phpDocReturnType, $phpDocParameterNameMapping, $phpDocParameterOutTypes, $immediatelyInvokedCallableParameters, $closureThisParameters, $phpDocFromStubs, $signatureType !== 'named', $closureScopeParameters);
 				}
 			}
 
@@ -915,6 +917,7 @@ final class PhpClassReflectionExtension
 		$templateTypeMap = TemplateTypeMap::createEmpty();
 		$immediatelyInvokedCallableParameters = [];
 		$closureThisParameters = [];
+		$closureScopeParameters = [];
 		$phpDocThrowType = null;
 		$isInternal = false;
 		$isFinal = false;
@@ -926,6 +929,7 @@ final class PhpClassReflectionExtension
 			$templateTypeMap = $resolvedPhpDoc->getTemplateTypeMap();
 			$immediatelyInvokedCallableParameters = array_map(static fn (bool $immediate) => TrinaryLogic::createFromBoolean($immediate), $resolvedPhpDoc->getParamsImmediatelyInvokedCallable());
 			$closureThisParameters = array_map(static fn ($tag) => $tag->getType(), $resolvedPhpDoc->getParamClosureThisTags());
+			$closureScopeParameters = array_map(static fn ($tag) => $tag->getType(), $resolvedPhpDoc->getParamClosureScopeTags());
 			foreach ($resolvedPhpDoc->getParamsPureUnlessCallableIsImpure() as $paramName => $isPureUnlessCallableIsImpure) {
 				$pureUnlessCallableIsImpureParameters[$paramName] = $isPureUnlessCallableIsImpure;
 			}
@@ -1009,6 +1013,7 @@ final class PhpClassReflectionExtension
 			$acceptsNamedArguments,
 			$this->attributeReflectionFactory->fromNativeReflection($methodReflection->getAttributes(), InitializerExprContext::fromClassMethod($actualDeclaringClass->getName(), $declaringTraitName, $methodReflection->getName(), $actualDeclaringClass->getFileName())),
 			$pureUnlessCallableIsImpureParameters,
+			$closureScopeParameters,
 		);
 	}
 
@@ -1018,6 +1023,7 @@ final class PhpClassReflectionExtension
 	 * @param array<string, Type> $phpDocParameterOutTypes
 	 * @param array<string, TrinaryLogic> $immediatelyInvokedCallableParameters
 	 * @param array<string, Type> $closureThisParameters
+	 * @param array<string, Type> $closureScopeParameters
 	 */
 	private function createNativeMethodVariant(
 		string $declaringClassName,
@@ -1031,6 +1037,7 @@ final class PhpClassReflectionExtension
 		array $closureThisParameters,
 		bool $phpDocFromStubs,
 		bool $usePhpDocParameterNames,
+		array $closureScopeParameters = [],
 	): ExtendedFunctionVariant
 	{
 		$parameters = [];
@@ -1061,6 +1068,11 @@ final class PhpClassReflectionExtension
 				$closureThisType = $closureThisParameters[$phpDocParameterName];
 			}
 
+			$closureScopeType = null;
+			if (isset($closureScopeParameters[$phpDocParameterName])) {
+				$closureScopeType = $closureScopeParameters[$phpDocParameterName];
+			}
+
 			$parameters[] = new ExtendedNativeParameterReflection(
 				$usePhpDocParameterNames
 					? $phpDocParameterName
@@ -1080,6 +1092,7 @@ final class PhpClassReflectionExtension
 				// pure-unless-callable-is-impure is not threaded here because no built-in method
 				// carries it (there are no Class::method entries in functionMetadata.php).
 				TrinaryLogic::createNo(),
+				$closureScopeType,
 			);
 		}
 
@@ -1187,7 +1200,7 @@ final class PhpClassReflectionExtension
 			$classScope = $classScope->enterNamespace($namespace);
 		}
 		$classScope = $classScope->enterClass($declaringClass);
-		[$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, , $phpDocComment, $asserts, $selfOutType, $phpDocParameterOutTypes, , , , $phpDocPureUnlessCallableIsImpureParameters] = $this->phpDocsResolver->getPhpDocs($classScope, $methodNode);
+		[$templateTypeMap, $phpDocParameterTypes, $phpDocImmediatelyInvokedCallableParameters, $phpDocClosureThisTypeParameters, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, , $phpDocComment, $asserts, $selfOutType, $phpDocParameterOutTypes, , , , $phpDocPureUnlessCallableIsImpureParameters, $phpDocClosureScopeTypeParameters] = $this->phpDocsResolver->getPhpDocs($classScope, $methodNode);
 		$methodScope = $classScope->enterClassMethod(
 			$methodNode,
 			$templateTypeMap,
@@ -1209,6 +1222,7 @@ final class PhpClassReflectionExtension
 			false,
 			null,
 			$phpDocPureUnlessCallableIsImpureParameters,
+			$phpDocClosureScopeTypeParameters,
 		);
 
 		$propertyTypes = [];

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -50,6 +50,7 @@ class PhpFunctionFromParserNodeReflection implements FunctionReflection, Extende
 	 * @param array<string, Type> $phpDocClosureThisTypeParameters
 	 * @param list<AttributeReflection> $attributes
 	 * @param array<string, bool> $pureUnlessCallableIsImpureParameters
+	 * @param array<string, Type> $phpDocClosureScopeTypeParameters
 	 */
 	public function __construct(
 		FunctionLike $functionLike,
@@ -74,6 +75,7 @@ class PhpFunctionFromParserNodeReflection implements FunctionReflection, Extende
 		private array $phpDocClosureThisTypeParameters,
 		private array $attributes,
 		private array $pureUnlessCallableIsImpureParameters,
+		private array $phpDocClosureScopeTypeParameters = [],
 	)
 	{
 		$this->functionLike = $functionLike;
@@ -180,6 +182,12 @@ class PhpFunctionFromParserNodeReflection implements FunctionReflection, Extende
 				$closureThisType = null;
 			}
 
+			if (isset($this->phpDocClosureScopeTypeParameters[$parameter->var->name])) {
+				$closureScopeType = $this->phpDocClosureScopeTypeParameters[$parameter->var->name];
+			} else {
+				$closureScopeType = null;
+			}
+
 			$pureUnlessCallableIsImpureParameter = TrinaryLogic::createFromBoolean($this->pureUnlessCallableIsImpureParameters[$parameter->var->name] ?? false);
 
 			$parameters[] = new PhpParameterFromParserNodeReflection(
@@ -197,6 +205,7 @@ class PhpFunctionFromParserNodeReflection implements FunctionReflection, Extende
 				$closureThisType,
 				$this->parameterAttributes[$parameter->var->name] ?? [],
 				$pureUnlessCallableIsImpureParameter,
+				$closureScopeType,
 			);
 		}
 

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -41,6 +41,7 @@ final class PhpFunctionReflection implements FunctionReflection
 	 * @param array<string, Type> $phpDocParameterClosureThisTypes
 	 * @param list<AttributeReflection> $attributes
 	 * @param array<string, bool> $phpDocParameterPureUnlessCallableIsImpure
+	 * @param array<string, Type> $phpDocParameterClosureScopeTypes
 	 */
 	public function __construct(
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
@@ -64,6 +65,7 @@ final class PhpFunctionReflection implements FunctionReflection
 		private array $phpDocParameterClosureThisTypes,
 		private array $attributes,
 		private array $phpDocParameterPureUnlessCallableIsImpure,
+		private array $phpDocParameterClosureScopeTypes = [],
 	)
 	{
 	}
@@ -133,6 +135,7 @@ final class PhpFunctionReflection implements FunctionReflection
 				$this->attributeReflectionFactory->fromNativeReflection($reflection->getAttributes(), InitializerExprContext::fromReflectionParameter($reflection)),
 				$this->allowedConstantsMapProvider->getForFunctionParameter(strtolower($this->reflection->getName()), $reflection->getName()),
 				TrinaryLogic::createFromBoolean($this->phpDocParameterPureUnlessCallableIsImpure[$reflection->getName()] ?? false),
+				$this->phpDocParameterClosureScopeTypes[$reflection->getName()] ?? null,
 			);
 		}, $this->reflection->getParameters());
 	}

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -43,6 +43,7 @@ final class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeR
 	 * @param array<string, bool> $immediatelyInvokedCallableParameters
 	 * @param array<string, Type> $phpDocClosureThisTypeParameters
 	 * @param list<AttributeReflection> $attributes
+	 * @param array<string, Type> $phpDocClosureScopeTypeParameters
 	 */
 	public function __construct(
 		private ClassReflection $declaringClass,
@@ -73,6 +74,7 @@ final class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeR
 		private bool $isConstructor,
 		array $attributes,
 		array $pureUnlessCallableIsImpureParameters,
+		array $phpDocClosureScopeTypeParameters = [],
 	)
 	{
 		if ($this->classMethod instanceof Node\PropertyHook) {
@@ -140,6 +142,7 @@ final class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeR
 			$phpDocClosureThisTypeParameters,
 			$attributes,
 			$pureUnlessCallableIsImpureParameters,
+			$phpDocClosureScopeTypeParameters,
 		);
 	}
 

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -64,6 +64,7 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 	 * @param array<string, Type> $phpDocClosureThisTypeParameters
 	 * @param list<AttributeReflection> $attributes
 	 * @param array<string, bool> $pureUnlessCallableIsImpureParameters
+	 * @param array<string, Type> $phpDocClosureScopeTypeParameters
 	 */
 	public function __construct(
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
@@ -92,6 +93,7 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 		private array $phpDocClosureThisTypeParameters,
 		private array $attributes,
 		private array $pureUnlessCallableIsImpureParameters,
+		private array $phpDocClosureScopeTypeParameters = [],
 	)
 	{
 	}
@@ -232,6 +234,7 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 			$this->attributeReflectionFactory->fromNativeReflection($reflection->getAttributes(), InitializerExprContext::fromReflectionParameter($reflection)),
 			$this->allowedConstantsMapProvider->getForMethodParameter($this->declaringClass->getName(), $this->reflection->getName(), $reflection->getName()),
 			TrinaryLogic::createFromBoolean($this->pureUnlessCallableIsImpureParameters[$reflection->getName()] ?? false),
+			$this->phpDocClosureScopeTypeParameters[$reflection->getName()] ?? null,
 		), $this->reflection->getParameters());
 	}
 
@@ -445,6 +448,7 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 			$this->phpDocClosureThisTypeParameters,
 			$this->attributes,
 			$this->pureUnlessCallableIsImpureParameters,
+			$this->phpDocClosureScopeTypeParameters,
 		);
 	}
 
@@ -480,6 +484,7 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 			$this->phpDocClosureThisTypeParameters,
 			$this->attributes,
 			$this->pureUnlessCallableIsImpureParameters,
+			$this->phpDocClosureScopeTypeParameters,
 		);
 	}
 

--- a/src/Reflection/Php/PhpMethodReflectionFactory.php
+++ b/src/Reflection/Php/PhpMethodReflectionFactory.php
@@ -21,6 +21,7 @@ interface PhpMethodReflectionFactory
 	 * @param array<string, Type> $phpDocClosureThisTypeParameters
 	 * @param list<AttributeReflection> $attributes
 	 * @param array<string, bool> $pureUnlessCallableIsImpureParameters
+	 * @param array<string, Type> $phpDocClosureScopeTypeParameters
 	 */
 	public function create(
 		ClassReflection $declaringClass,
@@ -45,6 +46,7 @@ interface PhpMethodReflectionFactory
 		bool $acceptsNamedArguments,
 		array $attributes,
 		array $pureUnlessCallableIsImpureParameters,
+		array $phpDocClosureScopeTypeParameters = [],
 	): PhpMethodReflection;
 
 }

--- a/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
@@ -34,6 +34,7 @@ final class PhpParameterFromParserNodeReflection implements ExtendedParameterRef
 		private ?Type $closureThisType,
 		private array $attributes,
 		private TrinaryLogic $pureUnlessCallableIsImpureParameter,
+		private ?Type $closureScopeType = null,
 	)
 	{
 	}
@@ -109,6 +110,11 @@ final class PhpParameterFromParserNodeReflection implements ExtendedParameterRef
 	public function getClosureThisType(): ?Type
 	{
 		return $this->closureThisType;
+	}
+
+	public function getClosureScopeType(): ?Type
+	{
+		return $this->closureScopeType;
 	}
 
 	public function getAttributes(): array

--- a/src/Reflection/Php/PhpParameterReflection.php
+++ b/src/Reflection/Php/PhpParameterReflection.php
@@ -38,6 +38,7 @@ final class PhpParameterReflection implements ExtendedParameterReflection
 		private array $attributes,
 		private ?ParameterAllowedConstants $allowedConstants,
 		private TrinaryLogic $pureUnlessCallableIsImpureParameter,
+		private ?Type $closureScopeType = null,
 	)
 	{
 	}
@@ -140,6 +141,11 @@ final class PhpParameterReflection implements ExtendedParameterReflection
 	public function getClosureThisType(): ?Type
 	{
 		return $this->closureThisType;
+	}
+
+	public function getClosureScopeType(): ?Type
+	{
+		return $this->closureScopeType;
 	}
 
 	public function getAttributes(): array

--- a/src/Reflection/ResolvedFunctionVariantWithOriginal.php
+++ b/src/Reflection/ResolvedFunctionVariantWithOriginal.php
@@ -108,6 +108,19 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 						);
 					}
 
+					$closureScopeType = $param->getClosureScopeType();
+					if ($closureScopeType !== null) {
+						$closureScopeType = TypeUtils::resolveLateResolvableTypes(
+							TemplateTypeHelper::resolveTemplateTypes(
+								$this->resolveConditionalTypesForParameter($closureScopeType),
+								$this->resolvedTemplateTypeMap,
+								$this->callSiteVarianceMap,
+								TemplateTypeVariance::createCovariant(),
+							),
+							false,
+						);
+					}
+
 					return new ExtendedDummyParameter(
 						$param->getName(),
 						$paramType,
@@ -123,6 +136,7 @@ final class ResolvedFunctionVariantWithOriginal implements ResolvedFunctionVaria
 						$param->getAttributes(),
 						$param->getAllowedConstants(),
 						$param->isPureUnlessCallableIsImpureParameter(),
+						$closureScopeType,
 					);
 				},
 				$this->parametersAcceptor->getParameters(),

--- a/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
+++ b/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
@@ -133,6 +133,7 @@ final class NativeFunctionReflectionProvider
 						$phpDocType = null;
 						$immediatelyInvokedCallable = TrinaryLogic::createMaybe();
 						$closureThisType = null;
+						$closureScopeType = null;
 						$pureUnlessCallableIsImpureParameter = TrinaryLogic::createFromBoolean($pureUnlessCallableIsImpureParameters[$name] ?? false);
 						if ($phpDoc !== null) {
 							if (array_key_exists($parameterSignature->getName(), $phpDoc->getParamTags())) {
@@ -143,6 +144,9 @@ final class NativeFunctionReflectionProvider
 							}
 							if (array_key_exists($parameterSignature->getName(), $phpDoc->getParamClosureThisTags())) {
 								$closureThisType = $phpDoc->getParamClosureThisTags()[$parameterSignature->getName()]->getType();
+							}
+							if (array_key_exists($parameterSignature->getName(), $phpDoc->getParamClosureScopeTags())) {
+								$closureScopeType = $phpDoc->getParamClosureScopeTags()[$parameterSignature->getName()]->getType();
 							}
 							if (($phpDoc->getParamsPureUnlessCallableIsImpure()[$parameterSignature->getName()] ?? false) === true) {
 								$pureUnlessCallableIsImpureParameter = TrinaryLogic::createYes();
@@ -164,6 +168,7 @@ final class NativeFunctionReflectionProvider
 							[],
 							$allowedConstantsMapProvider->getForFunctionParameter($lowerCasedFunctionName, $parameterSignature->getName()),
 							$pureUnlessCallableIsImpureParameter,
+							$closureScopeType,
 						);
 					}, $functionSignature->getParameters()),
 					$functionSignature->isVariadic(),

--- a/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
@@ -120,6 +120,7 @@ final class CallbackUnresolvedMethodPrototypeReflection implements UnresolvedMet
 							$parameter->getAttributes(),
 							$parameter->getAllowedConstants(),
 							$parameter->isPureUnlessCallableIsImpureParameter(),
+							$parameter->getClosureScopeType() !== null ? $this->transformStaticType($parameter->getClosureScopeType()) : null,
 						);
 					},
 					$acceptor->getParameters(),

--- a/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
@@ -107,6 +107,7 @@ final class CalledOnTypeUnresolvedMethodPrototypeReflection implements Unresolve
 						$parameter->getAttributes(),
 						$parameter->getAllowedConstants(),
 						$parameter->isPureUnlessCallableIsImpureParameter(),
+						$parameter->getClosureScopeType() !== null ? $this->transformStaticType($parameter->getClosureScopeType()) : null,
 					),
 					$acceptor->getParameters(),
 				),

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -754,6 +754,9 @@ final class FunctionDefinitionCheck
 		if ($parameter->getClosureThisType() !== null) {
 			$moreClasses = array_merge($moreClasses, $parameter->getClosureThisType()->getReferencedClasses());
 		}
+		if ($parameter->getClosureScopeType() !== null) {
+			$moreClasses = array_merge($moreClasses, $parameter->getClosureScopeType()->getReferencedClasses());
+		}
 
 		return array_merge(
 			$parameter->getNativeType()->getReferencedClasses(),

--- a/src/Rules/Functions/MissingFunctionParameterTypehintRule.php
+++ b/src/Rules/Functions/MissingFunctionParameterTypehintRule.php
@@ -52,6 +52,12 @@ final class MissingFunctionParameterTypehintRule implements Rule
 				}
 			}
 
+			if ($parameterReflection->getClosureScopeType() !== null) {
+				foreach ($this->checkFunctionParameter($functionReflection, sprintf('@param-closure-scope PHPDoc tag for parameter $%s', $parameterReflection->getName()), $parameterReflection->getClosureScopeType()) as $parameterMessage) {
+					$messages[] = $parameterMessage;
+				}
+			}
+
 			if ($parameterReflection->getOutType() === null) {
 				continue;
 			}

--- a/src/Rules/Methods/MissingMethodParameterTypehintRule.php
+++ b/src/Rules/Methods/MissingMethodParameterTypehintRule.php
@@ -52,6 +52,12 @@ final class MissingMethodParameterTypehintRule implements Rule
 				}
 			}
 
+			if ($parameterReflection->getClosureScopeType() !== null) {
+				foreach ($this->checkMethodParameter($methodReflection, sprintf('@param-closure-scope PHPDoc tag for parameter $%s', $parameterReflection->getName()), $parameterReflection->getClosureScopeType()) as $parameterMessage) {
+					$messages[] = $parameterMessage;
+				}
+			}
+
 			if ($parameterReflection->getOutType() === null) {
 				continue;
 			}

--- a/src/Rules/PhpDoc/ConditionalReturnTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/ConditionalReturnTypeRuleHelper.php
@@ -58,6 +58,16 @@ final class ConditionalReturnTypeRuleHelper
 				});
 			}
 
+			if ($parameter->getClosureScopeType() !== null) {
+				TypeTraverser::map($parameter->getClosureScopeType(), static function (Type $type, callable $traverse) use (&$conditionalTypes): Type {
+					if ($type instanceof ConditionalType || $type instanceof ConditionalTypeForParameter) {
+						$conditionalTypes[] = $type;
+					}
+
+					return $traverse($type);
+				});
+			}
+
 			$parametersByName[$parameter->getName()] = $parameter;
 		}
 

--- a/src/Rules/PhpDoc/IncompatiblePhpDocTypeCheck.php
+++ b/src/Rules/PhpDoc/IncompatiblePhpDocTypeCheck.php
@@ -49,7 +49,7 @@ final class IncompatiblePhpDocTypeCheck
 	{
 		$errors = [];
 
-		foreach (['@param' => $resolvedPhpDoc->getParamTags(), '@param-out' => $resolvedPhpDoc->getParamOutTags(), '@param-closure-this' => $resolvedPhpDoc->getParamClosureThisTags()] as $tagName => $parameters) {
+		foreach (['@param' => $resolvedPhpDoc->getParamTags(), '@param-out' => $resolvedPhpDoc->getParamOutTags(), '@param-closure-this' => $resolvedPhpDoc->getParamClosureThisTags(), '@param-closure-scope' => $resolvedPhpDoc->getParamClosureScopeTags()] as $tagName => $parameters) {
 			foreach ($parameters as $parameterName => $phpDocParamTag) {
 				$phpDocParamType = $phpDocParamTag->getType();
 				$unresolvableType = $this->unresolvableTypeHelper->getUnresolvableType($phpDocParamType);
@@ -169,7 +169,7 @@ final class IncompatiblePhpDocTypeCheck
 						}
 					}
 
-					if ($tagName === '@param-closure-this') {
+					if ($tagName === '@param-closure-this' || $tagName === '@param-closure-scope') {
 						$isNonClosure = (new ClosureType())->isSuperTypeOf($nativeParamType)->no();
 						if ($isNonClosure) {
 							$errors[] = RuleErrorBuilder::message(sprintf(
@@ -177,7 +177,7 @@ final class IncompatiblePhpDocTypeCheck
 								$tagName,
 								$parameterName,
 								$nativeParamType->describe(VerbosityLevel::typeOnly()),
-							))->identifier('paramClosureThis.nonClosure')->build();
+							))->identifier($tagName === '@param-closure-this' ? 'paramClosureThis.nonClosure' : 'paramClosureScope.nonClosure')->build();
 						}
 					}
 				}

--- a/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
+++ b/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
@@ -64,6 +64,7 @@ final class InvalidPHPStanDocTagRule implements Rule
 		'@phpstan-param-immediately-invoked-callable',
 		'@phpstan-param-later-invoked-callable',
 		'@phpstan-param-closure-this',
+		'@phpstan-param-closure-scope',
 		'@phpstan-all-methods-pure',
 		'@phpstan-all-methods-impure',
 	];

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -864,6 +864,9 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			if ($parameter->getClosureThisType() !== null && $parameter->getClosureThisType()->hasTemplateOrLateResolvableType()) {
 				return true;
 			}
+			if ($parameter->getClosureScopeType() !== null && $parameter->getClosureScopeType()->hasTemplateOrLateResolvableType()) {
+				return true;
+			}
 		}
 
 		foreach ($this->assertions->getAll() as $assertTag) {

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -997,6 +997,9 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 			if ($parameter->getClosureThisType() !== null && $parameter->getClosureThisType()->hasTemplateOrLateResolvableType()) {
 				return true;
 			}
+			if ($parameter->getClosureScopeType() !== null && $parameter->getClosureScopeType()->hasTemplateOrLateResolvableType()) {
+				return true;
+			}
 		}
 
 		foreach ($this->assertions->getAll() as $assertTag) {

--- a/tests/PHPStan/Analyser/nsrt/bug-15197.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-15197.php
@@ -1,0 +1,28 @@
+<?php // lint >= 8.0
+
+namespace Bug15197;
+
+use function PHPStan\Testing\assertType;
+
+interface DiInterface
+{
+	/**
+	 * @param-closure-this DiInterface $definition
+	 */
+	public function set(string $name, mixed $definition): void;
+
+	public function get(string $service): object;
+}
+
+class MyServiceProvider
+{
+	const SERVICE_FOO = 'foo';
+
+	public function provide(DiInterface $di): void {
+		$di->set('foobar', function () {
+			assertType(DiInterface::class, $this);
+			assertType("'foo'", self::SERVICE_FOO);
+			assertType('object', $this->get(self::SERVICE_FOO));
+		});
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/param-closure-this.php
+++ b/tests/PHPStan/Analyser/nsrt/param-closure-this.php
@@ -334,6 +334,7 @@ class StaticReturnClosureThis
 
 	/**
 	 * @param-closure-this FooChild $cb
+	 * @param-closure-scope FooChild $cb
 	 */
 	public function withFooChild(callable $cb): void
 	{
@@ -342,6 +343,7 @@ class StaticReturnClosureThis
 
 	/**
 	 * @param-closure-this Foo $cb
+	 * @param-closure-scope Foo $cb
 	 */
 	public function withFoo(callable $cb): void
 	{
@@ -384,6 +386,87 @@ class TestStaticResolutionInParamClosureThis
 		$o->withFoo(function (): ?static {
 			assertType('ParamClosureThis\Foo', $this);
 			return rand() ? $this : null;
+		});
+	}
+
+}
+
+class ClosureThisWithoutScope
+{
+
+	public const SERVICE_FOO = 'foo';
+
+	/**
+	 * @param-closure-this Some $cb
+	 */
+	public function paramClosureThisOnly(callable $cb): void
+	{
+
+	}
+
+	/**
+	 * @param-closure-scope Some $cb
+	 */
+	public function paramClosureScopeOnly(callable $cb): void
+	{
+
+	}
+
+	/**
+	 * @param-closure-this Some $cb
+	 * @param-closure-scope Some $cb
+	 */
+	public function paramClosureThisAndScope(callable $cb): void
+	{
+
+	}
+
+	public function testThisWithoutScope(): void
+	{
+		$this->paramClosureThisOnly(function () {
+			assertType(Some::class, $this);
+			assertType("'foo'", self::SERVICE_FOO);
+		});
+
+		$this->paramClosureThisOnly(fn () => assertType("'foo'", self::SERVICE_FOO));
+	}
+
+	public function testScopeWithoutThis(): void
+	{
+		$this->paramClosureScopeOnly(function () {
+			assertType(sprintf('$this(%s)', self::class), $this);
+		});
+	}
+
+	public function testThisAndScope(): void
+	{
+		$this->paramClosureThisAndScope(function () {
+			assertType(Some::class, $this);
+		});
+	}
+
+}
+
+class BoundScopeClass
+{
+	public const X = 'bound';
+}
+
+class ClosureScopeOnly
+{
+	public const X = 'enclosing';
+
+	/**
+	 * @param-closure-scope BoundScopeClass $cb
+	 */
+	public function withScope(callable $cb): void
+	{
+	}
+
+	public function test(): void
+	{
+		$this->withScope(function () {
+			assertType(sprintf('$this(%s)', ClosureScopeOnly::class), $this);
 		});
 	}
 

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -618,4 +618,15 @@ class ClassConstantRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12827-enum.php'], $expectedErrors);
 	}
 
+	public function testBug15197(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/data/bug-15197.php'], [
+			[
+				'Access to undefined constant Bug15197\BoundScope::MISSING.',
+				61,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-15197.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-15197.php
@@ -1,0 +1,64 @@
+<?php // lint >= 8.0
+
+namespace Bug15197;
+
+interface DiInterface
+{
+	/**
+	 * @param-closure-this DiInterface $definition
+	 */
+	public function set(string $name, mixed $definition): void;
+
+	public function get(string $service): object;
+}
+
+class MyServiceProvider
+{
+	const SERVICE_FOO = 'foo';
+
+	public function provide(DiInterface $di): void {
+		$di->set('foobar', function () {
+			return $this->get(self::SERVICE_FOO);
+		});
+	}
+}
+
+class BoundScope
+{
+	public const X = 'bound';
+}
+
+class Enclosing
+{
+	public const X = 'enclosing';
+
+	/**
+	 * @param-closure-scope BoundScope $cb
+	 */
+	public function withScope(callable $cb): void
+	{
+	}
+
+	/**
+	 * @param-closure-this BoundScope $cb
+	 * @param-closure-scope BoundScope $cb
+	 */
+	public function withThisAndScope(callable $cb): void
+	{
+	}
+
+	public function test(): void
+	{
+		$this->withScope(function () {
+			echo self::X;
+		});
+
+		$this->withThisAndScope(function () {
+			echo self::X;
+		});
+
+		$this->withScope(function () {
+			echo self::MISSING;
+		});
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-11010.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-11010.php
@@ -11,6 +11,7 @@ class HelloWorld
 
 	/**
 	 * @param-closure-this self $cb
+	 * @param-closure-scope self $cb
 	 */
 	public static function cb(\Closure $cb): void
 	{

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -454,6 +454,44 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testParamClosureScope(): void
+	{
+		$this->analyse([__DIR__ . '/data/param-closure-scope.php'], [
+			[
+				'PHPDoc tag @param-closure-scope references unknown parameter: $b',
+				20,
+			],
+			[
+				'PHPDoc tag @param-closure-scope for parameter $i contains unresolvable type.',
+				27,
+			],
+			[
+				'PHPDoc tag @param-closure-scope for parameter $i contains unresolvable type.',
+				34,
+			],
+			[
+				'PHPDoc tag @param-closure-scope is for parameter $i with non-Closure type string.',
+				41,
+			],
+			[
+				'PHPDoc tag @param-closure-scope for parameter $i contains generic type Exception<int, float> but class Exception is not generic.',
+				48,
+			],
+			[
+				'Generic type ParamClosureScopePhpDocRule\FooBar<mixed> in PHPDoc tag @param-closure-scope for parameter $i does not specify all template types of class ParamClosureScopePhpDocRule\FooBar: T, TT',
+				55,
+			],
+			[
+				'Type mixed in generic type ParamClosureScopePhpDocRule\FooBar<mixed> in PHPDoc tag @param-closure-scope for parameter $i is not subtype of template type T of int of class ParamClosureScopePhpDocRule\FooBar.',
+				55,
+			],
+			[
+				'Generic type ParamClosureScopePhpDocRule\FooBar<int> in PHPDoc tag @param-closure-scope for parameter $i does not specify all template types of class ParamClosureScopePhpDocRule\FooBar: T, TT',
+				62,
+			],
+		]);
+	}
+
 	public function testGenericStatic(): void
 	{
 		$this->analyse([__DIR__ . '/data/incompatible-phpdoc-generic-static.php'], [

--- a/tests/PHPStan/Rules/PhpDoc/data/param-closure-scope.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/param-closure-scope.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ParamClosureScopePhpDocRule;
+
+class Foo
+{
+
+}
+
+/**
+ * @param-closure-scope Foo $i
+ */
+function validParamClosureScope(callable $i) {
+
+}
+
+/**
+ * @param-closure-scope Foo $b
+ */
+function invalidParamClosureScopeParamName($a) {
+
+}
+
+/**
+ * @param-closure-scope string $i
+ */
+function nonObjectParamClosureScope(callable $i) {
+
+}
+
+/**
+ * @param-closure-scope \stdClass&\Exception $i
+ */
+function unresolvableParamClosureScope(callable $i) {
+
+}
+
+/**
+ * @param-closure-scope Foo $i
+ */
+function paramClosureScopeAboveNonClosure(string $i) {
+
+}
+
+/**
+ * @param-closure-scope \Exception<int, float> $i
+ */
+function invalidParamClosureScopeGeneric(callable $i) {
+
+}
+
+/**
+ * @param-closure-scope FooBar<mixed> $i
+ */
+function invalidParamClosureScopeWrongGenericParams(callable $i) {
+
+}
+
+/**
+ * @param-closure-scope FooBar<int> $i
+ */
+function invalidParamClosureScopeNotAllGenericParams(callable $i) {
+
+}
+
+/**
+ * @template T of int
+ * @template TT of string
+ */
+class FooBar {
+
+}


### PR DESCRIPTION
Hello!

This adds a new `@phpstan-closure-scope` tag to properly support both arguments to `Closure::bindTo`

Note, this depends on https://github.com/phpstan/phpdoc-parser/pull/319

Closes https://github.com/phpstan/phpstan/issues/15197

cc: @dantleech, @staabm 