### PR TITLE
Let a trait-pathed ignore entry take precedence over the class-pathed ones

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -745,6 +745,23 @@ jobs:
               ../bashunit -a exit_code "0" "../../bin/phpstan analyse --error-format=raw -c with-full-baseline.neon"
               ../bashunit -a exit_code "0" "../../bin/phpstan analyse --error-format=raw -c with-full-baseline.neon"
           - script: |
+              cd e2e/baseline-trait-context-own-error
+              # A using class may report its own error with the same message and identifier
+              # as an error deduplicated directly into the trait: --generate-baseline records
+              # the class's own occurrence under the class path and the deduplicated error
+              # under the trait path. The trait-pathed entry hides the deduplicated error for
+              # every using class, so the class-pathed entry accounts only for the class's
+              # own occurrence: the generated baseline holds on re-run, with both an empty
+              # and a primed result cache.
+              ../../bin/phpstan clear-result-cache
+              ../../bin/phpstan --generate-baseline=baseline.neon
+              ../bashunit -a contains 'path: src/AMailer.php' "$(cat baseline.neon)"
+              ../bashunit -a contains 'path: src/SomeTrait.php' "$(cat baseline.neon)"
+              ../bashunit -a not_contains 'BMailer.php' "$(cat baseline.neon)"
+              ../../bin/phpstan clear-result-cache
+              ../bashunit -a exit_code "0" "../../bin/phpstan analyse --error-format=raw -c with-baseline.neon"
+              ../bashunit -a exit_code "0" "../../bin/phpstan analyse --error-format=raw -c with-baseline.neon"
+          - script: |
               cd e2e/result-cache-meta-extension
               composer install
               ../../bin/phpstan -vvv

--- a/e2e/baseline-trait-context-own-error/.gitignore
+++ b/e2e/baseline-trait-context-own-error/.gitignore
@@ -1,0 +1,1 @@
+baseline.neon

--- a/e2e/baseline-trait-context-own-error/phpstan.neon
+++ b/e2e/baseline-trait-context-own-error/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: 4
+	paths:
+		- src
+	parallel:
+		maximumNumberOfProcesses: 1

--- a/e2e/baseline-trait-context-own-error/src/AMailer.php
+++ b/e2e/baseline-trait-context-own-error/src/AMailer.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace BaselineTraitContextOwnError;
+
+final class AMailer
+{
+
+	use SomeTrait;
+
+	public function send(bool $flag, ?string $value): void
+	{
+		$hash = null;
+		if ($value !== null) {
+			if ($flag) {
+				$hash = $value;
+			}
+		}
+
+		if ($hash !== null && $flag) {
+			echo $hash;
+		}
+	}
+
+}

--- a/e2e/baseline-trait-context-own-error/src/BMailer.php
+++ b/e2e/baseline-trait-context-own-error/src/BMailer.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace BaselineTraitContextOwnError;
+
+final class BMailer
+{
+
+	use SomeTrait;
+
+}

--- a/e2e/baseline-trait-context-own-error/src/SomeTrait.php
+++ b/e2e/baseline-trait-context-own-error/src/SomeTrait.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace BaselineTraitContextOwnError;
+
+trait SomeTrait
+{
+
+	public function run(bool $flag, ?string $value): void
+	{
+		$hash = null;
+		if ($value !== null) {
+			if ($flag) {
+				$hash = $value;
+			}
+		}
+
+		if ($hash !== null && $flag) {
+			echo $hash;
+		}
+	}
+
+}

--- a/e2e/baseline-trait-context-own-error/with-baseline.neon
+++ b/e2e/baseline-trait-context-own-error/with-baseline.neon
@@ -1,0 +1,3 @@
+includes:
+	- phpstan.neon
+	- baseline.neon

--- a/src/Analyser/Ignore/IgnoredErrorHelperResult.php
+++ b/src/Analyser/Ignore/IgnoredErrorHelperResult.php
@@ -204,6 +204,28 @@ final class IgnoredErrorHelperResult
 			$traitContexts = $error->getTraitContexts();
 			if (count($traitContexts) > 0) {
 				$errorTraitFilePath = $error->getTraitFilePath();
+
+				// An entry scoped to the trait file hides the deduplicated error for every
+				// using class: it takes precedence over the class-scoped entries, which then
+				// account only for the errors reported in the class files themselves. This
+				// is what --generate-baseline records when a using class has its own
+				// occurrence of the same error (same message and identifier).
+				if ($errorTraitFilePath !== null) {
+					$normalizedTraitFilePath = $this->fileHelper->normalizePath($errorTraitFilePath);
+					if (isset($this->ignoreErrorsByFile[$normalizedTraitFilePath])) {
+						$matchingTraitFileIgnoreErrors = $ignoreErrorsByFileAndIdentifier[$normalizedTraitFilePath][$identifierKey]
+							??= self::filterIgnoreErrorsByIdentifier($this->ignoreErrorsByFile[$normalizedTraitFilePath], $identifier);
+						foreach ($matchingTraitFileIgnoreErrors as $ignoreError) {
+							$i = $ignoreError['index'];
+							$ignore = $ignoreError['ignoreError'];
+							if (!$processIgnoreError($error, $i, $ignore)) {
+								$ignoredErrors[] = [$error, $ignore];
+								continue 2;
+							}
+						}
+					}
+				}
+
 				$remainingContexts = $traitContexts;
 				foreach (array_keys($traitContexts) as $contextFilePath) {
 					$contextError = $error->asReportedInTraitContext($contextFilePath);


### PR DESCRIPTION
When a class using a trait reports its own error with the same message and identifier as an error deduplicated directly into the trait, `--generate-baseline` records the class occurrence under the class path (`count: 1`) and the deduplicated error under the trait path (`count: 1`)
On re-run the class-pathed entry also absorbed the trait context of that class, so it was reported as expected 1 time but occurred 2 times: the generated baseline failed by itself.

An entry scoped to the trait file hides the deduplicated error for every using class, so it is now tried first: the class-pathed entries account only for the errors reported in the class files themselves.