### PR TITLE
Mark VariableWritesNode and VariableWrite as @api

### DIFF
--- a/src/Node/Variable/VariableWrite.php
+++ b/src/Node/Variable/VariableWrite.php
@@ -9,6 +9,8 @@ use PhpParser\Node;
  *
  * Immutable. Whether the written value was read afterwards is not a property
  * of the write - it is answered by VariableWritesNode::isRead().
+ *
+ * @api
  */
 final class VariableWrite
 {

--- a/src/Node/VariableWritesNode.php
+++ b/src/Node/VariableWritesNode.php
@@ -18,6 +18,8 @@ use PHPStan\Type\Type;
  * Emitted right after the body's ReturnStatementsNode, with the scope inside
  * the function-like. Arrow functions have no node of their own - their writes
  * belong to the enclosing function-like.
+ *
+ * @api
  */
 final class VariableWritesNode extends NodeAbstract implements VirtualNode
 {


### PR DESCRIPTION
Follow-up to #6414. phpstan-strict-rules now listens on `VariableWritesNode` and calls `VariableWrite::getKind()` / `getVariableName()`; without `@api` its level 8 self-analysis reports `phpstanApi.method` / `phpstanApi.classConstant` for every call. The other virtual nodes extensions listen on (`ReturnStatementsNode`, `InClassNode`, ...) are already `@api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYiPGg9cpsKLyK6X5BrJTT