### PR TITLE
`pcntl_exec()` is not supported by blackfire

### DIFF
--- a/src/Turbo/TurboProcessRestarter.php
+++ b/src/Turbo/TurboProcessRestarter.php
@@ -108,6 +108,13 @@ final class TurboProcessRestarter
 			return;
 		}
 		if (
+			isset($_SERVER['BLACKFIRE_AGENT_SOCKET'])
+		) {
+			// pcntl_exec() is not supported by blackfire
+			// see https://support.blackfire.platform.sh/hc/en-us/articles/4843014509202-Conflicts-with-pcntl-exec-calls
+			return;
+		}
+		if (
 			!function_exists('pcntl_exec')
 			|| !function_exists('pcntl_fork')
 			|| !function_exists('pcntl_waitpid')


### PR DESCRIPTION
Running `blackfire` on a php based codebase which uses `pcntl_exec()` will run until the end and die with 

> ERR Profile data is truncated. Please check https://support.blackfire.platform.sh/hc/en-us/sections/4792498935058-Troubleshooting

see https://support.blackfire.platform.sh/hc/en-us/articles/4843014509202-Conflicts-with-pcntl-exec-calls

---

after this PR I am able to create blackfire profiles again