### PR TITLE
Answer reflection cache misses without a failing include()

### DIFF
--- a/src/Cache/FileCacheStorage.php
+++ b/src/Cache/FileCacheStorage.php
@@ -49,6 +49,17 @@ final class FileCacheStorage implements CacheStorage
 	{
 		[,, $filePath] = $this->getFilePaths($key);
 
+		// Letting include() fail is an expensive way to learn that an entry was
+		// never written: PHP walks the include_path and builds two warnings only
+		// to have them discarded by the @, about 29us per miss, while the stat()
+		// that rules the file out costs about 1.4us and is free on the hit path
+		// (the include stats the file anyway). Misses are not rare - every class
+		// name that reaches the PHP-internal locator and turns out not to be a
+		// built-in is one, tens of thousands per run and per worker.
+		if (!is_file($filePath)) {
+			return null;
+		}
+
 		return (static function ($variableKey, $filePath) {
 			$cacheItem = @include $filePath;
 			if (!$cacheItem instanceof CacheItem) {

--- a/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
@@ -185,6 +185,7 @@ final class BetterReflectionSourceLocatorFactory
 				new PhpInternalSourceLocator($astPhp8Locator, $this->phpstormStubsSourceStubber),
 				$this->cache,
 				$this->phpVersion,
+				$this->phpstormStubsSourceStubber,
 			));
 
 			$locators[] = $this->skipBundledPolyfills(new AutoloadSourceLocator($this->fileNodesFetcher, true));

--- a/src/Reflection/BetterReflection/SourceLocator/CachedPhpInternalSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/CachedPhpInternalSourceLocator.php
@@ -11,6 +11,7 @@ use PHPStan\BetterReflection\Reflection\ReflectionConstant;
 use PHPStan\BetterReflection\Reflection\ReflectionEnum;
 use PHPStan\BetterReflection\Reflection\ReflectionFunction;
 use PHPStan\BetterReflection\Reflector\Reflector;
+use PHPStan\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\Cache\Cache;
 use PHPStan\Internal\ComposerHelper;
@@ -59,6 +60,7 @@ final class CachedPhpInternalSourceLocator implements SourceLocator
 		private SourceLocator $inner,
 		private Cache $cache,
 		private PhpVersion $phpVersion,
+		private PhpStormStubsSourceStubber $stubber,
 	)
 	{
 	}
@@ -70,6 +72,20 @@ final class CachedPhpInternalSourceLocator implements SourceLocator
 		if ($identifier->isClass() || $identifier->isFunction()) {
 			$name = strtolower($name);
 		}
+
+		// Almost everything that reaches this locator is a userland class name
+		// that every earlier locator failed to resolve, and a name the stubs do
+		// not have can never have been cached - the stubber is the only source
+		// the wrapped locator reads from. Ruling those out against the stubs map
+		// is an array lookup, where asking the cache means hashing the key and
+		// stat()ing a file that will never exist. The wrapped locator is still
+		// asked: it resolves class aliases before consulting the stubber, so it
+		// can answer for a name the map does not list - such an answer just does
+		// not get cached, under a key that would be the alias anyway.
+		if ($identifier->isClass() && !$this->stubber->hasClass($name)) {
+			return $this->inner->locateIdentifier($reflector, $identifier);
+		}
+
 		$cacheKey = sprintf('phpinternal-%s-%s', $identifier->getType()->getName(), $name);
 		$variableCacheKey = $this->getVariableCacheKey();
 

--- a/tests/PHPStan/Cache/FileCacheStorageTest.php
+++ b/tests/PHPStan/Cache/FileCacheStorageTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Cache;
+
+use FilesystemIterator;
+use Override;
+use PHPStan\Internal\DirectoryCreatorException;
+use PHPStan\Testing\PHPStanTestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use function is_dir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class FileCacheStorageTest extends PHPStanTestCase
+{
+
+	private string $directory;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->directory = sys_get_temp_dir() . '/' . uniqid('phpstan-cache-', true);
+	}
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		if (!is_dir($this->directory)) {
+			return;
+		}
+
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($this->directory, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST,
+		);
+		foreach ($files as $file) {
+			if ($file->isDir()) {
+				rmdir($file->getPathname());
+				continue;
+			}
+
+			unlink($file->getPathname());
+		}
+
+		rmdir($this->directory);
+	}
+
+	public function testMissingEntry(): void
+	{
+		$storage = new FileCacheStorage($this->directory);
+
+		$this->assertNull($storage->load('never-written', 'v1'));
+	}
+
+	/**
+	 * @throws DirectoryCreatorException
+	 */
+	public function testEntrySavedAfterAMissIsLoadedBack(): void
+	{
+		$storage = new FileCacheStorage($this->directory);
+
+		// the miss comes first on purpose: load() stat()s the file to avoid a
+		// failing include(), and PHP's stat cache must not answer the second
+		// load() with what the first one saw
+		$this->assertNull($storage->load('key', 'v1'));
+		$storage->save('key', 'v1', ['data' => 1]);
+
+		$this->assertSame(['data' => 1], $storage->load('key', 'v1'));
+	}
+
+	/**
+	 * @throws DirectoryCreatorException
+	 */
+	public function testEntryWithDifferentVariableKey(): void
+	{
+		$storage = new FileCacheStorage($this->directory);
+		$storage->save('key', 'v1', ['data' => 1]);
+
+		$this->assertNull($storage->load('key', 'v2'));
+		$this->assertSame(['data' => 1], $storage->load('key', 'v1'));
+	}
+
+}


### PR DESCRIPTION
`FileCacheStorage::load()` found out that an entry was never written by letting `@include` fail. That costs about **29 µs per miss**: PHP walks the include_path and builds two warnings, and then the `@` throws them away. A `stat()` rules the file out in about **1.4 µs**, and it's free on the hit path because the include stats the file anyway (90.0 vs 89.9 µs per hit, microbenchmarked).

Misses are common. `CachedPhpInternalSourceLocator` sits behind every file locator, so every class name those locators can't resolve asks the cache whether it's a PHP built-in. On a large project (slevomat, 10 workers, full analysis) that's **~114k misses per run**, in every run, whether the cache is warm or cold. The wrapped locator answers "not a built-in" in 3.8 µs, so the cache in front of it cost 8–12x more than the work it was caching.

Two changes:

- **`is_file()` guard in `FileCacheStorage::load()`**. This is general and helps every miss path.
- **Stubs-map gate in `CachedPhpInternalSourceLocator`**. The stubber is the only source the wrapped locator reads from, so a class not listed in `PhpStormStubsSourceStubber::hasClass()` can never have been cached. For those names we now skip the key hashing and the `stat()` too. The wrapped locator is still asked, so class-alias resolution behaves as before. Classes were 88% of the negative lookups; functions and constants have no cheap public check and just go through the guard.

### Measurements

Measured with an instrumented phar on slevomat (full analysis, result cache deleted in every leg, outputs byte-identical):

- With the guard alone, the cache-miss path dropped from **5.04 s to 1.95 s** of fleet-wide time.
- The whole run dropped by **2.3 s of user CPU**, consistent across 4 ABBA pairs.
- The stubs-map gate removes most of the remaining 1.95 s. It wasn't benchmarked separately.

### Tests

- New `FileCacheStorageTest` pins the one hazard the guard introduces: PHP's stat cache must not answer a `load()` after a miss → `save()` with the stale negative. I mutated the guard to memoize misses and `testEntrySavedAfterAMissIsLoadedBack` failed; with the real guard it passes.
- `make tests` (21416 tests), `make phpstan` and `make cs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2cdRMUX8Be44eUzEM6RQ2