### PR TITLE
Reject strict mixed when a template type is expected

### DIFF
--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -17,6 +17,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
+use PHPStan\Type\Generic\TemplateStrictMixedType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
@@ -61,7 +62,7 @@ class StrictMixedType implements CompoundType
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult
 	{
-		if ($acceptingType instanceof self) {
+		if ($acceptingType instanceof self && !$acceptingType instanceof TemplateStrictMixedType) {
 			return AcceptsResult::createYes();
 		}
 		if ($acceptingType instanceof MixedType && !$acceptingType instanceof TemplateMixedType) {
@@ -78,7 +79,7 @@ class StrictMixedType implements CompoundType
 
 	public function isSubTypeOf(Type $otherType): IsSuperTypeOfResult
 	{
-		if ($otherType instanceof self) {
+		if ($otherType instanceof self && !$otherType instanceof TemplateStrictMixedType) {
 			return IsSuperTypeOfResult::createYes();
 		}
 		if ($otherType instanceof MixedType && !$otherType instanceof TemplateMixedType) {

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -449,6 +449,10 @@ class CallCallablesRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/bug-11935.php'], [
 			[
+				'Parameter #1 of callable callable(A): A expects A, mixed given.',
+				16,
+			],
+			[
 				'Parameter #1 of callable callable(Bug11935\Inv<A>): Bug11935\Inv<A> expects Bug11935\Inv<A>, Bug11935\Inv<mixed> given.',
 				34,
 			],

--- a/tests/PHPStan/Type/StrictMixedTypeTest.php
+++ b/tests/PHPStan/Type/StrictMixedTypeTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\TemplateStrictMixedType;
+use PHPStan\Type\Generic\TemplateTypeParameterStrategy;
+use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\DataProvider;
+use function sprintf;
+
+class StrictMixedTypeTest extends PHPStanTestCase
+{
+
+	public static function dataIsSubTypeOf(): array
+	{
+		return [
+			[
+				new StrictMixedType(),
+				new StrictMixedType(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new StrictMixedType(),
+				new TemplateStrictMixedType(
+					scope: TemplateTypeScope::createWithFunction('identity'),
+					templateTypeStrategy: new TemplateTypeParameterStrategy(),
+					templateTypeVariance: TemplateTypeVariance::createInvariant(),
+					name: 'A',
+					bound: new StrictMixedType(),
+					default: null,
+				),
+				TrinaryLogic::createMaybe(),
+			],
+		];
+	}
+
+	#[DataProvider('dataIsSubTypeOf')]
+	public function testIsSubTypeOf(StrictMixedType $type, Type $otherType, TrinaryLogic $expectedResult): void
+	{
+		$actualResult = $type->isSubTypeOf($otherType);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSubTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
+		);
+	}
+
+	#[DataProvider('dataIsSubTypeOf')]
+	public function testIsSubTypeOfInversed(StrictMixedType $type, Type $otherType, TrinaryLogic $expectedResult): void
+	{
+		$actualResult = $otherType->isSuperTypeOf($type);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),
+		);
+	}
+
+}


### PR DESCRIPTION
At level 9 and above, passing explicitly typed `mixed` to `callable(A): A` should produce an error because the value is not guaranteed to match `A`.
This change adds that diagnostic.

Below level 9, passing `mixed` to `callable(A): A` is allowed. This behavior remains unchanged.

Closes https://github.com/phpstan/phpstan/issues/11935
