### PR TITLE
Fix PHP 8.6 deprecation in hoa/consistency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,8 @@
 				"patches/TreeNode.patch"
 			],
 			"hoa/consistency": [
-				"patches/Consistency.patch"
+				"patches/Consistency.patch",
+				"patches/Prelude.patch"
 			],
 			"hoa/protocol": [
 				"patches/Node.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "55d62e3e19cd6606c2f5269dd2b68db1",
+  "content-hash": "ff2813cff2047707b62386eb5c7906d7",
   "packages": [
     {
       "name": "clue/ndjson-react",

--- a/patches/Prelude.patch
+++ b/patches/Prelude.patch
@@ -1,0 +1,11 @@
+--- Prelude.php
++++ Prelude.php
+@@ -49,7 +49,7 @@
+ 
+ $define = function ($constantName, $constantValue, $case = false) {
+     if (!defined($constantName)) {
+-        return define($constantName, $constantValue, $case);
++        return define($constantName, $constantValue);
+     }
+ 
+     return false;


### PR DESCRIPTION
Running PHPStan on PHP 8.6 prints 24 deprecations before it does anything:

```
Deprecated: define(): Argument #3 ($case_insensitive) is ignored and treated as false since
declaration of case-insensitive constants is no longer supported, passing the argument
explicitly is unnecessary in vendor/hoa/consistency/Prelude.php on line 52
```

All 24 come from that one line. `Prelude.php` is in composer's `autoload.files`, so it runs on every
`vendor/autoload.php` include, and `hoa/consistency` arrives through `hoa/compiler` in `require`.

```php
$define = function ($constantName, $constantValue, $case = false) {
    if (!defined($constantName)) {
        return define($constantName, $constantValue, $case);
    }
```

Dropping the third argument changes nothing. All 27 `$define()` call sites pass two arguments, so `$case`
is always `false`. I parsed them with a brace-aware scan rather than a grep, because one call spans three
lines.

Measured on `8.6.0beta2`, through a real `composer install` so the patch goes through
`cweagans/composer-patches`:

| | deprecations on autoload |
| --- | --- |
| 8.6 before | 24 |
| 8.6 after | 0 |
| 8.5, either way | 0 |

Same three-file shape as d36a97f70 and 44deb6bf4, the two 8.5 deprecation fixes. The constants come out
identical afterwards: `SUCCEED`, `FAILED`, `WITH_COMPOSER`, `DS` and `PS` all keep their values.

This is one piece of PHP 8.6 support, and it stands on its own. It is the Hoa problem you expected in
point 3.
