### PR TITLE
Remove a union of values in one pass, and key types by value instead of by description

### DIFF
--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -57,6 +57,7 @@ use Throwable;
 use Traversable;
 use function array_key_exists;
 use function array_map;
+use function array_merge;
 use function array_values;
 use function count;
 use function get_class;
@@ -1751,11 +1752,24 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function subtract(Type $type): Type
 	{
-		if ($this->subtractedType !== null) {
-			$type = TypeCombinator::union($this->subtractedType, $type);
+		if ($this->subtractedType === null) {
+			return $this->changeSubtractedType($type);
 		}
 
-		return $this->changeSubtractedType($type);
+		// A sealed hierarchy rebuilds its subtraction from the flattened parts
+		// below, so normalising the union of the old and the new subtracted type
+		// first is wasted work - and quadratic when a removal peels the subtypes
+		// off one at a time, as removing a whole enum from its own type does.
+		// Only the path that keeps the subtracted type as it is needs the union.
+		$matched = $this->matchAllowedSubTypes(array_merge(
+			TypeUtils::flattenTypes($this->subtractedType),
+			TypeUtils::flattenTypes($type),
+		));
+		if ($matched !== null) {
+			return $matched;
+		}
+
+		return $this->changeSubtractedType(TypeCombinator::union($this->subtractedType, $type));
 	}
 
 	public function getTypeWithoutSubtractedType(): Type
@@ -1783,47 +1797,9 @@ class ObjectType implements TypeWithClassName, SubtractableType
 	public function changeSubtractedType(?Type $subtractedType): Type
 	{
 		if ($subtractedType !== null) {
-			$classReflection = $this->getClassReflection();
-			$allowedSubTypes = $classReflection !== null ? $classReflection->getAllowedSubTypes() : null;
-			if ($allowedSubTypes !== null) {
-				$preciseVerbosity = VerbosityLevel::precise();
-
-				$originalAllowedSubTypes = $allowedSubTypes;
-				$subtractedSubTypes = [];
-
-				$subtractedTypes = TypeUtils::flattenTypes($subtractedType);
-				foreach ($subtractedTypes as $subType) {
-					foreach ($allowedSubTypes as $key => $allowedSubType) {
-						if ($subType->equals($allowedSubType)) {
-							$description = $allowedSubType->describe($preciseVerbosity);
-							$subtractedSubTypes[$description] = $subType;
-							unset($allowedSubTypes[$key]);
-							continue 2;
-						}
-					}
-
-					return new self($this->className, $subtractedType);
-				}
-
-				if (count($allowedSubTypes) === 1) {
-					return array_values($allowedSubTypes)[0];
-				}
-
-				$subtractedSubTypes = array_values($subtractedSubTypes);
-				$subtractedSubTypesCount = count($subtractedSubTypes);
-				if ($subtractedSubTypesCount === count($originalAllowedSubTypes)) {
-					return new NeverType();
-				}
-
-				if ($subtractedSubTypesCount === 0) {
-					return new self($this->className);
-				}
-
-				if ($subtractedSubTypesCount === 1) {
-					return new self($this->className, $subtractedSubTypes[0]);
-				}
-
-				return new self($this->className, new UnionType($subtractedSubTypes));
+			$matched = $this->matchAllowedSubTypes(TypeUtils::flattenTypes($subtractedType));
+			if ($matched !== null) {
+				return $matched;
 			}
 		}
 
@@ -1832,6 +1808,59 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		return new self($this->className, $subtractedType);
+	}
+
+	/**
+	 * Rebuilds the type from the subtracted members of its sealed hierarchy.
+	 *
+	 * Returns null when the class has no allowed subtypes, or when a subtracted
+	 * type is not one of them - the caller then keeps the subtracted type whole.
+	 *
+	 * @param array<Type> $subtractedTypes flattened, may repeat
+	 */
+	private function matchAllowedSubTypes(array $subtractedTypes): ?Type
+	{
+		$classReflection = $this->getClassReflection();
+		$allowedSubTypes = $classReflection !== null ? $classReflection->getAllowedSubTypes() : null;
+		if ($allowedSubTypes === null) {
+			return null;
+		}
+
+		$allowedSubTypesCount = count($allowedSubTypes);
+		$subtractedSubTypes = [];
+
+		foreach ($subtractedTypes as $subType) {
+			foreach ($allowedSubTypes as $key => $allowedSubType) {
+				if ($subType->equals($allowedSubType)) {
+					// An allowed subtype is dropped as it matches, so no two matches
+					// can be the same one and the matches need no keying.
+					$subtractedSubTypes[] = $subType;
+					unset($allowedSubTypes[$key]);
+					continue 2;
+				}
+			}
+
+			return null;
+		}
+
+		if (count($allowedSubTypes) === 1) {
+			return array_values($allowedSubTypes)[0];
+		}
+
+		$subtractedSubTypesCount = count($subtractedSubTypes);
+		if ($subtractedSubTypesCount === $allowedSubTypesCount) {
+			return new NeverType();
+		}
+
+		if ($subtractedSubTypesCount === 0) {
+			return new self($this->className);
+		}
+
+		if ($subtractedSubTypesCount === 1) {
+			return new self($this->className, $subtractedSubTypes[0]);
+		}
+
+		return new self($this->className, new UnionType($subtractedSubTypes));
 	}
 
 	public function getSubtractedType(): ?Type

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -125,6 +125,14 @@ class ObjectType implements TypeWithClassName, SubtractableType
 	private ?string $cachedDescription = null;
 
 	/**
+	 * The class name as the reflection spells it - the properly cased name, or the
+	 * readable `class@anonymous...` form. Resolving it takes two ReflectionProvider
+	 * round-trips and both the type-only and the value level need it, the latter on
+	 * every operation RecursionGuard guards.
+	 */
+	private ?string $cachedPreciseName = null;
+
+	/**
 	 * The reflection resolved on demand by getClassReflection(), kept apart from the one
 	 * handed to the constructor. The constructor's reflection is part of the type's value
 	 * — it can differ from what the provider would return (an anonymous class is identified
@@ -742,13 +750,21 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function describe(VerbosityLevel $level): string
 	{
+		if ($this->cachedPreciseName !== null && ($level->isValue() || $level->isTypeOnly())) {
+			return $this->cachedPreciseName;
+		}
+
 		$preciseNameCallback = function (): string {
-			$reflectionProvider = ReflectionProviderStaticAccessor::getInstance();
-			if (!$reflectionProvider->hasClass($this->className)) {
-				return $this->className;
+			if ($this->cachedPreciseName !== null) {
+				return $this->cachedPreciseName;
 			}
 
-			return $reflectionProvider->getClassName($this->className);
+			$reflectionProvider = ReflectionProviderStaticAccessor::getInstance();
+			if (!$reflectionProvider->hasClass($this->className)) {
+				return $this->cachedPreciseName = $this->className;
+			}
+
+			return $this->cachedPreciseName = $reflectionProvider->getClassName($this->className);
 		};
 
 		$preciseWithSubtracted = fn (): string => $this->className . $this->describeSubtractedType($this->subtractedType, $level);

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -98,12 +98,54 @@ final class TypeCombinator
 		return self::doRemove($fromType, $typeToRemove);
 	}
 
+	/**
+	 * Whether removing the union's members all at once gives what removing them
+	 * one at a time would: true when the subtraction is a set difference, so no
+	 * order of removals can sharpen the result.
+	 *
+	 * Everywhere else the members have to come off one at a time - removing one
+	 * can narrow the type so that removing the next achieves more.
+	 */
+	private static function canRemoveUnionAtOnce(Type $fromType, UnionType $typeToRemove): bool
+	{
+		// A sealed hierarchy - an enum, or a hierarchy an
+		// AllowedSubTypesClassReflectionExtension seals - subtracts by dropping
+		// allowed subtypes, and which ones are dropped does not depend on order.
+		$classReflections = $fromType->getObjectClassReflections();
+		if (count($classReflections) === 1 && $classReflections[0]->getAllowedSubTypes() !== null) {
+			return true;
+		}
+
+		// A union removes the whole thing from each of its members, and each of
+		// those removals weighs this same question again - so a member that needs
+		// the removals one at a time still gets them that way.
+		return $fromType instanceof UnionType;
+	}
+
 	/** @internal Delegated to from TypeCombinatorCache, which the native extension shadows to memoize it. */
 	public static function doRemove(Type $fromType, Type $typeToRemove): Type
 	{
 		if ($typeToRemove instanceof UnionType) {
+			// Removing the members one at a time is what keeps the result precise:
+			// removing one can narrow the type so that removing the next achieves
+			// more. A sealed hierarchy is the exception - there the subtraction is
+			// a set difference over the allowed subtypes, so the order the members
+			// come off cannot matter, and peeling them would rebuild the whole
+			// subtraction once per member (removing an enum from its own type then
+			// costs O(cases^2)).
+			if (self::canRemoveUnionAtOnce($fromType, $typeToRemove)) {
+				$removed = $fromType->tryRemove($typeToRemove);
+				if ($removed !== null) {
+					return $removed;
+				}
+			}
+
 			foreach ($typeToRemove->getTypes() as $unionTypeToRemove) {
 				$fromType = self::remove($fromType, $unionTypeToRemove);
+				if ($fromType instanceof NeverType) {
+					// there is nothing left to remove from
+					break;
+				}
 			}
 			return $fromType;
 		}

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1662,7 +1662,11 @@ class UnionType implements CompoundType
 		$types = $this->notBenevolentPickFromTypes(static fn (Type $type) => $type->getFiniteTypes());
 		$uniquedTypes = [];
 		foreach ($types as $type) {
-			$uniquedTypes[$type->describe(VerbosityLevel::cache())] = $type;
+			// These are finite types, so FiniteTypeSet keys them by the value they
+			// stand for - which is what the uniquing wants and what describe() was
+			// standing in for. Floats have no such key (equals() does not agree with
+			// value identity for them) and keep describing themselves.
+			$uniquedTypes[FiniteTypeSet::key($type) ?? $type->describe(VerbosityLevel::cache())] = $type;
 		}
 
 		if (count($uniquedTypes) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -39,6 +39,7 @@ use Throwable;
 use function array_diff_assoc;
 use function array_fill_keys;
 use function array_intersect;
+use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -1566,6 +1567,50 @@ class UnionType implements CompoundType
 				}
 
 				return new UnionType($remainingTypes);
+			}
+
+			// Every member of this union is a distinct value, and so is every member
+			// of the removed one: the result is their set difference, which no order
+			// of removals can sharpen. Taking it in one pass keeps removing a union
+			// of values linear instead of re-deriving this union once per value.
+			if ($typeToRemove instanceof self) {
+				$keysToRemove = [];
+				foreach ($typeToRemove->getTypes() as $innerTypeToRemove) {
+					$innerKey = FiniteTypeSet::key($innerTypeToRemove);
+					if ($innerKey === null) {
+						$keysToRemove = null;
+						break;
+					}
+
+					$keysToRemove[$innerKey] = true;
+				}
+
+				if ($keysToRemove !== null) {
+					$remainingTypes = [];
+					$removedAny = false;
+					foreach ($finiteTypeSet->getMembers() as $memberKey => $member) {
+						if (array_key_exists($memberKey, $keysToRemove)) {
+							$removedAny = true;
+							continue;
+						}
+
+						$remainingTypes[] = $member;
+					}
+
+					if (!$removedAny) {
+						return null;
+					}
+
+					if (count($remainingTypes) === 0) {
+						return new NeverType();
+					}
+
+					if (count($remainingTypes) === 1) {
+						return $remainingTypes[0];
+					}
+
+					return new UnionType($remainingTypes);
+				}
 			}
 		}
 


### PR DESCRIPTION
Two independent costs in the type system, both pre-existing and both hit hard by any codebase with large enums.

### Removing a union peeled it one member at a time

Peeling is what keeps the result precise — removing one member can narrow the type so that removing the next achieves more, and an unguarded whole-union path loses that (it turned four `*NEVER*` expectations into `non-empty-array` and friends). But it is quadratic whenever removing a member rebuilds the from-type, and subtracting a sealed hierarchy from its own type rebuilds the whole subtraction once per member.

The whole union is now offered first only where the subtraction is a set difference and no order of removals can sharpen it: a sealed hierarchy, or a union — whose members each weigh the same question again, so a member that needs the removals one at a time still gets them that way. Alongside that, `UnionType::tryRemove()` takes a complete finite value set minus a union of values as one difference, and `ObjectType::subtract()` stops normalising a union that `changeSubtractedType()` only flattens and throws away.

The `describe(precise())` that keyed the matched subtypes goes with it — an allowed subtype is dropped as it matches, so the matches cannot repeat and never needed keying.

| micro-benchmark | before | after |
| --- | --- | --- |
| `remove(Enum\|null, union of 250 cases)` | 149.15 ms | **0.489 ms** |
| `remove(Enum, union of 250 cases)` | 145.89 ms | **0.284 ms** |
| `remove(250 strings, 125 strings)` | 6.06 ms | **0.028 ms** |
| `remove(250 strings, 250 strings)` | 8.11 ms | **0.047 ms** |

### Two hot paths built a description only to use it as a key

`RecursionGuard::run()` keys every operation it guards with `describe(VerbosityLevel::value())`, and that level resolves the class name through the ReflectionProvider — two round-trips per guarded call, for a string that never changes. It was 28.8% of all `describe()` calls in a profile of analysing Slevomat. `ObjectType` now remembers it.

`UnionType::getFiniteTypes()` uniqued its members by description. They are finite types, so `FiniteTypeSet` already keys them by the value they stand for, which is what the uniquing wants; floats have no such key — `equals()` does not agree with value identity for them — and keep describing themselves.

### Measurements

Analysing Slevomat, turbo on, forward+reverse passes to cancel session drift: **591.15s → 589.12s user CPU (−0.34%)**, with byte-identical output. The end-to-end number is modest on 2.2.x because it does not yet make the expensive subtraction calls that 2.3.x's conditional guards do — the micro-benchmarks above are what any project with big enums actually pays.

Tests: `tests/PHPStan/Analyser`, `tests/PHPStan/Type` and `tests/PHPStan/Rules` all green at both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDqrN1pcN3qWc7xzKfkJaF