### PR TITLE
Trust own types from a source checkout, memoize ClassReflection::getName(), inline getters in the phar build

### DIFF
--- a/build/PHPStan/Build/InlineCallCollector.php
+++ b/build/PHPStan/Build/InlineCallCollector.php
@@ -1,0 +1,522 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Build;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Parser\Parser;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\ShouldNotHappenException;
+use Throwable;
+use function array_keys;
+use function count;
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function in_array;
+use function is_string;
+use function json_decode;
+use function strtolower;
+use function substr;
+
+/**
+ * Source-level inliner for the phar build (compiler's PrepareCommand): for
+ * every method call whose receiver type resolves to a single class and whose
+ * callee body is one `return <expr>;`, records a textual replacement of the
+ * call with that expression ($this and parameters substituted), plus the
+ * non-public properties the expression reads (they become public for the
+ * rewrite to run — see InlineEditsApplier in the compiler).
+ *
+ * Callees are ones no subclass can override — final class, final or private
+ * method — or, closed-world, non-final ones nothing in the scanned code base
+ * overrides (OverridesScanner). Every call frame saved is engine work saved:
+ * a getter call costs about 40ns of frame setup for a body that reads one
+ * property; a self-analysis measured -4% user CPU.
+ *
+ * @implements Collector<MethodCall, array{file: string, start: int, end: int, replacement: string, callee: string, publicize: list<array{class: string, property: string, file: string|null}>}>
+ */
+final class InlineCallCollector implements Collector
+{
+
+	private const MAX_EXPR_NODES = 30;
+
+	/** @var array<string, array<string, Stmt\ClassMethod|null>> */
+	private array $methodNodes = [];
+
+	/** @var array<string, true>|null */
+	private ?array $overrides = null;
+
+	public function __construct(private Parser $parser, private ReflectionProvider $reflectionProvider)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return MethodCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): ?array
+	{
+		if (!$node->name instanceof Node\Identifier || $node->isFirstClassCallable()) {
+			return null;
+		}
+		$args = $node->getArgs();
+		foreach ($args as $arg) {
+			if ($arg->name !== null || $arg->unpack || $arg->byRef) {
+				return null;
+			}
+		}
+		$methodName = $node->name->toString();
+		$classReflections = $scope->getType($node->var)->getObjectClassReflections();
+		if (count($classReflections) !== 1) {
+			return null;
+		}
+		$classReflection = $classReflections[0];
+		if (!$classReflection->hasNativeMethod($methodName)) {
+			return null;
+		}
+		$method = $classReflection->getNativeMethod($methodName);
+		$declaringClass = $method->getDeclaringClass();
+		if ($method->isStatic()) {
+			return null;
+		}
+		// a turbo-shadowed class runs natively: its PHP twin's bodies (and
+		// properties) are not what executes, so they must not be inlined
+		if ($this->isShadowedByTurbo($declaringClass)) {
+			return null;
+		}
+		$guardFree = $declaringClass->isFinal() || $method->isFinal()->yes() || $method->isPrivate();
+		if (!$guardFree && $this->isOverridden($declaringClass, $methodName)) {
+			return null;
+		}
+
+		$methodNode = $this->findMethodNode($declaringClass, $methodName);
+		if ($methodNode === null || $methodNode->byRef || $methodNode->isStatic() || $methodNode->stmts === null) {
+			return null;
+		}
+		$stmts = $methodNode->stmts;
+		if (count($stmts) !== 1 || !$stmts[0] instanceof Stmt\Return_ || $stmts[0]->expr === null) {
+			return null;
+		}
+		if (count($args) !== count($methodNode->params)) {
+			return null;
+		}
+		$paramNames = [];
+		foreach ($methodNode->params as $i => $param) {
+			if ($param->byRef || $param->variadic || !$param->var instanceof Expr\Variable || !is_string($param->var->name)) {
+				return null;
+			}
+			$paramNames[$param->var->name] = $i;
+		}
+
+		$expr = $stmts[0]->expr;
+		$finder = new NodeFinder();
+		$forbidden = $finder->findFirst($expr, static function (Node $n) use ($paramNames): bool {
+			if ($n instanceof Expr\Closure || $n instanceof Expr\ArrowFunction || $n instanceof Expr\Yield_ || $n instanceof Expr\YieldFrom
+				|| $n instanceof Expr\Assign || $n instanceof Expr\AssignOp || $n instanceof Expr\AssignRef
+				|| $n instanceof Expr\PreInc || $n instanceof Expr\PostInc || $n instanceof Expr\PreDec || $n instanceof Expr\PostDec
+				|| $n instanceof Node\Scalar\MagicConst || $n instanceof Expr\Include_ || $n instanceof Expr\Eval_
+				|| $n instanceof Expr\Match_ || $n instanceof Expr\Throw_ || $n instanceof Expr\Exit_ || $n instanceof Expr\ErrorSuppress
+				|| $n instanceof Expr\List_ || $n instanceof Expr\Isset_ || $n instanceof Expr\Empty_) {
+				return true;
+			}
+			if (($n instanceof Expr\StaticCall || $n instanceof Expr\ClassConstFetch || $n instanceof Expr\StaticPropertyFetch || $n instanceof Expr\New_ || $n instanceof Expr\Instanceof_)
+				&& (!$n->class instanceof Node\Name || in_array(strtolower($n->class->toString()), ['self', 'static', 'parent'], true))) {
+				return true;
+			}
+			if ($n instanceof Expr\FuncCall) {
+				if (!$n->name instanceof Node\Name) {
+					return true;
+				}
+				if (in_array(strtolower($n->name->toString()), ['func_get_args', 'func_num_args', 'func_get_arg', 'compact', 'extract', 'get_called_class', 'get_class', 'debug_backtrace'], true)) {
+					return true;
+				}
+			}
+			if ($n instanceof Expr\Variable) {
+				if (!is_string($n->name)) {
+					return true;
+				}
+				if ($n->name !== 'this' && !isset($paramNames[$n->name])) {
+					return true; // superglobals, static vars, undefined
+				}
+			}
+			if ($n instanceof Expr\PropertyFetch && !($n->var instanceof Expr\Variable && $n->var->name === 'this')) {
+				return true; // could be a same-class private on another instance
+			}
+			if ($n instanceof Expr\NullsafePropertyFetch || $n instanceof Expr\NullsafeMethodCall) {
+				return true;
+			}
+			return false;
+		});
+		if ($forbidden !== null) {
+			return null;
+		}
+		if (count($finder->find($expr, static fn (): bool => true)) > self::MAX_EXPR_NODES) {
+			return null;
+		}
+
+		$thisUses = count($finder->find($expr, static fn (Node $n): bool => $n instanceof Expr\Variable && $n->name === 'this'));
+		if ($thisUses !== 1 && !self::isSimple($node->var)) {
+			return null;
+		}
+		foreach ($paramNames as $name => $i) {
+			$uses = count($finder->find($expr, static fn (Node $n): bool => $n instanceof Expr\Variable && $n->name === $name));
+			if ($uses !== 1 && !self::isSimple($args[$i]->value)) {
+				return null;
+			}
+		}
+
+		// everything the expression calls or reads must stay accessible from the
+		// call site's class — private methods, constants and constructors do not
+		if (!$this->innerMembersArePublic($expr, $declaringClass, $method, $paramNames)) {
+			return null;
+		}
+
+		$publicize = [];
+		$callSiteClass = $scope->getClassReflection();
+		foreach ($finder->findInstanceOf($expr, Expr\PropertyFetch::class) as $fetch) {
+			if (!$fetch->name instanceof Node\Identifier) {
+				return null;
+			}
+			$propertyName = $fetch->name->toString();
+			if (!$declaringClass->hasNativeProperty($propertyName)) {
+				return null;
+			}
+			$property = $declaringClass->getNativeProperty($propertyName);
+			if ($property->isPublic()) {
+				continue;
+			}
+			$propertyDeclaringClass = $property->getDeclaringClass();
+			if ($callSiteClass !== null && $callSiteClass->getName() === $propertyDeclaringClass->getName()) {
+				continue;
+			}
+			foreach ($this->publicizeTargets($propertyDeclaringClass->getName(), $propertyName) as $target) {
+				$publicize[] = $target;
+			}
+		}
+
+		// PHPStan synthesizes MethodCall nodes (nullsafe desugaring, closures, …)
+		// with position attributes copied from other nodes: accept only a node
+		// whose source slice literally is this call
+		$start = $node->getStartFilePos();
+		$end = $node->getEndFilePos();
+		if (!$this->sliceIsThisCall($scope->getFile(), $start, $end, $methodName, count($args))) {
+			return null;
+		}
+
+		$replacement = $this->substitute($expr, $node->var, $paramNames, $args);
+		$code = (new Standard())->prettyPrintExpr($replacement);
+		if (!self::isAtom($replacement)) {
+			$code = '(' . $code . ')';
+		}
+
+		return [
+			'file' => $scope->getFile(),
+			'start' => $start,
+			'end' => $end,
+			'replacement' => $code,
+			'callee' => $declaringClass->getName() . '::' . $methodName,
+			'publicize' => $publicize,
+		];
+	}
+
+	/**
+	 * @param array<string, int> $paramNames
+	 */
+	private function innerMembersArePublic(Expr $expr, ClassReflection $declaringClass, ExtendedMethodReflection $method, array $paramNames): bool
+	{
+		$finder = new NodeFinder();
+		$parameters = $method->getOnlyVariant()->getParameters();
+		foreach ($finder->findInstanceOf($expr, MethodCall::class) as $call) {
+			if (!$call->name instanceof Node\Identifier) {
+				return false;
+			}
+			$receivers = null;
+			if ($call->var instanceof Expr\Variable && $call->var->name === 'this') {
+				$receivers = [$declaringClass];
+			} elseif ($call->var instanceof Expr\Variable && is_string($call->var->name) && isset($paramNames[$call->var->name])) {
+				$parameter = $parameters[$paramNames[$call->var->name]] ?? null;
+				$receivers = $parameter === null ? null : $parameter->getType()->getObjectClassReflections();
+			} elseif ($call->var instanceof Expr\PropertyFetch && $call->var->var instanceof Expr\Variable && $call->var->var->name === 'this' && $call->var->name instanceof Node\Identifier) {
+				$propertyName = $call->var->name->toString();
+				$receivers = $declaringClass->hasNativeProperty($propertyName)
+					? $declaringClass->getNativeProperty($propertyName)->getReadableType()->getObjectClassReflections()
+					: null;
+			}
+			if ($receivers === null || $receivers === []) {
+				return false;
+			}
+			foreach ($receivers as $receiver) {
+				$name = $call->name->toString();
+				if (!$receiver->hasNativeMethod($name) || !$receiver->getNativeMethod($name)->isPublic()) {
+					return false;
+				}
+			}
+		}
+		foreach ($finder->findInstanceOf($expr, Expr\StaticCall::class) as $call) {
+			if (!$call->class instanceof Node\Name || !$call->name instanceof Node\Identifier || !$this->reflectionProvider->hasClass($call->class->toString())) {
+				return false;
+			}
+			$class = $this->reflectionProvider->getClass($call->class->toString());
+			if (!$class->hasNativeMethod($call->name->toString()) || !$class->getNativeMethod($call->name->toString())->isPublic()) {
+				return false;
+			}
+		}
+		foreach ($finder->findInstanceOf($expr, Expr\ClassConstFetch::class) as $fetch) {
+			if (!$fetch->class instanceof Node\Name || !$fetch->name instanceof Node\Identifier) {
+				return false;
+			}
+			if (strtolower($fetch->name->toString()) === 'class') {
+				continue;
+			}
+			if (!$this->reflectionProvider->hasClass($fetch->class->toString())) {
+				return false;
+			}
+			$class = $this->reflectionProvider->getClass($fetch->class->toString());
+			if (!$class->hasConstant($fetch->name->toString()) || !$class->getConstant($fetch->name->toString())->isPublic()) {
+				return false;
+			}
+		}
+		foreach ($finder->findInstanceOf($expr, Expr\New_::class) as $new) {
+			if (!$new->class instanceof Node\Name || !$this->reflectionProvider->hasClass($new->class->toString())) {
+				return false;
+			}
+			$class = $this->reflectionProvider->getClass($new->class->toString());
+			if ($class->hasConstructor() && !$class->getConstructor()->isPublic()) {
+				return false;
+			}
+		}
+		if ($finder->findFirstInstanceOf($expr, Expr\StaticPropertyFetch::class) !== null) {
+			return false; // rare; not worth resolving
+		}
+
+		return true;
+	}
+
+	/** @var array<string, string> */
+	private array $fileContents = [];
+
+	private function sliceIsThisCall(string $file, int $start, int $end, string $methodName, int $argCount): bool
+	{
+		if ($start < 0 || $end < $start) {
+			return false;
+		}
+		if (!isset($this->fileContents[$file])) {
+			$contents = file_get_contents($file);
+			$this->fileContents[$file] = $contents === false ? '' : $contents;
+		}
+		$slice = substr($this->fileContents[$file], $start, $end - $start + 1);
+		try {
+			$stmts = (new ParserFactory())->createForHostVersion()->parse('<?php ' . $slice . ';');
+		} catch (Throwable) {
+			return false;
+		}
+		if ($stmts === null || count($stmts) !== 1 || !$stmts[0] instanceof Stmt\Expression) {
+			return false;
+		}
+		$call = $stmts[0]->expr;
+
+		return $call instanceof MethodCall
+			&& $call->name instanceof Node\Identifier
+			&& $call->name->toString() === $methodName
+			&& !$call->isFirstClassCallable()
+			&& count($call->getArgs()) === $argCount;
+	}
+
+	private function findMethodNode(ClassReflection $classReflection, string $methodName): ?Stmt\ClassMethod
+	{
+		$file = $classReflection->getFileName();
+		if ($file === null) {
+			return null;
+		}
+		$key = $file . '#' . strtolower($classReflection->getName());
+		if (!isset($this->methodNodes[$key])) {
+			$this->methodNodes[$key] = [];
+			foreach ((new NodeFinder())->findInstanceOf($this->parser->parseFile($file), Stmt\ClassLike::class) as $classLike) {
+				if (!isset($classLike->namespacedName) || strtolower($classLike->namespacedName->toString()) !== strtolower($classReflection->getName())) {
+					continue;
+				}
+				foreach ($classLike->getMethods() as $classMethod) {
+					$this->methodNodes[$key][strtolower($classMethod->name->toString())] = $classMethod;
+				}
+			}
+		}
+
+		return $this->methodNodes[$key][strtolower($methodName)] ?? null;
+	}
+
+	/**
+	 * @param array<string, int> $paramNames
+	 * @param list<Node\Arg> $args
+	 */
+	private function substitute(Expr $expr, Expr $receiver, array $paramNames, array $args): Expr
+	{
+		$cloner = new NodeTraverser(new CloningVisitor());
+		$clone = $cloner->traverse([$expr])[0];
+		$substituted = (new NodeTraverser(new class ($receiver, $paramNames, $args) extends NodeVisitorAbstract {
+
+			/**
+			 * @param array<string, int> $paramNames
+			 * @param list<Node\Arg> $args
+			 */
+			public function __construct(private Expr $receiver, private array $paramNames, private array $args)
+			{
+			}
+
+			#[Override]
+			public function leaveNode(Node $node): ?Node
+			{
+				if (!$node instanceof Expr\Variable || !is_string($node->name)) {
+					return null;
+				}
+				if ($node->name === 'this') {
+					return (new NodeTraverser(new CloningVisitor()))->traverse([$this->receiver])[0];
+				}
+				if (isset($this->paramNames[$node->name])) {
+					return (new NodeTraverser(new CloningVisitor()))->traverse([$this->args[$this->paramNames[$node->name]]->value])[0];
+				}
+
+				return null;
+			}
+
+		}))->traverse([$clone])[0];
+		if (!$substituted instanceof Expr) {
+			throw new ShouldNotHappenException();
+		}
+
+		return $substituted;
+	}
+
+	private static function isSimple(Expr $expr): bool
+	{
+		if ($expr instanceof Expr\Variable) {
+			return is_string($expr->name);
+		}
+		if ($expr instanceof Expr\PropertyFetch) {
+			return $expr->name instanceof Node\Identifier && self::isSimple($expr->var);
+		}
+		return $expr instanceof Node\Scalar\String_
+			|| $expr instanceof Node\Scalar\Int_
+			|| $expr instanceof Node\Scalar\Float_
+			|| $expr instanceof Expr\ConstFetch
+			|| ($expr instanceof Expr\ClassConstFetch && $expr->class instanceof Node\Name);
+	}
+
+	private static function isAtom(Expr $expr): bool
+	{
+		return $expr instanceof Expr\Variable
+			|| $expr instanceof Expr\PropertyFetch
+			|| $expr instanceof Expr\MethodCall
+			|| $expr instanceof Expr\StaticCall
+			|| $expr instanceof Expr\FuncCall
+			|| $expr instanceof Expr\ConstFetch
+			|| $expr instanceof Expr\ClassConstFetch
+			|| $expr instanceof Expr\StaticPropertyFetch
+			|| $expr instanceof Expr\ArrayDimFetch
+			|| $expr instanceof Expr\Array_
+			|| $expr instanceof Node\Scalar;
+	}
+
+	/** @var array<string, true>|null lowercase FQCNs from vendor/turbo-shadowed-classes.json */
+	private ?array $shadowed = null;
+
+	private function isShadowedByTurbo(ClassReflection $classReflection): bool
+	{
+		if ($this->shadowed === null) {
+			$this->shadowed = [];
+			$manifest = dirname(__DIR__, 3) . '/vendor/turbo-shadowed-classes.json';
+			if (file_exists($manifest)) {
+				foreach (array_keys(json_decode((string) file_get_contents($manifest), true)) as $className) {
+					$this->shadowed[strtolower((string) $className)] = true;
+				}
+			}
+		}
+		foreach ([$classReflection, ...$classReflection->getParents()] as $class) {
+			if (isset($this->shadowed[strtolower($class->getName())])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private ?OverridesScanner $scanner = null;
+
+	private function scanner(): OverridesScanner
+	{
+		if ($this->scanner === null) {
+			$this->scanner = new OverridesScanner();
+			$this->overrides = $this->scanner->scan(self::directories());
+		}
+
+		return $this->scanner;
+	}
+
+	private function isOverridden(ClassReflection $declaringClass, string $methodName): bool
+	{
+		$this->scanner();
+
+		return isset($this->overrides[strtolower($declaringClass->getName()) . '::' . strtolower($methodName)]);
+	}
+
+	/**
+	 * The declaration to make public, in the class's own file or in the file
+	 * of the trait declaring it, plus every redeclaration in a subclass (a
+	 * caller reading the parent's property on a subclass instance would
+	 * otherwise hit the subclass's private one).
+	 *
+	 * @return list<array{class: string, property: string, file: string|null}>
+	 */
+	private function publicizeTargets(string $className, string $propertyName): array
+	{
+		$scanner = $this->scanner();
+		$lcClass = strtolower($className);
+		$targets = [[
+			'class' => $className,
+			'property' => $propertyName,
+			'file' => $scanner->propertyFile($lcClass, $propertyName),
+		]];
+		foreach ($scanner->redeclaringDescendants($lcClass, $propertyName) as $descendant) {
+			$targets[] = [
+				'class' => $descendant,
+				'property' => $propertyName,
+				'file' => $scanner->propertyFile($descendant, $propertyName),
+			];
+		}
+
+		return $targets;
+	}
+
+	/**
+	 * The code the phar holds and runs, as far as inlining reaches into it:
+	 * PHPStan itself and the three vendor packages on its hot paths (the
+	 * paths of build/inline.neon).
+	 *
+	 * @return list<string>
+	 */
+	public static function directories(): array
+	{
+		$root = dirname(__DIR__, 3);
+
+		return [
+			$root . '/src',
+			$root . '/vendor/nikic/php-parser/lib',
+			$root . '/vendor/phpstan/phpdoc-parser/src',
+			$root . '/vendor/ondrejmirtes/better-reflection/src',
+		];
+	}
+
+}

--- a/build/PHPStan/Build/InlineEditsRule.php
+++ b/build/PHPStan/Build/InlineEditsRule.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Build;
+
+use JsonException;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use function count;
+use function file_put_contents;
+use function fwrite;
+use function getenv;
+use function json_encode;
+use function sprintf;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const PHP_EOL;
+use const STDERR;
+
+/**
+ * Writes the edits gathered by InlineCallCollector to INLINE_EDITS_OUT.
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final class InlineEditsRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return CollectedDataNode::class;
+	}
+
+	/**
+	 * @throws JsonException
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$edits = [];
+		foreach ($node->get(InlineCallCollector::class) as $items) {
+			foreach ($items as $item) {
+				$edits[] = $item;
+			}
+		}
+		$out = getenv('INLINE_EDITS_OUT');
+		if ($out !== false) {
+			file_put_contents($out, json_encode($edits, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+		}
+		fwrite(STDERR, sprintf('inline edits collected: %d%s', count($edits), PHP_EOL));
+
+		return [];
+	}
+
+}

--- a/build/PHPStan/Build/OverridesScanner.php
+++ b/build/PHPStan/Build/OverridesScanner.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Build;
+
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Throwable;
+use function file_get_contents;
+use function is_dir;
+use function is_string;
+use function str_ends_with;
+use function strtolower;
+
+/**
+ * Which methods some class in the scanned code base overrides — the
+ * closed-world half of InlineCallCollector: a non-final method nothing
+ * overrides is as safe to inline as a final one, as long as the code base is
+ * the whole world (PHPStan's own phar, where extensions subclassing
+ * PHPStan's classes are the accepted exception: they still work, they just
+ * see the parent's inlined bodies at PHPStan's own call sites).
+ *
+ * Conservative: a method declared by a class (or by a trait it uses) counts
+ * as overriding it on every ancestor, whether or not that ancestor declares
+ * it.
+ */
+final class OverridesScanner
+{
+
+	/** @var array<string, array{file: string, parent: string|null, traits: list<string>, properties: array<string, true>}> lc class => facts */
+	private array $classes = [];
+
+	/**
+	 * The classes below $lcClass (transitively) that declare $property
+	 * themselves — a private property redeclared in a subclass is a distinct
+	 * property, and a caller reading the parent's, now public, one on a
+	 * subclass instance would hit the subclass's private one instead.
+	 *
+	 * @return list<string> lc class names
+	 */
+	public function redeclaringDescendants(string $lcClass, string $property): array
+	{
+		$result = [];
+		foreach ($this->classes as $name => $facts) {
+			if ($name === $lcClass || !isset($facts['properties'][$property])) {
+				continue;
+			}
+			$ancestor = $facts['parent'];
+			$depth = 0;
+			while ($ancestor !== null && $depth++ < 64) {
+				if ($ancestor === $lcClass) {
+					$result[] = $name;
+					break;
+				}
+				$ancestor = $this->classes[$ancestor]['parent'] ?? null;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * The file where $property of $lcClass is written: the class's own file,
+	 * or the file of the trait (transitively) that declares it.
+	 */
+	public function propertyFile(string $lcClass, string $property): ?string
+	{
+		$facts = $this->classes[$lcClass] ?? null;
+		if ($facts === null) {
+			return null;
+		}
+		if (isset($facts['properties'][$property])) {
+			return $facts['file'];
+		}
+		foreach ($facts['traits'] as $trait) {
+			$file = $this->propertyFile($trait, $property);
+			if ($file !== null) {
+				return $file;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param list<string> $directories
+	 * @return array<string, true> keys "lowercase\fqcn::lowercasemethod"
+	 */
+	public function scan(array $directories): array
+	{
+		$parser = (new ParserFactory())->createForHostVersion();
+		$finder = new NodeFinder();
+		$traverser = new NodeTraverser(new NameResolver());
+
+		/** @var array<string, string|null> $parents lc class => lc parent */
+		$parents = [];
+		/** @var array<string, list<string>> $traits lc class => lc traits */
+		$traits = [];
+		/** @var array<string, list<string>> $methods lc class => lc methods (own) */
+		$methods = [];
+
+		foreach ($directories as $directory) {
+			if (!is_dir($directory)) {
+				continue;
+			}
+			/** @var SplFileInfo $file */
+			foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
+				if (!$file->isFile() || !str_ends_with($file->getFilename(), '.php')) {
+					continue;
+				}
+				$contents = file_get_contents($file->getPathname());
+				if ($contents === false) {
+					continue;
+				}
+				try {
+					$stmts = $parser->parse($contents);
+				} catch (Throwable) {
+					continue;
+				}
+				if ($stmts === null) {
+					continue;
+				}
+				$stmts = $traverser->traverse($stmts);
+				foreach ($finder->findInstanceOf($stmts, Node\Stmt\ClassLike::class) as $classLike) {
+					if (!isset($classLike->namespacedName) || $classLike instanceof Node\Stmt\Interface_) {
+						continue;
+					}
+					$name = strtolower($classLike->namespacedName->toString());
+					$parents[$name] = $classLike instanceof Node\Stmt\Class_ && $classLike->extends !== null
+						? strtolower($classLike->extends->toString())
+						: null;
+					$traits[$name] = [];
+					foreach ($finder->findInstanceOf($classLike->stmts, Node\Stmt\TraitUse::class) as $traitUse) {
+						foreach ($traitUse->traits as $trait) {
+							$traits[$name][] = strtolower($trait->toString());
+						}
+					}
+					$methods[$name] = [];
+					foreach ($classLike->getMethods() as $method) {
+						$methods[$name][] = strtolower($method->name->toString());
+					}
+					$properties = [];
+					foreach ($classLike->getProperties() as $property) {
+						foreach ($property->props as $prop) {
+							$properties[$prop->name->toString()] = true;
+						}
+					}
+					$constructor = $classLike->getMethod('__construct');
+					if ($constructor !== null) {
+						foreach ($constructor->params as $param) {
+							if (!$param->isPromoted() || !($param->var instanceof Node\Expr\Variable) || !is_string($param->var->name)) {
+								continue;
+							}
+
+							$properties[$param->var->name] = true;
+						}
+					}
+					$this->classes[$name] = [
+						'file' => $file->getPathname(),
+						'parent' => $parents[$name],
+						'traits' => $traits[$name],
+						'properties' => $properties,
+					];
+				}
+			}
+		}
+
+		$overrides = [];
+		foreach ($parents as $class => $parent) {
+			$declared = $this->declaredMethods($class, $traits, $methods, []);
+			$ancestor = $parent;
+			$depth = 0;
+			while ($ancestor !== null && $depth++ < 64) {
+				foreach ($declared as $method) {
+					$overrides[$ancestor . '::' . $method] = true;
+				}
+				$ancestor = $parents[$ancestor] ?? null;
+			}
+		}
+
+		return $overrides;
+	}
+
+	/**
+	 * @param array<string, list<string>> $traits
+	 * @param array<string, list<string>> $methods
+	 * @param array<string, true> $seen
+	 * @return list<string>
+	 */
+	private function declaredMethods(string $class, array $traits, array $methods, array $seen): array
+	{
+		if (isset($seen[$class])) {
+			return [];
+		}
+		$seen[$class] = true;
+		$result = $methods[$class] ?? [];
+		foreach ($traits[$class] ?? [] as $trait) {
+			foreach ($this->declaredMethods($trait, $traits, $methods, $seen) as $method) {
+				$result[] = $method;
+			}
+		}
+
+		return $result;
+	}
+
+}

--- a/build/inline.neon
+++ b/build/inline.neon
@@ -1,0 +1,25 @@
+# Configuration of the phar build's inlining pass (compiler PrepareCommand →
+# InlineCallCollector): a level-0 analysis of PHPStan's own code that only
+# collects the call sites to rewrite. Paths must match
+# InlineCallCollector::directories().
+parameters:
+	level: 0
+	tmpDir: %currentWorkingDirectory%/tmp/inline
+	reportUnmatchedIgnoredErrors: false
+	paths:
+		- ../src
+		- ../vendor/nikic/php-parser/lib
+		- ../vendor/phpstan/phpdoc-parser/src
+		- ../vendor/ondrejmirtes/better-reflection/src
+
+services:
+	-
+		class: PHPStan\Build\InlineCallCollector
+		arguments:
+			parser: @defaultAnalysisParser
+		tags:
+			- phpstan.collector
+	-
+		class: PHPStan\Build\InlineEditsRule
+		tags:
+			- phpstan.rules.rule

--- a/build/readonly-property.neon
+++ b/build/readonly-property.neon
@@ -1,3 +1,8 @@
 parameters:
 	excludePaths:
 		- ../tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+
+	ignoreErrors:
+		-
+			message: '#^Class PrivatePropertyAttribute\\Foo not found\.$#'
+			path: ../tests/PHPStan/Reflection/ClassReflectionTest.php

--- a/compiler/src/Console/PrepareCommand.php
+++ b/compiler/src/Console/PrepareCommand.php
@@ -4,6 +4,7 @@ namespace PHPStan\Compiler\Console;
 
 use Exception;
 use PHPStan\Compiler\Filesystem\Filesystem;
+use PHPStan\Compiler\InlineEditsApplier;
 use PHPStan\ShouldNotHappenException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,6 +19,7 @@ use function file_put_contents;
 use function implode;
 use function in_array;
 use function is_dir;
+use function is_file;
 use function json_decode;
 use function json_encode;
 use function realpath;
@@ -50,6 +52,7 @@ final class PrepareCommand extends Command
 
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
+		$this->inlineSource($output);
 		$this->buildPreloadScript();
 		$this->deleteUnnecessaryVendorCode();
 		$this->fixComposerJson($this->buildDir);
@@ -255,6 +258,33 @@ php;
 
 		@unlink($vendorDir . '/nikic/php-parser/grammar/rebuildParsers.php');
 		@unlink($vendorDir . '/nikic/php-parser/bin/php-parse');
+	}
+
+	/**
+	 * Inlines PHPStan's own single-return getters at their call sites (see
+	 * build/PHPStan/Build/InlineCallCollector.php): the analysis knows the
+	 * receiver class at every call site, which the engine's optimizer does
+	 * not — it compiles callers before callees. Runs on the pristine tree,
+	 * before the downgrade, with PHPStan analysing itself.
+	 */
+	private function inlineSource(OutputInterface $output): void
+	{
+		$root = __DIR__ . '/../../..';
+		chdir($root);
+		$editsFile = $this->buildDir . '/inline-edits.json';
+		@unlink($editsFile);
+		exec(
+			'INLINE_EDITS_OUT=' . escapeshellarg($editsFile) . ' php bin/phpstan analyse -c build/inline.neon --no-progress --error-format=raw --memory-limit=2G 2>&1',
+			$outputLines,
+			$exitCode,
+		);
+		// level 0 findings in the analysed vendors are not what this run is for
+		if (!is_file($editsFile)) {
+			throw new ShouldNotHappenException("Inlining analysis produced no edits file:\n" . implode("\n", $outputLines));
+		}
+		$stats = (new InlineEditsApplier())->apply($editsFile);
+		unlink($editsFile);
+		$output->writeln(sprintf('Inlined %d call sites in %d files, %d properties made public', $stats['edits'], $stats['files'], $stats['properties']));
 	}
 
 	private function transformSource(): void

--- a/compiler/src/InlineEditsApplier.php
+++ b/compiler/src/InlineEditsApplier.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Compiler;
+
+use PHPStan\ShouldNotHappenException;
+use function array_keys;
+use function array_reverse;
+use function count;
+use function file_get_contents;
+use function file_put_contents;
+use function json_decode;
+use function preg_quote;
+use function preg_replace;
+use function sprintf;
+use function substr;
+use function usort;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Applies the call-site edits InlineCallCollector gathered (build/inline.neon)
+ * to the sources in place, then makes the non-public properties the inlined
+ * bodies read public — a property read moved from its class into a caller
+ * needs to be accessible there.
+ *
+ * Overlapping edits (a call inside an argument of another inlined call)
+ * resolve outermost-wins: the outer replacement was printed from the
+ * callee's body with the original argument source, so the inner call inside
+ * it simply stays a call.
+ */
+final class InlineEditsApplier
+{
+
+	/**
+	 * @return array{edits: int, files: int, properties: int}
+	 */
+	public function apply(string $editsJsonFile): array
+	{
+		/** @var list<array{file: string, start: int, end: int, replacement: string, callee: string, publicize: list<array{class: string, property: string, file: string|null}>}> $edits */
+		$edits = json_decode((string) file_get_contents($editsJsonFile), true, 512, JSON_THROW_ON_ERROR);
+
+		$byFile = [];
+		foreach ($edits as $edit) {
+			$byFile[$edit['file']][] = $edit;
+		}
+
+		$applied = 0;
+		$publicize = [];
+		foreach ($byFile as $file => $fileEdits) {
+			usort($fileEdits, static fn (array $a, array $b): int => $a['start'] <=> $b['start'] ?: $b['end'] <=> $a['end']);
+			$accepted = [];
+			$lastEnd = -1;
+			foreach ($fileEdits as $edit) {
+				if ($edit['start'] <= $lastEnd) {
+					continue;
+				}
+				$accepted[] = $edit;
+				$lastEnd = $edit['end'];
+			}
+			$source = file_get_contents($file);
+			if ($source === false) {
+				throw new ShouldNotHappenException(sprintf('Cannot read %s', $file));
+			}
+			foreach (array_reverse($accepted) as $edit) {
+				$source = substr($source, 0, $edit['start']) . $edit['replacement'] . substr($source, $edit['end'] + 1);
+				$applied++;
+				foreach ($edit['publicize'] as $property) {
+					if ($property['file'] === null) {
+						throw new ShouldNotHappenException(sprintf('No file for %s::$%s', $property['class'], $property['property']));
+					}
+					$publicize[$property['file']][$property['property']] = true;
+				}
+			}
+			file_put_contents($file, $source);
+		}
+
+		$properties = 0;
+		foreach ($publicize as $file => $names) {
+			$source = file_get_contents($file);
+			if ($source === false) {
+				throw new ShouldNotHappenException(sprintf('Cannot read %s', $file));
+			}
+			foreach (array_keys($names) as $name) {
+				// a declaration, a promoted constructor parameter or a trait property:
+				// visibility, optional modifiers and type, then the variable
+				$source = preg_replace(
+					'/\b(private|protected)(\s+(?:readonly\s+|static\s+)*(?:[?\w\\\\|&()]+\s+)?)\$' . preg_quote($name, '/') . '\b/',
+					'public$2$' . $name,
+					$source,
+					-1,
+					$count,
+				);
+				if ($source === null || $count === 0) {
+					throw new ShouldNotHappenException(sprintf('Property $%s not found in %s', $name, $file));
+				}
+				$properties += $count;
+			}
+			file_put_contents($file, $source);
+		}
+
+		return ['edits' => $applied, 'files' => count($byFile), 'properties' => $properties];
+	}
+
+}

--- a/compiler/src/InlineEditsApplier.php
+++ b/compiler/src/InlineEditsApplier.php
@@ -10,7 +10,7 @@ use function file_get_contents;
 use function file_put_contents;
 use function json_decode;
 use function preg_quote;
-use function preg_replace;
+use function preg_replace_callback;
 use function sprintf;
 use function substr;
 use function usort;
@@ -81,10 +81,17 @@ final class InlineEditsApplier
 			}
 			foreach (array_keys($names) as $name) {
 				// a declaration, a promoted constructor parameter or a trait property:
-				// visibility, optional modifiers and type, then the variable
-				$source = preg_replace(
+				// visibility, optional modifiers and type, then the variable — made
+				// public, with the source visibility recorded in an attribute PHPStan's
+				// own reflection honours (same line, so line numbers stay)
+				$source = preg_replace_callback(
 					'/\b(private|protected)(\s+(?:readonly\s+|static\s+)*(?:[?\w\\\\|&()]+\s+)?)\$' . preg_quote($name, '/') . '\b/',
-					'public$2$' . $name,
+					static fn (array $matches): string => sprintf(
+						'#[\PHPStan\Reflection\Attribute\%s] public%s$%s',
+						$matches[1] === 'private' ? 'PrivateProperty' : 'ProtectedProperty',
+						$matches[2],
+						$name,
+					),
 					$source,
 					-1,
 					$count,

--- a/compiler/tests/InlineEditsApplierTest.php
+++ b/compiler/tests/InlineEditsApplierTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use function file_get_contents;
+use function file_put_contents;
+use function json_encode;
+use function strlen;
+use function strpos;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+use const JSON_THROW_ON_ERROR;
+
+final class InlineEditsApplierTest extends TestCase
+{
+
+	public function testApply(): void
+	{
+		$caller = tempnam(sys_get_temp_dir(), 'caller');
+		$callee = tempnam(sys_get_temp_dir(), 'callee');
+		$source = "<?php\n\$a = \$foo->getBar();\n\$b = \$foo->getBar();\n";
+		file_put_contents($caller, $source);
+		file_put_contents($callee, "<?php\nclass Foo {\n\tprivate int \$bar = 1;\n\tpublic function __construct(private readonly ?string \$baz = null)\n\t{\n\t}\n}\n");
+
+		$start = strpos($source, '$foo->getBar()');
+		$edits = [
+			[
+				'file' => $caller,
+				'start' => $start,
+				'end' => $start + strlen('$foo->getBar()') - 1,
+				'replacement' => '$foo->bar',
+				'callee' => 'Foo::getBar',
+				'publicize' => [['class' => 'Foo', 'property' => 'bar', 'file' => $callee]],
+			],
+			[
+				// nested inside the first one: outermost wins, it is skipped
+				'file' => $caller,
+				'start' => $start,
+				'end' => $start + 3,
+				'replacement' => 'NOPE',
+				'callee' => 'Foo::getBar',
+				'publicize' => [],
+			],
+			[
+				'file' => $caller,
+				'start' => $start + strlen('$foo->getBar();' . "\n" . '$b = '),
+				'end' => $start + strlen('$foo->getBar();' . "\n" . '$b = ') + strlen('$foo->getBar()') - 1,
+				'replacement' => '$foo->bar',
+				'callee' => 'Foo::getBar',
+				'publicize' => [['class' => 'Foo', 'property' => 'baz', 'file' => $callee]],
+			],
+		];
+		$editsFile = tempnam(sys_get_temp_dir(), 'edits');
+		file_put_contents($editsFile, json_encode($edits, JSON_THROW_ON_ERROR));
+
+		$stats = (new InlineEditsApplier())->apply($editsFile);
+
+		self::assertSame(['edits' => 2, 'files' => 1, 'properties' => 2], $stats);
+		self::assertSame("<?php\n\$a = \$foo->bar;\n\$b = \$foo->bar;\n", file_get_contents($caller));
+		self::assertSame("<?php\nclass Foo {\n\tpublic int \$bar = 1;\n\tpublic function __construct(public readonly ?string \$baz = null)\n\t{\n\t}\n}\n", file_get_contents($callee));
+
+		unlink($caller);
+		unlink($callee);
+		unlink($editsFile);
+	}
+
+}

--- a/compiler/tests/InlineEditsApplierTest.php
+++ b/compiler/tests/InlineEditsApplierTest.php
@@ -59,7 +59,7 @@ final class InlineEditsApplierTest extends TestCase
 
 		self::assertSame(['edits' => 2, 'files' => 1, 'properties' => 2], $stats);
 		self::assertSame("<?php\n\$a = \$foo->bar;\n\$b = \$foo->bar;\n", file_get_contents($caller));
-		self::assertSame("<?php\nclass Foo {\n\tpublic int \$bar = 1;\n\tpublic function __construct(public readonly ?string \$baz = null)\n\t{\n\t}\n}\n", file_get_contents($callee));
+		self::assertSame("<?php\nclass Foo {\n\t#[\\PHPStan\\Reflection\\Attribute\\PrivateProperty] public int \$bar = 1;\n\tpublic function __construct(#[\\PHPStan\\Reflection\\Attribute\\PrivateProperty] public readonly ?string \$baz = null)\n\t{\n\t}\n}\n", file_get_contents($callee));
 
 		unlink($caller);
 		unlink($callee);

--- a/src/Reflection/Attribute/PrivateProperty.php
+++ b/src/Reflection/Attribute/PrivateProperty.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Attribute;
+
+use Attribute;
+
+/**
+ * Marks a property the phar build made public that is private in the
+ * source. The build inlines single-return getters at their call sites
+ * (compiler's PrepareCommand), so the properties those getters read have to
+ * be readable from the callers; for PHPStan's own reflection the property
+ * stays private (PhpClassReflectionExtension), so code analysed against
+ * the phar cannot access it.
+ */
+#[Attribute(flags: Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+final class PrivateProperty
+{
+
+}

--- a/src/Reflection/Attribute/ProtectedProperty.php
+++ b/src/Reflection/Attribute/ProtectedProperty.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Attribute;
+
+use Attribute;
+
+/**
+ * Marks a property the phar build made public that is protected in the
+ * source. The build inlines single-return getters at their call sites
+ * (compiler's PrepareCommand), so the properties those getters read have to
+ * be readable from the callers; for PHPStan's own reflection the property
+ * stays protected (PhpClassReflectionExtension), so code analysed against
+ * the phar cannot access it from outside the class hierarchy.
+ */
+#[Attribute(flags: Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+final class ProtectedProperty
+{
+
+}

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -172,6 +172,13 @@ final class ClassReflection
 	private array $hasStaticPropertyCache = [];
 
 	/**
+	 * getName() is the hottest call on this class (millions per run), two adapter frames deep
+	 *
+	 * @var class-string|null
+	 */
+	private ?string $name = null;
+
+	/**
 	 * @param ReflectionClass|ReflectionEnum $reflection
 	 * @param (Closure(): ?ResolvedPhpDocBlock)|null $stubPhpDocBlockCallback
 	 */
@@ -275,7 +282,7 @@ final class ClassReflection
 	 */
 	public function getName(): string
 	{
-		return $this->reflection->getName();
+		return $this->name ??= $this->reflection->getName();
 	}
 
 	public function getDisplayName(bool $withTemplateTypes = true): string

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -25,6 +25,8 @@ use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\Assertions;
+use PHPStan\Reflection\Attribute\PrivateProperty;
+use PHPStan\Reflection\Attribute\ProtectedProperty;
 use PHPStan\Reflection\AttributeReflectionFactory;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
 use PHPStan\Reflection\ClassReflection;
@@ -435,6 +437,16 @@ final class PhpClassReflectionExtension
 			}
 		}
 
+		// a property the phar build made public for its inlined getters keeps its source visibility here
+		$isPrivate = $propertyReflection->isPrivate();
+		$isPublic = $propertyReflection->isPublic();
+		if ($isPublic && count($propertyReflection->getAttributes(PrivateProperty::class)) > 0) {
+			$isPrivate = true;
+			$isPublic = false;
+		} elseif ($isPublic && count($propertyReflection->getAttributes(ProtectedProperty::class)) > 0) {
+			$isPublic = false;
+		}
+
 		$nativeProperty = new PhpPropertyReflection(
 			$declaringClassReflection,
 			$declaringTrait,
@@ -454,8 +466,8 @@ final class PhpClassReflectionExtension
 			$isFinal,
 			true,
 			true,
-			$propertyReflection->isPrivate(),
-			$propertyReflection->isPublic(),
+			$isPrivate,
+			$isPublic,
 		);
 
 		if (

--- a/src/Turbo/TurboDiagnoseExtension.php
+++ b/src/Turbo/TurboDiagnoseExtension.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Turbo;
 
-use Phar;
 use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Diagnose\DiagnoseExtension;
@@ -79,9 +78,6 @@ final class TurboDiagnoseExtension implements DiagnoseExtension
 		}
 		if (!TurboExtensionEnabler::isActive()) {
 			return 'off (extension inactive)';
-		}
-		if (Phar::running(false) === '') {
-			return 'off (not running from a phar)';
 		}
 
 		return 'off (--debug, or OPcache is not active)';

--- a/src/Turbo/TurboExtensionEnabler.php
+++ b/src/Turbo/TurboExtensionEnabler.php
@@ -12,6 +12,7 @@ use function in_array;
 use function is_file;
 use function json_decode;
 use function phpversion;
+use const DIRECTORY_SEPARATOR;
 
 final class TurboExtensionEnabler
 {
@@ -177,12 +178,13 @@ final class TurboExtensionEnabler
 	 * the engine's run-time checks of its parameter and return types re-check
 	 * what analysis already proved — at about 8% of the analysis CPU: a
 	 * class-typed parameter costs a class lookup and an instanceof on every
-	 * call, a typed return the same on the way out. With the extension active
-	 * and PHPStan running from a phar, its optimizer pass (TrustedTypes.cpp)
-	 * drops those checks from the code compiled out of the phar. Nothing else
-	 * is touched: extensions, bootstrap files and the analysed project keep
-	 * their checks, including on what they receive from PHPStan and return to
-	 * it — a check sits in the callee.
+	 * call, a typed return the same on the way out. With the extension
+	 * active, its optimizer pass (TrustedTypes.cpp) drops those checks from
+	 * the code compiled out of the running phar — or out of the source
+	 * checkout bin/phpstan runs from. Nothing else is touched: extensions,
+	 * bootstrap files and the analysed project keep their checks, including
+	 * on what they receive from PHPStan and return to it — a check sits in
+	 * the callee.
 	 *
 	 * What is lost is the TypeError at the boundary when such code passes a
 	 * wrong value into PHPStan: it surfaces later, deeper. That is why --debug
@@ -204,15 +206,17 @@ final class TurboExtensionEnabler
 		if (in_array('--debug', $argv, true)) {
 			return;
 		}
-		if (!class_exists('Phar', false)) {
-			return;
-		}
-		$pharPath = Phar::running(false);
-		if ($pharPath === '') {
-			return;
+		$pharPath = class_exists('Phar', false) ? Phar::running(false) : '';
+		if ($pharPath !== '') {
+			$prefix = 'phar://' . $pharPath . '/';
+		} else {
+			// bin/phpstan of a source checkout: src/, vendor/ and build/ of the
+			// checkout, the same code the phar would hold (compiled filenames
+			// are resolved paths, as __DIR__ is)
+			$prefix = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
 		}
 
-		self::$trustingOwnTypes = Runtime::trustTypesUnder('phar://' . $pharPath . '/');
+		self::$trustingOwnTypes = Runtime::trustTypesUnder($prefix);
 	}
 
 }

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -112,6 +112,34 @@ class ClassReflectionTest extends PHPStanTestCase
 		);
 	}
 
+	public function testPrivatePropertyAttribute(): void
+	{
+		// the phar build makes the properties its inlined getters read public
+		// and records the source visibility in an attribute
+		$reflectionProvider = self::createReflectionProvider();
+		$classReflection = $reflectionProvider->getClass(\PrivatePropertyAttribute\Foo::class);
+
+		$madePublic = $classReflection->getNativeProperty('madePublic');
+		$this->assertTrue($madePublic->isPrivate());
+		$this->assertFalse($madePublic->isPublic());
+
+		$madePublicFromProtected = $classReflection->getNativeProperty('madePublicFromProtected');
+		$this->assertFalse($madePublicFromProtected->isPrivate());
+		$this->assertFalse($madePublicFromProtected->isPublic());
+
+		$promoted = $classReflection->getNativeProperty('promoted');
+		$this->assertTrue($promoted->isPrivate());
+		$this->assertFalse($promoted->isPublic());
+
+		$reallyPublic = $classReflection->getNativeProperty('reallyPublic');
+		$this->assertFalse($reallyPublic->isPrivate());
+		$this->assertTrue($reallyPublic->isPublic());
+
+		$reallyPrivate = $classReflection->getNativeProperty('reallyPrivate');
+		$this->assertTrue($reallyPrivate->isPrivate());
+		$this->assertFalse($reallyPrivate->isPublic());
+	}
+
 	public function testVariadicTraitMethod(): void
 	{
 		$reflectionProvider = self::createReflectionProvider();

--- a/tests/PHPStan/Reflection/data/private-property-attribute.php
+++ b/tests/PHPStan/Reflection/data/private-property-attribute.php
@@ -1,0 +1,30 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace PrivatePropertyAttribute;
+
+use PHPStan\Reflection\Attribute\PrivateProperty;
+use PHPStan\Reflection\Attribute\ProtectedProperty;
+
+class Foo
+{
+
+	#[PrivateProperty]
+	public int $madePublic = 1;
+
+	#[ProtectedProperty]
+	public int $madePublicFromProtected = 2;
+
+	public int $reallyPublic = 3;
+
+	private int $reallyPrivate = 4;
+
+	public function __construct(
+		#[PrivateProperty]
+		public readonly string $promoted = 'x',
+	)
+	{
+	}
+
+}

--- a/turbo-ext/README.md
+++ b/turbo-ext/README.md
@@ -92,7 +92,8 @@ that does not exec() must `_exit()` instead.
 own code runs rather than replacing it: it arms an opcache optimizer pass
 (`TrustedTypes.cpp`) that drops the engine's argument and return type checks
 from scripts compiled under the given prefix — the running phar, passed by
-`TurboExtensionEnabler::trustOwnTypesIfSuitable()`. PHPStan's code is verified
+`TurboExtensionEnabler::trustOwnTypesIfSuitable()` — the running phar, or the
+source checkout `bin/phpstan` runs from. PHPStan's code is verified
 by PHPStan, so those checks re-check what analysis proved, at about 8% of the
 analysis CPU. Nothing outside the prefix is touched, and a check sits in the
 callee, so extensions and bootstrapped code keep checking what PHPStan hands


### PR DESCRIPTION
Three optimizations of how PHPStan's own code runs, each kept only after it cleared a 0.5% user-CPU bar in an interleaved A/B; everything else that was tried and measured is listed at the end.

## What changed

**1. The trusted-types optimizer pass also arms for a source checkout.** `TurboExtensionEnabler::trustOwnTypesIfSuitable()` only armed the pass from a phar, so `bin/phpstan` of a checkout — `make phpstan` included — kept every argument and return type check. The prefix is now the checkout root when there is no phar. `--debug` still keeps the checks; PHPUnit never reaches this code.

**2. `ClassReflection::getName()` is memoized.** It is the hottest call on the class (2.3M calls on a `src/Type` self-analysis), each going two adapter frames deep (`Adapter\ReflectionClass::getName` → BetterReflection `getName`).

**3. The phar build inlines single-return getters at their call sites.** A getter call costs a call frame for a body that reads one property, and the engine's optimizer cannot inline it (it compiles callers before callees). PHPStan's own analysis knows the receiver class at every call site, so `compiler/bin/prepare` now starts with a level-0 self-analysis (`build/inline.neon`) whose collector records, for every call whose receiver resolves to a single class and whose callee is a single `return <expr>;`, the textual replacement with `$this` and the parameters substituted. Callees are final classes, final or private methods, or — closed world — methods nothing in `src/` and the three scanned vendor packages overrides (`OverridesScanner`). Bodies with closures, assignments, `self`/`static`/`parent`, magic constants, nullsafe operators, non-`$this` property fetches or more than 30 nodes are skipped, every member the moved expression touches must stay accessible from the caller, arguments used more than once must be trivially simple, and the recorded position is re-parsed to be sure it is literally that call. Turbo-shadowed classes are never inlining sources. `InlineEditsApplier` applies the edits (outermost wins on overlaps) and makes the non-public properties the moved bodies read public — in the declaring class or trait and in every subclass redeclaring them — stamping `#[PHPStan\Reflection\Attribute\PrivateProperty]` (or `ProtectedProperty`) on the same line. `PhpClassReflectionExtension` reports such a property with its source visibility, so code analysed against the phar still cannot access it (`ClassReflectionTest::testPrivatePropertyAttribute`).

On the current tree the build inlines 9,005 call sites in 1,039 files and opens up 851 properties. Only the phar is transformed; the repository, tests and `make phpstan` never see inlined code. The inlining runs before the 7.4 downgrade, which keeps the attributes: property declarations keep theirs on the same line, and de-promoted constructor parameters get it copied onto the generated property declaration.

## Measurements

All runs interleaved (A/B/B/A), cold caches, output byte-identical in every pair, judged on user CPU (the machine was loaded during several runs, so wall time is less reliable).

| workload | before | after | delta |
|---|---|---|---|
| `make phpstan` (source checkout, change 1) | 119.3 s user | 116.4 s | −2.4%, 8/8, t=7.3 |
| single-process `src/Type` self-analysis, change 2 alone | 21.3 s | 21.0 s | −1.3%, 6/6, t=5.2 |
| single-process `src/Type`, change 3 alone (transformed tree vs pristine) | 19.5 s | 18.8 s | −3.5%, 5/6 |
| locally built phar, a ~2.5k-file web application (changes 2+3) | 623.0 s user, 88.3 s wall | 593.1 s, 84.8 s | **−4.8% user**, 3/3, t=14.7; wall −4.0%; peak RSS −1.9% |
| locally built phar, a large monorepo backend (changes 2+3) | 1349.8 s user, 218.9 s wall | 1304.4 s, 220.5 s | **−3.4% user**, 3/3, t=4.9; wall flat under load; RSS −0.6% |

Both phars ran with the same turbo binary (`e8e7544`; `turbo-ext/src` is untouched, so no version bump).

## Tried, measured, and left out

A dynamic opcode census of `make phpstan` (10.4G opcodes, counted with a user-opcode-handler extension) was read against the Zend VM handlers to find work that PHPStan-verified code makes redundant. Beyond the argument/return/property type checks, nothing an optimizer pass can strip remains: the rest is program semantics (`INSTANCEOF`, `TYPE_CHECK`, jumps) or frame lifecycle (`RETURN`, `DO_FCALL`, `INIT_METHOD_CALL` cache misses). Prototyped, benchmarked and rejected as below the 0.5% bar:

- removing the stripped `VERIFY_RETURN_TYPE` oplines instead of leaving NOPs (583M dispatches per run) plus dropping private property type checks (133M typed writes): −0.3%
- rewriting by-reference-unknown argument passing (`SEND_VAR_EX`, `CHECK_FUNC_ARG`, `FETCH_*_FUNC_ARG`, ~660M opcodes per run) to the plain forms from a generated table of by-ref callee names: −0.1%
- `zend.assertions=-1`: 0.0%

The stock optimizer already devirtualizes `$this->private()` and final-class calls, so no pass work there either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRLigetKoiZzYBe4iRQb3J
