### PR TITLE
Do not make php-parser and phpdoc-parser properties public when inlining getters in the phar build

### DIFF
--- a/build/PHPStan/Build/InlineCallCollector.php
+++ b/build/PHPStan/Build/InlineCallCollector.php
@@ -29,8 +29,11 @@ use function file_get_contents;
 use function in_array;
 use function is_string;
 use function json_decode;
+use function realpath;
+use function str_starts_with;
 use function strtolower;
 use function substr;
+use const DIRECTORY_SEPARATOR;
 
 /**
  * Source-level inliner for the phar build (compiler's PrepareCommand): for
@@ -38,7 +41,9 @@ use function substr;
  * callee body is one `return <expr>;`, records a textual replacement of the
  * call with that expression ($this and parameters substituted), plus the
  * non-public properties the expression reads (they become public for the
- * rewrite to run — see InlineEditsApplier in the compiler).
+ * rewrite to run — see InlineEditsApplier in the compiler). Properties of
+ * php-parser and phpdoc-parser are never made public
+ * (PROTECTED_PACKAGE_DIRECTORIES): a body reading one is left as a call.
  *
  * Callees are ones no subclass can override — final class, final or private
  * method — or, closed-world, non-final ones nothing in the scanned code base
@@ -52,6 +57,18 @@ final class InlineCallCollector implements Collector
 {
 
 	private const MAX_EXPR_NODES = 30;
+
+	/**
+	 * Packages the phar ships under their own, unprefixed namespaces and that
+	 * projects install on their own too — the copy loaded at run time may be
+	 * the project's, whose properties are still non-public. Their properties
+	 * are never made public; better-reflection is PHPStan's own fork.
+	 * Relative to the repository root; InlineEditsApplier keeps the same list.
+	 */
+	private const PROTECTED_PACKAGE_DIRECTORIES = [
+		'vendor/nikic/php-parser',
+		'vendor/phpstan/phpdoc-parser',
+	];
 
 	/** @var array<string, array<string, Stmt\ClassMethod|null>> */
 	private array $methodNodes = [];
@@ -215,6 +232,9 @@ final class InlineCallCollector implements Collector
 				continue;
 			}
 			foreach ($this->publicizeTargets($propertyDeclaringClass->getName(), $propertyName) as $target) {
+				if ($target['file'] !== null && $this->isInProtectedPackage($target['file'])) {
+					return null;
+				}
 				$publicize[] = $target;
 			}
 		}
@@ -509,6 +529,29 @@ final class InlineCallCollector implements Collector
 		}
 
 		return $targets;
+	}
+
+	/** @var list<string>|null */
+	private ?array $protectedDirectories = null;
+
+	private function isInProtectedPackage(string $file): bool
+	{
+		if ($this->protectedDirectories === null) {
+			$this->protectedDirectories = [];
+			foreach (self::PROTECTED_PACKAGE_DIRECTORIES as $directory) {
+				$directory = dirname(__DIR__, 3) . '/' . $directory;
+				$realDirectory = realpath($directory);
+				$this->protectedDirectories[] = ($realDirectory === false ? $directory : $realDirectory) . DIRECTORY_SEPARATOR;
+			}
+		}
+		$realFile = realpath($file);
+		foreach ($this->protectedDirectories as $directory) {
+			if (str_starts_with($realFile === false ? $file : $realFile, $directory)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/compiler/src/InlineEditsApplier.php
+++ b/compiler/src/InlineEditsApplier.php
@@ -6,21 +6,28 @@ use PHPStan\ShouldNotHappenException;
 use function array_keys;
 use function array_reverse;
 use function count;
+use function dirname;
 use function file_get_contents;
 use function file_put_contents;
 use function json_decode;
 use function preg_quote;
 use function preg_replace_callback;
+use function realpath;
 use function sprintf;
+use function str_starts_with;
 use function substr;
 use function usort;
+use const DIRECTORY_SEPARATOR;
 use const JSON_THROW_ON_ERROR;
 
 /**
  * Applies the call-site edits InlineCallCollector gathered (build/inline.neon)
  * to the sources in place, then makes the non-public properties the inlined
  * bodies read public — a property read moved from its class into a caller
- * needs to be accessible there.
+ * needs to be accessible there. Never a property of php-parser or
+ * phpdoc-parser (PROTECTED_PACKAGE_DIRECTORIES): the collector does not
+ * record those, and an edit that would need one is refused here rather than
+ * applied.
  *
  * Overlapping edits (a call inside an argument of another inlined call)
  * resolve outermost-wins: the outer replacement was printed from the
@@ -29,6 +36,37 @@ use const JSON_THROW_ON_ERROR;
  */
 final class InlineEditsApplier
 {
+
+	/**
+	 * Same list as InlineCallCollector::PROTECTED_PACKAGE_DIRECTORIES —
+	 * packages the phar ships unprefixed and projects install on their own
+	 * too, so the copy loaded at run time may be one with the properties
+	 * still non-public.
+	 */
+	private const PROTECTED_PACKAGE_DIRECTORIES = [
+		'vendor/nikic/php-parser',
+		'vendor/phpstan/phpdoc-parser',
+	];
+
+	/** @var list<string> */
+	private array $protectedDirectories = [];
+
+	/**
+	 * @param list<string>|null $protectedDirectories defaults to PROTECTED_PACKAGE_DIRECTORIES under the repository root
+	 */
+	public function __construct(?array $protectedDirectories = null)
+	{
+		if ($protectedDirectories === null) {
+			$protectedDirectories = [];
+			foreach (self::PROTECTED_PACKAGE_DIRECTORIES as $directory) {
+				$protectedDirectories[] = dirname(__DIR__, 2) . '/' . $directory;
+			}
+		}
+		foreach ($protectedDirectories as $directory) {
+			$realDirectory = realpath($directory);
+			$this->protectedDirectories[] = ($realDirectory === false ? $directory : $realDirectory) . DIRECTORY_SEPARATOR;
+		}
+	}
 
 	/**
 	 * @return array{edits: int, files: int, properties: int}
@@ -66,6 +104,9 @@ final class InlineEditsApplier
 				foreach ($edit['publicize'] as $property) {
 					if ($property['file'] === null) {
 						throw new ShouldNotHappenException(sprintf('No file for %s::$%s', $property['class'], $property['property']));
+					}
+					if ($this->isInProtectedPackage($property['file'])) {
+						throw new ShouldNotHappenException(sprintf('Refusing to make %s::$%s public, it is declared in a protected package (%s)', $property['class'], $property['property'], $property['file']));
 					}
 					$publicize[$property['file']][$property['property']] = true;
 				}
@@ -105,6 +146,18 @@ final class InlineEditsApplier
 		}
 
 		return ['edits' => $applied, 'files' => count($byFile), 'properties' => $properties];
+	}
+
+	private function isInProtectedPackage(string $file): bool
+	{
+		$realFile = realpath($file);
+		foreach ($this->protectedDirectories as $directory) {
+			if (str_starts_with($realFile === false ? $file : $realFile, $directory)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/compiler/tests/InlineEditsApplierTest.php
+++ b/compiler/tests/InlineEditsApplierTest.php
@@ -2,10 +2,13 @@
 
 namespace PHPStan\Compiler;
 
+use PHPStan\ShouldNotHappenException;
 use PHPUnit\Framework\TestCase;
 use function file_get_contents;
 use function file_put_contents;
 use function json_encode;
+use function mkdir;
+use function rmdir;
 use function strlen;
 use function strpos;
 use function sys_get_temp_dir;
@@ -64,6 +67,48 @@ final class InlineEditsApplierTest extends TestCase
 		unlink($caller);
 		unlink($callee);
 		unlink($editsFile);
+	}
+
+	public function testRefusesToPublicizeProtectedPackageProperty(): void
+	{
+		$vendor = tempnam(sys_get_temp_dir(), 'vendor');
+		unlink($vendor);
+		mkdir($vendor . '/acme/lib', 0777, true);
+		$caller = tempnam(sys_get_temp_dir(), 'caller');
+		$callee = $vendor . '/acme/lib/Foo.php';
+		$source = "<?php\n\$a = \$foo->getBar();\n";
+		file_put_contents($caller, $source);
+		$calleeSource = "<?php\nclass Foo {\n\tprivate int \$bar = 1;\n}\n";
+		file_put_contents($callee, $calleeSource);
+
+		$start = strpos($source, '$foo->getBar()');
+		$edits = [
+			[
+				'file' => $caller,
+				'start' => $start,
+				'end' => $start + strlen('$foo->getBar()') - 1,
+				'replacement' => '$foo->bar',
+				'callee' => 'Foo::getBar',
+				'publicize' => [['class' => 'Foo', 'property' => 'bar', 'file' => $callee]],
+			],
+		];
+		$editsFile = tempnam(sys_get_temp_dir(), 'edits');
+		file_put_contents($editsFile, json_encode($edits, JSON_THROW_ON_ERROR));
+
+		try {
+			(new InlineEditsApplier([$vendor . '/acme']))->apply($editsFile);
+			self::fail('Expected the property to be refused');
+		} catch (ShouldNotHappenException $e) {
+			self::assertStringContainsString('Refusing to make Foo::$bar public, it is declared in a protected package', $e->getMessage());
+		} finally {
+			self::assertSame($calleeSource, file_get_contents($callee));
+			unlink($caller);
+			unlink($callee);
+			unlink($editsFile);
+			rmdir($vendor . '/acme/lib');
+			rmdir($vendor . '/acme');
+			rmdir($vendor);
+		}
 	}
 
 }


### PR DESCRIPTION
Follow-up to #6406. The phar build's getter inliner made properties of the three vendor packages public (stamped with `#[PrivateProperty]` / `#[ProtectedProperty]`) so that their single-return getters could be inlined. For php-parser and phpdoc-parser that is unsafe: the phar ships both under their own, unprefixed namespaces (`PhpParser`, `PHPStan\PhpDocParser` are in scoper's `exclude-namespaces`), and projects install them on their own too, so the copy loaded at run time may be one whose properties are still non-public. Their properties are no longer touched. better-reflection is PHPStan's own fork and keeps being inlined.

## What changed

- `InlineCallCollector` skips a call site whenever the inlined body would need a property declared under `vendor/nikic/php-parser` or `vendor/phpstan/phpdoc-parser` made public (`PROTECTED_PACKAGE_DIRECTORIES`). The check runs against every publicize target (declaring class, trait file, subclass redeclarations). Getters of the two packages that only read public properties or call public methods are still inlined, and call sites inside them are still rewritten.
- `InlineEditsApplier` refuses such a target with an exception instead of applying it, so a collector regression fails the build loudly. The protected directories are a constructor argument defaulting to the same two, covered by a new test.

## Before vs. after

Collector output replayed with the applier's outermost-wins logic, then confirmed by a full `compiler/bin/prepare` run in a copy of the tree.

| | before | after |
|---|---|---|
| inlined call sites | 9,005 | 8,426 |
| of which inside vendor files | 813 | 562 |
| files rewritten | 1,039 | 976 |
| properties made public | 851 | 823 |
| of which in better-reflection | 73 | 73 |
| of which in php-parser + phpdoc-parser | 28 | 0 |
| attribute stamps under php-parser + phpdoc-parser after prepare | 28 | 0 |

The 587 dropped sites are exactly the ones that needed a php-parser (407) or phpdoc-parser (180) property; nothing else is lost. 336 of them were calls from `src/` into those getters, 251 were calls inside the two packages. Eight nested `src/` edits previously shadowed by an outer edit now apply on their own. Largest individual losses: `NodeAbstract::getStartLine` (203 sites), `NodeAbstract::getAttributes` (104), `TokenIterator::currentTokenValue` (53), `Comment::getText` (49), `TokenIterator::currentTokenLine` (46), `TokenIterator::currentTokenIndex` (34). No `src/` getter reads a property inherited from a php-parser parent, so no PHPStan-declared callee is affected.

The level-0 collection analysis reports the same findings before and after; the compiler test suite, its level-8 analysis and phpcs pass. The CPU cost of the dropped sites was not benchmarked; at the 28–40 ns/frame figure from #6406 it is well under half a percent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MenQLNmxZKVgpFuzRRTBGW
