### PR TITLE
Validate @phpstan-sealed types are subtypes of the annotated type

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -1,6 +1,7 @@
 parameters:
 	featureToggles:
 		bleedingEdge: true
+		checkSealedSubtypes: true
 		checkNonStringableDynamicAccess: true
 		checkParameterCastableToNumberFunctions: true
 		skipCheckGenericClasses!: []

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -26,6 +26,7 @@ parameters:
 			throwTypeCovariance: false
 	featureToggles:
 		bleedingEdge: false
+		checkSealedSubtypes: false
 		checkNonStringableDynamicAccess: false
 		checkParameterCastableToNumberFunctions: false
 		skipCheckGenericClasses:

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -30,6 +30,7 @@ parametersSchema:
 	])
 	featureToggles: structure([
 		bleedingEdge: bool(),
+		checkSealedSubtypes: bool(),
 		checkNonStringableDynamicAccess: bool(),
 		checkParameterCastableToNumberFunctions: bool(),
 		skipCheckGenericClasses: listOf(string()),

--- a/src/Rules/PhpDoc/SealedDefinitionClassRule.php
+++ b/src/Rules/PhpDoc/SealedDefinitionClassRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\PhpDoc;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\BleedingEdgeToggle;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\DependencyInjection\ValidatesStubFiles;
 use PHPStan\Node\InClassNode;
@@ -87,7 +88,8 @@ final class SealedDefinitionClassRule implements Rule
 				$sealedTypeReflection = $this->reflectionProvider->getClass($class);
 
 				if (
-					($sealedTypeReflection->isEnum() || $sealedTypeReflection->isFinal())
+					BleedingEdgeToggle::isBleedingEdge()
+					&& ($sealedTypeReflection->isEnum() || $sealedTypeReflection->isFinal())
 					&& !$sealedTypeReflection->is($classReflection->getName())
 				) {
 					$errorBuilder = RuleErrorBuilder::message(sprintf(

--- a/src/Rules/PhpDoc/SealedDefinitionClassRule.php
+++ b/src/Rules/PhpDoc/SealedDefinitionClassRule.php
@@ -5,7 +5,6 @@ namespace PHPStan\Rules\PhpDoc;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
-use PHPStan\DependencyInjection\BleedingEdgeToggle;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\DependencyInjection\ValidatesStubFiles;
 use PHPStan\Node\InClassNode;
@@ -35,6 +34,8 @@ final class SealedDefinitionClassRule implements Rule
 		private bool $checkClassCaseSensitivity,
 		#[AutowiredParameter(ref: '%tips.discoveringSymbols%')]
 		private bool $discoveringSymbolsTip,
+		#[AutowiredParameter(ref: '%featureToggles.checkSealedSubtypes%')]
+		private bool $checkSealedSubtypes,
 	)
 	{
 	}
@@ -88,7 +89,7 @@ final class SealedDefinitionClassRule implements Rule
 				$sealedTypeReflection = $this->reflectionProvider->getClass($class);
 
 				if (
-					BleedingEdgeToggle::isBleedingEdge()
+					$this->checkSealedSubtypes
 					&& ($sealedTypeReflection->isEnum() || $sealedTypeReflection->isFinal())
 					&& !$sealedTypeReflection->is($classReflection->getName())
 				) {

--- a/src/Rules/PhpDoc/SealedDefinitionClassRule.php
+++ b/src/Rules/PhpDoc/SealedDefinitionClassRule.php
@@ -84,9 +84,14 @@ final class SealedDefinitionClassRule implements Rule
 					continue;
 				}
 
-				if (!$this->reflectionProvider->getClass($class)->is($classReflection->getName())) {
+				$sealedTypeReflection = $this->reflectionProvider->getClass($class);
+
+				if (
+					($sealedTypeReflection->isEnum() || $sealedTypeReflection->isFinal())
+					&& !$sealedTypeReflection->is($classReflection->getName())
+				) {
 					$errorBuilder = RuleErrorBuilder::message(sprintf(
-						'PHPDoc tag @phpstan-sealed type %s is not subtype of %s.',
+						'PHPDoc tag @phpstan-sealed contains final type %s that is not subtype of %s.',
 						$class,
 						$classReflection->getName(),
 					))->identifier('sealed.notSubtype');

--- a/src/Rules/PhpDoc/SealedDefinitionClassRule.php
+++ b/src/Rules/PhpDoc/SealedDefinitionClassRule.php
@@ -84,6 +84,18 @@ final class SealedDefinitionClassRule implements Rule
 					continue;
 				}
 
+				if (!$this->reflectionProvider->getClass($class)->is($classReflection->getName())) {
+					$errorBuilder = RuleErrorBuilder::message(sprintf(
+						'PHPDoc tag @phpstan-sealed type %s is not subtype of %s.',
+						$class,
+						$classReflection->getName(),
+					))->identifier('sealed.notSubtype');
+
+					$errors[] = $errorBuilder->build();
+
+					continue;
+				}
+
 				$errors = array_merge(
 					$errors,
 					$this->classCheck->checkClassNames($scope, [

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Rules\PhpDoc;
 
 use PHPStan\Classes\ForbiddenClassNameExtension;
-use PHPStan\DependencyInjection\BleedingEdgeToggle;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
 use PHPStan\Rules\ClassForbiddenNameCheck;
 use PHPStan\Rules\ClassNameCheck;
@@ -17,6 +16,8 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
  */
 class SealedDefinitionClassRuleTest extends RuleTestCase
 {
+
+	private bool $checkSealedSubtypes = true;
 
 	protected function getRule(): Rule
 	{
@@ -33,6 +34,7 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 			),
 			true,
 			true,
+			$this->checkSealedSubtypes,
 		);
 	}
 
@@ -89,11 +91,10 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 	}
 
 	#[RequiresPhp('>= 8.1.0')]
-	public function testFinalSubtypesAreNotCheckedWithoutBleedingEdge(): void
+	public function testFinalSubtypesAreNotCheckedWhenDisabled(): void
 	{
-		BleedingEdgeToggle::withBleedingEdge(false, function (): void {
-			$this->analyse([__DIR__ . '/data/sealed-non-final-subtypes.php'], []);
-		});
+		$this->checkSealedSubtypes = false;
+		$this->analyse([__DIR__ . '/data/sealed-non-final-subtypes.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\PhpDoc;
 
 use PHPStan\Classes\ForbiddenClassNameExtension;
+use PHPStan\DependencyInjection\BleedingEdgeToggle;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
 use PHPStan\Rules\ClassForbiddenNameCheck;
 use PHPStan\Rules\ClassNameCheck;
@@ -85,6 +86,14 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 				8,
 			],
 		]);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
+	public function testFinalSubtypesAreNotCheckedWithoutBleedingEdge(): void
+	{
+		BleedingEdgeToggle::withBleedingEdge(false, function (): void {
+			$this->analyse([__DIR__ . '/data/sealed-non-final-subtypes.php'], []);
+		});
 	}
 
 }

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -54,9 +54,48 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
 			[
+				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeClass is not subtype of IncompatibleSealed\Valid.',
+				31,
+			],
+			[
+				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeClass is not subtype of IncompatibleSealed\ValidInterface.',
+				36,
+			],
+			[
+				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeInterface is not subtype of IncompatibleSealed\ValidInterface2.',
+				41,
+			],
+			[
 				'PHPDoc tag @phpstan-sealed contains unknown class IncompatibleSealed\UnknownClass.',
 				46,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
+			[
+				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeClass is not subtype of IncompatibleSealed\InvalidClassWithUnion.',
+				46,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.2.0')]
+	public function testSubtypes(): void
+	{
+		$this->analyse([__DIR__ . '/data/sealed-subtypes.php'], [
+			[
+				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YEnumInvalid is not subtype of SealedSubtypes\\__EnumError.',
+				23,
+			],
+			[
+				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YInterfaceInvalid is not subtype of SealedSubtypes\\__InterfaceError.',
+				37,
+			],
+			[
+				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YAbstractClassInvalid is not subtype of SealedSubtypes\\__AbstractClassError.',
+				51,
+			],
+			[
+				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YClassInvalid is not subtype of SealedSubtypes\\__ClassError.',
+				65,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -54,25 +54,9 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
 			[
-				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeClass is not subtype of IncompatibleSealed\Valid.',
-				31,
-			],
-			[
-				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeClass is not subtype of IncompatibleSealed\ValidInterface.',
-				36,
-			],
-			[
-				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeInterface is not subtype of IncompatibleSealed\ValidInterface2.',
-				41,
-			],
-			[
 				'PHPDoc tag @phpstan-sealed contains unknown class IncompatibleSealed\UnknownClass.',
 				46,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
-			],
-			[
-				'PHPDoc tag @phpstan-sealed type IncompatibleSealed\SomeClass is not subtype of IncompatibleSealed\InvalidClassWithUnion.',
-				46,
 			],
 		]);
 	}
@@ -82,20 +66,23 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/sealed-subtypes.php'], [
 			[
-				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YEnumInvalid is not subtype of SealedSubtypes\\__EnumError.',
+				'PHPDoc tag @phpstan-sealed contains final type SealedSubtypes\\__YEnumInvalid that is not subtype of SealedSubtypes\\__EnumError.',
 				23,
 			],
 			[
-				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YInterfaceInvalid is not subtype of SealedSubtypes\\__InterfaceError.',
-				37,
-			],
-			[
-				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YAbstractClassInvalid is not subtype of SealedSubtypes\\__AbstractClassError.',
-				51,
-			],
-			[
-				'PHPDoc tag @phpstan-sealed type SealedSubtypes\\__YClassInvalid is not subtype of SealedSubtypes\\__ClassError.',
+				'PHPDoc tag @phpstan-sealed contains final type SealedSubtypes\\__YClassInvalid that is not subtype of SealedSubtypes\\__ClassError.',
 				65,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.1.0')]
+	public function testNonFinalSubtypes(): void
+	{
+		$this->analyse([__DIR__ . '/data/sealed-non-final-subtypes.php'], [
+			[
+				'PHPDoc tag @phpstan-sealed contains final type SealedNonFinalSubtypes\\InvalidZ that is not subtype of SealedNonFinalSubtypes\\InvalidSealed.',
+				8,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -68,11 +68,11 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/sealed-subtypes.php'], [
 			[
 				'PHPDoc tag @phpstan-sealed contains final type SealedSubtypes\\__YEnumInvalid that is not subtype of SealedSubtypes\\__EnumError.',
-				23,
+				10,
 			],
 			[
 				'PHPDoc tag @phpstan-sealed contains final type SealedSubtypes\\__YClassInvalid that is not subtype of SealedSubtypes\\__ClassError.',
-				65,
+				20,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/data/sealed-non-final-subtypes.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/sealed-non-final-subtypes.php
@@ -1,0 +1,22 @@
+<?php // lint >= 8.1
+
+namespace SealedNonFinalSubtypes;
+
+/**
+ * @phpstan-sealed InvalidX|InvalidY|InvalidZ
+ */
+interface InvalidSealed {}
+
+final class InvalidX implements InvalidSealed {}
+final class InvalidY implements InvalidSealed {}
+final class InvalidZ {}
+
+/**
+ * @phpstan-sealed ValidX|ValidY|ValidZ
+ */
+interface ValidSealed {}
+
+final class ValidX implements ValidSealed {}
+final class ValidY implements ValidSealed {}
+class ValidZ {}
+class ValidZZ extends ValidZ {}

--- a/tests/PHPStan/Rules/PhpDoc/data/sealed-subtypes.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/sealed-subtypes.php
@@ -2,59 +2,14 @@
 
 namespace SealedSubtypes;
 
-/**
- * Subtyping is reflexive, so Reflexivity is a subtype of itself.
- * This is a degenerate sealed declaration, but it is valid and must not report an error.
- *
- * @phpstan-sealed Reflexivity
- */
-interface Reflexivity {}
-
 /** @phpstan-sealed _XEnum */
 interface _Enum {}
 enum _XEnum implements _Enum { case Value; }
-
-/** @phpstan-sealed __XEnum | __YEnum */
-interface __Enum {}
-enum __XEnum implements __Enum { case Value; }
-enum __YEnum implements __Enum { case Value; }
 
 /** @phpstan-sealed __XEnumValid | __YEnumInvalid */
 interface __EnumError {}
 enum __XEnumValid implements __EnumError { case Value; }
 enum __YEnumInvalid { case Value; }
-
-/** @phpstan-sealed _XInterface */
-interface _Interface {}
-interface _XInterface extends _Interface {}
-
-/** @phpstan-sealed __XInterface | __YInterface */
-interface __Interface {}
-interface __XInterface extends __Interface {}
-interface __YInterface extends __Interface {}
-
-/** @phpstan-sealed __XInterfaceValid | __YInterfaceInvalid */
-interface __InterfaceError {}
-interface __XInterfaceValid extends __InterfaceError {}
-interface __YInterfaceInvalid {}
-
-/** @phpstan-sealed _XAbstractClass */
-abstract readonly class _AbstractClass {}
-abstract readonly class _XAbstractClass extends _AbstractClass {}
-
-/** @phpstan-sealed __XAbstractClass | __YAbstractClass */
-abstract readonly class __AbstractClass {}
-abstract readonly class __XAbstractClass extends __AbstractClass {}
-abstract readonly class __YAbstractClass extends __AbstractClass {}
-
-/** @phpstan-sealed __XAbstractClassValid | __YAbstractClassInvalid */
-abstract readonly class __AbstractClassError {}
-abstract readonly class __XAbstractClassValid extends __AbstractClassError {}
-abstract readonly class __YAbstractClassInvalid {}
-
-/** @phpstan-sealed _XClass */
-abstract readonly class _Class {}
-final readonly class _XClass extends _Class {}
 
 /** @phpstan-sealed __XClass | __YClass */
 abstract readonly class __Class {}

--- a/tests/PHPStan/Rules/PhpDoc/data/sealed-subtypes.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/sealed-subtypes.php
@@ -1,0 +1,67 @@
+<?php // lint >= 8.2
+
+namespace SealedSubtypes;
+
+/**
+ * Subtyping is reflexive, so Reflexivity is a subtype of itself.
+ * This is a degenerate sealed declaration, but it is valid and must not report an error.
+ *
+ * @phpstan-sealed Reflexivity
+ */
+interface Reflexivity {}
+
+/** @phpstan-sealed _XEnum */
+interface _Enum {}
+enum _XEnum implements _Enum { case Value; }
+
+/** @phpstan-sealed __XEnum | __YEnum */
+interface __Enum {}
+enum __XEnum implements __Enum { case Value; }
+enum __YEnum implements __Enum { case Value; }
+
+/** @phpstan-sealed __XEnumValid | __YEnumInvalid */
+interface __EnumError {}
+enum __XEnumValid implements __EnumError { case Value; }
+enum __YEnumInvalid { case Value; }
+
+/** @phpstan-sealed _XInterface */
+interface _Interface {}
+interface _XInterface extends _Interface {}
+
+/** @phpstan-sealed __XInterface | __YInterface */
+interface __Interface {}
+interface __XInterface extends __Interface {}
+interface __YInterface extends __Interface {}
+
+/** @phpstan-sealed __XInterfaceValid | __YInterfaceInvalid */
+interface __InterfaceError {}
+interface __XInterfaceValid extends __InterfaceError {}
+interface __YInterfaceInvalid {}
+
+/** @phpstan-sealed _XAbstractClass */
+abstract readonly class _AbstractClass {}
+abstract readonly class _XAbstractClass extends _AbstractClass {}
+
+/** @phpstan-sealed __XAbstractClass | __YAbstractClass */
+abstract readonly class __AbstractClass {}
+abstract readonly class __XAbstractClass extends __AbstractClass {}
+abstract readonly class __YAbstractClass extends __AbstractClass {}
+
+/** @phpstan-sealed __XAbstractClassValid | __YAbstractClassInvalid */
+abstract readonly class __AbstractClassError {}
+abstract readonly class __XAbstractClassValid extends __AbstractClassError {}
+abstract readonly class __YAbstractClassInvalid {}
+
+/** @phpstan-sealed _XClass */
+abstract readonly class _Class {}
+final readonly class _XClass extends _Class {}
+
+/** @phpstan-sealed __XClass | __YClass */
+abstract readonly class __Class {}
+final readonly class __XClass extends __Class {}
+final readonly class __YClass extends __Class {}
+
+/** @phpstan-sealed __XClassValid | __YClassInvalid */
+abstract readonly class __ClassError {}
+final readonly class __XClassValid extends __ClassError {}
+final readonly class __YClassInvalid {}


### PR DESCRIPTION
Validate that every type listed in `@phpstan-sealed` is a subtype of the annotated class or interface.
Invalid entries are reported with the `sealed.notSubtype` error identifier.

Add regression coverage for valid and invalid enum, interface, abstract-class, and final-class sealed subtype declarations, including the reflexive case.

Closes [#15204](https://github.com/phpstan/phpstan/issues/15204)
