### PR TITLE
Infer closure parameter types in array arguments

### DIFF
--- a/src/Analyser/ExprHandler/ArrayHandler.php
+++ b/src/Analyser/ExprHandler/ArrayHandler.php
@@ -5,6 +5,8 @@ namespace PHPStan\Analyser\ExprHandler;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
@@ -25,7 +27,11 @@ use PHPStan\Node\LiteralArrayNode;
 use PHPStan\Node\Variable\VariableWrite;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\CallableType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
@@ -68,6 +74,9 @@ final class ArrayHandler implements ExprHandler
 		if ($literalWrite !== null && $literalWrite->isOffsetWrite()) {
 			$literalWrite = null;
 		}
+		$passedToType = $this->getExpectedArrayType($context->getPassedToType());
+		$nativePassedToType = $this->getExpectedArrayType($context->getNativePassedToType());
+		$hasExpectedType = $passedToType !== null || $nativePassedToType !== null;
 		$nextIndex = 0;
 		foreach ($expr->items as $arrayItem) {
 			$itemNodes[] = new LiteralArrayItem($scope, $arrayItem);
@@ -85,7 +94,11 @@ final class ArrayHandler implements ExprHandler
 			}
 
 			$valueContext = $context->enterDeepKeepingValueFlow();
-			if ($literalWrite !== null) {
+			$keyType = null;
+			if ($hasExpectedType && !$arrayItem->unpack && ($arrayItem->value instanceof Array_ || $arrayItem->value instanceof Closure || $arrayItem->value instanceof ArrowFunction)) {
+				$keyType = $keyResult !== null ? $keyResult->getType()->toArrayKey() : ($nextIndex !== null ? new ConstantIntegerType($nextIndex) : new IntegerType());
+			}
+			if ($literalWrite !== null || $hasExpectedType) {
 				if ($arrayItem->unpack) {
 					$offset = null;
 					$nextIndex = null;
@@ -102,9 +115,17 @@ final class ArrayHandler implements ExprHandler
 						$nextIndex = max($nextIndex, $offset + 1);
 					}
 				}
+			}
+			if ($literalWrite !== null) {
 				$itemWrite = new VariableWrite($literalWrite->getVariableName(), $arrayItem, spl_object_id($arrayItem), VariableWrite::KIND_ARRAY_LITERAL_ITEM, true, $offset, $literalWrite->getId());
 				$variableFlows[] = VariableFlow::write($itemWrite);
 				$valueContext = $context->enterDeep()->enterValueFlow($itemWrite, false);
+			}
+			if ($keyType !== null) {
+				$valueContext = $valueContext->enterPassedToType(
+					$this->getExpectedValueType($passedToType, $keyType),
+					$this->getExpectedValueType($nativePassedToType, $keyType),
+				);
 			}
 			$valueResult = $nodeScopeResolver->processExprNode($stmt, $arrayItem->value, $scope, $storage, $nodeCallback, $valueContext);
 			$itemResults[spl_object_id($arrayItem->value)] = $valueResult;
@@ -172,6 +193,28 @@ final class ArrayHandler implements ExprHandler
 			},
 			specifyTypesCallback: SpecifiedTypes::emptySpecifyCallback(),
 		);
+	}
+
+	private function getExpectedArrayType(?Type $type): ?Type
+	{
+		if ($type === null || $type->isIterable()->no()) {
+			return null;
+		}
+
+		if ($type->isArray()->yes()) {
+			return $type;
+		}
+
+		return TypeCombinator::intersect($type, new ArrayType(new MixedType(), new MixedType()));
+	}
+
+	private function getExpectedValueType(?Type $arrayType, Type $keyType): ?Type
+	{
+		if ($arrayType === null || $arrayType->hasOffsetValueType($keyType)->no()) {
+			return null;
+		}
+
+		return $arrayType->getOffsetValueType($keyType);
 	}
 
 }

--- a/src/Analyser/ExprHandler/ArrowFunctionHandler.php
+++ b/src/Analyser/ExprHandler/ArrowFunctionHandler.php
@@ -41,7 +41,7 @@ final class ArrowFunctionHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		$arrowFunctionResult = $nodeScopeResolver->processArrowFunctionNode($stmt, $expr, $scope, $storage, $nodeCallback, null, null, $context);
+		$arrowFunctionResult = $nodeScopeResolver->processArrowFunctionNode($stmt, $expr, $scope, $storage, $nodeCallback, $context->getPassedToType(), $context->getNativePassedToType(), $context);
 		$result = $arrowFunctionResult->getExpressionResult();
 
 		// A plain typeCallback recursing through getClosureType() would re-walk
@@ -63,6 +63,8 @@ final class ArrowFunctionHandler implements ExprHandler
 			$arrowFunctionResult->getInvalidateExpressions(),
 			false,
 			$storage,
+			$context->getPassedToType(),
+			$context->getNativePassedToType(),
 		);
 		$nativeType = $this->closureTypeResolver->buildClosureTypeForArrowFunction(
 			$scope,
@@ -73,6 +75,8 @@ final class ArrowFunctionHandler implements ExprHandler
 			$arrowFunctionResult->getInvalidateExpressions(),
 			true,
 			$storage,
+			$context->getPassedToType(),
+			$context->getNativePassedToType(),
 		);
 
 		return $this->expressionResultFactory->create(

--- a/src/Analyser/ExprHandler/ClosureHandler.php
+++ b/src/Analyser/ExprHandler/ClosureHandler.php
@@ -41,7 +41,7 @@ final class ClosureHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		$processClosureResult = $nodeScopeResolver->processClosureNode($stmt, $expr, $scope, $storage, $nodeCallback, $context, null);
+		$processClosureResult = $nodeScopeResolver->processClosureNode($stmt, $expr, $scope, $storage, $nodeCallback, $context, $context->getPassedToType(), $context->getNativePassedToType());
 
 		// A plain typeCallback recursing through getClosureType() would re-walk
 		// the body each getType() ask before the cache populates and hang;
@@ -67,6 +67,8 @@ final class ClosureHandler implements ExprHandler
 			$processClosureResult->getInvalidateExpressions(),
 			false,
 			$storage,
+			$context->getPassedToType(),
+			$context->getNativePassedToType(),
 		);
 		$nativeType = $type;
 

--- a/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
+++ b/src/Analyser/ExprHandler/Helper/ClosureTypeResolver.php
@@ -308,9 +308,11 @@ final class ClosureTypeResolver implements PerFileAnalysisResettable
 		array $invalidateExpressions,
 		bool $native = false,
 		?ExpressionResultStorage $storage = null,
+		?Type $passedToType = null,
+		?Type $nativePassedToType = null,
 	): ClosureType
 	{
-		[$parameters, $isVariadic, $callableParameters, $nativeCallableParameters] = $this->buildParametersAndAcceptors($scope, $expr, $storage);
+		[$parameters, $isVariadic, $callableParameters, $nativeCallableParameters] = $this->buildParametersAndAcceptors($scope, $expr, $storage, $passedToType, $nativePassedToType);
 
 		return $this->buildClosureTypeFromClosureWalk(
 			$scope,
@@ -356,9 +358,11 @@ final class ClosureTypeResolver implements PerFileAnalysisResettable
 		array $invalidateExpressions,
 		bool $native = false,
 		?ExpressionResultStorage $storage = null,
+		?Type $passedToType = null,
+		?Type $nativePassedToType = null,
 	): ClosureType
 	{
-		[$parameters, $isVariadic, $callableParameters, $nativeCallableParameters] = $this->buildParametersAndAcceptors($scope, $expr, $storage);
+		[$parameters, $isVariadic, $callableParameters, $nativeCallableParameters] = $this->buildParametersAndAcceptors($scope, $expr, $storage, $passedToType, $nativePassedToType);
 
 		$returnType = $this->resolveArrowFunctionReturnType($scope, $arrowScope, $expr, $native, $storage);
 
@@ -784,14 +788,13 @@ final class ClosureTypeResolver implements PerFileAnalysisResettable
 		MutatingScope $scope,
 		Node\Expr\Closure|ArrowFunction $expr,
 		?ExpressionResultStorage $storage = null,
+		?Type $passedToType = null,
+		?Type $nativePassedToType = null,
 	): array
 	{
 		[$parameters, $isVariadic] = $this->buildDeclaredParameters($scope, $expr);
-
-		$passedToType = null;
-		$nativePassedToType = null;
 		$inFunctionCallsStackCount = count($scope->inFunctionCallsStack);
-		if ($inFunctionCallsStackCount > 0) {
+		if ($passedToType === null && $inFunctionCallsStackCount > 0) {
 			[, $inParameter] = $scope->inFunctionCallsStack[$inFunctionCallsStackCount - 1];
 			if ($inParameter !== null) {
 				$passedToType = $inParameter->getType();

--- a/src/Analyser/ExpressionContext.php
+++ b/src/Analyser/ExpressionContext.php
@@ -25,6 +25,8 @@ final class ExpressionContext
 		private bool $arrayDimFetchRoot = false,
 		private bool $unsetTarget = false,
 		private ?bool $valueConsumed = null,
+		private ?Type $passedToType = null,
+		private ?Type $nativePassedToType = null,
 	)
 	{
 	}
@@ -46,7 +48,7 @@ final class ExpressionContext
 	 */
 	public function enterDeep(): self
 	{
-		if ($this->isDeep && $this->valueFlowTarget === null && !$this->arrayDimFetchRoot && !$this->unsetTarget) {
+		if ($this->isDeep && $this->valueFlowTarget === null && !$this->arrayDimFetchRoot && !$this->unsetTarget && $this->passedToType === null && $this->nativePassedToType === null) {
 			return $this;
 		}
 
@@ -74,7 +76,7 @@ final class ExpressionContext
 	 */
 	public function withoutValueFlow(): self
 	{
-		if ($this->valueFlowTarget === null && !$this->arrayDimFetchRoot && !$this->unsetTarget) {
+		if ($this->valueFlowTarget === null && !$this->arrayDimFetchRoot && !$this->unsetTarget && $this->passedToType === null && $this->nativePassedToType === null) {
 			return $this;
 		}
 
@@ -90,6 +92,30 @@ final class ExpressionContext
 	public function isValueConsumed(): bool
 	{
 		return $this->valueFlowTarget !== null || ($this->valueConsumed ?? $this->isDeep);
+	}
+
+	/** Applies only to this expression; child expressions must receive their own expected types. */
+	public function enterPassedToType(?Type $type, ?Type $nativeType): self
+	{
+		if ($this->passedToType === $type && $this->nativePassedToType === $nativeType) {
+			return $this;
+		}
+
+		$context = clone $this;
+		$context->passedToType = $type;
+		$context->nativePassedToType = $nativeType;
+
+		return $context;
+	}
+
+	public function getPassedToType(): ?Type
+	{
+		return $this->passedToType;
+	}
+
+	public function getNativePassedToType(): ?Type
+	{
+		return $this->nativePassedToType;
 	}
 
 	public function isDeep(): bool

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3143,7 +3143,11 @@ class NodeScopeResolver
 				if ($enterExpressionAssignForByRef) {
 					$scopeToPass = $scopeToPass->enterExpressionAssign($arg->value);
 				}
-				$exprResult = $this->processExprNode($stmt, $arg->value, $scopeToPass, $storage, $nodeCallback, $context->enterDeep());
+				$argContext = $context->enterDeep();
+				if (!$arg->unpack && $arg->value instanceof Expr\Array_) {
+					$argContext = $argContext->enterPassedToType($parameterType, $parameterNativeType);
+				}
+				$exprResult = $this->processExprNode($stmt, $arg->value, $scopeToPass, $storage, $nodeCallback, $argContext);
 				$argResults[spl_object_id($arg->value)] = $exprResult;
 				$exprType = $exprResult->getType();
 				$throwPoints = array_merge($throwPoints, $exprResult->getThrowPoints());

--- a/tests/PHPStan/Analyser/nsrt/array-closure-parameters.php
+++ b/tests/PHPStan/Analyser/nsrt/array-closure-parameters.php
@@ -1,0 +1,98 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace ArrayClosureParameters;
+
+use Closure;
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+/** @param list<callable(string, int): mixed> $callbacks */
+function callbacks(array $callbacks): void {}
+
+callbacks([
+	function ($value, $key) {
+		assertType('string', $value);
+		assertType('int', $key);
+		assertNativeType('mixed', $value);
+		assertNativeType('mixed', $key);
+		return $value;
+	},
+	fn ($value, $key) => [assertType('string', $value), assertType('int', $key), assertNativeType('mixed', $value)],
+	function (int $value, $key) {
+		assertType('int', $value);
+		assertType('int', $key);
+	},
+]);
+
+/** @param array{first: callable(string): mixed, second?: Closure(int): mixed} $callbacks */
+function shape(array $callbacks): void {}
+
+shape(callbacks: [
+	'second' => fn ($value) => assertType('int', $value),
+	'first' => function ($value) {
+		assertType('string', $value);
+		$unrelated = [function ($other) {
+			assertType('mixed', $other);
+		}];
+	},
+]);
+
+/** @param array{callable(string): mixed, callable(int): mixed} $callbacks */
+function tuple(array $callbacks): void {}
+
+tuple([
+	fn ($value) => assertType('string', $value),
+	fn ($value) => assertType('int', $value),
+]);
+
+/** @param array{5: string, 6: callable(int): mixed} $callbacks */
+function numericShape(array $callbacks): void {}
+
+numericShape([5 => 'value', fn ($value) => assertType('int', $value)]);
+
+/** @param array<string, list<callable(string): mixed>> $callbacks */
+function nested(array $callbacks): void {}
+
+nested(['first' => [function ($value) {
+	assertType('string', $value);
+}]]);
+
+/** @param list<callable(string): mixed>|null $callbacks */
+function nullable(?array $callbacks): void {}
+
+nullable([fn ($value) => assertType('string', $value)]);
+
+/** @param iterable<callable(string): mixed> $callbacks */
+function iterableCallbacks(iterable $callbacks): void {}
+
+iterableCallbacks([fn ($value) => assertType('string', $value)]);
+
+/**
+ * @template T
+ * @param T $value
+ * @param list<callable(T): mixed> $callbacks
+ */
+function generic($value, array $callbacks): void {}
+
+generic(new \stdClass(), [fn ($value) => assertType('stdClass', $value)]);
+
+class Receiver
+{
+	/** @param list<callable(string): mixed> $callbacks */
+	public function __construct(array $callbacks) {}
+
+	/** @param list<callable(int): mixed> $callbacks */
+	public static function run(array $callbacks): void {}
+
+	/** @param list<callable(string): mixed> ...$callbacks */
+	public function variadic(array ...$callbacks): void {}
+}
+
+$receiver = new Receiver([fn ($value) => assertType('string', $value)]);
+Receiver::run([fn ($value) => assertType('int', $value)]);
+$receiver->variadic([fn ($value) => assertType('string', $value)], [fn ($value) => assertType('string', $value)]);
+
+$unrelated = [fn ($value) => assertType('mixed', $value)];
+callbacks($unrelated);

--- a/tests/PHPStan/Analyser/nsrt/bug-11215.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11215.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11215;
+
+use function PHPStan\Testing\assertType;
+
+class User {}
+
+/** @template TModel */
+class Builder
+{
+}
+
+/** @template TModel */
+class Collection
+{
+
+	/** @param callable(Builder<TModel>): mixed $relation */
+	public function load($relation): void
+	{
+		//
+	}
+
+	/** @param array<string, (callable(Builder<TModel>): mixed)|string> $relations */
+	public function loadMany($relations): void
+	{
+		//
+	}
+
+}
+
+/** @var Collection<User> $users */
+$users->load(function ($query) {
+	assertType('Bug11215\Builder<Bug11215\User>', $query);
+});
+
+$users->loadMany(['foo' => function ($query) {
+	assertType('Bug11215\Builder<Bug11215\User>', $query);
+}]);

--- a/tests/PHPStan/Analyser/nsrt/bug-6430.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-6430.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6430;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class HelloWorld
+{
+
+	/**
+	 * @param array<int, (\Closure(TValue, TKey): mixed)> $callback
+	 */
+	public function sayHello($callback): void
+	{
+
+	}
+
+}
+
+/** @var HelloWorld<int, string> */
+$a = new HelloWorld;
+
+$a->sayHello([function ($u, $i) {
+	assertType('string', $u);
+	assertType('int', $i);
+	return true;
+}]);


### PR DESCRIPTION
Closures passed inside array arguments now inherit their parameter types from the expected array element type. For example, a closure inside an `array<Closure(string, int): mixed>` parameter sees `string` and `int` instead of `mixed`.

Pass the expected PHPDoc and native types through expression context to array elements and closure analysis. This also covers arrow functions, nested arrays, array shapes, nullable arrays, and iterable parameters while preserving explicit closure parameter types.

Added the original playground reproducers for both issues and additional inference coverage. All three regression fixtures fail without the source changes and pass with them restored. The full suite passes (21,799 tests, 67 skipped), as do `make phpstan` and coding style checks for the changed source files.

Closes https://github.com/phpstan/phpstan/issues/6430
Closes https://github.com/phpstan/phpstan/issues/11215
